### PR TITLE
Add bootstrap meta files: CoC, CONTRIBUTING, CODEOWNERS, issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Every file in this repository is owned by @bittelc.
+# Code owner review is required for any pull request that touches this repo.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @bittelc

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Configuration for the GitHub issue chooser. Issue templates live in
+# .github/ISSUE_TEMPLATE/*.md alongside this file.
+#
+# blank_issues_enabled stays true while no issue templates exist, so that
+# contributors are not blocked from filing reports. Switch to false once
+# real templates land.
+blank_issues_enabled: true
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/walt-app/walt-passes/security/advisories/new
+    about: Report privately via GitHub security advisories. See SECURITY.md for the full disclosure process.
+  - name: Email the maintainer
+    url: mailto:cole@walt.is
+    about: Use email if you cannot use GitHub private vulnerability reporting, or for anything else that does not fit a public issue.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Code of Conduct
+
+## Why this document exists
+
+Walt-passes is a small, security-focused open-source project. This Code of Conduct describes how the project expects people to behave when they participate here. It is a working agreement, not a legal contract. Its purpose is to keep this a place where good technical work is possible.
+
+## What good participation looks like
+
+- Stay on the technical substance of a change. The clearest path to a useful conversation is usually a code reference and a concrete suggestion.
+- Assume contributors mean well until you have specific evidence otherwise. Most disagreements are misunderstandings, not bad faith.
+- Explain disagreements with reasons rather than vibes. "I think this is wrong because X" is workable; "this is bad" is not.
+- Remember that security-critical code attracts strong opinions. Strong opinions are fine when they are about the code and expressed respectfully toward the person.
+- Make it easy for the next person. Clear commit messages, scoped PRs, links to the relevant beads issue or specification when one exists.
+- Credit prior work. If a fix is informed by another project's bug report or a paper, say so.
+
+## What is not okay
+
+- Harassment of any kind, including sustained unwanted contact, sexualized comments or imagery, and persistent personal attacks.
+- Slurs or demeaning language tied to identity, including (but not limited to) race, ethnicity, nationality, religion, gender, sexual orientation, disability, age, or appearance.
+- Doxxing or publishing private information about another contributor without their consent.
+- Posting unverified vulnerability claims publicly instead of using the disclosure process in [`SECURITY.md`](SECURITY.md). Responsible disclosure is part of the project's trust model.
+- Knowingly wasting maintainer time. Examples: low-effort AI-generated PRs that the submitter has not read or tested; reopening the same out-of-scope proposal after it has been declined with a reason; demanding response timelines from a single-maintainer project.
+- Retaliation against anyone who reports a violation in good faith.
+
+## Disagreement is not misconduct
+
+The following are explicitly not Code of Conduct matters:
+
+- A maintainer declining a pull request for being out of scope as defined in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+- A reviewer pointing out a real flaw in your code, including bluntly. "This unbounded loop will OOM on a malformed pass" is a security-critical observation, not an attack.
+- A contributor disagreeing with a design decision and saying so directly, with reasons.
+
+The line is whether someone is being attacked versus their work being criticized. Critique of code is welcome; critique of the person is not.
+
+## Scope
+
+This document applies to interactions in this repository: issues, pull requests, code reviews, and discussions. It also applies to direct project communication, such as email about a contribution or a security report.
+
+It does not try to govern behavior in unrelated venues. People are people in many places, and one project's Code of Conduct cannot reasonably extend to all of them.
+
+## Reporting a problem
+
+If you believe someone has violated this Code of Conduct, email **cole@walt.is**. Helpful things to include:
+
+- Who was involved.
+- Where it happened (a link to the issue, PR, or comment, if applicable).
+- What occurred, in your own words.
+- Any relevant context.
+
+Reports are read only by the maintainer. Your identity will not be shared with the person you are reporting without your consent. Asking for advice rather than filing a formal complaint is also fine.
+
+## What happens after a report
+
+A report will be acknowledged within five business days. The maintainer will review the situation, may ask you and the other party for clarification, and will respond with one of the following outcomes:
+
+- **No action.** The reported conduct does not appear to violate this document. The maintainer will explain why.
+- **Private warning.** A direct message to the other party explaining the problem and what should change.
+- **Public warning.** A comment on the relevant issue, PR, or discussion thread, naming the behavior and the expected change.
+- **Temporary ban.** Loss of access to the repository for a stated period, enforced via GitHub block and PR closure.
+- **Permanent ban.** As above, without an end date.
+
+Outcomes are at the maintainer's discretion. The aim is to be proportionate to the harm done and to the contributor's history.
+
+## Honest caveat: single maintainer
+
+While this project has one maintainer, that person is also the one who reads reports about themselves. This is structurally imperfect, and pretending otherwise would be worse than naming it.
+
+If you believe the maintainer is the problem and a direct conversation is unworkable, the realistic options are:
+
+- Escalate to GitHub itself if the conduct violates GitHub's community guidelines.
+- Stop participating. Walking away from a project is always allowed and is sometimes the right answer.
+
+When the project grows beyond a single maintainer, this section will be replaced with a real escalation path.
+
+## A living document
+
+This Code of Conduct will change as the project changes. Pull requests against it are welcome. The maintainer will treat proposed changes the same way as any other PR: on technical and substantive merit, with reasons given.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Walt-passes is an open-source carve-out from the closed-source [Walt](https://walt.is) Android wallet. Its purpose is **transparency-for-trust**: every security-and-privacy claim Walt makes about pass handling is implemented in code that lives here. That goal shapes what kinds of contributions fit.
+
+## What fits this repository
+
+- Bug fixes in PKPASS parsing, signature verification, encrypted storage, or the security-relevant UI flows listed in [`SECURITY.md`](SECURITY.md).
+- Additional parser hardening, fuzzing harnesses, or test coverage for malicious inputs.
+- Improvements that make security-and-privacy behavior easier to audit (clearer code, better naming, more direct trust-claim-to-code mapping).
+- Localization, accessibility, and visual polish in `passes-ui`, as long as the security-relevant composables (URL confirmation, expired badge, bounded image rendering) keep their guarantees.
+
+## What does not fit
+
+- Features that pull pass data off the device. There is no `webServiceURL` handling, no telemetry to issuers, no cloud sync. PRs that add network calls in `passes-core` or `passes-storage` will be declined.
+- NFC / HCE handling for passes. Passes never register a payment AID; the `nfc` PKPASS field is parsed-and-ignored. This is deliberate to avoid HCE conflicts with Walt's payment feature.
+- WebView-based rendering of pass content. HTML in back fields is rendered through an explicit subset and nothing else.
+- Generalizing the library beyond what Walt needs. Walt-passes is "Walt's open pass-handling kernel," not a general-purpose PKPASS library. Reuse by other apps is welcome as a side effect; the primary commitment is the audit trail.
+
+If you are unsure whether a contribution fits, open an issue first to discuss.
+
+## Reporting security issues
+
+Do **not** open a public GitHub issue. See [`SECURITY.md`](SECURITY.md) for the disclosure process.
+
+## Development setup
+
+The repo is in pre-alpha. Gradle modules and the build-logic convention plugins are introduced as the architecture phase concludes. Until then:
+
+- Source of truth for architectural intent: [`README.md`](README.md) and the [`CLAUDE.md`](CLAUDE.md) at the repo root.
+- The trust-claim-to-module audit map in `README.md` describes where each security-and-privacy claim is intended to live.
+- Issue tracking uses [beads](https://github.com/steveyegge/beads) (`bd`). Run `bd ready` to see available work in this repo. The umbrella epic for the Walt Passes feature lives in walt-android (`wlt-0tn`).
+
+## Code style
+
+- 100% Kotlin (no Java).
+- Sealed interfaces, not sealed classes.
+- `Result<T>` over thrown exceptions for recoverable errors. Throw only for programmer errors.
+- StateFlow, not LiveData.
+- JUnit 4 + Google Truth for tests.
+- `kotlinx.serialization` for JSON.
+- BouncyCastle (JVM) for PKCS#7 / X.509.
+- `passes-core` has **no** Android framework dependencies.
+
+## Pull request workflow
+
+1. Fork or create a topic branch.
+2. Keep PRs focused. One change per PR makes the audit trail readable.
+3. Reference the relevant beads issue in the description if one exists.
+4. Confirm the change does not regress any of the trust claims listed in `SECURITY.md`. If it does, that is the conversation to have in the PR.
+5. CI must be green. Tests, linters, and dependency review all run automatically.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0, the same license as the rest of the repository.


### PR DESCRIPTION
## Summary

Rounds out the meta files for the walt-passes repo bootstrap (wlt-29q).

- `CONTRIBUTING.md` - what fits the repo, what doesn't, dev setup, code style, PR workflow.
- `CODE_OF_CONDUCT.md` - original (non-Covenant) Code of Conduct sized to a single-maintainer security-focused FOSS project. Includes an honest single-maintainer caveat instead of pretending an appeals board exists.
- `.github/CODEOWNERS` - `@bittelc` owns everything; required reviewer on all PRs.
- `.github/ISSUE_TEMPLATE/config.yml` - `contact_links` for GitHub private vulnerability reporting and the maintainer email; pushes security reports out of public issues.

Deferred (will follow in later PRs as the architecture phase lands):
- `.github/workflows/` (CI) - nothing meaningful to build yet; `settings.gradle.kts` modules are still placeholders.
- `.github/dependabot.yml` - no Gradle deps and no workflows to scan.
- `build-logic/` convention plugins - deferred per wlt-29q until module decisions land.

Refs: wlt-29q (in walt-android beads); umbrella wpass-9vv.

## Test plan

- [ ] CODE_OF_CONDUCT.md renders cleanly on GitHub.
- [ ] `.github/ISSUE_TEMPLATE/config.yml` is picked up by GitHub (visible from the "New issue" picker).
- [ ] Security advisory link in `config.yml` resolves (will 404 if private vulnerability reporting is not enabled in repo settings - enable from Settings -> Code security if needed).
- [ ] CODEOWNERS triggers required-review on a follow-up PR.