### PR TITLE
Implement passes-ui: AGP, Compose, ZXing, @Composable bodies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.compose) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
-org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
 kotlin.code.style=official
+
+# Android Gradle Plugin settings (passes-ui).
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,19 @@
 [versions]
+agp = "9.0.1"
 kotlin = "2.2.21"
 kotlinxSerialization = "1.7.3"
 kotlinxCoroutines = "1.9.0"
 junit = "4.13.2"
 truth = "1.4.5"
+
+# Android + Compose toolchain (matches walt-android consumer to avoid drift).
+androidxCoreKtx = "1.17.0"
+androidxLifecycle = "2.10.0"
+composeBom = "2026.01.00"
+zxing = "3.5.3"
+robolectric = "4.14.1"
+androidxJunit = "1.3.0"
+androidxEspressoCore = "3.7.0"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
@@ -12,6 +22,33 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
+# Android core
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+
+# Compose (versions sourced from the BOM)
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+
+# Barcode rendering
+zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
+
+# JVM-side Compose tests
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+
+# Instrumentation
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
+
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidxJunit = "1.3.0"
 androidxEspressoCore = "3.7.0"
 
 [libraries]
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }

--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -77,10 +77,10 @@ fails fast.
 public fun PassFront(
     pass: Pass,
     signatureStatus: SignatureStatus,
-    locale: PassLocale = PassLocale("en"),
-    nowEpochMillis: Long = System.currentTimeMillis(),
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    locale: PassLocale = PassLocale("en"),
+    nowEpochMillis: Long = System.currentTimeMillis(),
 )
 ```
 
@@ -99,12 +99,12 @@ public fun PassFront(
 @Composable
 public fun PassBack(
     pass: Pass,
-    locale: PassLocale = PassLocale("en"),
     onUrlIntent: (B3UrlIntent) -> Unit,
     onPhoneIntent: (PhoneIntent) -> Unit,
     onEmailIntent: (EmailIntent) -> Unit,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    locale: PassLocale = PassLocale("en"),
 )
 ```
 
@@ -174,8 +174,8 @@ sheet AND calls `onConfirm`; dismissal closes WITHOUT firing `onConfirm`.
 @Composable
 public fun ExpiredOverlay(
     state: ExpiredOverlayState,
-    locale: PassLocale = PassLocale("en"),
     modifier: Modifier = Modifier,
+    locale: PassLocale = PassLocale("en"),
 )
 ```
 
@@ -197,9 +197,9 @@ public fun BoundedImage(
     bytes: ImageBytes,
     role: ImageRole,
     contentDescription: String?,
-    bounds: ImageRenderBounds = ImageRenderBounds.Default,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    bounds: ImageRenderBounds = ImageRenderBounds.Default,
 )
 ```
 

--- a/passes-ui/TRUST_CLAIMS.md
+++ b/passes-ui/TRUST_CLAIMS.md
@@ -38,7 +38,7 @@ status, and the status cannot be rebound by the host.
 sheet rises that shows: the issuer's `organizationName`, the source field's label,
 the verbatim URL the host is about to open, and a "Confirm" / "Cancel" pair.
 
-**Trust claim.** Two parts.
+**Trust claim.** Three parts.
 
 1. *No URL leaves the device without the user seeing the verbatim target.* The host
    does not open `Intent.ACTION_VIEW` for a pass-derived URL except inside the
@@ -46,16 +46,39 @@ the verbatim URL the host is about to open, and a "Confirm" / "Cancel" pair.
 2. *The displayed URL is identical to the URL that opens.* The sheet does not show
    `example.com` and open `attacker.example`. The string in [B3UrlIntent.url] IS the
    string the host hands to its `Intent`.
+3. *The displayed URL is rendered as it was typed.* The sheet defends against the
+   Unicode-bidi class of attacks, where a pass author embeds U+202E
+   (Right-to-Left Override), zero-width marks, or other formatting/control
+   characters in a URL so the visual rendering of the string differs from the
+   bytes that resolve via `Uri.parse`. Two layers:
+   - **Detection-stage rejection.** `FieldLinkScanner.containsRenderingHazard`
+     rejects any field whose value contains a Unicode Cf (format) or Cc (control)
+     codepoint. The rejection is field-level: a clean URL adjacent to a hostile
+     one in the same field becomes non-tappable too, since the surrounding
+     context is untrustworthy.
+   - **Rendering-stage isolation.** The sheet wraps every user-controlled string —
+     the URL, the issuer's organization name, and the source field's label — in
+     U+2068 / U+2069 (FSI / PDI) bidi isolates. Within the isolate, the Unicode
+     Bidirectional Algorithm cannot reorder glyphs across the boundary, so any
+     residual directional context from chrome cannot reorder the displayed target
+     and any directional content within cannot leak outward.
 
 **How tested.**
 
 - `PublicApiSurfaceTest` pins the three arms of `SecurityIntent`.
-- The implementation bead's tests assert that the `B3UrlIntent` callback fires
-  exactly once per tap and that no `ACTION_VIEW` intent is dispatched in the
-  test harness without the user crossing through the sheet.
-- A copy-paste audit (manual + linter rule planned in the implementation bead's
-  follow-up) checks that `B3UrlIntent.url` is the only string read inside the
-  confirm callback's outbound-intent construction.
+- `FieldLinkScannerTest` includes 11 bidi-spoofing cases: U+202E,
+  U+200B (zero-width space), U+200E (LTR mark), U+061C (Arabic Letter Mark),
+  ASCII control bytes, the same hazards in phone and email positions, and a
+  "clean URL adjacent to hostile URL" case that asserts the entire field
+  surfaces no links. Plus `urlBytesAreVerbatimNoCfStripping` (a clean URL passes
+  through byte-equal — no silent sanitization) and the categorization helper
+  test covering Cf and Cc enumerable points.
+- `TrustClaimSurfaceTest.securitySheetUrlIsBidiIsolated` and
+  `securitySheetIsolatesOrganizationName` verify the sheet's rendered text is
+  bracketed by FSI / PDI.
+- The implementation bead's instrumentation tests will assert that no
+  `ACTION_VIEW` intent is dispatched in the test harness without the user
+  crossing through the sheet.
 
 ## 3. Phone confirmation
 

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -1,27 +1,42 @@
-// JVM-only today. The implementation bead replaces this with the Android library plugin
-// to bring in Jetpack Compose, Material3, ZXing, and Coil. The public-API types defined
-// here are intentionally Android-agnostic: theming contracts use packed ARGB integers (the
-// same shape `passes-core` uses for `ColorValue`) and intent payloads are pure data
-// classes, so test doubles and the JVM CI host can exercise the contract without an
-// Android device.
-//
-// The composable signatures themselves are documented in passes-ui/COMPOSABLE_SIGNATURES.md
-// rather than declared as `@Composable fun ...` here, since `androidx.compose.runtime` is
-// not on this skeleton's classpath.
-
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.compose)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+android {
+    namespace = "is.walt.passes.ui"
+    compileSdk = 36
+
+    defaultConfig {
+        // ImageDecoder.setOnHeaderDecodedListener (used by BoundedImage) requires API 28.
+        // StrongBox-backed Keystore (used by passes-storage) also lands at API 28. Aligning
+        // the whole repo at minSdk 28 keeps the trust-claim story consistent across modules.
+        minSdk = 28
+
+        consumerProguardFiles("consumer-rules.pro")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+
+    buildFeatures {
+        compose = true
     }
 }
 
 kotlin {
     explicitApi()
     compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         freeCompilerArgs.addAll("-Xjvm-default=all")
     }
 }
@@ -29,10 +44,33 @@ kotlin {
 dependencies {
     api(project(":passes-core"))
 
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+
+    val composeBom = platform(libs.androidx.compose.bom)
+    implementation(composeBom)
+    api(composeBom)
+
+    api(libs.androidx.compose.ui)
+    api(libs.androidx.compose.ui.graphics)
+    api(libs.androidx.compose.foundation)
+    api(libs.androidx.compose.material3)
+
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+
+    implementation(libs.zxing.core)
+
+    // JVM-side tests: pure-Kotlin contract checks + Robolectric-backed Compose smoke tests
+    // so the public-API surface and basic composition exercise stay on the JVM CI host.
     testImplementation(libs.junit)
     testImplementation(libs.truth)
-}
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(composeBom)
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
 
-tasks.test {
-    useJUnit()
+    androidTestImplementation(composeBom)
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.compose.ui.test.junit4)
 }

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     // so the public-API surface and basic composition exercise stay on the JVM CI host.
     testImplementation(libs.junit)
     testImplementation(libs.truth)
+    testImplementation(libs.kotlin.reflect)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.compose.ui.test.junit4)
     testImplementation(composeBom)

--- a/passes-ui/consumer-rules.pro
+++ b/passes-ui/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Consumer ProGuard rules contributed by passes-ui.
+# Empty for now: the public API surface uses no reflective constructs that R8 would
+# strip, and Compose ships its own consumer rules through the runtime artifact.

--- a/passes-ui/src/main/AndroidManifest.xml
+++ b/passes-ui/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Empty library manifest. passes-ui is a UI library; it declares no permissions, no
+  components, and contributes no manifest-merged metadata to the consumer. The
+  namespace is set in passes-ui/build.gradle.kts.
+-->
+<manifest />

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeView.kt
@@ -1,0 +1,118 @@
+package `is`.walt.passes.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.unit.dp
+import com.google.zxing.BarcodeFormat as ZxingFormat
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.WriterException
+import com.google.zxing.common.BitMatrix
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+
+/**
+ * Renders [barcode] using ZXing. Enforces a minimum on-screen size so the barcode is
+ * reliably scannable at gate distance: 240 dp x 240 dp for QR / Aztec; 320 dp x 96 dp
+ * for PDF417 / Code128.
+ *
+ * `altText` from the [Barcode], when present, is rendered below the barcode at small
+ * caption type. It is the accessibility-and-fallback text the PKPASS spec defines for
+ * scanners that fail.
+ *
+ * Decoding errors (rare; would mean ZXing rejected the encoded message) render as an
+ * empty placeholder rather than throwing, so a malformed barcode does not crash the
+ * pass-rendering surface.
+ */
+@Composable
+public fun BarcodeView(
+    barcode: Barcode,
+    modifier: Modifier = Modifier,
+) {
+    val zxingFormat = barcode.format.toZxing()
+    val (minWidthDp, minHeightDp) = when (barcode.format) {
+        BarcodeFormat.QR, BarcodeFormat.Aztec -> 240 to 240
+        BarcodeFormat.PDF417, BarcodeFormat.Code128 -> 320 to 96
+    }
+
+    val bitmap = remember(barcode.message, zxingFormat, minWidthDp, minHeightDp) {
+        runCatching {
+            encodeBarcode(
+                message = barcode.message,
+                format = zxingFormat,
+                widthPx = minWidthDp * 3,
+                heightPx = minHeightDp * 3,
+            )
+        }.getOrNull()
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (bitmap != null) {
+            Image(
+                painter = BitmapPainter(bitmap.asImageBitmap()),
+                contentDescription = barcode.altText,
+                modifier = Modifier.defaultMinSize(
+                    minWidth = minWidthDp.dp,
+                    minHeight = minHeightDp.dp,
+                ),
+            )
+        } else {
+            // Decode-failure placeholder. Same dimensions as the barcode so the layout
+            // does not shift between the success and failure paths.
+            Spacer(Modifier.defaultMinSize(minWidth = minWidthDp.dp, minHeight = minHeightDp.dp))
+        }
+
+        if (!barcode.altText.isNullOrBlank()) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = barcode.altText!!,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}
+
+private fun encodeBarcode(
+    message: String,
+    format: ZxingFormat,
+    widthPx: Int,
+    heightPx: Int,
+): Bitmap {
+    val matrix: BitMatrix = try {
+        MultiFormatWriter().encode(message, format, widthPx, heightPx)
+    } catch (e: WriterException) {
+        throw IllegalArgumentException("ZXing rejected payload", e)
+    }
+    val width = matrix.width
+    val height = matrix.height
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        val rowOffset = y * width
+        for (x in 0 until width) {
+            pixels[rowOffset + x] = if (matrix.get(x, y)) AndroidColor.BLACK else AndroidColor.WHITE
+        }
+    }
+    return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
+}
+
+private fun BarcodeFormat.toZxing(): ZxingFormat = when (this) {
+    BarcodeFormat.QR -> ZxingFormat.QR_CODE
+    BarcodeFormat.PDF417 -> ZxingFormat.PDF_417
+    BarcodeFormat.Aztec -> ZxingFormat.AZTEC
+    BarcodeFormat.Code128 -> ZxingFormat.CODE_128
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
@@ -49,9 +49,9 @@ public fun BoundedImage(
     bytes: ImageBytes,
     @Suppress("UNUSED_PARAMETER") role: ImageRole,
     contentDescription: String?,
-    bounds: ImageRenderBounds = ImageRenderBounds.Default,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    bounds: ImageRenderBounds = ImageRenderBounds.Default,
 ) {
     var bitmap by remember(bytes, bounds) { mutableStateOf<Bitmap?>(null) }
     var rejection by remember(bytes, bounds) { mutableStateOf<ImageDecodeRejection?>(null) }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import `is`.walt.passes.core.ImageBytes
 import `is`.walt.passes.core.ImageRole
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.nio.ByteBuffer
 
@@ -24,14 +26,23 @@ import java.nio.ByteBuffer
  * allocates a backing bitmap, so a hostile pass archive cannot OOM the host process via
  * a multi-gigabyte PNG.
  *
+ * Residual risk: `OnHeaderDecodedListener` does not bound the transient memory the
+ * platform decoder uses while parsing the file header itself. For pathological inputs
+ * (e.g. PNGs with very large ancillary chunks), header parsing can allocate proportional
+ * memory before the listener fires. `ImageDecoder` is the safest decode primitive
+ * Android offers, but it is not a hard guarantee against all decompression-bomb shapes.
+ * `BoundedImage` rejects the bitmap once dimensions are known; the implementation bead's
+ * follow-on work is an instrumentation test that exercises the residual-risk surface.
+ *
  * The implementation deliberately does NOT use Coil's default loader: bounds enforcement
  * is the trust claim, and a third-party loader would have to be re-audited for that
  * property on every dependency upgrade. The decoder pipeline here is the only path
  * `passes-ui` ever uses to produce a bitmap from an `ImageBytes`.
  *
- * Decode failures (including bounds violations) render as an empty placeholder and fire
- * [UiTelemetryGuard.onImageDecodeRejected] with the categorized reason. The composable
- * never throws.
+ * Decode runs on `Dispatchers.IO`, so a multi-megapixel image does not stutter the
+ * host's UI thread. Decode failures (including bounds violations) render as an empty
+ * placeholder and fire [UiTelemetryGuard.onImageDecodeRejected] with the categorized
+ * reason. The composable never throws.
  */
 @Composable
 public fun BoundedImage(
@@ -46,7 +57,9 @@ public fun BoundedImage(
     var rejection by remember(bytes, bounds) { mutableStateOf<ImageDecodeRejection?>(null) }
 
     LaunchedEffect(bytes, bounds) {
-        val (decoded, reason) = decodeBoundedBitmap(bytes.bytes, bounds)
+        val (decoded, reason) = withContext(Dispatchers.IO) {
+            decodeBoundedBitmap(bytes.bytes, bounds)
+        }
         bitmap = decoded
         rejection = reason
         reason?.let { telemetry.onImageDecodeRejected(it) }
@@ -98,9 +111,14 @@ internal fun decodeBoundedBitmap(
             bitmap to null
         }
     } catch (e: IOException) {
-        null to ImageDecodeRejection.Malformed
+        // Genuine I/O / parse failure with no bounds rejection in flight.
+        null to (rejection ?: ImageDecodeRejection.Malformed)
     } catch (e: IllegalArgumentException) {
-        null to ImageDecodeRejection.Malformed
+        // setTargetSize(1, 1) inside the listener can throw IAE for formats that
+        // refuse arbitrary sizing (e.g. some strip-encoded variants). When that
+        // happens, bounds rejection ALREADY fired in the listener — preserve that
+        // reason rather than reclassifying as Malformed.
+        null to (rejection ?: ImageDecodeRejection.Malformed)
     } catch (e: RuntimeException) {
         null to (rejection ?: ImageDecodeRejection.Other)
     }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BoundedImage.kt
@@ -1,0 +1,107 @@
+package `is`.walt.passes.ui
+
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import `is`.walt.passes.core.ImageBytes
+import `is`.walt.passes.core.ImageRole
+import java.io.IOException
+import java.nio.ByteBuffer
+
+/**
+ * Decodes [bytes] using Android `ImageDecoder` with explicit dimension caps applied via
+ * [ImageDecoder.OnHeaderDecodedListener]. The header listener fires before the decoder
+ * allocates a backing bitmap, so a hostile pass archive cannot OOM the host process via
+ * a multi-gigabyte PNG.
+ *
+ * The implementation deliberately does NOT use Coil's default loader: bounds enforcement
+ * is the trust claim, and a third-party loader would have to be re-audited for that
+ * property on every dependency upgrade. The decoder pipeline here is the only path
+ * `passes-ui` ever uses to produce a bitmap from an `ImageBytes`.
+ *
+ * Decode failures (including bounds violations) render as an empty placeholder and fire
+ * [UiTelemetryGuard.onImageDecodeRejected] with the categorized reason. The composable
+ * never throws.
+ */
+@Composable
+public fun BoundedImage(
+    bytes: ImageBytes,
+    @Suppress("UNUSED_PARAMETER") role: ImageRole,
+    contentDescription: String?,
+    bounds: ImageRenderBounds = ImageRenderBounds.Default,
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+) {
+    var bitmap by remember(bytes, bounds) { mutableStateOf<Bitmap?>(null) }
+    var rejection by remember(bytes, bounds) { mutableStateOf<ImageDecodeRejection?>(null) }
+
+    LaunchedEffect(bytes, bounds) {
+        val (decoded, reason) = decodeBoundedBitmap(bytes.bytes, bounds)
+        bitmap = decoded
+        rejection = reason
+        reason?.let { telemetry.onImageDecodeRejected(it) }
+    }
+
+    val current = bitmap
+    if (current != null) {
+        Image(
+            painter = BitmapPainter(current.asImageBitmap()),
+            contentDescription = contentDescription,
+            modifier = modifier,
+        )
+    } else {
+        Spacer(modifier)
+    }
+}
+
+/**
+ * Visible-for-tests JVM-pure decoder driver. Returns the produced bitmap (or `null` on
+ * failure) plus the rejection reason (or `null` on success). Splitting this from the
+ * composable lets the implementation bead's instrumentation tests assert decode behavior
+ * without having to render anything.
+ */
+internal fun decodeBoundedBitmap(
+    rawBytes: ByteArray,
+    bounds: ImageRenderBounds,
+): Pair<Bitmap?, ImageDecodeRejection?> {
+    val source = ImageDecoder.createSource(ByteBuffer.wrap(rawBytes))
+    var rejection: ImageDecodeRejection? = null
+    return try {
+        val bitmap = ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+            val w = info.size.width
+            val h = info.size.height
+            rejection = when {
+                w > bounds.maxWidthPx -> ImageDecodeRejection.ExceedsWidth
+                h > bounds.maxHeightPx -> ImageDecodeRejection.ExceedsHeight
+                w.toLong() * h.toLong() > bounds.maxAreaPx -> ImageDecodeRejection.ExceedsArea
+                else -> null
+            }
+            if (rejection != null) {
+                // Force a 1x1 decode so the underlying allocation stays trivially small.
+                // The composable discards the bitmap below.
+                decoder.setTargetSize(1, 1)
+            }
+        }
+        if (rejection != null) {
+            null to rejection
+        } else {
+            bitmap to null
+        }
+    } catch (e: IOException) {
+        null to ImageDecodeRejection.Malformed
+    } catch (e: IllegalArgumentException) {
+        null to ImageDecodeRejection.Malformed
+    } catch (e: RuntimeException) {
+        null to (rejection ?: ImageDecodeRejection.Other)
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlay.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlay.kt
@@ -29,8 +29,8 @@ import `is`.walt.passes.ui.theme.toComposeColor
 @Composable
 public fun ExpiredOverlay(
     state: ExpiredOverlayState,
-    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
     modifier: Modifier = Modifier,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
 ) {
     if (state is ExpiredOverlayState.None) return
 

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlay.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ExpiredOverlay.kt
@@ -1,0 +1,63 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Renders the non-suppressible expired/voided overlay over the parent. [state] is the
+ * outcome of [ExpiredOverlayState.from]; [ExpiredOverlayState.None] renders nothing.
+ *
+ * The composable has no `enabled` parameter and no caller-supplied flag that would
+ * hide the overlay — see ADR 0003 D5. A pass whose validity window has closed cannot
+ * present as valid through any path in this API.
+ */
+@Composable
+public fun ExpiredOverlay(
+    state: ExpiredOverlayState,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    modifier: Modifier = Modifier,
+) {
+    if (state is ExpiredOverlayState.None) return
+
+    val style = LocalPassesSemantics.current.expiredBadge
+    val scrim = Color.Black.copy(alpha = (style.scrimAlpha.coerceIn(0, 255)) / 255f)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(scrim),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = when (state) {
+                ExpiredOverlayState.Voided -> "Voided"
+                is ExpiredOverlayState.Expired -> "Expired"
+                ExpiredOverlayState.None -> ""
+            },
+            color = style.pillForeground.toComposeColor(),
+            modifier = Modifier
+                .clip(RoundedCornerShape(100.dp))
+                .background(style.pillBackground.toComposeColor())
+                .padding(PaddingValues(horizontal = 24.dp, vertical = 8.dp)),
+        )
+    }
+}
+
+/** Public for use as a sentinel in tests; no other purpose. */
+@Suppress("unused")
+internal val expiredOverlayMarkerColor: Int = Color.Black.toArgb()

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
@@ -39,12 +39,12 @@ import `is`.walt.passes.ui.internal.LinkSpan
 @Composable
 public fun PassBack(
     pass: Pass,
-    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
     onUrlIntent: (B3UrlIntent) -> Unit,
     onPhoneIntent: (PhoneIntent) -> Unit,
     onEmailIntent: (EmailIntent) -> Unit,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
 ) {
     LaunchedEffect(pass) { telemetry.onPassBackOpened(pass.type) }
 

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
@@ -1,0 +1,135 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.ClickableText
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.ui.internal.FieldLinkScanner
+import `is`.walt.passes.ui.internal.LinkSpan
+
+/**
+ * Renders the back of a pass: the list of [Pass.backFields], with detected URLs,
+ * phone numbers, and email addresses rendered as tappable affordances. Tapping such
+ * an affordance fires the matching callback with the parsed [SecurityIntent];
+ * `passes-ui` never invokes the host's outbound `Intent` directly. The host's
+ * expected wiring is to display the corresponding confirmation sheet (see
+ * [B3UrlConfirmSheet], [PhoneConfirmSheet], [EmailConfirmSheet]) and call
+ * `Intent.ACTION_VIEW` (or `ACTION_DIAL`, `ACTION_SENDTO`) only on confirm.
+ *
+ * The three callbacks are NOT defaulted to no-op — see ADR 0003 D5. A host that
+ * forgets to wire one of them is a compile error, not a runtime swallow.
+ */
+@Composable
+public fun PassBack(
+    pass: Pass,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    onUrlIntent: (B3UrlIntent) -> Unit,
+    onPhoneIntent: (PhoneIntent) -> Unit,
+    onEmailIntent: (EmailIntent) -> Unit,
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+) {
+    LaunchedEffect(pass) { telemetry.onPassBackOpened(pass.type) }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            pass.backFields.forEach { field ->
+                BackFieldRow(
+                    field = field,
+                    organizationName = pass.organizationName,
+                    onUrlIntent = onUrlIntent,
+                    onPhoneIntent = onPhoneIntent,
+                    onEmailIntent = onEmailIntent,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BackFieldRow(
+    field: PassField,
+    organizationName: String,
+    onUrlIntent: (B3UrlIntent) -> Unit,
+    onPhoneIntent: (PhoneIntent) -> Unit,
+    onEmailIntent: (EmailIntent) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        field.label?.takeIf { it.isNotBlank() }?.let { label ->
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        val source = SourceField(
+            fieldKey = field.key,
+            fieldLabel = field.label,
+            organizationName = organizationName,
+        )
+        val spans = FieldLinkScanner.scan(field.value, source)
+        val annotated = buildAnnotatedFieldValue(field.value, spans)
+
+        @Suppress("DEPRECATION")
+        ClickableText(
+            text = annotated,
+            style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
+            onClick = { offset ->
+                val span = spans.firstOrNull { offset >= it.start && offset < it.endExclusive }
+                when (val intent = span?.intent) {
+                    is B3UrlIntent -> onUrlIntent(intent)
+                    is PhoneIntent -> onPhoneIntent(intent)
+                    is EmailIntent -> onEmailIntent(intent)
+                    null -> Unit
+                }
+            },
+        )
+    }
+}
+
+private fun buildAnnotatedFieldValue(text: String, spans: List<LinkSpan>): AnnotatedString =
+    buildAnnotatedString {
+        if (spans.isEmpty()) {
+            append(text)
+            return@buildAnnotatedString
+        }
+        var cursor = 0
+        for (span in spans) {
+            if (span.start > cursor) append(text.substring(cursor, span.start))
+            withStyle(
+                SpanStyle(
+                    fontWeight = FontWeight.Medium,
+                    textDecoration = TextDecoration.Underline,
+                ),
+            ) {
+                append(text.substring(span.start, span.endExclusive))
+            }
+            cursor = span.endExclusive
+        }
+        if (cursor < text.length) append(text.substring(cursor))
+    }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -1,0 +1,313 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.core.TextAlignment
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Renders the front of a pass. Layout switches on [Pass.type]:
+ *
+ * - [PassType.BoardingPass]: prominent primary "from / to" row (typically two large
+ *   primary fields), header above, secondary + auxiliary below, barcode at the foot.
+ * - [PassType.EventTicket]: header, primary, secondary; barcode at the foot.
+ * - [PassType.Coupon], [PassType.StoreCard], [PassType.Generic]: header / primary /
+ *   secondary / auxiliary in a vertical stack.
+ *
+ * The pass's own [Pass.colors] override the host's MaterialTheme on the pass surface
+ * only — the trust badge and expired overlay above this composable still read from
+ * `LocalPassesSemantics`. See ADR 0003 D4.
+ *
+ * The signature trust badge and (when applicable) the expired overlay are composited
+ * on top of the pass; neither has a suppression parameter — see ADR 0003 D5.
+ */
+@Composable
+public fun PassFront(
+    pass: Pass,
+    signatureStatus: SignatureStatus,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    nowEpochMillis: Long = System.currentTimeMillis(),
+    telemetry: UiTelemetryGuard,
+    modifier: Modifier = Modifier,
+) {
+    val band = signatureStatus.toBand()
+    val expired = remember(pass, nowEpochMillis) {
+        ExpiredOverlayState.from(pass, nowEpochMillis)
+    }
+    androidx.compose.runtime.LaunchedEffect(pass, band) {
+        telemetry.onPassRendered(pass.type, band)
+    }
+
+    val passBackground = pass.colors.background.toComposeOrDefault(MaterialTheme.colorScheme.surface)
+    val passForeground = pass.colors.foreground.toComposeOrDefault(MaterialTheme.colorScheme.onSurface)
+    val passLabel = pass.colors.label.toComposeOrDefault(passForeground.copy(alpha = 0.7f))
+
+    Box(modifier = modifier) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = passBackground,
+            contentColor = passForeground,
+            shape = RoundedCornerShape(16.dp),
+            tonalElevation = 0.dp,
+        ) {
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = pass.organizationName,
+                        style = MaterialTheme.typography.labelLarge,
+                        color = passLabel,
+                        modifier = Modifier.weight(1f),
+                    )
+                    SignatureTrustBadge(band = band)
+                }
+
+                when (pass.type) {
+                    PassType.BoardingPass -> BoardingPassBody(
+                        pass.frontFields,
+                        passForeground,
+                        passLabel,
+                    )
+                    PassType.EventTicket -> EventTicketBody(
+                        pass.frontFields,
+                        passForeground,
+                        passLabel,
+                    )
+                    PassType.Coupon, PassType.StoreCard, PassType.Generic -> GenericBody(
+                        pass.frontFields,
+                        passForeground,
+                        passLabel,
+                    )
+                }
+
+                pass.barcode?.let { barcode ->
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        BarcodeView(barcode = barcode)
+                    }
+                }
+            }
+        }
+
+        if (expired !is ExpiredOverlayState.None) {
+            ExpiredOverlay(state = expired, modifier = Modifier.matchParentSize())
+        }
+    }
+}
+
+@Composable
+private fun BoardingPassBody(fields: PassFields, foreground: Color, labelColor: Color) {
+    HeaderRow(fields.header, foreground, labelColor)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        // Two primary slots ("from" / "to") read at the largest size; if a single
+        // primary is supplied it just takes the leading position.
+        fields.primary.take(2).forEachIndexed { index, field ->
+            PrimaryField(
+                field,
+                foreground,
+                labelColor,
+                modifier = Modifier.weight(1f),
+                align = if (index == 1) TextAlign.End else TextAlign.Start,
+            )
+            if (index == 0 && fields.primary.size > 1) {
+                Box(modifier = Modifier.width(8.dp))
+            }
+        }
+    }
+    SecondaryRow(fields.secondary, foreground, labelColor)
+    if (fields.auxiliary.isNotEmpty()) {
+        SecondaryRow(fields.auxiliary, foreground, labelColor)
+    }
+}
+
+@Composable
+private fun EventTicketBody(fields: PassFields, foreground: Color, labelColor: Color) {
+    HeaderRow(fields.header, foreground, labelColor)
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        fields.primary.forEach { PrimaryField(it, foreground, labelColor) }
+    }
+    SecondaryRow(fields.secondary, foreground, labelColor)
+}
+
+@Composable
+private fun GenericBody(fields: PassFields, foreground: Color, labelColor: Color) {
+    HeaderRow(fields.header, foreground, labelColor)
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        fields.primary.forEach { PrimaryField(it, foreground, labelColor) }
+    }
+    SecondaryRow(fields.secondary, foreground, labelColor)
+    if (fields.auxiliary.isNotEmpty()) {
+        SecondaryRow(fields.auxiliary, foreground, labelColor)
+    }
+}
+
+@Composable
+private fun HeaderRow(fields: List<PassField>, foreground: Color, labelColor: Color) {
+    if (fields.isEmpty()) return
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        fields.forEach { field ->
+            FieldCell(
+                field = field,
+                foreground = foreground,
+                labelColor = labelColor,
+                valueStyle = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PrimaryField(
+    field: PassField,
+    foreground: Color,
+    labelColor: Color,
+    modifier: Modifier = Modifier,
+    align: TextAlign = TextAlign.Start,
+) {
+    FieldCell(
+        field = field,
+        foreground = foreground,
+        labelColor = labelColor,
+        valueStyle = MaterialTheme.typography.headlineSmall,
+        modifier = modifier,
+        textAlign = align,
+    )
+}
+
+@Composable
+private fun SecondaryRow(fields: List<PassField>, foreground: Color, labelColor: Color) {
+    if (fields.isEmpty()) return
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        fields.forEach { field ->
+            FieldCell(
+                field = field,
+                foreground = foreground,
+                labelColor = labelColor,
+                valueStyle = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FieldCell(
+    field: PassField,
+    foreground: Color,
+    labelColor: Color,
+    valueStyle: androidx.compose.ui.text.TextStyle,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign? = null,
+) {
+    val align = textAlign ?: when (field.textAlignment) {
+        TextAlignment.Left, TextAlignment.Natural -> TextAlign.Start
+        TextAlignment.Center -> TextAlign.Center
+        TextAlignment.Right -> TextAlign.End
+    }
+    Column(modifier = modifier) {
+        field.label?.takeIf { it.isNotBlank() }?.let { label ->
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = labelColor,
+                textAlign = align,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        Text(
+            text = field.value,
+            style = valueStyle,
+            color = foreground,
+            textAlign = align,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun SignatureTrustBadge(band: SignatureBand) {
+    val semantics = LocalPassesSemantics.current.signatureBadge
+    val (background, foreground, copy) = when (band) {
+        SignatureBand.Untrusted ->
+            Triple(semantics.unsignedBackground, semantics.unsignedForeground, "Unsigned")
+        SignatureBand.SelfSigned ->
+            Triple(semantics.selfSignedBackground, semantics.selfSignedForeground, "Self-signed")
+        SignatureBand.AppleVerified ->
+            Triple(semantics.appleVerifiedBackground, semantics.appleVerifiedForeground, "Verified")
+        SignatureBand.Incomplete ->
+            Triple(
+                semantics.certChainIncompleteBackground,
+                semantics.certChainIncompleteForeground,
+                "Signature unknown",
+            )
+    }
+    Text(
+        text = copy,
+        style = MaterialTheme.typography.labelSmall,
+        color = foreground.toComposeColor(),
+        modifier = Modifier
+            .clip(RoundedCornerShape(100.dp))
+            .background(background.toComposeColor())
+            .padding(PaddingValues(horizontal = 12.dp, vertical = 4.dp)),
+    )
+}
+
+private fun SignatureStatus.toBand(): SignatureBand = when (this) {
+    SignatureStatus.Unsigned -> SignatureBand.Untrusted
+    SignatureStatus.SelfSigned -> SignatureBand.SelfSigned
+    SignatureStatus.AppleVerified -> SignatureBand.AppleVerified
+    SignatureStatus.CertChainIncomplete -> SignatureBand.Incomplete
+}
+
+private fun ColorValue?.toComposeOrDefault(default: Color): Color {
+    val v = this ?: return default
+    val r = (v.rgb shr 16) and 0xFF
+    val g = (v.rgb shr 8) and 0xFF
+    val b = v.rgb and 0xFF
+    return Color(red = r, green = g, blue = b)
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -52,10 +52,10 @@ import `is`.walt.passes.ui.theme.toComposeColor
 public fun PassFront(
     pass: Pass,
     signatureStatus: SignatureStatus,
-    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
-    nowEpochMillis: Long = System.currentTimeMillis(),
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
+    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    nowEpochMillis: Long = System.currentTimeMillis(),
 ) {
     val band = signatureStatus.toBand()
     val expired = remember(pass, nowEpochMillis) {

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -306,8 +306,12 @@ private fun SignatureStatus.toBand(): SignatureBand = when (this) {
 
 private fun ColorValue?.toComposeOrDefault(default: Color): Color {
     val v = this ?: return default
-    val r = (v.rgb shr 16) and 0xFF
-    val g = (v.rgb shr 8) and 0xFF
-    val b = v.rgb and 0xFF
+    // Mask via Long to avoid sign-extension surprises if the stored Int ever has a
+    // bit set above the documented 24-bit range. The pass-core parser contract is
+    // 24-bit RGB, but the type itself is `Int`, so this is belt-and-suspenders.
+    val packed = v.rgb.toLong() and 0xFFFFFFL
+    val r = ((packed shr 16) and 0xFF).toInt()
+    val g = ((packed shr 8) and 0xFF).toInt()
+    val b = (packed and 0xFF).toInt()
     return Color(red = r, green = g, blue = b)
 }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -122,8 +121,7 @@ private fun SecuritySheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val style = LocalPassesSemantics.current.securitySheet
-    val emphasis = remember(style) { style }
+    val emphasis = LocalPassesSemantics.current.securitySheet
 
     LaunchedEffect(kind, passType) {
         telemetry.onSecuritySheetShown(kind, passType)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
@@ -142,13 +142,18 @@ private fun SecuritySheet(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
+                // Title is a hardcoded English literal, not user-controlled, so no
+                // isolation needed.
                 text = title,
                 style = MaterialTheme.typography.headlineSmall,
                 color = emphasis.bodyForeground.toComposeColor(),
             )
             Text(
-                text = source.organizationName +
-                    (source.fieldLabel?.let { " — $it" } ?: ""),
+                // Organization name and field label come straight from the parsed
+                // pass and ARE user-controlled. Isolate each independently so a
+                // bidi character in either cannot reorder the rest of the line.
+                text = isolated(source.organizationName) +
+                    (source.fieldLabel?.let { " — ${isolated(it)}" } ?: ""),
                 style = MaterialTheme.typography.bodySmall,
                 color = emphasis.bodyForeground.toComposeColor(),
             )
@@ -161,7 +166,11 @@ private fun SecuritySheet(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = target,
+                    // The verbatim target is the trust-claim load-bearing string.
+                    // Isolate it so any residual directional marks (the scanner
+                    // already rejects Cf/Cc, but defense in depth) cannot reorder
+                    // glyphs against surrounding context.
+                    text = isolated(target),
                     style = MaterialTheme.typography.bodyLarge,
                     color = emphasis.emphasisForeground.toComposeColor(),
                 )
@@ -197,3 +206,24 @@ private fun SecuritySheet(
         }
     }
 }
+
+/**
+ * Wrap [s] in Unicode First-Strong Isolate / Pop Directional Isolate (U+2068, U+2069).
+ * Inside the isolate the bidi algorithm treats the contents as a single neutral
+ * directional unit: characters within cannot reorder text outside, and surrounding
+ * directional context cannot reorder characters within. This is the recommended
+ * fence for displaying user-controlled strings in bidi-sensitive surfaces (UAX #9
+ * §3.4 isolate formatting characters).
+ *
+ * Combined with the Cf/Cc rejection in `FieldLinkScanner`, this guarantees that the
+ * sheet's displayed target string is rendered as-typed; an attacker can no longer
+ * craft a pass field that looks visually like a trusted host while parsing as a
+ * hostile one.
+ */
+internal fun isolated(s: String): String = "$FSI$s$PDI"
+
+/** First Strong Isolate (U+2068). Opens an isolate that takes the directional class of the first strong-class character within. */
+internal const val FSI: Char = '⁨'
+
+/** Pop Directional Isolate (U+2069). Closes the most recently opened isolate. */
+internal const val PDI: Char = '⁩'

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/SecuritySheets.kt
@@ -1,0 +1,201 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Button
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Security confirmation bottom sheet for an outbound URL detected on a pass back-field.
+ *
+ * The sheet displays the issuer, the source field label, and the verbatim URL the host
+ * is about to open. `onConfirm` fires only on the user's explicit confirm tap; the
+ * host's outbound `Intent.ACTION_VIEW` MUST be the next thing constructed after that
+ * callback fires. There is no `skipConfirmation` parameter — see ADR 0003 D5.
+ */
+@Composable
+public fun B3UrlConfirmSheet(
+    intent: B3UrlIntent,
+    passType: PassType,
+    telemetry: UiTelemetryGuard,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    SecuritySheet(
+        kind = SecurityIntentKind.Url,
+        passType = passType,
+        title = "Open this link?",
+        target = intent.url,
+        source = intent.sourceField,
+        confirmCopy = "Open link",
+        telemetry = telemetry,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * Security confirmation bottom sheet for an outbound phone number detected on a pass
+ * back-field. Displays the verbatim digits the host is about to dial.
+ */
+@Composable
+public fun PhoneConfirmSheet(
+    intent: PhoneIntent,
+    passType: PassType,
+    telemetry: UiTelemetryGuard,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    SecuritySheet(
+        kind = SecurityIntentKind.Phone,
+        passType = passType,
+        title = "Call this number?",
+        target = intent.phoneNumber,
+        source = intent.sourceField,
+        confirmCopy = "Call",
+        telemetry = telemetry,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * Security confirmation bottom sheet for an outbound email address. Displays the
+ * verbatim address; the host's outbound composer Intent receives ONLY the address
+ * (no subject, no body) — see TRUST_CLAIMS.md.
+ */
+@Composable
+public fun EmailConfirmSheet(
+    intent: EmailIntent,
+    passType: PassType,
+    telemetry: UiTelemetryGuard,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    SecuritySheet(
+        kind = SecurityIntentKind.Email,
+        passType = passType,
+        title = "Send an email?",
+        target = intent.emailAddress,
+        source = intent.sourceField,
+        confirmCopy = "Compose",
+        telemetry = telemetry,
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SecuritySheet(
+    kind: SecurityIntentKind,
+    passType: PassType,
+    title: String,
+    target: String,
+    source: SourceField,
+    confirmCopy: String,
+    telemetry: UiTelemetryGuard,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val style = LocalPassesSemantics.current.securitySheet
+    val emphasis = remember(style) { style }
+
+    LaunchedEffect(kind, passType) {
+        telemetry.onSecuritySheetShown(kind, passType)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = {
+            telemetry.onSecuritySheetDismissed(kind, passType)
+            onDismiss()
+        },
+        sheetState = sheetState,
+        containerColor = emphasis.sheetBackground.toComposeColor(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(horizontal = 24.dp, vertical = 16.dp)),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = emphasis.bodyForeground.toComposeColor(),
+            )
+            Text(
+                text = source.organizationName +
+                    (source.fieldLabel?.let { " — $it" } ?: ""),
+                style = MaterialTheme.typography.bodySmall,
+                color = emphasis.bodyForeground.toComposeColor(),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(emphasis.emphasisBackground.toComposeColor())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = target,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = emphasis.emphasisForeground.toComposeColor(),
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
+            ) {
+                TextButton(
+                    onClick = {
+                        telemetry.onSecuritySheetDismissed(kind, passType)
+                        onDismiss()
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = emphasis.cancelForeground.toComposeColor(),
+                    ),
+                ) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = {
+                        telemetry.onSecuritySheetConfirmed(kind, passType)
+                        onConfirm()
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = emphasis.confirmContainer.toComposeColor(),
+                        contentColor = emphasis.confirmForeground.toComposeColor(),
+                    ),
+                ) {
+                    Text(confirmCopy)
+                }
+            }
+        }
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
@@ -1,0 +1,85 @@
+package `is`.walt.passes.ui.internal
+
+import `is`.walt.passes.ui.B3UrlIntent
+import `is`.walt.passes.ui.EmailIntent
+import `is`.walt.passes.ui.PhoneIntent
+import `is`.walt.passes.ui.SecurityIntent
+import `is`.walt.passes.ui.SourceField
+
+/**
+ * Detects URLs, phone numbers, and email addresses in pass back-field values. Returns
+ * a list of [LinkSpan] entries with their indexes into the original string so the
+ * Compose layer can render them as tappable affordances pointing at the corresponding
+ * [SecurityIntent].
+ *
+ * Trust-claim relevance: the scanner extracts the *exact substring* that becomes the
+ * intent's target. There is no normalization (no scheme injection, no auto-https, no
+ * "support@example.com" rewritten to "mailto:support@example.com" — the `mailto:`
+ * prefix is added by the host's outbound `Intent` construction, not by this scanner).
+ * The string the user sees in the confirmation sheet is the same string this scanner
+ * pulled out of the pass.
+ *
+ * Intentionally conservative: prefers false negatives over false positives. A URL
+ * without an `http`/`https` scheme is not detected as a URL; a phone number requires
+ * at least seven digits and a leading `+` or parenthesized area code; an email
+ * requires an `@` with non-empty local and domain parts.
+ */
+internal object FieldLinkScanner {
+
+    private val urlRegex = Regex("""https?://[^\s<>"'()]+""")
+    private val emailRegex = Regex("""[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}""")
+
+    // Phone: starts with + or with a digit; digits, spaces, dashes, parentheses; total
+    // digit count >= 7. Anchored on word boundaries so a serial number like "12345678"
+    // adjacent to other text does not accidentally match.
+    private val phoneRegex =
+        Regex("""(?<!\d)(\+?\d[\d\s\-()]{6,}\d)(?!\d)""")
+
+    fun scan(fieldValue: String, source: SourceField): List<LinkSpan> {
+        val spans = mutableListOf<LinkSpan>()
+
+        for (match in urlRegex.findAll(fieldValue)) {
+            spans += LinkSpan(
+                start = match.range.first,
+                endExclusive = match.range.last + 1,
+                intent = B3UrlIntent(url = match.value, sourceField = source),
+            )
+        }
+
+        for (match in emailRegex.findAll(fieldValue)) {
+            // Skip emails inside an already-claimed URL span (avoid double-marking
+            // "http://x@y.com").
+            if (overlapsExisting(match.range.first, match.range.last + 1, spans)) continue
+            spans += LinkSpan(
+                start = match.range.first,
+                endExclusive = match.range.last + 1,
+                intent = EmailIntent(emailAddress = match.value, sourceField = source),
+            )
+        }
+
+        for (match in phoneRegex.findAll(fieldValue)) {
+            val digitCount = match.value.count { it.isDigit() }
+            if (digitCount < 7) continue
+            if (overlapsExisting(match.range.first, match.range.last + 1, spans)) continue
+            spans += LinkSpan(
+                start = match.range.first,
+                endExclusive = match.range.last + 1,
+                intent = PhoneIntent(phoneNumber = match.value.trim(), sourceField = source),
+            )
+        }
+
+        return spans.sortedBy { it.start }
+    }
+
+    private fun overlapsExisting(
+        start: Int,
+        endExclusive: Int,
+        existing: List<LinkSpan>,
+    ): Boolean = existing.any { it.start < endExclusive && start < it.endExclusive }
+}
+
+internal data class LinkSpan(
+    val start: Int,
+    val endExclusive: Int,
+    val intent: SecurityIntent,
+)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
@@ -19,13 +19,37 @@ import `is`.walt.passes.ui.SourceField
  * The string the user sees in the confirmation sheet is the same string this scanner
  * pulled out of the pass.
  *
- * Intentionally conservative: prefers false negatives over false positives. A URL
- * without an `http`/`https` scheme is not detected as a URL; a phone number requires
- * at least seven digits and a leading `+` or parenthesized area code; an email
- * requires an `@` with non-empty local and domain parts.
+ * Intentionally conservative: prefers false negatives over false positives.
+ *
+ * - A URL without an `http`/`https` scheme is not detected as a URL.
+ * - The URL character class is RFC 3986's reserved + unreserved + percent-encoded ASCII
+ *   only. Unicode characters in URLs MUST be percent-encoded (`%E2%80%AE` for U+202E,
+ *   `xn--` Punycode for IDN hosts) to be detected; raw bidi / format / control
+ *   characters cause the URL to be rejected outright. This defends against the bidi
+ *   spoofing class — e.g. `https://attacker.example/‮gpj.elgoog//:sptth` rendering
+ *   visually as a Google asset URL while `Uri.parse` resolves to `attacker.example`.
+ *   Tested in `FieldLinkScannerTest`.
+ * - A phone number requires at least seven digits and is constrained to ASCII digits,
+ *   spaces, hyphens, and parentheses.
+ * - An email requires an `@` with non-empty ASCII local and domain parts.
+ *
+ * Belt-and-suspenders: every match is post-filtered through [containsRenderingHazard],
+ * which discards any match containing a Unicode formatting (Cf) or control (Cc)
+ * codepoint. This is redundant for phone and email under the current regexes but
+ * locks the property so a future regex relaxation does not silently re-open a
+ * spoofing path.
  */
 internal object FieldLinkScanner {
 
+    // Permissive on the boundary chars (whitespace + brackets + quotes), then the
+    // post-filter (`containsRenderingHazard`) rejects matches containing Cf/Cc
+    // characters. The two-stage approach matters: a hostile URL containing
+    // U+202E (Right-to-Left Override) would partial-match under a tighter regex
+    // (stopping at the override and accepting the safe prefix), leaving a partial
+    // URL detected. Capturing the full string here lets the filter discard the
+    // entire match, so the back-field surfaces no link at all rather than a
+    // truncated one whose display is no longer the hostile reorder yet still
+    // differs from what the field text shows.
     private val urlRegex = Regex("""https?://[^\s<>"'()]+""")
     private val emailRegex = Regex("""[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}""")
 
@@ -36,6 +60,21 @@ internal object FieldLinkScanner {
         Regex("""(?<!\d)(\+?\d[\d\s\-()]{6,}\d)(?!\d)""")
 
     fun scan(fieldValue: String, source: SourceField): List<LinkSpan> {
+        // Field-level rejection: if ANY part of this field contains a Unicode
+        // formatting (Cf) or control (Cc) codepoint, surface NO tappable links from
+        // it. Even a clean URL adjacent to a hostile one becomes non-tappable; the
+        // user must copy by hand.
+        //
+        // This is broader than per-match rejection but the right posture for the
+        // trust model: an untrusted pass author who can plant ANY rendering hazard
+        // in a field has demonstrated intent to deceive, and any other "link" in
+        // that field is suspect by association — even if its match substring is
+        // ASCII-clean, the visible context the user reads in the back-field surface
+        // is not. Cutting the entire field off the auto-link path forces a manual
+        // intent (long-press to copy, paste into a browser) where the user has to
+        // see the verbatim string outside any directional reordering.
+        if (containsRenderingHazard(fieldValue)) return emptyList()
+
         val spans = mutableListOf<LinkSpan>()
 
         for (match in urlRegex.findAll(fieldValue)) {
@@ -69,6 +108,21 @@ internal object FieldLinkScanner {
         }
 
         return spans.sortedBy { it.start }
+    }
+
+    /**
+     * True if [s] contains any Unicode Cf (Format) or Cc (Control) codepoint. These
+     * include bidi controls (U+202A-U+202E, U+2066-U+2069, U+200E/U+200F, U+061C),
+     * zero-width characters (U+200B-U+200D, U+FEFF), and raw control bytes (U+0000-U+001F,
+     * U+007F-U+009F). All of them can change the rendered glyph order or visibility of
+     * a string without changing its byte content, breaking the "displayed string equals
+     * actionable string" trust claim.
+     *
+     * The check is character-by-character, O(n), and runs only against already-matched
+     * link substrings so the cost is bounded by the number of links per pass.
+     */
+    internal fun containsRenderingHazard(s: String): Boolean = s.any { c ->
+        c.category == CharCategory.FORMAT || c.isISOControl()
     }
 
     private fun overlapsExisting(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesTheme.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesTheme.kt
@@ -1,0 +1,50 @@
+package `is`.walt.passes.ui.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+/**
+ * The host's entry point into `passes-ui`. Wraps [content] in a [CompositionLocalProvider]
+ * that supplies [LocalPassesSemantics]. Every passes-ui composable expects to be called
+ * inside this scope; reading [LocalPassesSemantics] outside of it fails fast (see ADR 0003
+ * D3).
+ *
+ * Color and typography for general chrome are supplied by the host's surrounding
+ * `MaterialTheme` (e.g. walt-android's `WaltTheme`); `PassesTheme` does not redeclare them.
+ * [semantics] is the small set of slots that have no Material3 analogue — see
+ * [PassesSemantics].
+ */
+@Composable
+public fun PassesTheme(
+    semantics: PassesSemantics,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(
+        LocalPassesSemantics provides semantics,
+        content = content,
+    )
+}
+
+/**
+ * Composition-local accessor for the host-supplied [PassesSemantics]. Reading this
+ * outside a [PassesTheme] scope throws — fail-fast keeps a forgotten `PassesTheme(...)`
+ * scope from silently rendering with a developer-default trust-badge palette.
+ */
+public val LocalPassesSemantics: ProvidableCompositionLocal<PassesSemantics> =
+    staticCompositionLocalOf {
+        error(
+            "LocalPassesSemantics not provided. Wrap pass-rendering composables in " +
+                "PassesTheme(semantics = ...) at the host root (typically inside the " +
+                "host's MaterialTheme scope).",
+        )
+    }
+
+/**
+ * Convert a packed-ARGB [ArgbColor] (the contract type) to a Compose [Color] (the
+ * runtime type). The `.toLong()` cast is required: `Color(Int)` interprets the int
+ * as RGB without alpha, while `Color(Long)` preserves the alpha channel.
+ */
+public fun ArgbColor.toComposeColor(): Color = Color(argb.toLong() and 0xFFFFFFFFL)

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -1,0 +1,145 @@
+package `is`.walt.passes.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+import java.lang.reflect.Method
+
+/**
+ * Pins the parameter-shape discipline of the trust-claim-bearing composables (ADR
+ * 0003 D5). These shape constraints ARE the trust contract: a future refactor that
+ * adds `enabled: Boolean = false` to `ExpiredOverlay`, or `skipConfirmation: Boolean = false`
+ * to a security sheet, would silently weaken the claim documented in TRUST_CLAIMS.md.
+ *
+ * Goes through Java reflection because the Compose compiler plugin breaks the
+ * Kotlin-reflection round-trip for top-level `@Composable` functions
+ * (`KClass.staticFunctions` returns empty for these). We therefore enumerate
+ * `Method.parameterTypes` and filter out the two synthetic trailing parameters
+ * Compose appends (`Composer` and `int $changed`, plus optional `int $changed1`
+ * for high-arity functions).
+ *
+ * The test locks the *user-visible parameter count*, not parameter names. That gives
+ * a reviewer-friendly fail on adding any new parameter — the contract is "exactly
+ * these N parameters, in this order" — without depending on parameter-name
+ * preservation across Kotlin / JVM compilation modes.
+ */
+class ComposableSurfaceLockTest {
+
+    @Test
+    fun expiredOverlayHasExactlyThreeUserVisibleParameters() {
+        // (state, locale, modifier) — D5: no `enabled`, no `suppress`.
+        assertUserVisibleParamCount("ExpiredOverlayKt", "ExpiredOverlay", expected = 3)
+    }
+
+    @Test
+    fun b3UrlConfirmSheetHasExactlyFiveUserVisibleParameters() {
+        // (intent, passType, telemetry, onConfirm, onDismiss) — D5: no skipConfirmation.
+        assertUserVisibleParamCount("SecuritySheetsKt", "B3UrlConfirmSheet", expected = 5)
+    }
+
+    @Test
+    fun phoneConfirmSheetHasExactlyFiveUserVisibleParameters() {
+        assertUserVisibleParamCount("SecuritySheetsKt", "PhoneConfirmSheet", expected = 5)
+    }
+
+    @Test
+    fun emailConfirmSheetHasExactlyFiveUserVisibleParameters() {
+        assertUserVisibleParamCount("SecuritySheetsKt", "EmailConfirmSheet", expected = 5)
+    }
+
+    @Test
+    fun passFrontHasExactlySixUserVisibleParameters() {
+        // (pass, signatureStatus, locale, nowEpochMillis, telemetry, modifier) — D5:
+        // no showTrustBadge, no showExpired, no expiredOverlay override.
+        assertUserVisibleParamCount("PassFrontKt", "PassFront", expected = 6)
+    }
+
+    @Test
+    fun passBackHasExactlySevenUserVisibleParameters() {
+        // (pass, locale, onUrlIntent, onPhoneIntent, onEmailIntent, telemetry, modifier).
+        // D5 also requires the three intent callbacks to be non-defaulted; that's
+        // structurally enforced because they have no default expressions in source.
+        assertUserVisibleParamCount("PassBackKt", "PassBack", expected = 7)
+    }
+
+    @Test
+    fun boundedImageHasExactlySixUserVisibleParameters() {
+        // (bytes, role, contentDescription, bounds, telemetry, modifier). D5: no
+        // form of `bounds: ImageRenderBounds? = null` that would let a caller opt out.
+        assertUserVisibleParamCount("BoundedImageKt", "BoundedImage", expected = 6)
+    }
+
+    @Test
+    fun boundedImageBoundsParameterIsTheImageRenderBoundsType() {
+        // Belt: locking the count guarantees no extra params; suspenders: confirm the
+        // bounds parameter is in fact the strong type, not e.g. a nullable.
+        val method = findComposable("BoundedImageKt", "BoundedImage")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertThat(typeNames).contains("ImageRenderBounds")
+    }
+
+    @Test
+    fun securitySheetsAllAcceptUiTelemetryGuard() {
+        listOf("B3UrlConfirmSheet", "PhoneConfirmSheet", "EmailConfirmSheet").forEach { name ->
+            val method = findComposable("SecuritySheetsKt", name)
+            val typeNames = method.parameterTypes.map { it.simpleName }
+            assertWithMessage("$name must declare a UiTelemetryGuard parameter")
+                .that(typeNames)
+                .contains("UiTelemetryGuard")
+        }
+    }
+
+    // -- helpers -------------------------------------------------------------------
+
+    private fun findComposable(fileClassSimpleName: String, methodName: String): Method {
+        val klass = Class.forName("is.walt.passes.ui.$fileClassSimpleName")
+        // Kotlin's value-class name mangling appends `-<hash>` to a JVM method name
+        // when the function takes a value-class parameter. `passes-core` exposes
+        // several value classes (`PassLocale`, `PassInstant`, `ImageBytes`,
+        // `ColorValue`), so most of these composables compile to e.g.
+        // `PassFront-I15CzMI`. Match either the bare name or the mangled prefix.
+        return klass.methods
+            .filter { it.name == methodName || it.name.startsWith("$methodName-") }
+            .maxByOrNull { it.parameterCount }
+            ?: error("Composable $fileClassSimpleName.$methodName not found")
+    }
+
+    private fun userVisibleParameterCount(method: Method): Int {
+        // Compose appends `Composer $composer` and `int $changed` (and `int $changed1`
+        // for high-arity functions). Strip them by their JVM type names.
+        val params = method.parameterTypes
+        var count = params.size
+        // Walk backwards stripping Composer and int parameters that are clearly
+        // Compose-synthetic. We stop at the first parameter that is neither Composer
+        // nor a primitive int.
+        var i = params.lastIndex
+        while (i >= 0) {
+            val t = params[i]
+            val isComposer = t.name == "androidx.compose.runtime.Composer"
+            val isInt = t.name == "int"
+            if (!isComposer && !isInt) break
+            count--
+            i--
+        }
+        // The very-last user-visible parameter could legitimately be an `Int`
+        // (e.g. PassFront accepts `nowEpochMillis: Long`, not Int — so this is safe
+        // for our composables). If a future composable adds a trailing `Int` arg,
+        // re-anchor the strip on the Composer parameter only.
+        return count
+    }
+
+    private fun assertUserVisibleParamCount(
+        fileClassSimpleName: String,
+        methodName: String,
+        expected: Int,
+    ) {
+        val method = findComposable(fileClassSimpleName, methodName)
+        val actual = userVisibleParameterCount(method)
+        assertWithMessage(
+            "$methodName user-visible parameter count drifted; review ADR 0003 D5 " +
+                "before changing this number. Full method signature: $method",
+        )
+            .that(actual)
+            .isEqualTo(expected)
+    }
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -1,0 +1,296 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.ImageBytes
+import `is`.walt.passes.core.ImageRole
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed Compose smoke tests for the trust-claim-bearing surfaces.
+ *
+ * Each test exercises a single surface and asserts the audit-relevant property,
+ * not visual fidelity. Screenshot / pixel-level coverage is the implementation
+ * bead's emulator-backed instrumentation work; here we lock the behavioral
+ * contract: badge appears, overlay appears, security sheets show the verbatim
+ * target, telemetry fires the documented events.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class TrustClaimSurfaceTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val telemetry = RecordingGuard()
+
+    private val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = ArgbColor(0xFFFFE0E0.toInt()),
+            unsignedForeground = ArgbColor(0xFF101010.toInt()),
+            selfSignedBackground = ArgbColor(0xFFFFF0E0.toInt()),
+            selfSignedForeground = ArgbColor(0xFF101010.toInt()),
+            appleVerifiedBackground = ArgbColor(0xFFE0FFE0.toInt()),
+            appleVerifiedForeground = ArgbColor(0xFF101010.toInt()),
+            certChainIncompleteBackground = ArgbColor(0xFFFFFFE0.toInt()),
+            certChainIncompleteForeground = ArgbColor(0xFF101010.toInt()),
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = ArgbColor(0xFF202020.toInt()),
+            pillForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = ArgbColor(0xFFFFFFFF.toInt()),
+            emphasisBackground = ArgbColor(0xFFEFEFEF.toInt()),
+            emphasisForeground = ArgbColor(0xFF000000.toInt()),
+            bodyForeground = ArgbColor(0xFF202020.toInt()),
+            confirmContainer = ArgbColor(0xFF202020.toInt()),
+            confirmForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            cancelForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = ArgbColor(0xFF1D4ED8.toInt()),
+            eventTicket = ArgbColor(0xFF7C2D92.toInt()),
+            coupon = ArgbColor(0xFF555555.toInt()),
+            storeCard = ArgbColor(0xFF555555.toInt()),
+            generic = ArgbColor(0xFF555555.toInt()),
+        ),
+    )
+
+    @Test
+    fun trustBadgeIsVisibleAndBoundToSignatureStatus() {
+        composeRule.setContent {
+            ThemedHost {
+                PassFront(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.AppleVerified,
+                    nowEpochMillis = 0L,
+                    telemetry = telemetry,
+                )
+            }
+        }
+        composeRule.onNodeWithText("Verified").assertIsDisplayed()
+    }
+
+    @Test
+    fun trustBadgeUnsignedCopy() = trustBadgeCopy(SignatureStatus.Unsigned, "Unsigned")
+    @Test
+    fun trustBadgeSelfSignedCopy() = trustBadgeCopy(SignatureStatus.SelfSigned, "Self-signed")
+    @Test
+    fun trustBadgeIncompleteCopy() = trustBadgeCopy(SignatureStatus.CertChainIncomplete, "Signature unknown")
+
+    private fun trustBadgeCopy(status: SignatureStatus, expected: String) {
+        composeRule.setContent {
+            ThemedHost {
+                PassFront(
+                    pass = passFixture(),
+                    signatureStatus = status,
+                    nowEpochMillis = 0L,
+                    telemetry = telemetry,
+                )
+            }
+        }
+        composeRule.onNodeWithText(expected).assertIsDisplayed()
+    }
+
+    @Test
+    fun expiredOverlayShowsForExpiredPass() {
+        composeRule.setContent {
+            ThemedHost {
+                ExpiredOverlay(state = ExpiredOverlayState.Expired(PassInstant(0L)))
+            }
+        }
+        composeRule.onNodeWithText("Expired").assertIsDisplayed()
+    }
+
+    @Test
+    fun voidedOverlayShowsForVoidedPass() {
+        composeRule.setContent {
+            ThemedHost {
+                ExpiredOverlay(state = ExpiredOverlayState.Voided)
+            }
+        }
+        composeRule.onNodeWithText("Voided").assertIsDisplayed()
+    }
+
+    @Test
+    fun expiredOverlayRendersNothingForValidPass() {
+        composeRule.setContent {
+            ThemedHost {
+                ExpiredOverlay(state = ExpiredOverlayState.None)
+                Text("sentinel")
+            }
+        }
+        composeRule.onNodeWithText("sentinel").assertIsDisplayed()
+    }
+
+    @Test
+    fun securitySheetVerbatimUrlAndConfirmTelemetry() {
+        var confirmed = 0
+        var dismissed = 0
+        val intent = B3UrlIntent(
+            url = "https://example.com/help",
+            sourceField = SourceField("support", "Support", "Acme"),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                B3UrlConfirmSheet(
+                    intent = intent,
+                    passType = PassType.BoardingPass,
+                    telemetry = telemetry,
+                    onConfirm = { confirmed++ },
+                    onDismiss = { dismissed++ },
+                )
+            }
+        }
+        // Sheet shows the verbatim URL and the show-telemetry has fired.
+        composeRule.onNodeWithText("https://example.com/help").assertIsDisplayed()
+        composeRule.waitForIdle()
+
+        assertThat(telemetry.events).contains("shown:Url:BoardingPass")
+        assertThat(confirmed).isEqualTo(0)
+        assertThat(dismissed).isEqualTo(0)
+    }
+
+    @Test
+    fun securitySheetVerbatimPhone() {
+        val intent = PhoneIntent(
+            phoneNumber = "+1 (555) 123-4567",
+            sourceField = SourceField("phone", "Phone", "Acme"),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                PhoneConfirmSheet(
+                    intent = intent,
+                    passType = PassType.EventTicket,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("+1 (555) 123-4567").assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertThat(telemetry.events).contains("shown:Phone:EventTicket")
+    }
+
+    @Test
+    fun securitySheetVerbatimEmail() {
+        val intent = EmailIntent(
+            emailAddress = "support@example.com",
+            sourceField = SourceField("email", "Email", "Acme"),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                EmailConfirmSheet(
+                    intent = intent,
+                    passType = PassType.Coupon,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("support@example.com").assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertThat(telemetry.events).contains("shown:Email:Coupon")
+    }
+
+    @Test
+    fun boundedImageDecoderRejectsOversizedInput() {
+        // Tests the decoder driver directly rather than going through the composable,
+        // since Robolectric's coroutine harness does not progress `LaunchedEffect`
+        // dispatched onto `Dispatchers.IO` to completion within `waitForIdle()`. The
+        // composable is exercised on a real device by the implementation bead's
+        // instrumentation tests; here we lock the JVM-pure decode-and-classify logic
+        // that the composable wraps.
+        //
+        // Robolectric's ImageDecoder shadow returns a stub bitmap (typically 100 x 100
+        // for arbitrary input rather than rejecting the malformed bytes), so we use
+        // pathologically tight bounds (1 x 1 / 1 px area) to force the bounds-check
+        // path. Any non-empty bitmap exceeds these caps; the rejection reason should
+        // be one of the bounds arms, not Malformed or Other.
+        val anyBytes = ByteArray(64) { (it * 31).toByte() }
+        val tightBounds = ImageRenderBounds(maxWidthPx = 1, maxHeightPx = 1, maxAreaPx = 1L)
+        val (_, rejection) = decodeBoundedBitmap(anyBytes, tightBounds)
+        assertThat(rejection).isNotNull()
+        assertThat(rejection!!.name).matches("ExceedsWidth|ExceedsHeight|ExceedsArea")
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme {
+            PassesTheme(semantics = semantics, content = content)
+        }
+    }
+
+    private fun passFixture(
+        type: PassType = PassType.Generic,
+        expirationDate: PassInstant? = null,
+        voided: Boolean = false,
+    ): Pass = Pass(
+        type = type,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = "Acme",
+        expirationDate = expirationDate,
+        voided = voided,
+        colors = PassColors(
+            foreground = ColorValue(0x000000),
+            background = ColorValue(0xFFFFFF),
+            label = ColorValue(0x444444),
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = "From", value = "JFK")),
+        ),
+        backFields = emptyList(),
+        barcode = null,
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+}
+
+private class RecordingGuard : UiTelemetryGuard {
+    val events: MutableList<String> = mutableListOf()
+    override fun onPassRendered(type: PassType, signatureBand: SignatureBand) {
+        events += "rendered:${type.name}:${signatureBand.name}"
+    }
+    override fun onPassBackOpened(type: PassType) { events += "back:${type.name}" }
+    override fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType) {
+        events += "shown:${intentKind.name}:${type.name}"
+    }
+    override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType) {
+        events += "confirm:${intentKind.name}:${type.name}"
+    }
+    override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType) {
+        events += "dismiss:${intentKind.name}:${type.name}"
+    }
+    override fun onImageDecodeRejected(reason: ImageDecodeRejection) {
+        events += "decode:${reason.name}"
+    }
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -168,8 +168,13 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        // Sheet shows the verbatim URL and the show-telemetry has fired.
-        composeRule.onNodeWithText("https://example.com/help").assertIsDisplayed()
+        // Sheet shows the verbatim URL (substring match because the actual displayed
+        // text is wrapped in FSI/PDI bidi isolates — see the dedicated isolation tests
+        // below for that property) and the show-telemetry has fired.
+        composeRule.onNodeWithText(
+            "https://example.com/help",
+            substring = true,
+        ).assertIsDisplayed()
         composeRule.waitForIdle()
 
         assertThat(telemetry.events).contains("shown:Url:BoardingPass")
@@ -194,7 +199,7 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        composeRule.onNodeWithText("+1 (555) 123-4567").assertIsDisplayed()
+        composeRule.onNodeWithText("+1 (555) 123-4567", substring = true).assertIsDisplayed()
         composeRule.waitForIdle()
         assertThat(telemetry.events).contains("shown:Phone:EventTicket")
     }
@@ -216,9 +221,60 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        composeRule.onNodeWithText("support@example.com").assertIsDisplayed()
+        composeRule.onNodeWithText("support@example.com", substring = true).assertIsDisplayed()
         composeRule.waitForIdle()
         assertThat(telemetry.events).contains("shown:Email:Coupon")
+    }
+
+    @Test
+    fun securitySheetUrlIsBidiIsolated() {
+        // Defense-in-depth: even after the scanner rejects bidi-bearing matches, the
+        // sheet wraps the displayed URL in U+2068...U+2069 (FSI/PDI) so any residual
+        // directional context from surrounding chrome cannot reorder the URL glyphs.
+        val intent = B3UrlIntent(
+            url = "https://example.com/help",
+            sourceField = SourceField("support", "Support", "Acme"),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                B3UrlConfirmSheet(
+                    intent = intent,
+                    passType = PassType.BoardingPass,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        // The displayed text is FSI + url + PDI. Look up by the full isolated form.
+        val isolatedUrl = "⁨https://example.com/help⁩"
+        composeRule.onNodeWithText(isolatedUrl).assertIsDisplayed()
+    }
+
+    @Test
+    fun securitySheetIsolatesOrganizationName() {
+        // The organization name comes from the parsed pass and is rendered in the
+        // sheet's body line. A bidi character in the org name must not reorder
+        // surrounding chrome text. Test by verifying the org name displays inside
+        // the FSI/PDI fence.
+        val intent = B3UrlIntent(
+            url = "https://example.com",
+            sourceField = SourceField("support", "Support", "Acme Corp"),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                B3UrlConfirmSheet(
+                    intent = intent,
+                    passType = PassType.BoardingPass,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "⁨Acme Corp⁩ — ⁨Support⁩",
+        ).assertIsDisplayed()
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
@@ -5,6 +5,7 @@ import `is`.walt.passes.ui.EmailIntent
 import `is`.walt.passes.ui.PhoneIntent
 import `is`.walt.passes.ui.SourceField
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import org.junit.Test
 
 class FieldLinkScannerTest {
@@ -129,5 +130,138 @@ class FieldLinkScannerTest {
         FieldLinkScanner.scan(pathological, source)
         val elapsedMs = (System.nanoTime() - start) / 1_000_000
         assertThat(elapsedMs).isLessThan(500L)
+    }
+
+    // -- Bidi / formatting-control rejection ------------------------------------
+    //
+    // The auditor scenario: an adversary embeds U+202E (Right-to-Left Override) in a
+    // URL so the sheet renders one host visually while `Uri.parse` resolves another.
+    // The scanner MUST refuse to detect such URLs as URLs, and the value handed into
+    // `B3UrlIntent.url` MUST be byte-identical to the substring that matched the
+    // regex (no silent Cf-stripping, which would itself violate the
+    // "displayed string equals actionable string" claim by changing the bytes the
+    // host opens versus what the user saw).
+
+    @Test
+    fun urlContainingRightToLeftOverrideIsRejected() {
+        val attack = "https://attacker.example/‮gpj.elgoog//:sptth"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun urlContainingZeroWidthSpaceIsRejected() {
+        val attack = "https://goog​le.com/path"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun urlContainingLeftToRightMarkIsRejected() {
+        val attack = "https://example.com/‎path"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun urlContainingArabicLetterMarkIsRejected() {
+        val attack = "https://example.com/؜path"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun urlContainingControlCharIsRejected() {
+        val attack = "https://example.com/beep"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun emailContainingBidiCharIsRejected() {
+        // Email's character class is already ASCII-only so the regex itself excludes
+        // bidi chars, but lock the property via the post-filter so a future regex
+        // relaxation cannot regress.
+        val attack = "support‮@example.com"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun phoneContainingBidiCharIsRejected() {
+        // Phone is similarly ASCII-only; same lock.
+        val attack = "+1 555‮ 123 4567"
+        val spans = FieldLinkScanner.scan(attack, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun cleanAdjacentToBidiHostileSurfacesNothingFromTheField() {
+        // Field-level rejection: if any rendering hazard appears anywhere in the
+        // field, ALL detection is dropped. The user is forced to act manually
+        // outside the auto-link path. The clean URL is collateral damage; the
+        // alternative (still surfacing the clean one) leaves the user reading the
+        // bidi-reordered field and tapping a link with no clear association.
+        val mixed = "Visit https://example.com or https://attacker.example/‮gpj.elgoog//:sptth"
+        val spans = FieldLinkScanner.scan(mixed, source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun urlBytesAreVerbatimNoCfStripping() {
+        // A clean URL passes through unchanged. The explicit byte-equality check
+        // guards the trust claim that the displayed string equals the actionable
+        // string — if the scanner ever sanitizes inputs (e.g. by stripping Cf
+        // characters), the displayed and actioned strings would diverge.
+        val clean = "https://example.com/path?q=1"
+        val spans = FieldLinkScanner.scan(clean, source)
+        val intent = spans.single().intent as B3UrlIntent
+        assertThat(intent.url).isEqualTo(clean)
+    }
+
+    @Test
+    fun percentEncodedBidiInUrlIsAccepted() {
+        // %E2%80%AE is the percent-encoding of U+202E. After percent-decoding, the
+        // URL would contain a bidi char; pre-decoding, the bytes are pure ASCII and
+        // safe to render. This is the legitimate way for a pass author to include
+        // non-ASCII data in a URL — the renderer never sees the decoded form.
+        val url = "https://example.com/%E2%80%AEsomething"
+        val spans = FieldLinkScanner.scan(url, source)
+        assertThat(spans).hasSize(1)
+        val intent = spans.single().intent as B3UrlIntent
+        assertThat(intent.url).isEqualTo(url)
+    }
+
+    @Test
+    fun containsRenderingHazardCoversFormatAndControlCategories() {
+        // Direct check on the helper so the categorization is locked even if regexes
+        // change. The category enum is the source of truth.
+        listOf(
+            "‮", // Right-to-Left Override (Cf)
+            "‭", // Left-to-Right Override (Cf)
+            "⁦", // Left-to-Right Isolate (Cf)
+            "⁧", // Right-to-Left Isolate (Cf)
+            "⁨", // First Strong Isolate (Cf)
+            "⁩", // Pop Directional Isolate (Cf)
+            "​", // Zero Width Space (Cf)
+            "‎", // Left-to-Right Mark (Cf)
+            "‏", // Right-to-Left Mark (Cf)
+            "؜", // Arabic Letter Mark (Cf)
+            "﻿", // Zero-Width No-Break Space / BOM (Cf)
+            " ", // NUL (Cc)
+            "", // BEL (Cc)
+            "", // ESC (Cc)
+        ).forEach { hazard ->
+            val codepoint = "U+%04X".format(hazard.first().code)
+            assertWithMessage("$codepoint must be flagged as rendering hazard")
+                .that(FieldLinkScanner.containsRenderingHazard("safe$hazard"))
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun containsRenderingHazardAcceptsPlainAscii() {
+        assertThat(FieldLinkScanner.containsRenderingHazard("https://example.com/path"))
+            .isFalse()
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
@@ -96,4 +96,38 @@ class FieldLinkScannerTest {
         val spans = FieldLinkScanner.scan("https://example.com", source)
         assertThat(spans.single().intent.sourceField).isEqualTo(source)
     }
+
+    /**
+     * Tripwire for ReDoS / catastrophic-backtracking in the phone-number regex. The
+     * phone pattern uses a quantified character class with optional digit boundary;
+     * a hostile back-field could in principle force quadratic-or-worse backtracking.
+     * This test feeds a 4 KB digit-soup field that has no valid match anchor, with a
+     * generous 500 ms budget. Real linear-ish behavior completes in under a few ms;
+     * exponential pathology would blow this budget by orders of magnitude.
+     */
+    @Test
+    fun phoneScanCompletesQuicklyOnPathologicalInput() {
+        val pathological = buildString {
+            repeat(4096) { append((it % 10).digitToChar()) }
+        }
+        val start = System.nanoTime()
+        FieldLinkScanner.scan(pathological, source)
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+        assertThat(elapsedMs).isLessThan(500L)
+    }
+
+    @Test
+    fun mixedAlphaDigitSoupCompletesQuickly() {
+        val pathological = buildString {
+            repeat(2048) {
+                append((it % 10).digitToChar())
+                append(' ')
+                append('-')
+            }
+        }
+        val start = System.nanoTime()
+        FieldLinkScanner.scan(pathological, source)
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+        assertThat(elapsedMs).isLessThan(500L)
+    }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
@@ -1,0 +1,99 @@
+package `is`.walt.passes.ui.internal
+
+import `is`.walt.passes.ui.B3UrlIntent
+import `is`.walt.passes.ui.EmailIntent
+import `is`.walt.passes.ui.PhoneIntent
+import `is`.walt.passes.ui.SourceField
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FieldLinkScannerTest {
+
+    private val source = SourceField(
+        fieldKey = "support_url",
+        fieldLabel = "Support",
+        organizationName = "Acme",
+    )
+
+    @Test
+    fun detectsHttpsUrl() {
+        val spans = FieldLinkScanner.scan(
+            "Visit https://acme.example/help for assistance.",
+            source,
+        )
+        assertThat(spans).hasSize(1)
+        val span = spans.single()
+        assertThat(span.intent).isInstanceOf(B3UrlIntent::class.java)
+        assertThat((span.intent as B3UrlIntent).url).isEqualTo("https://acme.example/help")
+    }
+
+    @Test
+    fun detectsHttpUrl() {
+        val spans = FieldLinkScanner.scan("http://example.com/x", source)
+        assertThat(spans.single().intent).isInstanceOf(B3UrlIntent::class.java)
+    }
+
+    @Test
+    fun doesNotDetectSchemeLessUrl() {
+        val spans = FieldLinkScanner.scan("acme.example", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun detectsEmail() {
+        val spans = FieldLinkScanner.scan("Email support@acme.example for help", source)
+        assertThat(spans.single().intent).isInstanceOf(EmailIntent::class.java)
+        assertThat((spans.single().intent as EmailIntent).emailAddress)
+            .isEqualTo("support@acme.example")
+    }
+
+    @Test
+    fun detectsInternationalPhone() {
+        val spans = FieldLinkScanner.scan("Call us at +1 (555) 123-4567 anytime.", source)
+        assertThat(spans.single().intent).isInstanceOf(PhoneIntent::class.java)
+        assertThat((spans.single().intent as PhoneIntent).phoneNumber)
+            .isEqualTo("+1 (555) 123-4567")
+    }
+
+    @Test
+    fun rejectsShortDigitRunsAsPhone() {
+        // 5 digits: too short to be a phone number
+        val spans = FieldLinkScanner.scan("Promo code 12345", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun emailInsideUrlIsNotDoubleClaimed() {
+        val spans = FieldLinkScanner.scan("https://x@example.com/path", source)
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().intent).isInstanceOf(B3UrlIntent::class.java)
+    }
+
+    @Test
+    fun multipleLinksReturnInOrder() {
+        val text = "Site https://a.example or call +1-555-123-4567 or mailto:b@c.example."
+        val spans = FieldLinkScanner.scan(text, source)
+        // URL, phone, email (order in the source string).
+        assertThat(spans.map { it.intent::class.simpleName }).containsExactly(
+            "B3UrlIntent",
+            "PhoneIntent",
+            "EmailIntent",
+        ).inOrder()
+    }
+
+    @Test
+    fun targetStringIsVerbatim() {
+        val text = "Reach me at  +44  20  7946  0958 ."
+        val spans = FieldLinkScanner.scan(text, source)
+        val intent = spans.single().intent as PhoneIntent
+        // Trim is applied at the boundary so only the surrounding whitespace is removed;
+        // internal whitespace is preserved verbatim, matching what the user sees.
+        assertThat(intent.phoneNumber).isEqualTo("+44  20  7946  0958")
+    }
+
+    @Test
+    fun sourceFieldIsCarriedThrough() {
+        val spans = FieldLinkScanner.scan("https://example.com", source)
+        assertThat(spans.single().intent.sourceField).isEqualTo(source)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,12 @@
 pluginManagement {
     repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }
@@ -8,6 +15,13 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
     }
 }


### PR DESCRIPTION
## Summary

Closes `wpass-del` (passes-ui implementation, follow-on to the closed skeleton bead `wpass-9vv.4`). Lands the AGP toolchain and the actual Compose composables against the contract fixed in ADR 0003 and `passes-ui/COMPOSABLE_SIGNATURES.md`.

### Build infrastructure

- AGP 9.0.1, Compose BOM 2026.01.00, Kotlin 2.2.21 — matches walt-android's versions to avoid drift.
- `com.android.library` + `org.jetbrains.kotlin.plugin.compose` in `passes-ui` (AGP 9.0 dropped the requirement for `kotlin.android`).
- `minSdk = 28` — the floor for `ImageDecoder.setOnHeaderDecodedListener` (used by `BoundedImage`) and StrongBox-backed Keystore (which `passes-storage` will use).
- ZXing 3.5.3 for barcode rendering. Robolectric 4.14.1 wired for JVM-side Compose tests.
- `google()` repo, `android.useAndroidX`, `android.nonTransitiveRClass` in `gradle.properties`.

### Composables (per ADR 0003)

| File | Surface |
|---|---|
| `theme/PassesTheme.kt` | `PassesTheme(...) { content() }` + `LocalPassesSemantics` (fail-fast outside scope). |
| `ExpiredOverlay.kt` | Non-suppressible; no `enabled` parameter (D5). |
| `BarcodeView.kt` | ZXing wrapper. Minimum scannable size: 240 dp QR/Aztec, 320 x 96 dp PDF417/Code128. |
| `BoundedImage.kt` | `ImageDecoder.setOnHeaderDecodedListener` path. Bounds rejection reported via `UiTelemetryGuard.onImageDecodeRejected`. Decode-failure → empty placeholder, never throws. |
| `SecuritySheets.kt` | `B3UrlConfirmSheet` / `PhoneConfirmSheet` / `EmailConfirmSheet` as `ModalBottomSheet`s with verbatim target panel and show/confirm/dismiss telemetry. |
| `PassFront.kt` | Per-`PassType` layouts. Per-pass colors override `MaterialTheme` on the pass surface only (D4). Trust badge composited unconditionally. |
| `PassBack.kt` | `FieldLinkScanner` detects URLs / phones / emails; tappable spans fire the matching `SecurityIntent` callback. Callbacks not defaulted (D5). |
| `internal/FieldLinkScanner.kt` | Conservative regex scan. URLs require `http(s)://`; phones require ≥7 digits; emails require RFC-shaped local + domain. Verbatim target preserved. |

### Tests

- `FieldLinkScannerTest` (JVM, 9 cases): URL / email / phone detection, no-scheme URL rejection, short-digit phone rejection, email-inside-URL guard, multi-link ordering, verbatim-target invariant, source-field passthrough.
- Existing `PublicApiSurfaceTest` (10 cases) continues to lock the contract types.

### Setup notes for reviewers

The repo now requires an Android SDK at `/opt/homebrew/share/android-commandlinetools` (the path walt-android already uses). `local.properties` is gitignored. To build locally:

```
brew install --cask android-commandlinetools
yes | sdkmanager --licenses
sdkmanager "platforms;android-36" "build-tools;36.0.0" "platform-tools"
echo "sdk.dir=/opt/homebrew/share/android-commandlinetools" > local.properties
```

## Test plan

- [x] `./gradlew :passes-ui:compileDebugKotlin` — green.
- [x] `./gradlew :passes-ui:testDebugUnitTest` — 19 tests pass (10 surface lock + 9 link scanner).
- [x] `./gradlew check` — green across passes-core, passes-storage, passes-ui.
- [ ] Follow-on bead: instrumentation tests for security-sheet interaction (ComposeTestRule + ActivityScenario), screenshot tests per `PassType`, decode-bomb instrumentation test feeding an oversized PNG. Robolectric is wired but not yet exercised in this PR.
- [ ] Follow-on bead: replace `ClickableText` (deprecated) with the new `LinkAnnotation.Clickable` API.