### PR TITLE
Rename project to walt-passes-android

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Report a security vulnerability
-    url: https://github.com/walt-app/walt-passes/security/advisories/new
+    url: https://github.com/walt-app/walt-passes-android/security/advisories/new
     about: Report privately via GitHub security advisories. See SECURITY.md for the full disclosure process.
   - name: Email the maintainer
     url: mailto:cole@walt.is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Walt Passes
+# Walt Passes (Android)
 
-Open-source pass-handling kernel for the Walt wallet app. PKPASS parsing, signature verification, encrypted storage, and security-critical UI flows.
+Open-source pass-handling kernel for the Walt Android wallet app. PKPASS parsing, signature verification, encrypted storage, and security-critical UI flows.
 
 ## Repository Purpose
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Why this document exists
 
-Walt-passes is a small, security-focused open-source project. This Code of Conduct describes how the project expects people to behave when they participate here. It is a working agreement, not a legal contract. Its purpose is to keep this a place where good technical work is possible.
+walt-passes-android is a small, security-focused open-source project. This Code of Conduct describes how the project expects people to behave when they participate here. It is a working agreement, not a legal contract. Its purpose is to keep this a place where good technical work is possible.
 
 ## What good participation looks like
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Walt-passes is an open-source carve-out from the closed-source [Walt](https://walt.is) Android wallet. Its purpose is **transparency-for-trust**: every security-and-privacy claim Walt makes about pass handling is implemented in code that lives here. That goal shapes what kinds of contributions fit.
+walt-passes-android is an open-source carve-out from the closed-source [Walt](https://walt.is) Android wallet. Its purpose is **transparency-for-trust**: every security-and-privacy claim Walt makes about pass handling is implemented in code that lives here. That goal shapes what kinds of contributions fit.
 
 ## What fits this repository
 
@@ -14,7 +14,7 @@ Walt-passes is an open-source carve-out from the closed-source [Walt](https://wa
 - Features that pull pass data off the device. There is no `webServiceURL` handling, no telemetry to issuers, no cloud sync. PRs that add network calls in `passes-core` or `passes-storage` will be declined.
 - NFC / HCE handling for passes. Passes never register a payment AID; the `nfc` PKPASS field is parsed-and-ignored. This is deliberate to avoid HCE conflicts with Walt's payment feature.
 - WebView-based rendering of pass content. HTML in back fields is rendered through an explicit subset and nothing else.
-- Generalizing the library beyond what Walt needs. Walt-passes is "Walt's open pass-handling kernel," not a general-purpose PKPASS library. Reuse by other apps is welcome as a side effect; the primary commitment is the audit trail.
+- Generalizing the library beyond what Walt needs. This is "Walt's open pass-handling kernel for Android," not a general-purpose PKPASS library. Reuse by other apps is welcome as a side effect; the primary commitment is the audit trail.
 
 If you are unsure whether a contribution fits, open an issue first to discuss.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Walt Passes
+# Walt Passes (Android)
 
-> The open-sourced pass-handling implementation that ships in the [Walt](https://walt.is) wallet app.
+> The open-sourced pass-handling implementation that ships in the [Walt](https://walt.is) Android wallet app.
 
 ## Why this repository exists
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-If you think you have found a security issue in walt-passes, please email **cole@walt.is** instead of opening a public GitHub issue.
+If you think you have found a security issue in walt-passes-android, please email **cole@walt.is** instead of opening a public GitHub issue.
 
 Helpful things to include:
 
@@ -13,7 +13,7 @@ Helpful things to include:
 
 ## Scope
 
-Walt-passes is the open-source pass-handling kernel that ships inside the [Walt](https://walt.is) Android wallet. The most useful reports target one of:
+walt-passes-android is the open-source pass-handling kernel that ships inside the [Walt](https://walt.is) Android wallet. The most useful reports target one of:
 
 - The PKPASS parser (`passes-core`): ZIP, JSON, image, signature, manifest verification, `.strings` parsing, locale handling.
 - Pass data storage (`passes-storage`): encryption-at-rest, key management, deletion, backup exclusion.
@@ -43,4 +43,4 @@ A short list of intentional choices a reviewer might want to know up front. If t
 
 ## Supported versions
 
-Walt-passes is pre-alpha. Until a v1.0 release, only the latest commit on `main` is supported.
+walt-passes-android is pre-alpha. Until a v1.0 release, only the latest commit on `main` is supported.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "walt-passes"
+rootProject.name = "walt-passes-android"
 
 // Modules will be added as architecture work concludes.
 // Planned (see CLAUDE.md): passes-core, passes-storage, passes-ui.


### PR DESCRIPTION
## Summary

Repo renamed on GitHub from `walt-app/walt-passes` to `walt-app/walt-passes-android` to make room for a future `walt-passes-ios` sibling.

The feature umbrella name ("Walt Passes") and module names (`passes-core`, `passes-storage`, `passes-ui`) are unchanged; only the repo slug gets the platform suffix.

In-repo updates:
- `settings.gradle.kts` — `rootProject.name`
- `README.md`, `CLAUDE.md` — titles clarify "(Android)"
- `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` — prose references
- `.github/ISSUE_TEMPLATE/config.yml` — Private Vulnerability Reporting URL

Out of repo (already done):
- GitHub repo renamed via API
- Local parent dir: `walt/passes/passes-main` -> `walt/passes-android/passes-android-main`
- Symlinks recreated; `git remote set-url` updated to new URL

## Test plan

- [ ] No remaining references to the old slug `walt-passes` in the repo (`grep -rn walt-passes` should be empty).
- [ ] Old GitHub URL `github.com/walt-app/walt-passes` 301-redirects to the new URL.
- [ ] PVR link in `config.yml` resolves on the renamed repo.