### PR TITLE
Bootstrap passes-storage: API skeletons, schema, ADR 0002

### DIFF
--- a/docs/adr/0002-passes-storage.md
+++ b/docs/adr/0002-passes-storage.md
@@ -1,0 +1,192 @@
+# ADR 0002: passes-storage architecture
+
+- Status: Accepted
+- Date: 2026-05-04
+- Tracks: parent epic `wpass-9vv`; design bead `wpass-9vv.3`
+- Decision context: `decision-wlt-0tn-q3-4` (deletion mechanism, no VACUUM), `decision-wlt-0tn-q5` (three-module shape), `decision-wlt-0tn-q3-3` (full localization)
+
+## Context
+
+`passes-storage` is the Android-only Gradle module that owns the at-rest representation of imported passes. Its scope is limited and deliberate:
+
+- **Persist** parsed `Pass` values from `passes-core` so the wallet UI does not re-parse on every cold start.
+- **Encrypt** that data at rest with a hardware-backed key, so a stolen device or a physical-recovery attempt cannot recover pass content without breaking the device's hardware key store.
+- **Exclude** the passes database from Android Auto Backup and device-to-device transfer, so cloud-side compromise of a backup blob does not surface pass content.
+- **Delete irreversibly** with no soft-delete, no trash bin, no undo, and with cached decoded data wiped in the same operation.
+- **Surface** trust-relevant storage events (`PassImported`, `PassDeleted`, `KeyUnwrapFailed`) through a `StorageTelemetryGuard` whose method signatures structurally forbid PII, mirroring the `passes-core` `TelemetryGuard` discipline.
+
+Out of scope for `passes-storage`: pass acquisition (parser lives in `passes-core`), rendering (Compose lives in `passes-ui`), confirmation dialogs (`passes-ui`), Hilt wiring (lives in walt-android's `core/data-passes`).
+
+This ADR fixes the storage contract today; the implementation bead that follows wires Android Gradle Plugin, SQLCipher, Android Keystore, and the manifest backup-exclusion rules against this contract.
+
+## Decisions
+
+### D1. Single SQLCipher database, single page-level key
+
+The persistent store is one SQLCipher database, `walt_passes.db`, encrypted at the page level with one 32-byte raw key. The library does not maintain per-pass keys.
+
+Rationale: a per-pass key scheme would add complexity (key directory, per-row unwrap-on-read, separate IV/AAD discipline) without changing the threat model. A process-compromise adversary that can read SQLCipher's in-memory key material can read every pass key the same way; a physical-recovery adversary that cannot reach the Keystore master key cannot reach either layer. The only place per-pass keys would help is "selective leak of a single pass key without leaking the database," which is not a threat model `passes-storage` defends against.
+
+### D2. The database key is wrapped, not derived
+
+The DB key is generated once at first open as 32 random bytes from `SecureRandom`, then wrapped (AES-256-GCM) with a master key resident in Android Keystore. The wrapped blob and its IV are stored in the `schema_meta` table. On subsequent opens, the wrapped blob is unwrapped via Keystore and the resulting raw bytes are passed to SQLCipher's `PRAGMA key`.
+
+Why wrapped, not Keystore-derived directly: Android Keystore does not export raw symmetric key bytes for AES keys (the keys are non-exportable by design). SQLCipher requires a raw 32-byte key to derive its page key via PBKDF2. Wrapping is the bridge: the master key never leaves Keystore (so hardware-backing applies), and the unwrapped DB key is held in process memory only as long as the database is open.
+
+StrongBox is requested via `KeyGenParameterSpec.Builder.setIsStrongBoxBacked(true)` and the library falls back to TEE-backed when StrongBox is unavailable. The `StorageTelemetryGuard.onKeyProviderInitialized` event reports which backing was actually used (via the `KeyBacking` enum), so consumers can surface `StrongBox` / `Tee` / `Software` to the user without inspecting strings.
+
+### D3. Schema separates query columns, blob, images, and locales
+
+Four tables. Schema version 1:
+
+```sql
+CREATE TABLE schema_meta (
+    key   TEXT PRIMARY KEY NOT NULL,
+    value BLOB NOT NULL
+);
+-- Reserved keys: 'schema_version' (TEXT-encoded int), 'wrapped_db_key' (raw bytes),
+-- 'wrapped_db_key_iv' (raw bytes), 'key_alias' (TEXT), 'key_backing' (TEXT enum).
+
+CREATE TABLE passes (
+    id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+    type                  TEXT    NOT NULL,                  -- PassType enum name
+    serial_number         TEXT    NOT NULL,
+    organization_name     TEXT    NOT NULL,
+    description           TEXT    NOT NULL,
+    expiration_epoch_ms   INTEGER,                           -- nullable
+    voided                INTEGER NOT NULL DEFAULT 0,        -- 0/1
+    signature_status_kind TEXT    NOT NULL,                  -- SignatureStatusKind enum name
+    pass_json             BLOB    NOT NULL,                  -- kotlinx-serialized Pass minus images and locales
+    created_at_epoch_ms   INTEGER NOT NULL,
+    updated_at_epoch_ms   INTEGER NOT NULL
+);
+CREATE INDEX idx_passes_type            ON passes(type);
+CREATE INDEX idx_passes_expiration      ON passes(expiration_epoch_ms);
+CREATE UNIQUE INDEX idx_passes_identity ON passes(type, serial_number, organization_name);
+
+CREATE TABLE pass_images (
+    pass_id INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+    role    TEXT    NOT NULL,                                -- ImageRole enum name
+    bytes   BLOB    NOT NULL,
+    PRIMARY KEY (pass_id, role)
+);
+
+CREATE TABLE pass_locales (
+    pass_id      INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+    locale_tag   TEXT    NOT NULL,                           -- BCP-47, verbatim
+    strings_json BLOB    NOT NULL,                           -- kotlinx-serialized LocalizedStrings
+    PRIMARY KEY (pass_id, locale_tag)
+);
+```
+
+Why split: the wallet list view needs the query columns (type, organization, expiration, voided) for tens to low hundreds of passes. Pulling tens of MB of image bytes and locale tables for that view is wasteful. Separating images and locales lets the list query touch only the `passes` row, and the detail view fetches images/locales lazily by `pass_id`.
+
+`pass_json` carries the structured `Pass` body (fields, colors, barcode) so the renderer reconstructs the same object the parser produced, without re-running the PKCS#7 verification. The `signature_status_kind` column captures the trust band at import time so the badge remains visible without re-parsing.
+
+The unique index on `(type, serial_number, organization_name)` enforces PKPASS identity per the Apple spec: a re-imported pass with the same identity replaces the prior row (transactional UPSERT in `PassRepository.upsert`), so updated passes do not accumulate duplicate rows.
+
+### D4. Decoded summary cache is the row itself, not a separate cache layer
+
+The parser-decoded query columns ARE the summary cache. There is no separate Room `@Entity`-style cache, no in-memory `LruCache`, no second source of truth.
+
+Why: a separate cache layer creates two consistency surfaces and a pair of failure modes (cache stale, cache evicted while DB updated). The bead description spoke of a "decoded summary cache"; we deliver that semantic by denormalizing into the row at insert time, so a single transaction maintains both the canonical blob and the queryable summary.
+
+A schema-migration breakage in the decoder (e.g. `pass_json` format changes) is recovered by re-deserializing every `pass_json` blob during the migration; if a row fails to migrate, the migration logs the failure through `StorageTelemetryGuard.onMigrationRowDropped(MigrationFailureKind)` and drops the row. Pass content is recoverable by re-import from the user's original `.pkpass` file; the database is not the system of record.
+
+### D5. Backup exclusion is library-shipped rules + a documented consumer contract
+
+`passes-storage` ships two manifest-merged XML resources:
+
+- `res/xml/walt_passes_backup_rules.xml` — `<full-backup-content>` excluding the passes database for API 23 - 30.
+- `res/xml/walt_passes_data_extraction_rules.xml` — `<data-extraction-rules>` excluding the passes database for API 31+ (covers both cloud backup and device-to-device transfer).
+
+The library manifest declares both via `android:fullBackupContent` and `android:dataExtractionRules` on a `<application>` placeholder. Manifest merge applies these to the consumer.
+
+The library does NOT set `android:allowBackup="false"` on the consumer, because that is a process-wide setting and walt-android may legitimately back up other data. The trust claim "pass data is excluded from cloud backup" is delivered by the rules files; consumers are documented to verify their merged manifest includes them.
+
+A consumer-side `assertBackupRulesApplied()` helper is exposed from `passes-storage` for use in instrumentation tests, so the trust claim is checkable in CI rather than relying on documentation review.
+
+### D6. Deletion is items 1+3+4+5+6 from `decision-wlt-0tn-q3-4`
+
+`PassRepository.delete(id)`:
+
+1. Begins a transaction.
+2. Issues `DELETE FROM passes WHERE id = ?` (cascades to `pass_images` and `pass_locales`).
+3. Commits.
+4. Updates the in-memory `StateFlow<List<PassSummary>>` to remove the deleted entry, before returning.
+5. Emits `StorageTelemetryGuard.onPassDeleted(PassType, SignatureStatusKind)` (no PII).
+
+What is intentionally NOT included:
+
+- No `VACUUM` (Q3.4): SQLCipher's page encryption + non-exportable Keystore master + Android FBE + backup opt-out is the load-bearing erasure; `VACUUM` cannot reach flash wear-leveled physical bits anyway.
+- No undo, no trash bin, no soft-delete column: the row goes; "unscheduled un-deletion" is a feature gap, not a defect.
+- No confirmation dialog: that lives in `passes-ui` (the `B3 URL confirmation sheet` family). `passes-storage` trusts callers; the UI owns intent-confirmation.
+
+### D7. The repository surface is `Result<T, StorageError>`-style, not exceptions
+
+`PassRepository` returns `StorageResult<T>`, a sealed interface (`Success`, `Failure(StorageError)`), where `StorageError` is itself sealed (`KeyUnavailable`, `KeyUnwrapFailed`, `DatabaseLocked`, `IntegrityViolation`, `Unsupported`, `Unknown`).
+
+Rationale: matches CLAUDE.md's `Result<T> over exceptions` rule and gives the consumer the same partition `passes-core` already provides for parse failures. `KeyUnwrapFailed` in particular is a security-relevant signal (possible Keystore tampering / deleted key) and must be distinguishable from `DatabaseLocked` (concurrent open).
+
+### D8. `passes-storage` exposes interfaces, not Android types, at its API boundary
+
+Public-API types of `passes-storage`:
+
+- `PassRepository` interface
+- `PassKeyProvider` interface (the Keystore-backed implementation is an internal class produced by `AndroidKeystorePassKeyProvider.create(context)`)
+- `StorageResult`, `StorageError` sealed interfaces
+- `StoredPass`, `PassSummary` data classes
+- `StorageTelemetryGuard` interface and its event types
+- `KeyBacking` enum
+
+Internal-only: SQLCipher cursor handling, PRAGMA invocation, manifest assertion helpers, the `AndroidKeystorePassKeyProvider` class body.
+
+Rationale: walt-android's `core/data-passes` wraps `PassRepository` behind a Hilt-provided binding; if `passes-storage` leaks `SQLiteDatabase` or `Cursor` into the public API, walt-android picks up an incidental dependency on those types and the contract gets harder to swap (e.g. for an in-memory test double). Keeping the surface narrow keeps the contract testable on the JVM with a fake `PassKeyProvider` and an in-memory SQLite.
+
+## Key flow
+
+```mermaid
+sequenceDiagram
+    participant UI as walt-android UI
+    participant Repo as PassRepository (passes-storage)
+    participant KP as AndroidKeystorePassKeyProvider
+    participant KS as Android Keystore
+    participant DB as SQLCipher DB
+
+    UI->>Repo: open()
+    Repo->>KP: provideDatabaseKey()
+    KP->>DB: read schema_meta(wrapped_db_key, iv, alias)
+    alt first launch
+        KP->>KS: getOrCreateMasterKey(alias, StrongBox preferred)
+        KS-->>KP: SecretKey handle (non-exportable)
+        KP->>KP: dbKey = SecureRandom 32 bytes
+        KP->>KS: AES-256-GCM wrap(dbKey)
+        KS-->>KP: wrappedBlob, iv
+        KP->>DB: write schema_meta entries
+    else subsequent launches
+        KP->>KS: AES-256-GCM unwrap(wrappedBlob, iv)
+        KS-->>KP: dbKey (raw 32 bytes, in-process)
+    end
+    KP-->>Repo: dbKey
+    Repo->>DB: PRAGMA key = x'<hex(dbKey)>'
+    Repo->>DB: PRAGMA cipher_compatibility = 4
+    Repo->>Repo: zero out dbKey from local buffers
+    Note over Repo,DB: Repo holds an open SQLiteDatabase handle;<br/>raw key bytes live only inside SQLCipher's internal page-key derivation buffer.
+```
+
+The raw DB key bytes are zeroed in the `PassKeyProvider` after they are handed to SQLCipher. SQLCipher's own internal copy lives for the lifetime of the open connection; the library does not attempt to control SQLCipher's internal memory.
+
+## Consequences
+
+- The implementation bead can land Android Gradle Plugin, SQLCipher, Keystore wiring, and manifest XML against a fixed contract; no public-API renegotiation.
+- walt-android's `core/data-passes` can write its Hilt module today, binding the `PassRepository` interface to a stub for early integration work.
+- `passes-storage` builds on JVM-only today (Kotlin/JVM module mirroring `passes-core`); the AGP wiring is a follow-on. Tests of the contract types and schema DDL run on the JVM CI host.
+- `StorageTelemetryGuard` carries the same security-policy review gate that `TelemetryGuard` does: any future addition of a `String` (or `Pass`, or `PassField`) parameter is a security-policy change, not an API addition.
+- The decoded summary cache is the row itself, so any future "richer summary" (e.g. event ticket subtype) requires a column add and a schema migration, not a new cache layer.
+
+## Open follow-ups
+
+- Implementation bead: AGP wiring, SQLCipher dependency, manifest rules XML, `AndroidKeystorePassKeyProvider` body, schema DDL execution, instrumentation tests covering Auto Backup exclusion via `bmgr` shell harness.
+- Migration tooling: schema version 2 candidates (event ticket subtype indexing, barcode message search) are deferred until the wallet feature surfaces them.
+- StrongBox availability matrix: which devices in the walt-android target population actually have StrongBox is a deployment-data question for walt-android, not for this module.
+- Multi-user / work-profile behavior: the library assumes per-user Android profiles isolate Keystore aliases (they do); no extra logic is required, but the implementation bead's instrumentation tests should cover work-profile install once.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,14 @@
 [versions]
 kotlin = "2.2.21"
 kotlinxSerialization = "1.7.3"
+kotlinxCoroutines = "1.9.0"
 junit = "4.13.2"
 truth = "1.4.5"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 

--- a/passes-storage/build.gradle.kts
+++ b/passes-storage/build.gradle.kts
@@ -1,0 +1,36 @@
+// JVM-only today. The implementation bead replaces this with the Android library plugin
+// to bring in SQLCipher and Android Keystore. The public-API types defined here are
+// intentionally Android-agnostic so that test doubles and the JVM CI host can exercise them
+// without an Android device.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    explicitApi()
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjvm-default=all")
+    }
+}
+
+dependencies {
+    api(project(":passes-core"))
+    api(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+
+tasks.test {
+    useJUnit()
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
@@ -1,0 +1,70 @@
+package `is`.walt.passes.storage
+
+/**
+ * Source of the 32-byte raw key handed to SQLCipher's `PRAGMA key`. The Android-only
+ * implementation wraps a randomly generated key with a non-exportable Keystore master
+ * key (see ADR 0002 D2); the JVM-test implementation supplies a fixed key for round-trip
+ * tests of the schema.
+ *
+ * The Android implementation is produced by `AndroidKeystorePassKeyProvider.create(...)`,
+ * which is the only place that touches `android.security.keystore.*` types. Keeping that
+ * dependency off the public interface lets the contract be exercised on JVM CI.
+ */
+public interface PassKeyProvider {
+    /**
+     * Returns the 32-byte raw database key. Implementations MUST zero out any local
+     * buffers holding the key bytes after returning; SQLCipher takes ownership of the
+     * returned array internally.
+     *
+     * Returns [StorageError.KeyUnavailable] if the master alias is gone; returns
+     * [StorageError.KeyUnwrapFailed] if the wrapped blob exists but cannot be unwrapped.
+     */
+    public fun provideDatabaseKey(): StorageResult<DatabaseKey>
+
+    /**
+     * Reports which Keystore backing was actually selected for the master key. Surfaced
+     * via [StorageTelemetryGuard.onKeyProviderInitialized]; useful in the wallet UI when
+     * the user wants to verify hardware-backing on their device.
+     */
+    public val keyBacking: KeyBacking
+}
+
+/**
+ * Wrapper around the raw 32-byte database key. Exists to make accidental logging
+ * discouragingly verbose: the class deliberately overrides `toString()` to a redacted
+ * form, and exposes byte access only via [withBytes], which scopes the lifetime of the
+ * borrowed array.
+ */
+public class DatabaseKey(private val bytes: ByteArray) {
+    init {
+        require(bytes.size == 32) { "DatabaseKey must be exactly 32 bytes" }
+    }
+
+    /**
+     * Hands the raw key bytes to [block] and zeros the internal buffer when [block]
+     * returns. Callers MUST NOT retain the [ByteArray] beyond the block.
+     */
+    public fun <R> withBytes(block: (ByteArray) -> R): R {
+        try {
+            return block(bytes)
+        } finally {
+            bytes.fill(0)
+        }
+    }
+
+    override fun toString(): String = "DatabaseKey(redacted)"
+}
+
+/**
+ * Reports which Android Keystore backing was used for the master key that wraps the DB
+ * key. The wallet UI surfaces this so users can verify hardware-backing on their device.
+ *
+ * `Software` is reachable on emulators and on devices whose Keystore implementation
+ * declined to provide a hardware-backed key; the library does NOT refuse to operate in
+ * this case, because doing so would brick the wallet on emulator-based development.
+ */
+public enum class KeyBacking {
+    StrongBox,
+    Tee,
+    Software,
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -1,0 +1,95 @@
+package `is`.walt.passes.storage
+
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The single repository contract that walt-android's `core/data-passes` Hilt module binds
+ * against. Backed by a SQLCipher database with a Keystore-wrapped key (see ADR 0002).
+ *
+ * All trust-claim-bearing storage logic lives behind this interface: encryption-at-rest,
+ * backup exclusion, irreversible deletion, decoded summary maintenance.
+ */
+public interface PassRepository {
+    /**
+     * Hot list of pass summaries, sorted by `created_at_epoch_ms` descending. Backed by the
+     * `passes` row's query columns; image and locale data are NOT loaded here.
+     */
+    public val passes: StateFlow<List<PassSummary>>
+
+    /**
+     * Insert a parsed pass, or replace an existing row whose
+     * `(type, serial_number, organization_name)` identity matches. Returns the assigned
+     * [PassRecordId] in [StorageResult.Success.value].
+     *
+     * On replacement the existing image and locale rows are atomically replaced inside the
+     * same transaction. The decoded summary is recomputed from [pass]; callers do not pass
+     * a separate summary.
+     */
+    public suspend fun upsert(
+        pass: Pass,
+        signatureStatus: SignatureStatus,
+    ): StorageResult<PassRecordId>
+
+    /**
+     * Load a stored pass with all images and locales materialized. Use [summaryOf] for the
+     * list view; [load] is the detail-view path.
+     */
+    public suspend fun load(id: PassRecordId): StorageResult<StoredPass>
+
+    /**
+     * Single-pass summary lookup without materializing image/locale rows.
+     */
+    public suspend fun summaryOf(id: PassRecordId): StorageResult<PassSummary>
+
+    /**
+     * Irreversible delete (ADR 0002 D6). Deletes the `passes` row and its cascaded image
+     * and locale rows in one transaction, updates the [passes] StateFlow, then emits the
+     * `onPassDeleted` telemetry event. No undo, no soft-delete, no VACUUM.
+     *
+     * Confirmation UI is the caller's responsibility; the repository trusts the call.
+     */
+    public suspend fun delete(id: PassRecordId): StorageResult<Unit>
+}
+
+/**
+ * The list-view projection of a stored pass. Mirrors the indexed columns of the `passes`
+ * table so the wallet list does not pay for image or locale I/O.
+ */
+public data class PassSummary(
+    public val id: PassRecordId,
+    public val type: PassType,
+    public val serialNumber: String,
+    public val organizationName: String,
+    public val description: String,
+    public val expirationDate: PassInstant?,
+    public val voided: Boolean,
+    public val signatureStatus: SignatureStatus,
+    public val createdAt: PassInstant,
+    public val updatedAt: PassInstant,
+)
+
+/**
+ * The detail-view projection. The fully materialized [Pass] from passes-core, plus the
+ * trust band recorded at import time and the storage timestamps. Re-rendering uses
+ * [Pass] directly; [signatureStatus] drives the trust badge without re-running PKCS#7
+ * verification.
+ */
+public data class StoredPass(
+    public val id: PassRecordId,
+    public val pass: Pass,
+    public val signatureStatus: SignatureStatus,
+    public val createdAt: PassInstant,
+    public val updatedAt: PassInstant,
+)
+
+/**
+ * Auto-incremented primary-key surrogate for a row in the `passes` table. Distinct from
+ * the PKPASS identity tuple (`type`, `serialNumber`, `organizationName`) because the same
+ * identity may legitimately be re-imported across the same `id` over time.
+ */
+@JvmInline
+public value class PassRecordId(public val value: Long)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -1,0 +1,90 @@
+package `is`.walt.passes.storage
+
+/**
+ * The on-disk schema. Single source of truth for table and column names, version, and
+ * DDL statements. The Android implementation executes [DDL] verbatim against the
+ * SQLCipher-opened database; JVM tests execute the same statements against an in-memory
+ * SQLite to verify schema-roundtrip behavior without Android dependencies.
+ *
+ * Bumping [VERSION] requires a new entry in [MIGRATIONS] and a corresponding test that
+ * walks every prior version up to current. Forward-only: rollback is not supported, per
+ * ADR 0002 (a downgraded build refuses to open the DB and surfaces
+ * [StorageError.Unsupported]).
+ */
+public object Schema {
+    public const val DATABASE_NAME: String = "walt_passes.db"
+
+    public const val VERSION: Int = 1
+
+    public object Tables {
+        public const val SCHEMA_META: String = "schema_meta"
+        public const val PASSES: String = "passes"
+        public const val PASS_IMAGES: String = "pass_images"
+        public const val PASS_LOCALES: String = "pass_locales"
+    }
+
+    public object MetaKeys {
+        public const val SCHEMA_VERSION: String = "schema_version"
+        public const val WRAPPED_DB_KEY: String = "wrapped_db_key"
+        public const val WRAPPED_DB_KEY_IV: String = "wrapped_db_key_iv"
+        public const val KEY_ALIAS: String = "key_alias"
+        public const val KEY_BACKING: String = "key_backing"
+    }
+
+    /**
+     * The DDL block that brings a fresh database to [VERSION]. Statements are listed in
+     * dependency order (parent tables before child tables); they are executed in a single
+     * transaction by the implementation.
+     */
+    public val DDL: List<String> = listOf(
+        """
+        CREATE TABLE IF NOT EXISTS schema_meta (
+            key   TEXT PRIMARY KEY NOT NULL,
+            value BLOB NOT NULL
+        )
+        """.trimIndent(),
+        """
+        CREATE TABLE IF NOT EXISTS passes (
+            id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+            type                  TEXT    NOT NULL,
+            serial_number         TEXT    NOT NULL,
+            organization_name     TEXT    NOT NULL,
+            description           TEXT    NOT NULL,
+            expiration_epoch_ms   INTEGER,
+            voided                INTEGER NOT NULL DEFAULT 0,
+            signature_status_kind TEXT    NOT NULL,
+            pass_json             BLOB    NOT NULL,
+            created_at_epoch_ms   INTEGER NOT NULL,
+            updated_at_epoch_ms   INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_passes_type ON passes(type)",
+        "CREATE INDEX IF NOT EXISTS idx_passes_expiration ON passes(expiration_epoch_ms)",
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_passes_identity
+            ON passes(type, serial_number, organization_name)
+        """.trimIndent(),
+        """
+        CREATE TABLE IF NOT EXISTS pass_images (
+            pass_id INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+            role    TEXT    NOT NULL,
+            bytes   BLOB    NOT NULL,
+            PRIMARY KEY (pass_id, role)
+        )
+        """.trimIndent(),
+        """
+        CREATE TABLE IF NOT EXISTS pass_locales (
+            pass_id      INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+            locale_tag   TEXT    NOT NULL,
+            strings_json BLOB    NOT NULL,
+            PRIMARY KEY (pass_id, locale_tag)
+        )
+        """.trimIndent(),
+    )
+
+    /**
+     * Schema migrations. Empty at version 1; future entries follow the shape
+     * `(fromVersion, listOf("ALTER ...", ...))`.
+     */
+    public val MIGRATIONS: Map<Int, List<String>> = emptyMap()
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -1,0 +1,78 @@
+package `is`.walt.passes.storage
+
+/**
+ * The result type for every [PassRepository] call. Mirrors the `Result<T> over exceptions`
+ * convention from CLAUDE.md and gives the consumer a typed partition of the failure space:
+ * key custody failures must be distinguishable from concurrent-open failures from
+ * transient-DB failures, because the appropriate UI response differs.
+ */
+public sealed interface StorageResult<out T> {
+    public data class Success<T>(public val value: T) : StorageResult<T>
+    public data class Failure(public val error: StorageError) : StorageResult<Nothing>
+}
+
+/**
+ * Storage failure modes. The arms are deliberately coarse: the consumer needs enough
+ * resolution to render the right user-facing message, not enough to second-guess the
+ * library's internal handling.
+ */
+public sealed interface StorageError {
+    /**
+     * The Keystore master alias has been removed (factory reset partial, app-data clear,
+     * Android upgrade dropped the entry, lock-screen credential deleted on a setup that
+     * required user-authentication-bound keys). The wrapped DB key cannot be unwrapped;
+     * the existing database is unrecoverable. The UI should surface this as
+     * "secure storage was reset by the system" and offer to re-import passes.
+     */
+    public data object KeyUnavailable : StorageError
+
+    /**
+     * The Keystore master alias is present but unwrap of [`schema_meta.wrapped_db_key`]
+     * failed (GCM tag mismatch, IV mismatch, alias rotated). This is a security-relevant
+     * signal distinct from [KeyUnavailable]; the database file may have been replaced
+     * out-of-band.
+     */
+    public data object KeyUnwrapFailed : StorageError
+
+    /**
+     * Another process holds an exclusive lock on the database file. Transient; the caller
+     * may retry.
+     */
+    public data object DatabaseLocked : StorageError
+
+    /**
+     * A row failed to deserialize at load time and was dropped (e.g. schema-migration
+     * partial failure for that row). The repository continues to serve other rows.
+     */
+    public data class IntegrityViolation(public val recordId: PassRecordId) : StorageError
+
+    /**
+     * The schema version on disk is newer than this build of `passes-storage` understands.
+     * This happens when a user downgrades the wallet app. The DB is read-only-protected
+     * until a forward-compatible build runs again.
+     */
+    public data class Unsupported(public val onDiskSchemaVersion: Int) : StorageError
+
+    /**
+     * Catch-all for failures that do not warrant a typed arm. Carries a stable [kind] for
+     * the telemetry guard; the [cause] is `Throwable?` so the caller can log internally,
+     * but [kind] is what flows through telemetry.
+     */
+    public data class Unknown(
+        public val kind: UnknownStorageFailureKind,
+        public val cause: Throwable? = null,
+    ) : StorageError
+}
+
+/**
+ * Stable telemetry-friendly enumeration of the open-ended failure space. New arms here
+ * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
+ * routing telemetry through enums rather than free-form strings.
+ */
+public enum class UnknownStorageFailureKind {
+    DiskFull,
+    PermissionDenied,
+    DatabaseCorrupt,
+    SerializationFailure,
+    Other,
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -1,0 +1,86 @@
+package `is`.walt.passes.storage
+
+import `is`.walt.passes.core.PassType
+
+/**
+ * The storage-side counterpart to `passes-core`'s `TelemetryGuard`. Carries the same
+ * structural-PII-prevention discipline: every method takes only enums, counts, and
+ * durations. There is no `String`, `Pass`, `PassField`, or `ByteArray` parameter
+ * anywhere in this interface.
+ *
+ * The trust claim "pass content never appears in storage telemetry" is delivered by the
+ * shape of these methods, not by documentation. Reviewers MUST treat any future addition
+ * of a free-form parameter as a security-policy change.
+ */
+public interface StorageTelemetryGuard {
+    /**
+     * Emitted once per database open after the key provider is initialized. Reports the
+     * actual Keystore backing chosen so the wallet can surface hardware-backing status
+     * without inspecting strings.
+     */
+    public fun onKeyProviderInitialized(backing: KeyBacking)
+
+    /**
+     * A pass was inserted or replaced. Carries the type and trust band only.
+     */
+    public fun onPassUpserted(
+        type: PassType,
+        signatureStatus: SignatureStatusKind,
+        wasReplacement: Boolean,
+    )
+
+    /**
+     * A pass row was deleted (D6). Emitted after the transaction commits and after the
+     * StateFlow is updated.
+     */
+    public fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind)
+
+    /**
+     * A row failed to deserialize during a load or schema migration and was dropped.
+     * Carries only the failure kind; the row identity is intentionally NOT part of the
+     * event because the row is gone.
+     */
+    public fun onMigrationRowDropped(kind: MigrationFailureKind)
+
+    /**
+     * A storage call returned [StorageResult.Failure]. The [kind] is the structural
+     * arm of [StorageError]; for [StorageError.Unknown] cases the [unknownKind] carries
+     * the [UnknownStorageFailureKind].
+     */
+    public fun onStorageFailure(
+        kind: StorageFailureKind,
+        unknownKind: UnknownStorageFailureKind?,
+    )
+}
+
+/**
+ * Flattened enum mirror of `passes-core`'s `SignatureStatus` arms, suitable for crossing
+ * a metric backend that wants string dimensions. New arms here MUST mirror new arms in
+ * `SignatureStatus`.
+ */
+public enum class SignatureStatusKind {
+    Unsigned,
+    SelfSigned,
+    AppleVerified,
+    CertChainIncomplete,
+}
+
+/**
+ * Stable telemetry projection of [StorageError]. Mirrors the sealed-interface arms
+ * one-for-one. New arms in [StorageError] require new arms here.
+ */
+public enum class StorageFailureKind {
+    KeyUnavailable,
+    KeyUnwrapFailed,
+    DatabaseLocked,
+    IntegrityViolation,
+    Unsupported,
+    Unknown,
+}
+
+public enum class MigrationFailureKind {
+    JsonShapeMismatch,
+    UnknownEnumValue,
+    BlobTruncated,
+    Other,
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -1,0 +1,238 @@
+package `is`.walt.passes.storage
+
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Locks the public API surface of `passes-storage`. Mirrors the discipline of
+ * `passes-core`'s `PublicApiSurfaceTest`: every sealed arm is reached via an exhaustive
+ * `when` so that adding or removing an arm forces a compile-time conversation.
+ *
+ * Implementation behavior (SQLCipher round-trip, Keystore wrapping, Auto Backup
+ * exclusion) is exercised by the implementation bead's instrumentation tests; this file
+ * stays JVM-only.
+ */
+class PublicApiSurfaceTest {
+
+    @Test
+    fun storageResultArmsAreReachableViaWhen() {
+        val result: StorageResult<Long> = StorageResult.Success(7L)
+        val branch = when (result) {
+            is StorageResult.Success -> "success:${result.value}"
+            is StorageResult.Failure -> "failure"
+        }
+        assertThat(branch).isEqualTo("success:7")
+    }
+
+    @Test
+    fun storageErrorArmsAreReachableViaWhen() {
+        val errors: List<StorageError> = listOf(
+            StorageError.KeyUnavailable,
+            StorageError.KeyUnwrapFailed,
+            StorageError.DatabaseLocked,
+            StorageError.IntegrityViolation(PassRecordId(1L)),
+            StorageError.Unsupported(onDiskSchemaVersion = 99),
+            StorageError.Unknown(UnknownStorageFailureKind.DiskFull),
+        )
+        val labels = errors.map { error ->
+            when (error) {
+                StorageError.KeyUnavailable -> "key-unavailable"
+                StorageError.KeyUnwrapFailed -> "key-unwrap-failed"
+                StorageError.DatabaseLocked -> "db-locked"
+                is StorageError.IntegrityViolation -> "integrity:${error.recordId.value}"
+                is StorageError.Unsupported -> "unsupported:${error.onDiskSchemaVersion}"
+                is StorageError.Unknown -> "unknown:${error.kind.name}"
+            }
+        }
+        assertThat(labels).containsExactly(
+            "key-unavailable",
+            "key-unwrap-failed",
+            "db-locked",
+            "integrity:1",
+            "unsupported:99",
+            "unknown:DiskFull",
+        ).inOrder()
+    }
+
+    @Test
+    fun unknownStorageFailureKindCoversTheDocumentedFiveBuckets() {
+        assertThat(UnknownStorageFailureKind.entries.map { it.name }).containsExactly(
+            "DiskFull",
+            "PermissionDenied",
+            "DatabaseCorrupt",
+            "SerializationFailure",
+            "Other",
+        ).inOrder()
+    }
+
+    @Test
+    fun keyBackingEnumeratesTheThreeDocumentedBackings() {
+        assertThat(KeyBacking.entries.map { it.name }).containsExactly(
+            "StrongBox",
+            "Tee",
+            "Software",
+        ).inOrder()
+    }
+
+    @Test
+    fun signatureStatusKindMirrorsCoreSignatureStatusArms() {
+        val statuses: List<SignatureStatus> = listOf(
+            SignatureStatus.Unsigned,
+            SignatureStatus.SelfSigned,
+            SignatureStatus.AppleVerified,
+            SignatureStatus.CertChainIncomplete,
+        )
+        // Exhaustive when on SignatureStatus side; flip to SignatureStatusKind keeps lockstep.
+        val kinds = statuses.map { status ->
+            when (status) {
+                SignatureStatus.Unsigned -> SignatureStatusKind.Unsigned
+                SignatureStatus.SelfSigned -> SignatureStatusKind.SelfSigned
+                SignatureStatus.AppleVerified -> SignatureStatusKind.AppleVerified
+                SignatureStatus.CertChainIncomplete -> SignatureStatusKind.CertChainIncomplete
+            }
+        }
+        assertThat(kinds.toSet()).containsExactlyElementsIn(SignatureStatusKind.entries)
+    }
+
+    @Test
+    fun migrationFailureKindCoversTheDocumentedBuckets() {
+        assertThat(MigrationFailureKind.entries.map { it.name }).containsExactly(
+            "JsonShapeMismatch",
+            "UnknownEnumValue",
+            "BlobTruncated",
+            "Other",
+        ).inOrder()
+    }
+
+    @Test
+    fun storageFailureKindMirrorsStorageErrorArmsOneForOne() {
+        val errors: List<StorageError> = listOf(
+            StorageError.KeyUnavailable,
+            StorageError.KeyUnwrapFailed,
+            StorageError.DatabaseLocked,
+            StorageError.IntegrityViolation(PassRecordId(1L)),
+            StorageError.Unsupported(0),
+            StorageError.Unknown(UnknownStorageFailureKind.Other),
+        )
+        val kinds = errors.map { error ->
+            when (error) {
+                StorageError.KeyUnavailable -> StorageFailureKind.KeyUnavailable
+                StorageError.KeyUnwrapFailed -> StorageFailureKind.KeyUnwrapFailed
+                StorageError.DatabaseLocked -> StorageFailureKind.DatabaseLocked
+                is StorageError.IntegrityViolation -> StorageFailureKind.IntegrityViolation
+                is StorageError.Unsupported -> StorageFailureKind.Unsupported
+                is StorageError.Unknown -> StorageFailureKind.Unknown
+            }
+        }
+        assertThat(kinds.toSet()).containsExactlyElementsIn(StorageFailureKind.entries)
+    }
+
+    @Test
+    fun schemaDeclaresFourTablesAndIsAtVersionOne() {
+        assertThat(Schema.VERSION).isEqualTo(1)
+        assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
+        assertThat(Schema.Tables.PASSES).isEqualTo("passes")
+        assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
+        assertThat(Schema.Tables.PASS_LOCALES).isEqualTo("pass_locales")
+        // 1 schema_meta + 1 passes + 3 indexes + 1 pass_images + 1 pass_locales = 7 statements.
+        assertThat(Schema.DDL).hasSize(7)
+        assertThat(Schema.MIGRATIONS).isEmpty()
+    }
+
+    @Test
+    fun metaKeysAreThePersistenceVocabularyDocumentedInTheADR() {
+        assertThat(Schema.MetaKeys.SCHEMA_VERSION).isEqualTo("schema_version")
+        assertThat(Schema.MetaKeys.WRAPPED_DB_KEY).isEqualTo("wrapped_db_key")
+        assertThat(Schema.MetaKeys.WRAPPED_DB_KEY_IV).isEqualTo("wrapped_db_key_iv")
+        assertThat(Schema.MetaKeys.KEY_ALIAS).isEqualTo("key_alias")
+        assertThat(Schema.MetaKeys.KEY_BACKING).isEqualTo("key_backing")
+    }
+
+    @Test
+    fun passRecordIdIsAValueClassWrappingALong() {
+        val id = PassRecordId(42L)
+        assertThat(id.value).isEqualTo(42L)
+    }
+
+    @Test
+    fun databaseKeyRejectsNon32ByteInput() {
+        try {
+            DatabaseKey(ByteArray(31))
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            assertThat(expected.message).contains("32 bytes")
+        }
+    }
+
+    @Test
+    fun databaseKeyToStringIsRedacted() {
+        val key = DatabaseKey(ByteArray(32))
+        assertThat(key.toString()).isEqualTo("DatabaseKey(redacted)")
+    }
+
+    @Test
+    fun databaseKeyWithBytesZerosTheBufferAfterTheBlockReturns() {
+        val raw = ByteArray(32) { (it + 1).toByte() }
+        val key = DatabaseKey(raw)
+        var sawNonZero = false
+        key.withBytes { borrowed ->
+            sawNonZero = borrowed.any { it.toInt() != 0 }
+        }
+        assertThat(sawNonZero).isTrue()
+        assertThat(raw.all { it.toInt() == 0 }).isTrue()
+    }
+
+    /**
+     * Pins the `StorageTelemetryGuard` PII discipline (ADR 0002 D8). Every event method
+     * is reachable here with enums-and-primitives-only arguments. Adding a free-form
+     * `String`, `ByteArray`, `Pass`, or `PassField` parameter to any method below would
+     * fail to compile against this lock without a deliberate edit.
+     */
+    @Test
+    fun storageTelemetryGuardEventsAreEnumsAndPrimitivesOnly() {
+        val recorded = mutableListOf<String>()
+        val guard = object : StorageTelemetryGuard {
+            override fun onKeyProviderInitialized(backing: KeyBacking) {
+                recorded += "init:${backing.name}"
+            }
+
+            override fun onPassUpserted(
+                type: PassType,
+                signatureStatus: SignatureStatusKind,
+                wasReplacement: Boolean,
+            ) {
+                recorded += "upsert:${type.name}:${signatureStatus.name}:$wasReplacement"
+            }
+
+            override fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind) {
+                recorded += "delete:${type.name}:${signatureStatus.name}"
+            }
+
+            override fun onMigrationRowDropped(kind: MigrationFailureKind) {
+                recorded += "drop:${kind.name}"
+            }
+
+            override fun onStorageFailure(
+                kind: StorageFailureKind,
+                unknownKind: UnknownStorageFailureKind?,
+            ) {
+                recorded += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
+            }
+        }
+        guard.onKeyProviderInitialized(KeyBacking.StrongBox)
+        guard.onPassUpserted(PassType.BoardingPass, SignatureStatusKind.AppleVerified, false)
+        guard.onPassDeleted(PassType.EventTicket, SignatureStatusKind.SelfSigned)
+        guard.onMigrationRowDropped(MigrationFailureKind.JsonShapeMismatch)
+        guard.onStorageFailure(StorageFailureKind.Unknown, UnknownStorageFailureKind.DiskFull)
+
+        assertThat(recorded).containsExactly(
+            "init:StrongBox",
+            "upsert:BoardingPass:AppleVerified:false",
+            "delete:EventTicket:SelfSigned",
+            "drop:JsonShapeMismatch",
+            "failure:Unknown:DiskFull",
+        ).inOrder()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,4 +15,5 @@ dependencyResolutionManagement {
 rootProject.name = "walt-passes-android"
 
 include(":passes-core")
-// passes-storage and passes-ui modules will be added by their respective architecture beads.
+include(":passes-storage")
+// passes-ui module will be added by its architecture bead.


### PR DESCRIPTION
## Summary

Closes the design output for `wpass-9vv.3` (passes-storage interfaces, schema, key derivation).

- ADR 0002 covers single-page-key SQLCipher design, Keystore wrap/unwrap flow for the DB key (rationale: Keystore won't export raw AES bytes; wrapping bridges that), the four-table schema (`schema_meta`, `passes`, `pass_images`, `pass_locales`), library-shipped backup-rules XML contract, irreversible-deletion semantics matching `decision-wlt-0tn-q3-4` (no VACUUM, items 1+3+4+5+6), and the `StorageTelemetryGuard` PII discipline that mirrors `passes-core`'s `TelemetryGuard`.
- Kotlin source skeletons (`PassRepository`, `StorageResult`/`StorageError`, `PassKeyProvider` with a zeroing `DatabaseKey` wrapper, `StorageTelemetryGuard` with enum-only event shapes, `Schema` holding version-1 DDL).
- `PublicApiSurfaceTest` pins every sealed arm via exhaustive `when` and exercises the telemetry guard with enums-and-primitives-only arguments, so a free-form parameter addition fails compilation against the lock.

The Android wiring (AGP, SQLCipher, Keystore implementation, manifest backup XMLs) is the implementation bead's scope and lands against this fixed contract.

## Test plan

- [x] `./gradlew :passes-storage:test` (12 tests, all green)
- [x] `./gradlew test` (passes-core + passes-storage, all green)
- [ ] Implementation bead's instrumentation tests (out of scope here): SQLCipher round-trip, Keystore-wrapped key recovery across app reinstall, Auto Backup exclusion via `bmgr` shell harness