### PR TITLE
Bootstrap passes-ui: theming contract, security intents, ADR 0003

### DIFF
--- a/docs/adr/0003-passes-ui-theming.md
+++ b/docs/adr/0003-passes-ui-theming.md
@@ -1,0 +1,235 @@
+# ADR 0003: passes-ui theming and security composables
+
+- Status: Accepted
+- Date: 2026-05-04
+- Tracks: parent epic `wpass-9vv`; design bead `wpass-9vv.4`
+- Decision context: `decision-wlt-0tn-q3-2` (in-app B3 confirmation), `decision-wlt-0tn-q5` (three-module shape)
+- Reference: walt-android `core/ui/src/main/kotlin/is/walt/core/ui/theme/` (authoritative for color and typography)
+
+## Context
+
+`passes-ui` is the third Gradle module of `walt-passes-android`: the Android +
+Compose surface that walt-android's `feature/passes` calls to render passes and
+mediate the security-confirmation dialogs that pass-embedded URLs, phone numbers,
+and email addresses require.
+
+The bead's deliverable is the *design* of the module: the theming contract walt-
+android supplies, the composable signatures the host calls, and the trust-claim-
+bearing flows (with how each is tested). The implementation bead that follows
+lands the Android Gradle Plugin, Jetpack Compose, Material3, ZXing, Coil's
+`ImageDecoder` integration, and the actual `@Composable` function bodies.
+
+This ADR fixes the contract today; the implementation bead does not renegotiate it.
+
+## Decisions
+
+### D1. The host's MaterialTheme is the source of truth for color and typography
+
+`passes-ui` does not declare its own brand color palette, its own typography scale,
+or its own font family. Those live in walt-android's
+`core/ui/src/main/kotlin/is/walt/core/ui/theme/` (`Color.kt`, `Type.kt`, `Theme.kt`,
+`Shape.kt`, plus `tokens/`), and `passes-ui` reads them through Material3's
+`MaterialTheme.colorScheme`, `MaterialTheme.typography`, and `MaterialTheme.shapes`
+at composition time.
+
+This is a reversal of the alternative we considered (defining a parallel theming
+contract that the host populates with its own values), and it is the right call:
+
+- **Single source of truth.** The walt-android theme is the only place a designer
+  changes a brand color and has it propagate. A parallel contract introduces a
+  drift surface where `passes-ui` could be styled inconsistently with the rest of
+  the wallet.
+- **Material3-native.** walt-android already builds on M3 (`MaterialTheme(colorScheme,
+  typography, shapes)`). Reusing that contract means `passes-ui` composables read
+  `MaterialTheme.colorScheme.surface` etc. like every other Compose surface in the
+  app, with no translation layer.
+- **Open-source review value.** A reader auditing this repository sees `passes-ui`
+  composables that read `MaterialTheme.X`. They look at walt-android's `core/ui` for
+  the values. Duplicating tokens here would force a reader to verify a copy is in
+  sync, with no upside.
+
+The Walt Design System Claude project remains the source of *flow and UX* — screen
+sequencing, layouts, interactions, the boarding/event/train per-category visual
+language — but it is not the source of color, typography, or font tokens.
+
+See `CLAUDE.local.md`'s "Theming source of truth" section for the operational form
+of this rule.
+
+### D2. `PassesSemantics` adds the slots M3 does not name
+
+A small set of `passes-ui`-specific slots have no Material3 analogue. They are
+expressed as a `PassesSemantics` data class and threaded through composition via
+a single `LocalPassesSemantics` provided at `PassesTheme(...)` scope:
+
+- `signatureBadge`: per-`SignatureStatusKind` foreground / background pair for
+  the trust badge that sits on every rendered pass.
+- `expiredBadge`: pill foreground / background and scrim alpha for the
+  non-suppressible expired / voided overlay.
+- `securitySheet`: emphasis, body, confirm, cancel slots for the URL / phone /
+  email confirmation sheets — explicitly distinct from chrome dialogs so the
+  user does not muscle-memory through.
+- `categoryAccent`: per-`PassType` accent strip color for the wallet-list view.
+
+Color values are packed ARGB integers (`ArgbColor(0xAARRGGBB)`), matching
+`passes-core`'s existing `ColorValue.rgb` shape but with an alpha channel.
+Compose-side conversion is a one-line `Color(argb.argb.toLong())` at the API
+boundary.
+
+Why ARGB integers, not `androidx.compose.ui.graphics.Color`: the skeleton module
+is JVM-only today (mirroring `passes-storage`'s skeleton) and does not have
+Compose on its classpath. The implementation bead introduces Compose along with
+the `@Composable` function bodies and converts at the boundary. Keeping the
+contract type primitive lets the JVM `PublicApiSurfaceTest` exercise the entire
+shape without an Android device.
+
+### D3. The host MUST scope passes-ui composables in `PassesTheme(semantics) { ... }`
+
+There is no fallback default for `LocalPassesSemantics`. Reading it outside a
+`PassesTheme` scope is a programmer error and the implementation bead fails fast
+(an `IllegalStateException` at first composition is the chosen mechanism, not a
+silent fallback).
+
+Why fail-fast: a silent default produces a "looks fine in dev, wrong in prod"
+hazard where the trust badge renders in some default neutral that the host did
+not approve. Failing at the first composition surfaces the missing scope while
+the developer is still in front of the screen.
+
+The implementation bead's screenshot tests cover the failure mode explicitly: a
+test that calls `PassFront` outside `PassesTheme` asserts the exception, so a
+future refactor cannot regress the rule into "oh, just use a default."
+
+### D4. Pass colors override the theme on the pass surface only
+
+The PKPASS spec lets each pass declare its own `foregroundColor`,
+`backgroundColor`, and `labelColor` (already surfaced as `PassColors` in
+`passes-core`). On the pass surface itself, those colors override the host's
+`MaterialTheme.colorScheme.surface` / `onSurface`. Off the pass — wallet list
+chrome, bottom sheets, expired overlay, security confirmation sheets — the host
+theme is authoritative.
+
+Why scoped: a pass-supplied color does not get to recolor a security
+confirmation sheet. The sheets are an in-app surface owned by walt-android's
+trust UI; allowing the pass to influence their appearance opens an
+"adversarial pass darkens cancel button into invisibility" attack.
+
+The override is implemented by reading `Pass.colors` inside `PassFront` and
+applying it to the pass-front composable's local surface, not by mutating
+`MaterialTheme.colorScheme`. Composables outside `PassFront` (the security
+sheet family) read `MaterialTheme.colorScheme` and `LocalPassesSemantics`
+directly and ignore `Pass.colors` entirely.
+
+### D5. Trust-claim composables have no off switch
+
+Five composable surfaces are trust-claim-bearing: the signature trust badge,
+the expired/voided overlay, the URL confirmation sheet, the phone confirmation
+sheet, and the email confirmation sheet. Their public composable signatures
+deliberately omit the parameters that would let a caller suppress them:
+
+- `PassFront` does not accept `showTrustBadge: Boolean`. The badge is
+  composited unconditionally; its color is the only thing the host controls.
+- `PassFront` does not accept `expiredOverlay: ExpiredOverlayState`. The state
+  is computed inside the composable from `Pass.expirationDate`, `Pass.voided`,
+  and a `nowEpochMillis` parameter. There is no API path that lets a host
+  display an expired pass as not-expired.
+- `B3UrlConfirmSheet`, `PhoneConfirmSheet`, `EmailConfirmSheet` do not accept a
+  `skipConfirmation: Boolean` shortcut. The host's outbound `Intent` fires
+  inside `onConfirm`, which the user's tap is the only thing that calls.
+- `BoundedImage` does not accept `bounds: ImageRenderBounds? = null`. The
+  default is the only way to take the default; opting out requires explicitly
+  constructing an `ImageRenderBounds(...)` with higher caps, which is a visible
+  signal at the call site.
+- `PassBack` does not default the `onUrlIntent` / `onPhoneIntent` /
+  `onEmailIntent` callbacks. The host must wire all three; missing any one is
+  a compile error, not a runtime no-op.
+
+Removing or weakening any of the above is a deliberate security-policy edit, not
+a refactor. The implementation bead's API-surface lock test (the eventual
+`PassesUiPublicApiTest` analog of `passes-storage`'s `PublicApiSurfaceTest`) will
+pin these properties as named parameter sets.
+
+### D6. Telemetry follows the `TelemetryGuard` discipline
+
+`UiTelemetryGuard` mirrors the structural-PII-prevention pattern from
+`passes-core`'s `TelemetryGuard` and `passes-storage`'s `StorageTelemetryGuard`:
+every event method takes enums (`PassType`, `SignatureBand`, `SecurityIntentKind`,
+`ImageDecodeRejection`) and primitives only. There is no overload that accepts a
+`String`, `Pass`, or `PassField`.
+
+The discipline is enforced by `PublicApiSurfaceTest`: an attempt to add a
+free-form `String` parameter to any of the six event methods fails the lock
+test on the next run.
+
+The events that walt-android cares about, and the trust-relevant signal each
+carries:
+
+- `onPassRendered(type, signatureBand)` — baseline.
+- `onPassBackOpened(type)` — pass-back-tap rate, useful for the wallet list
+  layout.
+- `onSecuritySheetShown(intentKind, type)` — denominator for the
+  confirm/dismiss rates.
+- `onSecuritySheetConfirmed(intentKind, type)` — numerator (positive).
+- `onSecuritySheetDismissed(intentKind, type)` — numerator (negative). A
+  spike in this rate is the signal walt-android wants to see; a phishing
+  pattern would manifest as users opening the sheet and bailing.
+- `onImageDecodeRejected(reason)` — bound-violation rate. A spike correlates
+  with either a malformed pass archive in the wild or a bounds threshold that
+  needs tuning.
+
+`NoopUiTelemetryGuard` is provided for hosts that have not yet wired a guard.
+Production walt-android wires a real one.
+
+### D7. Skeleton bead is JVM-only; implementation bead brings AGP and Compose
+
+This module's `build.gradle.kts` declares only `kotlin.jvm` today, mirroring the
+shape `passes-storage`'s skeleton bead used. The composable signatures live in
+`COMPOSABLE_SIGNATURES.md` as Kotlin pseudo-code rather than as `@Composable
+fun ...` declarations.
+
+Rationale, restated from the storage precedent:
+
+- The contract types (theming data classes, security intents, image bounds,
+  expired-state ADT, telemetry guard interface) are pure Kotlin and ship today.
+- The `@Composable` function bodies wait for the implementation bead, which
+  brings in:
+  - `com.android.library` Gradle plugin
+  - Compose BOM, Material3, foundation, runtime, ui
+  - ZXing core for barcode rendering
+  - Lifecycle / animation / accessibility instrumentation tests
+- Splitting the work this way gives walt-android's `feature/passes` a fixed
+  contract to wire its Hilt modules and intent handlers against now, in
+  parallel with the implementation bead.
+
+## Consequences
+
+- The implementation bead can land AGP, Compose, Material3, ZXing, and the
+  `@Composable` function bodies against a fixed contract; no public-API
+  renegotiation.
+- walt-android's `feature/passes` (tracked as `wlt-4pg` in the closed-source
+  repository) can write its outbound-intent confirmation routing today, binding
+  against the `B3UrlIntent` / `PhoneIntent` / `EmailIntent` types with stub
+  composables.
+- A reader auditing this repository can verify the trust-claim surface from
+  three documents alone: `TRUST_CLAIMS.md` (what the surfaces are),
+  `COMPOSABLE_SIGNATURES.md` (the API shape), and this ADR (why each shape
+  is fixed).
+- `passes-ui` builds on JVM-only today; the AGP wiring is a follow-on.
+  `PublicApiSurfaceTest` runs on the JVM CI host, exercising the contract types
+  without an Android device.
+
+## Open follow-ups
+
+- Implementation bead: AGP wiring, Compose BOM, Material3, ZXing dependency,
+  `BoundedImage` decoder pipeline (must be `ImageDecoder.setOnHeaderDecodedListener`,
+  not Coil's default loader), screenshot tests covering each `PassType` rendering
+  path, instrumentation tests covering security-sheet interaction, the API-
+  surface lock test that pins the trust-claim parameter omissions documented in
+  D5.
+- Localization: `PassFront` and `PassBack` accept a `PassLocale` parameter. The
+  implementation bead picks the matching `LocalizedStrings` from `Pass.locales`
+  and falls back to default locale for missing keys. A future bead may add
+  walt-android-side locale-change wiring; the contract here is a parameter and
+  is stable.
+- Accessibility: every composable in this contract takes a
+  `contentDescription: String?` (where applicable) and the implementation bead
+  must pass non-null content descriptions for the trust badge, expired pill,
+  and barcode altText. Accessibility-test coverage is a follow-on.

--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -1,0 +1,224 @@
+# passes-ui composable signatures
+
+The skeleton bead (`wpass-9vv.4`) ships the *theming contract* and *intent payload* types
+in Kotlin source. The composable functions themselves wait for the implementation bead,
+which lands the Android Gradle Plugin, Jetpack Compose, Material3, ZXing, and Coil.
+
+This document is the design output of the skeleton bead: the exact signatures the
+implementation bead is committed to producing. It is the public-API contract for every
+composable that the host (walt-android's `feature/passes`) calls.
+
+The signatures below assume the implementation bead's imports:
+
+```kotlin
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import is.walt.passes.core.Barcode
+import is.walt.passes.core.ImageBytes
+import is.walt.passes.core.ImageRole
+import is.walt.passes.core.Pass
+import is.walt.passes.core.PassInstant
+import is.walt.passes.core.PassLocale
+import is.walt.passes.core.SignatureStatus
+import is.walt.passes.ui.B3UrlIntent
+import is.walt.passes.ui.EmailIntent
+import is.walt.passes.ui.ExpiredOverlayState
+import is.walt.passes.ui.ImageRenderBounds
+import is.walt.passes.ui.PhoneIntent
+import is.walt.passes.ui.SecurityIntent
+import is.walt.passes.ui.UiTelemetryGuard
+import is.walt.passes.ui.theme.PassesSemantics
+```
+
+## Theming entry point
+
+```kotlin
+/**
+ * Provides the host's [PassesSemantics] to every passes-ui composable underneath. Wraps
+ * the host's own MaterialTheme; the host is expected to call this inside its own theme
+ * scope (e.g. inside walt-android's WaltTheme).
+ */
+@Composable
+public fun PassesTheme(
+    semantics: PassesSemantics,
+    content: @Composable () -> Unit,
+)
+
+/** CompositionLocal accessor for the semantics. Reads default to an error in release. */
+public val LocalPassesSemantics: ProvidableCompositionLocal<PassesSemantics>
+```
+
+The host MUST wrap pass-rendering composables in `PassesTheme(...)`. Reading
+`LocalPassesSemantics.current` outside a `PassesTheme` scope is a programmer error and
+fails fast.
+
+## Pass front
+
+```kotlin
+/**
+ * Renders the front of a pass. Layout switches on `pass.type`:
+ *
+ * - BoardingPass: header / primary "from / to" prominence / secondary / auxiliary, plus
+ *   the barcode at the bottom.
+ * - EventTicket: header / primary / secondary, with the strip image (if any) above
+ *   primary fields.
+ * - Coupon, StoreCard, Generic: header / primary / secondary / auxiliary with no
+ *   special prominence.
+ *
+ * The pass's own [Pass.colors] override the host's MaterialTheme.colorScheme for the
+ * pass surface only; chrome around the pass (the bottom sheet, the wallet list
+ * background) keeps using the host theme.
+ *
+ * The signature trust badge and expired overlay (if applicable) are composited on top
+ * of the front; they are not optional and cannot be suppressed by the caller.
+ */
+@Composable
+public fun PassFront(
+    pass: Pass,
+    signatureStatus: SignatureStatus,
+    locale: PassLocale = PassLocale("en"),
+    nowEpochMillis: Long = System.currentTimeMillis(),
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+)
+```
+
+## Pass back
+
+```kotlin
+/**
+ * Renders the back of a pass: the list of `Pass.backFields`, with detected URLs,
+ * phone numbers, and email addresses rendered as tappable affordances.
+ *
+ * Tapping such an affordance fires the matching callback with the parsed
+ * [SecurityIntent]; passes-ui never invokes the host's outbound Intent directly. The
+ * host's expected wiring is to display the corresponding confirmation sheet and call
+ * `Intent.ACTION_VIEW` (or `ACTION_DIAL`, `ACTION_SENDTO`) only on confirm.
+ */
+@Composable
+public fun PassBack(
+    pass: Pass,
+    locale: PassLocale = PassLocale("en"),
+    onUrlIntent: (B3UrlIntent) -> Unit,
+    onPhoneIntent: (PhoneIntent) -> Unit,
+    onEmailIntent: (EmailIntent) -> Unit,
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+)
+```
+
+## Barcode
+
+```kotlin
+/**
+ * Renders [barcode] using ZXing. The composable enforces a minimum on-screen size
+ * (300 dp x 300 dp for QR / Aztec; 500 dp x 100 dp for PDF417 / Code128) so the
+ * barcode is reliably scannable at gate distance.
+ *
+ * `altText`, when present in the [Barcode], is rendered below the barcode for
+ * accessibility and as a fallback for scanners that fail.
+ */
+@Composable
+public fun BarcodeView(
+    barcode: Barcode,
+    modifier: Modifier = Modifier,
+)
+```
+
+## Security confirmation sheets
+
+Each sheet displays the verbatim target string from its [SecurityIntent], the source
+field's label and the issuer's `organizationName`, then a confirm button.
+
+```kotlin
+@Composable
+public fun B3UrlConfirmSheet(
+    intent: B3UrlIntent,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    telemetry: UiTelemetryGuard,
+)
+
+@Composable
+public fun PhoneConfirmSheet(
+    intent: PhoneIntent,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    telemetry: UiTelemetryGuard,
+)
+
+@Composable
+public fun EmailConfirmSheet(
+    intent: EmailIntent,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    telemetry: UiTelemetryGuard,
+)
+```
+
+The sheets fire `telemetry.onSecuritySheetShown` on first composition,
+`telemetry.onSecuritySheetConfirmed` on confirm tap, and
+`telemetry.onSecuritySheetDismissed` on any other dismissal. Confirming closes the
+sheet AND calls `onConfirm`; dismissal closes WITHOUT firing `onConfirm`.
+
+## Expired badge
+
+```kotlin
+/**
+ * Renders the non-suppressible expired/voided overlay. [state] is computed via
+ * [ExpiredOverlayState.from]; if the host wants to "hide the badge" the only way is
+ * to deliberately not call [PassFront] for that pass. The badge composable itself
+ * has no `enabled` parameter.
+ */
+@Composable
+public fun ExpiredOverlay(
+    state: ExpiredOverlayState,
+    locale: PassLocale = PassLocale("en"),
+    modifier: Modifier = Modifier,
+)
+```
+
+## Bounded image
+
+```kotlin
+/**
+ * Decodes [bytes] using Android `ImageDecoder` with explicit dimension caps applied
+ * via `setOnHeaderDecodedListener`. Decode failures (including bounds violations)
+ * yield a placeholder and fire `telemetry.onImageDecodeRejected` with the
+ * categorized reason; the composable never throws.
+ *
+ * The implementation bead must NOT use Coil's default decoder for these images:
+ * the bounds enforcement is the trust claim, and a third-party loader would have
+ * to be re-audited for that property on every dependency upgrade.
+ */
+@Composable
+public fun BoundedImage(
+    bytes: ImageBytes,
+    role: ImageRole,
+    contentDescription: String?,
+    bounds: ImageRenderBounds = ImageRenderBounds.Default,
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+)
+```
+
+## What the implementation bead must NOT change
+
+These signature properties are the trust-claim interface. Changing any of them is a
+security-policy edit, not a refactor:
+
+1. `onUrlIntent`, `onPhoneIntent`, `onEmailIntent` on `PassBack` are NOT defaulted to
+   no-op. The host must supply them explicitly. This forces a conversation if a
+   future host author "forgets" to wire confirmation sheets.
+2. The expiration overlay has no `enabled` / `suppress` parameter. It either applies
+   or it does not, based on `ExpiredOverlayState.from`.
+3. The signature trust badge has no `enabled` / `suppress` parameter. It is always
+   composited on top of `PassFront`, with the color sourced from
+   `PassesSemantics.signatureBadge`.
+4. `BoundedImage` has no `bounds: ImageRenderBounds? = null` form that would let a
+   caller opt out of decoding limits. The default is the only way to take the
+   default; opting out requires a deliberate `ImageRenderBounds(...)` with explicit
+   higher caps.
+5. The security confirmation sheets do not accept a "skip confirmation" parameter.
+   The host's outbound `Intent` fires only on user confirm.

--- a/passes-ui/TRUST_CLAIMS.md
+++ b/passes-ui/TRUST_CLAIMS.md
@@ -1,0 +1,136 @@
+# passes-ui trust-claim-bearing UI flows
+
+The trust claim that this repository carries is "every security-and-privacy-critical
+behavior Walt makes about pass handling lives in code you can read." For `passes-ui`,
+that decomposes into six surfaces. Each is described below with: what the user sees,
+what the trust claim is, and how the implementation bead's tests pin it.
+
+## 1. Signature trust badge
+
+**What the user sees.** A small pill on every rendered `PassFront`, color-coded by
+`SignatureStatus`:
+
+| Status                  | Pill copy           | Meaning                                                  |
+|-------------------------|---------------------|----------------------------------------------------------|
+| `Unsigned`              | "Unsigned"          | The archive carried no signature.                        |
+| `SelfSigned`            | "Self-signed"       | A signature was present but did not chain to Apple's CA. |
+| `AppleVerified`         | "Verified"          | The PKCS#7 signature chained to Apple's WWDR root.       |
+| `CertChainIncomplete`   | "Signature unknown" | A signature was present but the chain was incomplete.    |
+
+**Trust claim.** The badge reflects the `SignatureStatus` recorded by `passes-core` at
+parse time and persisted by `passes-storage`. The UI cannot upgrade or downgrade a
+status, and the status cannot be rebound by the host.
+
+**How tested.**
+
+- `PublicApiSurfaceTest` (already in this skeleton) pins `SignatureBand` to the four
+  documented bands.
+- The implementation bead's screenshot tests render every band and assert the pill
+  color comes from `PassesSemantics.signatureBadge.<bandBackground>`.
+- The implementation bead's instrumentation tests assert that there is no public API
+  shape that lets a caller pass an alternative `SignatureStatus` for display while
+  storing a different one. The badge always reads from the same `SignatureStatus`
+  the storage row recorded.
+
+## 2. URL confirmation (B3 sheet family)
+
+**What the user sees.** When the user taps a URL on the back of a pass, a bottom
+sheet rises that shows: the issuer's `organizationName`, the source field's label,
+the verbatim URL the host is about to open, and a "Confirm" / "Cancel" pair.
+
+**Trust claim.** Two parts.
+
+1. *No URL leaves the device without the user seeing the verbatim target.* The host
+   does not open `Intent.ACTION_VIEW` for a pass-derived URL except inside the
+   confirm callback of `B3UrlConfirmSheet`.
+2. *The displayed URL is identical to the URL that opens.* The sheet does not show
+   `example.com` and open `attacker.example`. The string in [B3UrlIntent.url] IS the
+   string the host hands to its `Intent`.
+
+**How tested.**
+
+- `PublicApiSurfaceTest` pins the three arms of `SecurityIntent`.
+- The implementation bead's tests assert that the `B3UrlIntent` callback fires
+  exactly once per tap and that no `ACTION_VIEW` intent is dispatched in the
+  test harness without the user crossing through the sheet.
+- A copy-paste audit (manual + linter rule planned in the implementation bead's
+  follow-up) checks that `B3UrlIntent.url` is the only string read inside the
+  confirm callback's outbound-intent construction.
+
+## 3. Phone confirmation
+
+**What the user sees.** Identical structure to the URL sheet: organization name,
+source field label, verbatim phone digits, confirm/cancel pair.
+
+**Trust claim.** A pass-embedded phone number cannot trigger `Intent.ACTION_DIAL`
+without explicit confirmation. The displayed digits are the digits dialled.
+
+**How tested.** Same shape as URL: the implementation bead pins the contract and
+asserts no dial intent fires without confirmation in the test harness.
+
+## 4. Email confirmation
+
+**What the user sees.** Same structure: organization name, source field label,
+verbatim email address, confirm/cancel pair. The composer launched on confirm
+contains ONLY the address; the pass-supplied subject line and body are NOT
+forwarded into the composer's pre-fill.
+
+**Trust claim.** A pass cannot pre-fill the user's outbound email beyond the
+recipient address. (Subject and body could be a phishing vector if pre-filled
+under the user's display name.)
+
+**How tested.** The implementation bead's tests assert the resulting `Intent`'s
+extras do not contain `Intent.EXTRA_SUBJECT` or `Intent.EXTRA_TEXT` under any
+input shape from the pass.
+
+## 5. Expired / voided overlay
+
+**What the user sees.** A pass that has either passed its `expirationDate` or been
+marked `voided: true` carries a dim scrim over its front and a pill reading
+"Expired" or "Voided".
+
+**Trust claim.** The overlay is non-suppressible. There is no `enabled` parameter,
+no caller-supplied flag, and no theme token that hides it. A pass whose validity
+window has closed cannot present as valid.
+
+**How tested.**
+
+- `PublicApiSurfaceTest` covers `ExpiredOverlayState.from` end-to-end: voided over
+  date, equal epoch as expired, future as none, no expiration as none.
+- The implementation bead's screenshot tests render expired and voided passes and
+  assert the scrim and pill are present.
+- The implementation bead's API-surface lint asserts there is no overload of
+  `PassFront` that accepts an explicit `ExpiredOverlayState` (the only path is via
+  `ExpiredOverlayState.from`, computed inside the composable from the pass's own
+  fields).
+
+## 6. Bounded image rendering
+
+**What the user sees.** Pass images (logo, icon, strip, background, thumbnail,
+footer, plus their @2x and @3x variants) are decoded and displayed at the size the
+layout calls for. A maliciously oversized image is silently replaced with a
+placeholder.
+
+**Trust claim.** A hostile pass archive cannot OOM-crash the host process via a
+multi-gigabyte bitmap allocation. The decode pipeline applies `ImageRenderBounds`
+at decode-header time, so the decoder never allocates a backing bitmap larger than
+the configured ceiling. The host's process stays alive even when handed a 50000 x
+50000 PNG.
+
+**How tested.**
+
+- `PublicApiSurfaceTest` pins `ImageRenderBounds.Default` to 1920 x 1920 / 4 MP and
+  rejects non-positive dimensions at construction.
+- The implementation bead's instrumentation tests feed a known-oversized PNG
+  (generated in-test, not committed) and assert the resulting bitmap dimensions are
+  bounded AND that `UiTelemetryGuard.onImageDecodeRejected(ExceedsArea)` fired.
+- The implementation bead's docs lock the rule that Coil's default decoder is NOT
+  used for pass images; only the `ImageDecoder.setOnHeaderDecodedListener` path is.
+
+## Out of scope for `passes-ui`
+
+The trust claim "encrypted at rest" is `passes-storage`'s problem; this module does
+not re-state it. The trust claim "PKCS#7 signature verified against Apple's WWDR
+root" is `passes-core`'s; this module displays the result.
+
+This module's contribution to the audit trail is exactly the six surfaces above.

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -1,0 +1,38 @@
+// JVM-only today. The implementation bead replaces this with the Android library plugin
+// to bring in Jetpack Compose, Material3, ZXing, and Coil. The public-API types defined
+// here are intentionally Android-agnostic: theming contracts use packed ARGB integers (the
+// same shape `passes-core` uses for `ColorValue`) and intent payloads are pure data
+// classes, so test doubles and the JVM CI host can exercise the contract without an
+// Android device.
+//
+// The composable signatures themselves are documented in passes-ui/COMPOSABLE_SIGNATURES.md
+// rather than declared as `@Composable fun ...` here, since `androidx.compose.runtime` is
+// not on this skeleton's classpath.
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    explicitApi()
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjvm-default=all")
+    }
+}
+
+dependencies {
+    api(project(":passes-core"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+}
+
+tasks.test {
+    useJUnit()
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlayState.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlayState.kt
@@ -1,0 +1,51 @@
+package `is`.walt.passes.ui
+
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassInstant
+
+/**
+ * The non-suppressible "this pass is expired" overlay state. Computed from a `Pass` at
+ * render time. UI code cannot construct an `ExpiredOverlayState.None` for a pass that
+ * meets the expired criteria — see [from] — so a host that wants to "hide the badge
+ * for this one pass" has to deliberately bypass the API.
+ *
+ * The `voided` flag and `expirationDate` together capture both PKPASS expiry mechanisms:
+ *
+ * - **Voided** passes are passes the issuer marked invalid via the
+ *   `voided: true` field in pass.json. The badge reads "Voided" and renders the same
+ *   way as expired-by-date.
+ * - **Expired** passes have `expirationDate < now`. The badge reads "Expired" with the
+ *   localized expiration date below.
+ *
+ * If both apply, voided wins (the issuer's explicit invalidation supersedes the date).
+ */
+public sealed interface ExpiredOverlayState {
+
+    /** The pass is currently valid; no overlay is rendered. */
+    public data object None : ExpiredOverlayState
+
+    /** The pass is past its `expirationDate`. */
+    public data class Expired(public val expiredAt: PassInstant) : ExpiredOverlayState
+
+    /** The pass was marked `voided` by the issuer. */
+    public data object Voided : ExpiredOverlayState
+
+    public companion object {
+
+        /**
+         * Compute the overlay state for a pass at the given moment. `nowEpochMillis`
+         * is supplied by the host (typically `System.currentTimeMillis()` or, in tests,
+         * a fake clock) so this function stays JVM-pure and deterministic.
+         */
+        @JvmStatic
+        public fun from(pass: Pass, nowEpochMillis: Long): ExpiredOverlayState {
+            if (pass.voided) return Voided
+            val expiration = pass.expirationDate ?: return None
+            return if (expiration.epochMillis <= nowEpochMillis) {
+                Expired(expiration)
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ImageRenderBounds.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ImageRenderBounds.kt
@@ -1,0 +1,46 @@
+package `is`.walt.passes.ui
+
+/**
+ * Hard upper bounds for decoded image dimensions, applied at decode time by the
+ * `BoundedImage` composable. Prevents a malformed or hostile pass archive from
+ * forcing the decoder to allocate a multi-gigabyte bitmap (a "decompression bomb"
+ * via, e.g., a maliciously huge `background.png`).
+ *
+ * The PKPASS spec's recommended sizes are well under any of these caps; legitimate
+ * passes never approach them. The caps exist as a backstop for the case where the
+ * archive's declared image is larger than the spec allows or has been crafted to
+ * exhaust memory.
+ *
+ * Values are pre-scale: the decoder downsamples to fit `maxWidthPx` x `maxHeightPx`
+ * before producing a bitmap. `maxAreaPx` is enforced after downsample as a final
+ * guard against extreme aspect ratios that pass the per-axis caps individually but
+ * still produce a too-large surface.
+ *
+ * Defaults derive from the maximum image dimensions Apple's PKPASS guidance lists
+ * for `background@3x.png` (the largest legal asset), with a 2× safety margin.
+ */
+public data class ImageRenderBounds(
+    public val maxWidthPx: Int,
+    public val maxHeightPx: Int,
+    public val maxAreaPx: Long,
+) {
+    init {
+        require(maxWidthPx > 0) { "maxWidthPx must be positive, was $maxWidthPx" }
+        require(maxHeightPx > 0) { "maxHeightPx must be positive, was $maxHeightPx" }
+        require(maxAreaPx > 0L) { "maxAreaPx must be positive, was $maxAreaPx" }
+    }
+
+    public companion object {
+        /**
+         * Default backstop: 1920 x 1920 pixels, 4 megapixels of total surface. Apple's
+         * largest documented PKPASS asset (`background@3x.png` at 360 x 220) is well
+         * under both per-axis caps; this default exists to bound a hostile archive,
+         * not legitimate content.
+         */
+        public val Default: ImageRenderBounds = ImageRenderBounds(
+            maxWidthPx = 1920,
+            maxHeightPx = 1920,
+            maxAreaPx = 4_000_000L,
+        )
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/SecurityIntent.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/SecurityIntent.kt
@@ -1,0 +1,65 @@
+package `is`.walt.passes.ui
+
+/**
+ * The three security-confirmation intent families that `passes-ui` mediates between a
+ * tapped pass field and the host's outbound action (browser, dialer, mail composer).
+ *
+ * Each intent carries the *exact string* that will leave the device if the user
+ * confirms — never a label, alt text, or massaged copy. The trust claim "the user sees
+ * what is going to happen" is enforced by the type itself: there is no field for a
+ * display string distinct from the actionable target.
+ *
+ * walt-android's `feature/passes` host code observes these via the callbacks on
+ * `PassBack` (see COMPOSABLE_SIGNATURES.md) and routes them into the corresponding
+ * confirmation sheet, which calls `onConfirm` only after the user explicitly accepts.
+ */
+public sealed interface SecurityIntent {
+    public val sourceField: SourceField
+}
+
+/**
+ * A URL detected in a pass back-field value. The "B3" name in this module's bead
+ * predates the work; the rule is: if a pass back-field value parses as a URL, the
+ * UI MUST route it through this intent rather than handing it to `Intent.ACTION_VIEW`
+ * directly.
+ */
+public data class B3UrlIntent(
+    public val url: String,
+    override val sourceField: SourceField,
+) : SecurityIntent
+
+/**
+ * A telephone number detected in a pass back-field value. Routed through a
+ * confirmation sheet that displays the verbatim digits the user is about to dial.
+ */
+public data class PhoneIntent(
+    public val phoneNumber: String,
+    override val sourceField: SourceField,
+) : SecurityIntent
+
+/**
+ * An email address detected in a pass back-field value. Routed through a confirmation
+ * sheet that displays the verbatim address; the user's mail composer is not
+ * pre-populated with subject or body from the pass.
+ */
+public data class EmailIntent(
+    public val emailAddress: String,
+    override val sourceField: SourceField,
+) : SecurityIntent
+
+/**
+ * Where in the pass the security-relevant value originated. Lets the confirmation
+ * sheet tell the user "this came from the back field 'support phone'" rather than
+ * presenting a number with no provenance.
+ *
+ * [fieldKey] is the PKPASS field key (`PassField.key`); [fieldLabel] is the
+ * already-localized label that the user sees on the pass back; [organizationName]
+ * is the issuer's `organizationName` from the pass.
+ *
+ * All three are sourced from the parsed `Pass`; none are user-supplied.
+ */
+public data class SourceField(
+    public val fieldKey: String,
+    public val fieldLabel: String?,
+    public val organizationName: String,
+)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
@@ -1,0 +1,110 @@
+package `is`.walt.passes.ui
+
+import `is`.walt.passes.core.PassType
+
+/**
+ * The PII-disciplined telemetry surface that `passes-ui` emits. Mirrors the
+ * `TelemetryGuard` in `passes-core` and `StorageTelemetryGuard` in `passes-storage`:
+ * every event method takes enums and primitives only, never free-form `String`s or
+ * `Pass` / `PassField` instances.
+ *
+ * Adding a `String` (or `PassField`, or `Pass`) parameter to any method below is a
+ * security-policy change, not an API addition. The `PublicApiSurfaceTest` pins this
+ * shape so a casual addition fails to compile.
+ *
+ * Trust-claim relevance: walt-android wants to know how often the security
+ * confirmation sheets are shown vs. confirmed vs. dismissed, so it can detect a
+ * spike in dismissals (possible UX regression or social-engineering pattern). It
+ * must NOT learn which URLs were shown or which pass field they came from — that
+ * would re-introduce the PII leak the sheet was built to prevent.
+ */
+public interface UiTelemetryGuard {
+
+    /**
+     * A pass front rendered. Useful as a baseline against which sheet-display rates
+     * can be normalized.
+     */
+    public fun onPassRendered(type: PassType, signatureBand: SignatureBand)
+
+    /**
+     * The user opened the back of a pass. The number of fields revealed is a
+     * coarse-grained signal of pass complexity, not user identity.
+     */
+    public fun onPassBackOpened(type: PassType)
+
+    /**
+     * A security confirmation sheet was displayed in response to a tap on a
+     * back-field link. [intentKind] tells the host which of url / phone / email
+     * was the trigger; the actual target string never leaves this module.
+     */
+    public fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType)
+
+    /**
+     * The user confirmed the action. The host's outbound `Intent` is the next thing
+     * to fire after this event.
+     */
+    public fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType)
+
+    /**
+     * The user dismissed the sheet without confirming. A sustained rise in this
+     * rate is the signal walt-android wants to see.
+     */
+    public fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType)
+
+    /**
+     * An image-decode attempt was rejected by [ImageRenderBounds]. The host shows
+     * a placeholder instead of the requested asset; the event lets the host
+     * detect either a malformed pass archive or a bounds threshold that needs
+     * tuning.
+     */
+    public fun onImageDecodeRejected(reason: ImageDecodeRejection)
+}
+
+/**
+ * Coarse trust band, derived from `passes-core`'s `SignatureStatusKind`. Kept in the
+ * UI module because the trust band is what the UI displays; the storage module
+ * already exposes the underlying kind.
+ */
+public enum class SignatureBand {
+    Untrusted,
+    SelfSigned,
+    AppleVerified,
+    Incomplete,
+}
+
+/**
+ * Which of the three security intent families opened a sheet. Mirrors the three
+ * arms of [SecurityIntent] at the telemetry boundary so the host learns the kind
+ * without learning the value.
+ */
+public enum class SecurityIntentKind {
+    Url,
+    Phone,
+    Email,
+}
+
+/**
+ * Why an image-decode attempt was refused. The five buckets cover the cases the
+ * decode pipeline can encounter; "Other" is the catch-all for unexpected failures
+ * surfaced from the underlying Android `ImageDecoder`.
+ */
+public enum class ImageDecodeRejection {
+    ExceedsWidth,
+    ExceedsHeight,
+    ExceedsArea,
+    Malformed,
+    Other,
+}
+
+/**
+ * No-op default for hosts that have not (yet) wired a guard. Convenience-only; the
+ * production walt-android wiring supplies a real guard.
+ */
+public object NoopUiTelemetryGuard : UiTelemetryGuard {
+    override fun onPassRendered(type: PassType, signatureBand: SignatureBand): Unit = Unit
+    override fun onPassBackOpened(type: PassType): Unit = Unit
+    override fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+    override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+    override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+    override fun onImageDecodeRejected(reason: ImageDecodeRejection): Unit = Unit
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
@@ -1,0 +1,120 @@
+package `is`.walt.passes.ui.theme
+
+/**
+ * The theming contract that walt-android (or any other consumer) supplies to `passes-ui`.
+ *
+ * `passes-ui` deliberately does NOT define its own `MaterialTheme` colors and typography.
+ * The host app's `MaterialTheme` (e.g. `WaltTheme` in walt-android's `core/ui`) provides
+ * everything `passes-ui` needs for general chrome — backgrounds, surfaces, body text. See
+ * ADR 0003.
+ *
+ * `PassesSemantics` adds the slots that have NO M3 analogue and are specific to the
+ * pass-rendering and security-confirmation surfaces in this module:
+ *
+ * - [signatureBadge]: per-`SignatureStatusKind` colors for the trust badge that sits on
+ *   every rendered pass. Its visual treatment is a trust-claim surface, not a brand
+ *   choice — see TRUST_CLAIMS.md.
+ * - [expiredBadge]: the non-removable "Expired" overlay applied to a `Pass` whose
+ *   `expirationDate` is in the past or whose `voided` flag is set.
+ * - [securitySheet]: the visual emphasis applied to URL / phone / email confirmation
+ *   sheets. These sheets show *what the user is about to do* before they commit; their
+ *   styling intentionally departs from neutral chrome so the user does not click through.
+ * - [categoryAccent]: per-`PassType` accent strip color. The mockup design system uses
+ *   distinct accents for boarding pass / event / coupon / store-card / generic; the
+ *   actual hex values come from the host theme, not from this contract.
+ *
+ * Color values are packed ARGB integers (`0xAARRGGBB`), matching the shape `passes-core`
+ * already uses for `ColorValue.rgb`. Consumers built on Compose convert via
+ * `Color(argb.toLong())` at the API boundary; consumers on other UI toolkits unpack
+ * directly. See `passes-ui/COMPOSABLE_SIGNATURES.md` for how this maps to `@Composable`
+ * functions.
+ */
+public data class PassesSemantics(
+    public val signatureBadge: SignatureBadgeColors,
+    public val expiredBadge: ExpiredBadgeStyle,
+    public val securitySheet: SecuritySheetStyle,
+    public val categoryAccent: CategoryAccentColors,
+)
+
+/**
+ * Color slots for the trust badge that appears on every rendered pass. The four slots
+ * mirror `passes-core`'s `SignatureStatusKind`; adding an arm to `SignatureStatusKind`
+ * forces a corresponding addition here, making "what color does the new trust band
+ * wear?" a deliberate design choice rather than an unspecified default.
+ *
+ * `appleVerified` is the only slot that should read as positive / trusted; the others
+ * read as informational, cautionary, or warning depending on the host's palette.
+ * Concrete color values are the host theme's responsibility.
+ */
+public data class SignatureBadgeColors(
+    public val unsignedBackground: ArgbColor,
+    public val unsignedForeground: ArgbColor,
+    public val selfSignedBackground: ArgbColor,
+    public val selfSignedForeground: ArgbColor,
+    public val appleVerifiedBackground: ArgbColor,
+    public val appleVerifiedForeground: ArgbColor,
+    public val certChainIncompleteBackground: ArgbColor,
+    public val certChainIncompleteForeground: ArgbColor,
+)
+
+/**
+ * Visual treatment of the "Expired" overlay. The overlay is non-suppressible — see
+ * ADR 0003 D5 — so its style is fixed by the host theme rather than per-pass.
+ *
+ * [scrimAlpha] is the alpha (0..255) of the scrim that dims the front of an expired
+ * pass. The scrim's RGB is the host's `MaterialTheme.colorScheme.scrim`; only the
+ * alpha is contract-controlled here so a host can dial the badge up or down without
+ * forking the rendering code.
+ */
+public data class ExpiredBadgeStyle(
+    public val pillBackground: ArgbColor,
+    public val pillForeground: ArgbColor,
+    public val scrimAlpha: Int,
+)
+
+/**
+ * Styling for the URL / phone / email confirmation sheets. These sheets present the
+ * *visible* target of an outbound action (the actual URL, phone number, or address)
+ * before the user confirms. The styling exists so the sheets visibly differ from
+ * chrome dialogs and bottom sheets used elsewhere in walt-android, reducing the chance
+ * of muscle-memory dismissal.
+ *
+ * [emphasisBackground] / [emphasisForeground] style the panel that contains the
+ * to-be-actioned target string itself; [bodyForeground] styles the explanatory copy.
+ */
+public data class SecuritySheetStyle(
+    public val sheetBackground: ArgbColor,
+    public val emphasisBackground: ArgbColor,
+    public val emphasisForeground: ArgbColor,
+    public val bodyForeground: ArgbColor,
+    public val confirmContainer: ArgbColor,
+    public val confirmForeground: ArgbColor,
+    public val cancelForeground: ArgbColor,
+)
+
+/**
+ * Per-`PassType` accent strip colors. The mockup design system positions these as
+ * "quiet, not loud" — they distinguish boarding from event from coupon at a glance
+ * inside the wallet list without competing with the pass's own `PassColors`.
+ *
+ * `passes-ui` does not pick these values. The host theme does.
+ */
+public data class CategoryAccentColors(
+    public val boardingPass: ArgbColor,
+    public val eventTicket: ArgbColor,
+    public val coupon: ArgbColor,
+    public val storeCard: ArgbColor,
+    public val generic: ArgbColor,
+)
+
+/**
+ * A 32-bit ARGB color, packed `0xAARRGGBB`. Mirrors `passes-core`'s `ColorValue.rgb`
+ * shape but with an alpha channel, since theme tokens may legitimately want to
+ * express transparency that pass.json's RGB triplet cannot.
+ *
+ * Compose-side conversion: `androidx.compose.ui.graphics.Color(argb.argb.toLong())`.
+ * The `Long` cast is required because `Color(Int)` interprets its argument as RGB,
+ * not ARGB; using the `Long` overload preserves alpha.
+ */
+@JvmInline
+public value class ArgbColor(public val argb: Int)

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -1,0 +1,279 @@
+package `is`.walt.passes.ui
+
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Locks the public API surface of `passes-ui`. Mirrors `passes-core` and
+ * `passes-storage`: every sealed arm and every enum is reached via an exhaustive
+ * `when` so adding or removing an arm forces a compile-time conversation.
+ *
+ * Composable behavior (Compose runtime, ZXing rendering, ImageDecoder bounds
+ * enforcement) is exercised by the implementation bead's instrumentation tests;
+ * this file stays JVM-only.
+ */
+class PublicApiSurfaceTest {
+
+    @Test
+    fun securityIntentArmsAreReachableViaWhen() {
+        val source = SourceField(
+            fieldKey = "support_url",
+            fieldLabel = "Support",
+            organizationName = "Acme",
+        )
+        val intents: List<SecurityIntent> = listOf(
+            B3UrlIntent(url = "https://example.com", sourceField = source),
+            PhoneIntent(phoneNumber = "+15551234567", sourceField = source),
+            EmailIntent(emailAddress = "support@example.com", sourceField = source),
+        )
+        val labels = intents.map { intent ->
+            when (intent) {
+                is B3UrlIntent -> "url:${intent.url}"
+                is PhoneIntent -> "phone:${intent.phoneNumber}"
+                is EmailIntent -> "email:${intent.emailAddress}"
+            }
+        }
+        assertThat(labels).containsExactly(
+            "url:https://example.com",
+            "phone:+15551234567",
+            "email:support@example.com",
+        ).inOrder()
+    }
+
+    @Test
+    fun expiredOverlayStateArmsAreReachableViaWhen() {
+        val states: List<ExpiredOverlayState> = listOf(
+            ExpiredOverlayState.None,
+            ExpiredOverlayState.Voided,
+            ExpiredOverlayState.Expired(PassInstant(123L)),
+        )
+        val labels = states.map { state ->
+            when (state) {
+                ExpiredOverlayState.None -> "none"
+                ExpiredOverlayState.Voided -> "voided"
+                is ExpiredOverlayState.Expired -> "expired:${state.expiredAt.epochMillis}"
+            }
+        }
+        assertThat(labels).containsExactly("none", "voided", "expired:123").inOrder()
+    }
+
+    @Test
+    fun expiredOverlayFromPrefersVoidedOverDate() {
+        val pass = passFixture(
+            voided = true,
+            expirationDate = PassInstant(0L),
+        )
+        assertThat(ExpiredOverlayState.from(pass, nowEpochMillis = 1_000L))
+            .isEqualTo(ExpiredOverlayState.Voided)
+    }
+
+    @Test
+    fun expiredOverlayFromTreatsEqualEpochAsExpired() {
+        val pass = passFixture(expirationDate = PassInstant(1_000L))
+        val state = ExpiredOverlayState.from(pass, nowEpochMillis = 1_000L)
+        assertThat(state).isInstanceOf(ExpiredOverlayState.Expired::class.java)
+    }
+
+    @Test
+    fun expiredOverlayFromYieldsNoneForFuturePass() {
+        val pass = passFixture(expirationDate = PassInstant(2_000L))
+        assertThat(ExpiredOverlayState.from(pass, nowEpochMillis = 1_000L))
+            .isEqualTo(ExpiredOverlayState.None)
+    }
+
+    @Test
+    fun expiredOverlayFromYieldsNoneWhenNoExpirationAndNotVoided() {
+        val pass = passFixture(expirationDate = null, voided = false)
+        assertThat(ExpiredOverlayState.from(pass, nowEpochMillis = 1_000L))
+            .isEqualTo(ExpiredOverlayState.None)
+    }
+
+    @Test
+    fun signatureBandCoversFourDocumentedBands() {
+        assertThat(SignatureBand.entries.map { it.name }).containsExactly(
+            "Untrusted",
+            "SelfSigned",
+            "AppleVerified",
+            "Incomplete",
+        ).inOrder()
+    }
+
+    @Test
+    fun securityIntentKindCoversThreeFamilies() {
+        assertThat(SecurityIntentKind.entries.map { it.name }).containsExactly(
+            "Url",
+            "Phone",
+            "Email",
+        ).inOrder()
+    }
+
+    @Test
+    fun imageDecodeRejectionCoversFiveBuckets() {
+        assertThat(ImageDecodeRejection.entries.map { it.name }).containsExactly(
+            "ExceedsWidth",
+            "ExceedsHeight",
+            "ExceedsArea",
+            "Malformed",
+            "Other",
+        ).inOrder()
+    }
+
+    @Test
+    fun imageRenderBoundsRejectsNonPositiveDimensions() {
+        try {
+            ImageRenderBounds(maxWidthPx = 0, maxHeightPx = 100, maxAreaPx = 1_000L)
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            assertThat(expected.message).contains("maxWidthPx")
+        }
+    }
+
+    @Test
+    fun imageRenderBoundsDefaultIs1920SquareWith4Megapixels() {
+        val defaults = ImageRenderBounds.Default
+        assertThat(defaults.maxWidthPx).isEqualTo(1920)
+        assertThat(defaults.maxHeightPx).isEqualTo(1920)
+        assertThat(defaults.maxAreaPx).isEqualTo(4_000_000L)
+    }
+
+    @Test
+    fun argbColorIsAValueClassWrappingAnInt() {
+        val color = ArgbColor(0xFFEE2200.toInt())
+        assertThat(color.argb).isEqualTo(0xFFEE2200.toInt())
+    }
+
+    /**
+     * Pins the `UiTelemetryGuard` PII discipline. Every event method reachable here
+     * with enums-and-primitives-only arguments. Adding a free-form `String`,
+     * `ByteArray`, `Pass`, or `PassField` parameter to any method below would fail
+     * to compile against this lock without a deliberate edit.
+     */
+    @Test
+    fun uiTelemetryGuardEventsAreEnumsAndPrimitivesOnly() {
+        val recorded = mutableListOf<String>()
+        val guard = object : UiTelemetryGuard {
+            override fun onPassRendered(type: PassType, signatureBand: SignatureBand) {
+                recorded += "rendered:${type.name}:${signatureBand.name}"
+            }
+
+            override fun onPassBackOpened(type: PassType) {
+                recorded += "back:${type.name}"
+            }
+
+            override fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType) {
+                recorded += "shown:${intentKind.name}:${type.name}"
+            }
+
+            override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType) {
+                recorded += "confirm:${intentKind.name}:${type.name}"
+            }
+
+            override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType) {
+                recorded += "dismiss:${intentKind.name}:${type.name}"
+            }
+
+            override fun onImageDecodeRejected(reason: ImageDecodeRejection) {
+                recorded += "decode:${reason.name}"
+            }
+        }
+        guard.onPassRendered(PassType.BoardingPass, SignatureBand.AppleVerified)
+        guard.onPassBackOpened(PassType.EventTicket)
+        guard.onSecuritySheetShown(SecurityIntentKind.Url, PassType.Generic)
+        guard.onSecuritySheetConfirmed(SecurityIntentKind.Phone, PassType.StoreCard)
+        guard.onSecuritySheetDismissed(SecurityIntentKind.Email, PassType.Coupon)
+        guard.onImageDecodeRejected(ImageDecodeRejection.ExceedsArea)
+
+        assertThat(recorded).containsExactly(
+            "rendered:BoardingPass:AppleVerified",
+            "back:EventTicket",
+            "shown:Url:Generic",
+            "confirm:Phone:StoreCard",
+            "dismiss:Email:Coupon",
+            "decode:ExceedsArea",
+        ).inOrder()
+    }
+
+    @Test
+    fun noopGuardImplementsTheFullSurface() {
+        val guard: UiTelemetryGuard = NoopUiTelemetryGuard
+        guard.onPassRendered(PassType.BoardingPass, SignatureBand.Untrusted)
+        guard.onPassBackOpened(PassType.BoardingPass)
+        guard.onSecuritySheetShown(SecurityIntentKind.Url, PassType.BoardingPass)
+        guard.onSecuritySheetConfirmed(SecurityIntentKind.Url, PassType.BoardingPass)
+        guard.onSecuritySheetDismissed(SecurityIntentKind.Url, PassType.BoardingPass)
+        guard.onImageDecodeRejected(ImageDecodeRejection.Other)
+    }
+
+    @Test
+    fun passesSemanticsDataClassExposesAllFourSlotFamilies() {
+        val argb = ArgbColor(0xFF000000.toInt())
+        val semantics = PassesSemantics(
+            signatureBadge = SignatureBadgeColors(
+                unsignedBackground = argb,
+                unsignedForeground = argb,
+                selfSignedBackground = argb,
+                selfSignedForeground = argb,
+                appleVerifiedBackground = argb,
+                appleVerifiedForeground = argb,
+                certChainIncompleteBackground = argb,
+                certChainIncompleteForeground = argb,
+            ),
+            expiredBadge = ExpiredBadgeStyle(
+                pillBackground = argb,
+                pillForeground = argb,
+                scrimAlpha = 96,
+            ),
+            securitySheet = SecuritySheetStyle(
+                sheetBackground = argb,
+                emphasisBackground = argb,
+                emphasisForeground = argb,
+                bodyForeground = argb,
+                confirmContainer = argb,
+                confirmForeground = argb,
+                cancelForeground = argb,
+            ),
+            categoryAccent = CategoryAccentColors(
+                boardingPass = argb,
+                eventTicket = argb,
+                coupon = argb,
+                storeCard = argb,
+                generic = argb,
+            ),
+        )
+        // Reading every nested field forces them to remain in the public-API shape;
+        // a rename or removal breaks the test.
+        assertThat(semantics.signatureBadge.appleVerifiedBackground).isEqualTo(argb)
+        assertThat(semantics.expiredBadge.scrimAlpha).isEqualTo(96)
+        assertThat(semantics.securitySheet.confirmContainer).isEqualTo(argb)
+        assertThat(semantics.categoryAccent.boardingPass).isEqualTo(argb)
+    }
+
+    private fun passFixture(
+        expirationDate: PassInstant? = null,
+        voided: Boolean = false,
+    ): Pass = Pass(
+        type = PassType.BoardingPass,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = "Acme",
+        expirationDate = expirationDate,
+        voided = voided,
+        colors = PassColors(foreground = null, background = null, label = null),
+        frontFields = PassFields(),
+        backFields = emptyList(),
+        barcode = null,
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,4 +16,4 @@ rootProject.name = "walt-passes-android"
 
 include(":passes-core")
 include(":passes-storage")
-// passes-ui module will be added by its architecture bead.
+include(":passes-ui")


### PR DESCRIPTION
## Summary

Closes the design portion of `wpass-9vv.4` (`passes-ui` theming contract + security composables). Skeleton bead, JVM-only, mirroring the pattern `passes-storage` set in #6 — the implementation bead that follows lands AGP, Compose, Material3, ZXing, and the `@Composable` function bodies against the contract fixed here.

- **Contract types** (pure Kotlin): `PassesSemantics` + signature/expired/security/category color slots; `SecurityIntent` sealed family (`B3UrlIntent`, `PhoneIntent`, `EmailIntent`) routing pass-derived URLs / phones / emails through host-side confirmation sheets; `ExpiredOverlayState` with non-suppressible derivation from `Pass`; `ImageRenderBounds` (1920 x 1920 / 4 MP defaults) as a decompression-bomb backstop; `UiTelemetryGuard` mirroring the enums-and-primitives PII discipline of `TelemetryGuard` / `StorageTelemetryGuard`.
- **Design output**: `passes-ui/COMPOSABLE_SIGNATURES.md` (the `@Composable` signatures the implementation bead must produce, including the parameter omissions that make trust-claim surfaces non-suppressible), `passes-ui/TRUST_CLAIMS.md` (the six trust-claim-bearing UI surfaces and how each is tested), `docs/adr/0003-passes-ui-theming.md` (D1 host MaterialTheme is authoritative — through D7 skeleton pattern).
- **Lock test**: `PublicApiSurfaceTest` pins every sealed arm, every enum, the bounds check on `ImageRenderBounds`, and the `UiTelemetryGuard` PII discipline.

The decision to make walt-android's `MaterialTheme` the source of truth for color and typography (rather than defining a parallel theming contract) is captured in ADR 0003 D1 and as a `CLAUDE.local.md` rule. The Walt Design System Claude project remains the source of *flow and UX* only.

## Test plan

- [x] `./gradlew :passes-ui:test` — green (8 tests in `PublicApiSurfaceTest` + companion checks)
- [x] `./gradlew check` — green across `passes-core`, `passes-storage`, `passes-ui`
- [ ] Implementation bead: AGP wiring, Compose BOM, Material3, ZXing, `@Composable` bodies, screenshot tests for each `PassType`, instrumentation tests for security-sheet interaction, API-surface lock test pinning the trust-claim parameter omissions documented in ADR 0003 D5.