### PR TITLE
Implement passes-storage: AGP, SQLCipher, Keystore, manifest XMLs

### DIFF
--- a/docs/adr/0002-passes-storage.md
+++ b/docs/adr/0002-passes-storage.md
@@ -29,7 +29,11 @@ Rationale: a per-pass key scheme would add complexity (key directory, per-row un
 
 ### D2. The database key is wrapped, not derived
 
-The DB key is generated once at first open as 32 random bytes from `SecureRandom`, then wrapped (AES-256-GCM) with a master key resident in Android Keystore. The wrapped blob and its IV are stored in the `schema_meta` table. On subsequent opens, the wrapped blob is unwrapped via Keystore and the resulting raw bytes are passed to SQLCipher's `PRAGMA key`.
+The DB key is generated once at first open as 32 random bytes from `SecureRandom`, then wrapped (AES-256-GCM) with a master key resident in Android Keystore. The wrapped blob and its IV are persisted in a private SharedPreferences file (`is.walt.passes.storage.key_envelope`) outside the SQLCipher database itself. On subsequent opens, the wrapped blob is unwrapped via Keystore and the resulting raw bytes are passed to SQLCipher's `PRAGMA key`.
+
+The envelope MUST live outside the encrypted database it unlocks: storing it inside `schema_meta` would create a chicken-and-egg (you would need the DB key to read schema_meta, but the schema_meta entry IS the DB key). The earlier draft of this ADR placed the envelope in `schema_meta`; the implementation bead corrected this to a SharedPreferences file. The envelope is itself ciphertext under a Keystore-resident, non-exportable master, so the SharedPreferences file's lack of file-level encryption does not weaken the trust claim. The same `walt_passes_backup_rules.xml` / `walt_passes_data_extraction_rules.xml` rules exclude this preferences file from cloud backup and device-to-device transfer (the SharedPreferences domain is opted out alongside the database).
+
+The envelope is written synchronously (`commit()`, not async `apply()`) before the unwrapped DB key is handed to SQLCipher. A crash between an async write and the disk flush would leave SQLCipher pages encrypted with a key whose envelope was never persisted, irreversibly bricking the at-rest data on next launch.
 
 Why wrapped, not Keystore-derived directly: Android Keystore does not export raw symmetric key bytes for AES keys (the keys are non-exportable by design). SQLCipher requires a raw 32-byte key to derive its page key via PBKDF2. Wrapping is the bridge: the master key never leaves Keystore (so hardware-backing applies), and the unwrapped DB key is held in process memory only as long as the database is open.
 
@@ -133,13 +137,14 @@ Rationale: matches CLAUDE.md's `Result<T> over exceptions` rule and gives the co
 Public-API types of `passes-storage`:
 
 - `PassRepository` interface
-- `PassKeyProvider` interface (the Keystore-backed implementation is an internal class produced by `AndroidKeystorePassKeyProvider.create(context)`)
+- `PassKeyProvider` interface (the Keystore-backed implementation is the `AndroidKeystorePassKeyProvider` class, public-but-only-constructable-via-`create(context)`)
 - `StorageResult`, `StorageError` sealed interfaces
 - `StoredPass`, `PassSummary` data classes
 - `StorageTelemetryGuard` interface and its event types
 - `KeyBacking` enum
+- `BackupRulesAssertion.assertBackupRulesApplied(context)` helper, so consumer instrumentation tests can verify the manifest-merge in CI
 
-Internal-only: SQLCipher cursor handling, PRAGMA invocation, manifest assertion helpers, the `AndroidKeystorePassKeyProvider` class body.
+Internal-only: SQLCipher cursor handling, PRAGMA invocation, the `AndroidKeystorePassKeyProvider` class body, the `SqlCipherPassRepository` class body. (An earlier draft listed manifest-assertion helpers as internal-only; the implementation bead promoted `BackupRulesAssertion` to the public surface so the trust claim "rules are applied" is checkable from the consumer's instrumentation test suite.)
 
 Rationale: walt-android's `core/data-passes` wraps `PassRepository` behind a Hilt-provided binding; if `passes-storage` leaks `SQLiteDatabase` or `Cursor` into the public API, walt-android picks up an incidental dependency on those types and the contract gets harder to swap (e.g. for an in-memory test double). Keeping the surface narrow keeps the contract testable on the JVM with a fake `PassKeyProvider` and an in-memory SQLite.
 
@@ -155,21 +160,22 @@ sequenceDiagram
 
     UI->>Repo: open()
     Repo->>KP: provideDatabaseKey()
-    KP->>DB: read schema_meta(wrapped_db_key, iv, alias)
+    KP->>KP: read SharedPreferences(envelope)
     alt first launch
         KP->>KS: getOrCreateMasterKey(alias, StrongBox preferred)
         KS-->>KP: SecretKey handle (non-exportable)
         KP->>KP: dbKey = SecureRandom 32 bytes
         KP->>KS: AES-256-GCM wrap(dbKey)
         KS-->>KP: wrappedBlob, iv
-        KP->>DB: write schema_meta entries
+        KP->>KP: SharedPreferences.commit(envelope)  // synchronous, fsync-bounded
     else subsequent launches
         KP->>KS: AES-256-GCM unwrap(wrappedBlob, iv)
         KS-->>KP: dbKey (raw 32 bytes, in-process)
     end
     KP-->>Repo: dbKey
-    Repo->>DB: PRAGMA key = x'<hex(dbKey)>'
+    Repo->>DB: openOrCreateDatabase(path, dbKey)
     Repo->>DB: PRAGMA cipher_compatibility = 4
+    Repo->>DB: PRAGMA foreign_keys = ON
     Repo->>Repo: zero out dbKey from local buffers
     Note over Repo,DB: Repo holds an open SQLiteDatabase handle;<br/>raw key bytes live only inside SQLCipher's internal page-key derivation buffer.
 ```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ zxing = "3.5.3"
 robolectric = "4.14.1"
 androidxJunit = "1.3.0"
 androidxEspressoCore = "3.7.0"
-sqlcipher = "4.5.4"
+sqlcipher = "4.6.1"
 androidxStartup = "1.2.0"
 xerial = "3.46.0.0"
 
@@ -51,8 +51,10 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
 
-# SQLCipher (Android-only) — encrypted SQLite at rest.
-sqlcipher-android = { group = "net.zetetic", name = "android-database-sqlcipher", version.ref = "sqlcipher" }
+# SQLCipher (Android-only) — encrypted SQLite at rest. Uses the current
+# `net.zetetic:sqlcipher-android` artifact; the older `android-database-sqlcipher` line
+# is deprecated upstream and no longer carries CVE backports.
+sqlcipher-android = { group = "net.zetetic", name = "sqlcipher-android", version.ref = "sqlcipher" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxStartup" }
 # SQLCipher's SQLiteDatabase implements androidx.sqlite's SupportSQLiteDatabase as of 4.5.x;
 # this brings that supertype onto the compile classpath so Kotlin can resolve the hierarchy.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,9 @@ zxing = "3.5.3"
 robolectric = "4.14.1"
 androidxJunit = "1.3.0"
 androidxEspressoCore = "3.7.0"
+sqlcipher = "4.5.4"
+androidxStartup = "1.2.0"
+xerial = "3.46.0.0"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -47,6 +50,16 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 # Instrumentation
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspressoCore" }
+
+# SQLCipher (Android-only) — encrypted SQLite at rest.
+sqlcipher-android = { group = "net.zetetic", name = "android-database-sqlcipher", version.ref = "sqlcipher" }
+androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "androidxStartup" }
+# SQLCipher's SQLiteDatabase implements androidx.sqlite's SupportSQLiteDatabase as of 4.5.x;
+# this brings that supertype onto the compile classpath so Kotlin can resolve the hierarchy.
+androidx-sqlite = { group = "androidx.sqlite", name = "sqlite", version = "2.5.2" }
+
+# JVM-side schema-DDL test driver.
+xerial-sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "xerial" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/passes-storage/build.gradle.kts
+++ b/passes-storage/build.gradle.kts
@@ -1,22 +1,37 @@
-// JVM-only today. The implementation bead replaces this with the Android library plugin
-// to bring in SQLCipher and Android Keystore. The public-API types defined here are
-// intentionally Android-agnostic so that test doubles and the JVM CI host can exercise them
-// without an Android device.
-
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+android {
+    namespace = "is.walt.passes.storage"
+    compileSdk = 36
+
+    defaultConfig {
+        // StrongBox-backed Keystore lands at API 28; aligning with passes-ui (also minSdk 28)
+        // keeps the trust-claim story consistent across the three modules.
+        minSdk = 28
+
+        consumerProguardFiles("consumer-rules.pro")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 
 kotlin {
     explicitApi()
     compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         freeCompilerArgs.addAll("-Xjvm-default=all")
     }
 }
@@ -26,11 +41,19 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 
+    // SQLCipher: encrypted SQLite at rest. ADR 0002 D1/D2.
+    implementation(libs.sqlcipher.android)
+    implementation(libs.androidx.sqlite)
+
+    // JVM-side tests: schema-DDL via xerial sqlite-jdbc; Robolectric for the StateFlow +
+    // delete contract (no SQLCipher native libs needed — the repo is constructed with an
+    // in-memory PassStore fake that exercises the contract without touching JNI).
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
-}
+    testImplementation(libs.robolectric)
+    testImplementation(libs.xerial.sqlite.jdbc)
+    testImplementation(libs.androidx.test.junit)
 
-tasks.test {
-    useJUnit()
+    androidTestImplementation(libs.androidx.test.junit)
 }

--- a/passes-storage/consumer-rules.pro
+++ b/passes-storage/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Consumer ProGuard rules contributed by passes-storage.
+# Empty for now: the public API surface uses no reflective constructs that R8 would
+# strip, and SQLCipher ships its own consumer rules through the AAR.

--- a/passes-storage/src/main/AndroidManifest.xml
+++ b/passes-storage/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  passes-storage library manifest. Contributes backup-exclusion rules to the consumer's
+  merged manifest per ADR 0002 D5. The library deliberately does NOT set
+  android:allowBackup="false" — that is a process-wide setting and walt-android may
+  legitimately back up other (non-pass) data. Pass-database exclusion is delivered by
+  the rules files referenced below; consumers can verify the merge with
+  `BackupRulesAssertion.assertBackupRulesApplied(context)`.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:fullBackupContent="@xml/walt_passes_backup_rules"
+        android:dataExtractionRules="@xml/walt_passes_data_extraction_rules"
+        tools:targetApi="31" />
+
+</manifest>

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
@@ -19,17 +19,14 @@ import javax.crypto.spec.GCMParameterSpec
 /**
  * Android-only `PassKeyProvider`. Owns the master AES-256 key in Android Keystore (StrongBox
  * preferred, TEE fallback, software last) and the AES-GCM-wrapped 32-byte database key it
- * produces. ADR 0002 D2.
+ * produces.
  *
  * The master key is non-exportable by Keystore design; the wrapping construction is the
  * bridge between "key never leaves hardware" and "SQLCipher needs raw bytes for its page-key
- * derivation." The unwrapped database key is held in process memory only as long as
- * [provideDatabaseKey] is being invoked; callers wrap it in a [DatabaseKey] which zeros its
- * internal buffer when [DatabaseKey.withBytes] returns.
+ * derivation." The unwrapped database key is held in process memory only inside the
+ * [DatabaseKey] returned here; [DatabaseKey.withBytes] zeros its internal buffer on return.
  *
- * The class is `public` so consumer Hilt modules can refer to its `create` factory by name;
- * its constructor is internal so the only construction path is `create(context)`, which runs
- * the key-provisioning flow and returns the typed `StorageResult`.
+ * The constructor is internal; the only construction path is [create].
  */
 public class AndroidKeystorePassKeyProvider internal constructor(
     private val masterKey: SecretKey,
@@ -57,8 +54,8 @@ public class AndroidKeystorePassKeyProvider internal constructor(
                 val envelope = wrap(raw)
                 if (!wrappedKeyStorage.write(envelope, keyBacking)) {
                     // Critical: do NOT proceed to open SQLCipher if the envelope did not
-                    // durably reach disk. Returning a key that exists only in process
-                    // memory would brick the DB on the next launch.
+                    // durably reach disk. A key that lives only in process memory would
+                    // brick the DB on the next launch.
                     raw.fill(0)
                     return StorageResult.Failure(StorageError.KeyUnavailable)
                 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
@@ -46,7 +46,13 @@ public class AndroidKeystorePassKeyProvider internal constructor(
             } else {
                 val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
                 val envelope = wrap(raw)
-                wrappedKeyStorage.write(envelope, keyBacking)
+                if (!wrappedKeyStorage.write(envelope, keyBacking)) {
+                    // Critical: do NOT proceed to open SQLCipher if the envelope did not
+                    // durably reach disk. Returning a key that exists only in process
+                    // memory would brick the DB on the next launch (ADR review #1).
+                    raw.fill(0)
+                    return StorageResult.Failure(StorageError.KeyUnavailable)
+                }
                 StorageResult.Success(DatabaseKey(raw))
             }
         } catch (e: javax.crypto.AEADBadTagException) {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
@@ -1,0 +1,179 @@
+package `is`.walt.passes.storage
+
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyInfo
+import android.security.keystore.KeyProperties
+import android.security.keystore.StrongBoxUnavailableException
+import `is`.walt.passes.storage.internal.WrappedKeyEnvelope
+import `is`.walt.passes.storage.internal.WrappedKeyStorage
+import java.security.KeyStore
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Android-only `PassKeyProvider`. Owns the master AES-256 key in Android Keystore (StrongBox
+ * preferred, TEE fallback, software last) and the AES-GCM-wrapped 32-byte database key it
+ * produces. ADR 0002 D2.
+ *
+ * The master key is non-exportable by Keystore design; the wrapping construction is the
+ * bridge between "key never leaves hardware" and "SQLCipher needs raw bytes for its page-key
+ * derivation." The unwrapped database key is held in process memory only as long as
+ * [provideDatabaseKey] is being invoked; callers wrap it in a [DatabaseKey] which zeros its
+ * internal buffer when [DatabaseKey.withBytes] returns.
+ *
+ * The class is `public` so consumer Hilt modules can refer to its `create` factory by name;
+ * its constructor is internal so the only construction path is `create(context)`, which runs
+ * the key-provisioning flow and returns the typed `StorageResult`.
+ */
+public class AndroidKeystorePassKeyProvider internal constructor(
+    private val masterKey: SecretKey,
+    override val keyBacking: KeyBacking,
+    private val wrappedKeyStorage: WrappedKeyStorage,
+) : PassKeyProvider {
+
+    override fun provideDatabaseKey(): StorageResult<DatabaseKey> {
+        val existing = wrappedKeyStorage.read()
+        return try {
+            if (existing != null) {
+                val raw = unwrap(existing)
+                StorageResult.Success(DatabaseKey(raw))
+            } else {
+                val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
+                val envelope = wrap(raw)
+                wrappedKeyStorage.write(envelope, keyBacking)
+                StorageResult.Success(DatabaseKey(raw))
+            }
+        } catch (e: javax.crypto.AEADBadTagException) {
+            StorageResult.Failure(StorageError.KeyUnwrapFailed)
+        } catch (e: java.security.UnrecoverableKeyException) {
+            StorageResult.Failure(StorageError.KeyUnavailable)
+        } catch (e: java.security.KeyStoreException) {
+            StorageResult.Failure(StorageError.KeyUnavailable)
+        }
+    }
+
+    private fun wrap(raw: ByteArray): WrappedKeyEnvelope {
+        val cipher = Cipher.getInstance(GCM_TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, masterKey)
+        val ciphertext = cipher.doFinal(raw)
+        return WrappedKeyEnvelope(
+            ciphertext = ciphertext,
+            iv = cipher.iv,
+            keyAlias = MASTER_KEY_ALIAS,
+        )
+    }
+
+    private fun unwrap(envelope: WrappedKeyEnvelope): ByteArray {
+        val cipher = Cipher.getInstance(GCM_TRANSFORMATION)
+        val spec = GCMParameterSpec(GCM_TAG_BITS, envelope.iv)
+        cipher.init(Cipher.DECRYPT_MODE, masterKey, spec)
+        return cipher.doFinal(envelope.ciphertext)
+    }
+
+    public companion object {
+        internal const val MASTER_KEY_ALIAS: String = "is.walt.passes.storage.master_key.v1"
+        internal const val GCM_TRANSFORMATION: String = "AES/GCM/NoPadding"
+        internal const val GCM_TAG_BITS: Int = 128
+
+        /**
+         * Provisions the master Keystore alias (creating it on first call) and returns a
+         * provider ready for [PassKeyProvider.provideDatabaseKey]. Reports
+         * [StorageError.KeyUnavailable] if the AndroidKeyStore service refuses to load
+         * (Keystore wiped, lock-screen credential removed on a setup that bound keys to it).
+         */
+        @JvmStatic
+        public fun create(context: Context): StorageResult<AndroidKeystorePassKeyProvider> =
+            createInternal(WrappedKeyStorage.sharedPreferences(context))
+
+        internal fun createInternal(
+            wrappedKeyStorage: WrappedKeyStorage,
+        ): StorageResult<AndroidKeystorePassKeyProvider> {
+            return try {
+                val (key, backing) = getOrCreateMasterKey()
+                StorageResult.Success(
+                    AndroidKeystorePassKeyProvider(
+                        masterKey = key,
+                        keyBacking = backing,
+                        wrappedKeyStorage = wrappedKeyStorage,
+                    ),
+                )
+            } catch (e: java.security.KeyStoreException) {
+                StorageResult.Failure(StorageError.KeyUnavailable)
+            } catch (e: java.security.UnrecoverableKeyException) {
+                StorageResult.Failure(StorageError.KeyUnavailable)
+            } catch (e: java.security.NoSuchProviderException) {
+                StorageResult.Failure(StorageError.KeyUnavailable)
+            }
+        }
+
+        private fun getOrCreateMasterKey(): Pair<SecretKey, KeyBacking> {
+            val keystore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+            val existing = keystore.getKey(MASTER_KEY_ALIAS, null) as? SecretKey
+            val key: SecretKey = existing ?: generateMasterKey()
+            return key to detectBacking(key)
+        }
+
+        private fun generateMasterKey(): SecretKey {
+            val builder = KeyGenParameterSpec.Builder(
+                MASTER_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+
+            // StrongBox is best-effort. P preferred (API 28+); on devices that advertise the
+            // feature but actually fail, fall back to TEE. The library never refuses to run
+            // on emulators or Software-only Keystore implementations: doing so would brick
+            // the wallet during development.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                builder.setIsStrongBoxBacked(true)
+            }
+
+            val gen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+            return try {
+                gen.init(builder.build())
+                gen.generateKey()
+            } catch (e: StrongBoxUnavailableException) {
+                val fallback = KeyGenParameterSpec.Builder(
+                    MASTER_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(256)
+                    .build()
+                gen.init(fallback)
+                gen.generateKey()
+            }
+        }
+
+        private fun detectBacking(key: SecretKey): KeyBacking {
+            return try {
+                val factory = SecretKeyFactory.getInstance(key.algorithm, "AndroidKeyStore")
+                val info = factory.getKeySpec(key, KeyInfo::class.java) as KeyInfo
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    when (info.securityLevel) {
+                        KeyProperties.SECURITY_LEVEL_STRONGBOX -> KeyBacking.StrongBox
+                        KeyProperties.SECURITY_LEVEL_TRUSTED_ENVIRONMENT -> KeyBacking.Tee
+                        KeyProperties.SECURITY_LEVEL_SOFTWARE,
+                        KeyProperties.SECURITY_LEVEL_UNKNOWN_SECURE,
+                        KeyProperties.SECURITY_LEVEL_UNKNOWN -> KeyBacking.Software
+                        else -> KeyBacking.Software
+                    }
+                } else {
+                    @Suppress("DEPRECATION")
+                    if (info.isInsideSecureHardware) KeyBacking.Tee else KeyBacking.Software
+                }
+            } catch (e: Throwable) {
+                KeyBacking.Software
+            }
+        }
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProvider.kt
@@ -35,6 +35,7 @@ public class AndroidKeystorePassKeyProvider internal constructor(
     private val masterKey: SecretKey,
     override val keyBacking: KeyBacking,
     private val wrappedKeyStorage: WrappedKeyStorage,
+    private val databaseFileExists: () -> Boolean,
 ) : PassKeyProvider {
 
     override fun provideDatabaseKey(): StorageResult<DatabaseKey> {
@@ -44,12 +45,20 @@ public class AndroidKeystorePassKeyProvider internal constructor(
                 val raw = unwrap(existing)
                 StorageResult.Success(DatabaseKey(raw))
             } else {
+                // Envelope is missing. If the encrypted DB still exists on disk, the prior
+                // DB key is unrecoverable: generating a fresh one would silently surface
+                // later as DatabaseCorrupt when SQLCipher rejects the wrong key. Surface
+                // KeyUnavailable so the wallet can guide the user through "secure storage
+                // was reset; re-import passes" instead.
+                if (databaseFileExists()) {
+                    return StorageResult.Failure(StorageError.KeyUnavailable)
+                }
                 val raw = ByteArray(32).also { SecureRandom().nextBytes(it) }
                 val envelope = wrap(raw)
                 if (!wrappedKeyStorage.write(envelope, keyBacking)) {
                     // Critical: do NOT proceed to open SQLCipher if the envelope did not
                     // durably reach disk. Returning a key that exists only in process
-                    // memory would brick the DB on the next launch (ADR review #1).
+                    // memory would brick the DB on the next launch.
                     raw.fill(0)
                     return StorageResult.Failure(StorageError.KeyUnavailable)
                 }
@@ -94,11 +103,17 @@ public class AndroidKeystorePassKeyProvider internal constructor(
          * (Keystore wiped, lock-screen credential removed on a setup that bound keys to it).
          */
         @JvmStatic
-        public fun create(context: Context): StorageResult<AndroidKeystorePassKeyProvider> =
-            createInternal(WrappedKeyStorage.sharedPreferences(context))
+        public fun create(context: Context): StorageResult<AndroidKeystorePassKeyProvider> {
+            val dbFile = context.applicationContext.getDatabasePath(Schema.DATABASE_NAME)
+            return createInternal(
+                wrappedKeyStorage = WrappedKeyStorage.sharedPreferences(context),
+                databaseFileExists = { dbFile.exists() },
+            )
+        }
 
         internal fun createInternal(
             wrappedKeyStorage: WrappedKeyStorage,
+            databaseFileExists: () -> Boolean,
         ): StorageResult<AndroidKeystorePassKeyProvider> {
             return try {
                 val (key, backing) = getOrCreateMasterKey()
@@ -107,6 +122,7 @@ public class AndroidKeystorePassKeyProvider internal constructor(
                         masterKey = key,
                         keyBacking = backing,
                         wrappedKeyStorage = wrappedKeyStorage,
+                        databaseFileExists = databaseFileExists,
                     ),
                 )
             } catch (e: java.security.KeyStoreException) {
@@ -126,6 +142,22 @@ public class AndroidKeystorePassKeyProvider internal constructor(
         }
 
         private fun generateMasterKey(): SecretKey {
+            // StrongBox is best-effort. P preferred (API 28+); on devices that advertise the
+            // feature but actually fail, fall back to TEE. The library never refuses to run
+            // on emulators or Software-only Keystore implementations: doing so would brick
+            // the wallet during development.
+            val canRequestStrongBox = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+            return try {
+                generateWithSpec(strongBoxBacked = canRequestStrongBox)
+            } catch (e: StrongBoxUnavailableException) {
+                // KeyGenerator state after a failed init() is undefined per the Keystore
+                // contract; use a fresh instance for the fallback so we are not relying on
+                // implementation-defined recovery behavior.
+                generateWithSpec(strongBoxBacked = false)
+            }
+        }
+
+        private fun generateWithSpec(strongBoxBacked: Boolean): SecretKey {
             val builder = KeyGenParameterSpec.Builder(
                 MASTER_KEY_ALIAS,
                 KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
@@ -133,31 +165,12 @@ public class AndroidKeystorePassKeyProvider internal constructor(
                 .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                 .setKeySize(256)
-
-            // StrongBox is best-effort. P preferred (API 28+); on devices that advertise the
-            // feature but actually fail, fall back to TEE. The library never refuses to run
-            // on emulators or Software-only Keystore implementations: doing so would brick
-            // the wallet during development.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (strongBoxBacked && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 builder.setIsStrongBoxBacked(true)
             }
-
             val gen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
-            return try {
-                gen.init(builder.build())
-                gen.generateKey()
-            } catch (e: StrongBoxUnavailableException) {
-                val fallback = KeyGenParameterSpec.Builder(
-                    MASTER_KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
-                )
-                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                    .setKeySize(256)
-                    .build()
-                gen.init(fallback)
-                gen.generateKey()
-            }
+            gen.init(builder.build())
+            return gen.generateKey()
         }
 
         private fun detectBacking(key: SecretKey): KeyBacking {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -1,0 +1,75 @@
+package `is`.walt.passes.storage
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+
+/**
+ * Verifies that the consumer's merged `AndroidManifest.xml` actually carries the
+ * library-shipped backup-exclusion rules from ADR 0002 D5. Intended for the consumer's
+ * instrumentation test suite; the trust claim "pass data is excluded from cloud backup"
+ * becomes checkable in CI rather than relying on manifest review.
+ *
+ * The assertion only checks that the consumer's `<application>` references rule resources
+ * named `walt_passes_backup_rules` (API 23-30) and `walt_passes_data_extraction_rules`
+ * (API 31+). It does NOT parse the rules XML. Combined with the resources we ship, this
+ * narrows the consumer-side risk to "the consumer overrode our rules with a non-walt
+ * resource of the same name," which is a deliberate act, not an oversight.
+ *
+ * The two ApplicationInfo fields we check (`fullBackupContent` and `dataExtractionRulesRes`)
+ * are hidden public-API fields in recent Android SDKs (greylisted, accessible via
+ * reflection). Using reflection here is intentional: the alternative is parsing the
+ * merged manifest XML by hand, which is more brittle than a hidden-API field whose
+ * semantics have not changed since the feature shipped.
+ */
+public object BackupRulesAssertion {
+    public sealed interface Outcome {
+        public data object Applied : Outcome
+        public data class FullBackupContentMismatch(public val actualResId: Int) : Outcome
+        public data class DataExtractionRulesMissing(public val actualResId: Int) : Outcome
+        public data object PackageInfoUnavailable : Outcome
+        public data object FieldUnavailable : Outcome
+    }
+
+    @JvmStatic
+    public fun assertBackupRulesApplied(context: Context): Outcome {
+        val pm = context.packageManager
+        val appInfo: ApplicationInfo = try {
+            pm.getApplicationInfo(context.packageName, 0)
+        } catch (e: PackageManager.NameNotFoundException) {
+            return Outcome.PackageInfoUnavailable
+        }
+
+        val expectedFullBackup = context.resources
+            .getIdentifier(FULL_BACKUP_CONTENT_RES_NAME, "xml", context.packageName)
+        val actualFullBackup = readIntField(appInfo, "fullBackupContent")
+            ?: return Outcome.FieldUnavailable
+        if (actualFullBackup != expectedFullBackup) {
+            return Outcome.FullBackupContentMismatch(actualFullBackup)
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val expectedDxr = context.resources
+                .getIdentifier(DATA_EXTRACTION_RULES_RES_NAME, "xml", context.packageName)
+            val actualDxr = readIntField(appInfo, "dataExtractionRulesRes")
+                ?: return Outcome.FieldUnavailable
+            if (actualDxr != expectedDxr) {
+                return Outcome.DataExtractionRulesMissing(actualDxr)
+            }
+        }
+        return Outcome.Applied
+    }
+
+    private fun readIntField(target: Any, name: String): Int? = try {
+        val field = target.javaClass.getDeclaredField(name).also { it.isAccessible = true }
+        field.getInt(target)
+    } catch (e: NoSuchFieldException) {
+        null
+    } catch (e: IllegalAccessException) {
+        null
+    }
+
+    internal const val FULL_BACKUP_CONTENT_RES_NAME: String = "walt_passes_backup_rules"
+    internal const val DATA_EXTRACTION_RULES_RES_NAME: String = "walt_passes_data_extraction_rules"
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -53,6 +53,18 @@ public interface PassRepository {
      * Confirmation UI is the caller's responsibility; the repository trusts the call.
      */
     public suspend fun delete(id: PassRecordId): StorageResult<Unit>
+
+    /**
+     * Releases the underlying database connection. Idempotent: calling [close] more than
+     * once is a no-op, and method calls after [close] return [StorageError.DatabaseLocked]
+     * rather than throwing. Intended for consumer paths where the repository's lifetime is
+     * shorter than the process (logout, multi-user switching, instrumentation tear-down).
+     *
+     * The default Hilt-singleton wiring in walt-android does not call [close]; the process
+     * exit reclaims the handle. This method exists so the contract permits explicit
+     * teardown rather than relying on process lifetime alone.
+     */
+    public fun close()
 }
 
 /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -3,11 +3,11 @@ package `is`.walt.passes.storage
 import android.content.Context
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.core.toKind
 import `is`.walt.passes.storage.internal.PassStore
 import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
 import `is`.walt.passes.storage.internal.SqlCipherPassStore
 import `is`.walt.passes.storage.internal.toFailureKind
-import `is`.walt.passes.storage.internal.toSignatureStatusKind
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -20,14 +20,9 @@ import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Production [PassRepository]. Backed by SQLCipher via [SqlCipherPassStore]; the StateFlow,
- * delete sequencing, and telemetry sequencing live here so they can be exercised in
- * isolation against a fake [PassStore] (see test sources).
- *
- * The constructor is internal so the only construction path is [create], which provisions
- * the database key, opens SQLCipher, runs the schema DDL, and seeds the StateFlow from
- * disk. Hilt modules in walt-android's `core/data-passes` bind [PassRepository] to the
- * value returned by this factory.
+ * Production [PassRepository]. The StateFlow, delete sequencing, and telemetry sequencing
+ * live here so they can be exercised against an in-memory fake [PassStore]. The constructor
+ * is internal; [create] is the only construction path.
  */
 public class SqlCipherPassRepository internal constructor(
     private val store: PassStore,
@@ -51,7 +46,6 @@ public class SqlCipherPassRepository internal constructor(
         pass: Pass,
         signatureStatus: SignatureStatus,
     ): StorageResult<PassRecordId> = runIo {
-        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val outcome = writeMutex.withLock {
             val o = store.upsert(pass, signatureStatus, clock())
             _passes.value = store.listSummaries()
@@ -59,28 +53,25 @@ public class SqlCipherPassRepository internal constructor(
         }
         telemetryGuard.onPassUpserted(
             type = pass.type,
-            signatureStatus = signatureStatus.toSignatureStatusKind(),
+            signatureStatus = signatureStatus.toKind(),
             wasReplacement = outcome.wasReplacement,
         )
         StorageResult.Success(outcome.recordId)
     }
 
     override suspend fun load(id: PassRecordId): StorageResult<StoredPass> = runIo {
-        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val stored = store.loadById(id)
             ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(stored)
     }
 
     override suspend fun summaryOf(id: PassRecordId): StorageResult<PassSummary> = runIo {
-        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val summary = store.summaryById(id)
             ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(summary)
     }
 
     override suspend fun delete(id: PassRecordId): StorageResult<Unit> = runIo {
-        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val deleted = writeMutex.withLock {
             val outcome = store.delete(id) ?: return@withLock null
             _passes.value = _passes.value.filterNot { it.id == id }
@@ -89,7 +80,7 @@ public class SqlCipherPassRepository internal constructor(
 
         telemetryGuard.onPassDeleted(
             type = deleted.summary.type,
-            signatureStatus = deleted.summary.signatureStatus.toSignatureStatusKind(),
+            signatureStatus = deleted.summary.signatureStatus.toKind(),
         )
         StorageResult.Success(Unit)
     }
@@ -100,11 +91,6 @@ public class SqlCipherPassRepository internal constructor(
         }
     }
 
-    /**
-     * Single emission point for `StorageResult.Failure`. Every failure-returning code path
-     * routes through here so [StorageTelemetryGuard.onStorageFailure] fires once per
-     * Failure, with the structural arm and (for Unknown) the open-ended kind.
-     */
     private fun <T> failure(error: StorageError): StorageResult<T> {
         telemetryGuard.onStorageFailure(
             kind = error.toFailureKind(),
@@ -115,11 +101,12 @@ public class SqlCipherPassRepository internal constructor(
 
     private suspend inline fun <T> runIo(crossinline block: suspend () -> StorageResult<T>): StorageResult<T> =
         withContext(ioDispatcher) {
+            if (closed.get()) return@withContext failure(StorageError.DatabaseLocked)
             try {
                 block()
             } catch (e: CancellationException) {
-                // Honor structured cancellation. A swallow here would silently break callers
-                // that rely on coroutine cancellation to abort an in-flight load/save.
+                // Honor structured cancellation; swallowing would silently break callers
+                // that rely on it to abort an in-flight load/save.
                 throw e
             } catch (e: Throwable) {
                 failure(
@@ -134,9 +121,7 @@ public class SqlCipherPassRepository internal constructor(
     public companion object {
         /**
          * Provisions SQLCipher with the `keyProvider`'s database key, runs [Schema.DDL] on
-         * first open, and returns a [PassRepository] ready for use. The returned repository
-         * should outlive the wallet activity stack; consumers typically hold the binding
-         * inside a Hilt singleton scope and let process exit reclaim it.
+         * first open, and returns a [PassRepository] ready for use.
          */
         @JvmStatic
         public fun create(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -8,6 +8,7 @@ import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
 import `is`.walt.passes.storage.internal.SqlCipherPassStore
 import `is`.walt.passes.storage.internal.toFailureKind
 import `is`.walt.passes.storage.internal.toSignatureStatusKind
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Production [PassRepository]. Backed by SQLCipher via [SqlCipherPassStore]; the StateFlow,
@@ -36,6 +38,7 @@ public class SqlCipherPassRepository internal constructor(
 ) : PassRepository {
 
     private val writeMutex = Mutex()
+    private val closed = AtomicBoolean(false)
 
     private val _passes: MutableStateFlow<List<PassSummary>> = MutableStateFlow(store.listSummaries())
     override val passes: StateFlow<List<PassSummary>> = _passes.asStateFlow()
@@ -48,6 +51,7 @@ public class SqlCipherPassRepository internal constructor(
         pass: Pass,
         signatureStatus: SignatureStatus,
     ): StorageResult<PassRecordId> = runIo {
+        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val outcome = writeMutex.withLock {
             val o = store.upsert(pass, signatureStatus, clock())
             _passes.value = store.listSummaries()
@@ -62,23 +66,26 @@ public class SqlCipherPassRepository internal constructor(
     }
 
     override suspend fun load(id: PassRecordId): StorageResult<StoredPass> = runIo {
+        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val stored = store.loadById(id)
-            ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+            ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(stored)
     }
 
     override suspend fun summaryOf(id: PassRecordId): StorageResult<PassSummary> = runIo {
+        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val summary = store.summaryById(id)
-            ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+            ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(summary)
     }
 
     override suspend fun delete(id: PassRecordId): StorageResult<Unit> = runIo {
+        if (closed.get()) return@runIo failure(StorageError.DatabaseLocked)
         val deleted = writeMutex.withLock {
             val outcome = store.delete(id) ?: return@withLock null
             _passes.value = _passes.value.filterNot { it.id == id }
             outcome
-        } ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+        } ?: return@runIo failure(StorageError.IntegrityViolation(id))
 
         telemetryGuard.onPassDeleted(
             type = deleted.summary.type,
@@ -87,29 +94,49 @@ public class SqlCipherPassRepository internal constructor(
         StorageResult.Success(Unit)
     }
 
+    override fun close() {
+        if (closed.compareAndSet(false, true)) {
+            store.close()
+        }
+    }
+
+    /**
+     * Single emission point for `StorageResult.Failure`. Every failure-returning code path
+     * routes through here so [StorageTelemetryGuard.onStorageFailure] fires once per
+     * Failure, with the structural arm and (for Unknown) the open-ended kind.
+     */
+    private fun <T> failure(error: StorageError): StorageResult<T> {
+        telemetryGuard.onStorageFailure(
+            kind = error.toFailureKind(),
+            unknownKind = (error as? StorageError.Unknown)?.kind,
+        )
+        return StorageResult.Failure(error)
+    }
+
     private suspend inline fun <T> runIo(crossinline block: suspend () -> StorageResult<T>): StorageResult<T> =
         withContext(ioDispatcher) {
             try {
                 block()
+            } catch (e: CancellationException) {
+                // Honor structured cancellation. A swallow here would silently break callers
+                // that rely on coroutine cancellation to abort an in-flight load/save.
+                throw e
             } catch (e: Throwable) {
-                val unknown = StorageError.Unknown(
-                    kind = UnknownStorageFailureKind.Other,
-                    cause = e,
+                failure(
+                    StorageError.Unknown(
+                        kind = UnknownStorageFailureKind.Other,
+                        cause = e,
+                    ),
                 )
-                telemetryGuard.onStorageFailure(
-                    kind = unknown.toFailureKind(),
-                    unknownKind = unknown.kind,
-                )
-                StorageResult.Failure(unknown)
             }
         }
 
     public companion object {
         /**
          * Provisions SQLCipher with the `keyProvider`'s database key, runs [Schema.DDL] on
-         * first open, and returns a [PassRepository] ready for use. The returned scope-bound
-         * repository should outlive the wallet activity stack; consumers typically hold the
-         * binding inside a Hilt singleton scope.
+         * first open, and returns a [PassRepository] ready for use. The returned repository
+         * should outlive the wallet activity stack; consumers typically hold the binding
+         * inside a Hilt singleton scope and let process exit reclaim it.
          */
         @JvmStatic
         public fun create(
@@ -122,19 +149,16 @@ public class SqlCipherPassRepository internal constructor(
             val keyResult = keyProvider.provideDatabaseKey()
             val key = when (keyResult) {
                 is StorageResult.Success -> keyResult.value
-                is StorageResult.Failure -> return StorageResult.Failure(keyResult.error)
+                is StorageResult.Failure -> {
+                    telemetryGuard.onStorageFailure(
+                        kind = keyResult.error.toFailureKind(),
+                        unknownKind = (keyResult.error as? StorageError.Unknown)?.kind,
+                    )
+                    return StorageResult.Failure(keyResult.error)
+                }
             }
-            return try {
-                val db = SqlCipherDatabaseFactory.openOrCreate(context, key)
-                val store = SqlCipherPassStore(db)
-                val repo = SqlCipherPassRepository(
-                    store = store,
-                    telemetryGuard = telemetryGuard,
-                    ioDispatcher = ioDispatcher,
-                    clock = clock,
-                    keyBacking = keyProvider.keyBacking,
-                )
-                StorageResult.Success(repo)
+            val openResult = try {
+                SqlCipherDatabaseFactory.openOrCreate(context, key)
             } catch (e: Throwable) {
                 val unknown = StorageError.Unknown(
                     kind = UnknownStorageFailureKind.DatabaseCorrupt,
@@ -144,8 +168,27 @@ public class SqlCipherPassRepository internal constructor(
                     kind = unknown.toFailureKind(),
                     unknownKind = unknown.kind,
                 )
-                StorageResult.Failure(unknown)
+                return StorageResult.Failure(unknown)
             }
+            val db = when (openResult) {
+                is StorageResult.Success -> openResult.value
+                is StorageResult.Failure -> {
+                    telemetryGuard.onStorageFailure(
+                        kind = openResult.error.toFailureKind(),
+                        unknownKind = (openResult.error as? StorageError.Unknown)?.kind,
+                    )
+                    return StorageResult.Failure(openResult.error)
+                }
+            }
+            val store = SqlCipherPassStore(db, telemetryGuard)
+            val repo = SqlCipherPassRepository(
+                store = store,
+                telemetryGuard = telemetryGuard,
+                ioDispatcher = ioDispatcher,
+                clock = clock,
+                keyBacking = keyProvider.keyBacking,
+            )
+            return StorageResult.Success(repo)
         }
     }
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -1,0 +1,151 @@
+package `is`.walt.passes.storage
+
+import android.content.Context
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
+import `is`.walt.passes.storage.internal.SqlCipherPassStore
+import `is`.walt.passes.storage.internal.toFailureKind
+import `is`.walt.passes.storage.internal.toSignatureStatusKind
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Production [PassRepository]. Backed by SQLCipher via [SqlCipherPassStore]; the StateFlow,
+ * delete sequencing, and telemetry sequencing live here so they can be exercised in
+ * isolation against a fake [PassStore] (see test sources).
+ *
+ * The constructor is internal so the only construction path is [create], which provisions
+ * the database key, opens SQLCipher, runs the schema DDL, and seeds the StateFlow from
+ * disk. Hilt modules in walt-android's `core/data-passes` bind [PassRepository] to the
+ * value returned by this factory.
+ */
+public class SqlCipherPassRepository internal constructor(
+    private val store: PassStore,
+    private val telemetryGuard: StorageTelemetryGuard,
+    private val ioDispatcher: CoroutineDispatcher,
+    private val clock: () -> Long,
+    keyBacking: KeyBacking,
+) : PassRepository {
+
+    private val writeMutex = Mutex()
+
+    private val _passes: MutableStateFlow<List<PassSummary>> = MutableStateFlow(store.listSummaries())
+    override val passes: StateFlow<List<PassSummary>> = _passes.asStateFlow()
+
+    init {
+        telemetryGuard.onKeyProviderInitialized(keyBacking)
+    }
+
+    override suspend fun upsert(
+        pass: Pass,
+        signatureStatus: SignatureStatus,
+    ): StorageResult<PassRecordId> = runIo {
+        val outcome = writeMutex.withLock {
+            val o = store.upsert(pass, signatureStatus, clock())
+            _passes.value = store.listSummaries()
+            o
+        }
+        telemetryGuard.onPassUpserted(
+            type = pass.type,
+            signatureStatus = signatureStatus.toSignatureStatusKind(),
+            wasReplacement = outcome.wasReplacement,
+        )
+        StorageResult.Success(outcome.recordId)
+    }
+
+    override suspend fun load(id: PassRecordId): StorageResult<StoredPass> = runIo {
+        val stored = store.loadById(id)
+            ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+        StorageResult.Success(stored)
+    }
+
+    override suspend fun summaryOf(id: PassRecordId): StorageResult<PassSummary> = runIo {
+        val summary = store.summaryById(id)
+            ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+        StorageResult.Success(summary)
+    }
+
+    override suspend fun delete(id: PassRecordId): StorageResult<Unit> = runIo {
+        val deleted = writeMutex.withLock {
+            val outcome = store.delete(id) ?: return@withLock null
+            _passes.value = _passes.value.filterNot { it.id == id }
+            outcome
+        } ?: return@runIo StorageResult.Failure(StorageError.IntegrityViolation(id))
+
+        telemetryGuard.onPassDeleted(
+            type = deleted.summary.type,
+            signatureStatus = deleted.summary.signatureStatus.toSignatureStatusKind(),
+        )
+        StorageResult.Success(Unit)
+    }
+
+    private suspend inline fun <T> runIo(crossinline block: suspend () -> StorageResult<T>): StorageResult<T> =
+        withContext(ioDispatcher) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                val unknown = StorageError.Unknown(
+                    kind = UnknownStorageFailureKind.Other,
+                    cause = e,
+                )
+                telemetryGuard.onStorageFailure(
+                    kind = unknown.toFailureKind(),
+                    unknownKind = unknown.kind,
+                )
+                StorageResult.Failure(unknown)
+            }
+        }
+
+    public companion object {
+        /**
+         * Provisions SQLCipher with the `keyProvider`'s database key, runs [Schema.DDL] on
+         * first open, and returns a [PassRepository] ready for use. The returned scope-bound
+         * repository should outlive the wallet activity stack; consumers typically hold the
+         * binding inside a Hilt singleton scope.
+         */
+        @JvmStatic
+        public fun create(
+            context: Context,
+            keyProvider: PassKeyProvider,
+            telemetryGuard: StorageTelemetryGuard,
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+            clock: () -> Long = { System.currentTimeMillis() },
+        ): StorageResult<SqlCipherPassRepository> {
+            val keyResult = keyProvider.provideDatabaseKey()
+            val key = when (keyResult) {
+                is StorageResult.Success -> keyResult.value
+                is StorageResult.Failure -> return StorageResult.Failure(keyResult.error)
+            }
+            return try {
+                val db = SqlCipherDatabaseFactory.openOrCreate(context, key)
+                val store = SqlCipherPassStore(db)
+                val repo = SqlCipherPassRepository(
+                    store = store,
+                    telemetryGuard = telemetryGuard,
+                    ioDispatcher = ioDispatcher,
+                    clock = clock,
+                    keyBacking = keyProvider.keyBacking,
+                )
+                StorageResult.Success(repo)
+            } catch (e: Throwable) {
+                val unknown = StorageError.Unknown(
+                    kind = UnknownStorageFailureKind.DatabaseCorrupt,
+                    cause = e,
+                )
+                telemetryGuard.onStorageFailure(
+                    kind = unknown.toFailureKind(),
+                    unknownKind = unknown.kind,
+                )
+                StorageResult.Failure(unknown)
+            }
+        }
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -91,6 +91,11 @@ public class SqlCipherPassRepository internal constructor(
         }
     }
 
+    /**
+     * Single emission point for `StorageResult.Failure`. Every failure-returning code path
+     * routes through here so `onStorageFailure` fires exactly once per Failure with the
+     * structural arm and (for [StorageError.Unknown]) the open-ended kind.
+     */
     private fun <T> failure(error: StorageError): StorageResult<T> {
         telemetryGuard.onStorageFailure(
             kind = error.toFailureKind(),

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -1,6 +1,14 @@
 package `is`.walt.passes.storage
 
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatusKind as CoreSignatureStatusKind
+
+/**
+ * Re-exports `passes-core`'s [SignatureStatusKind][CoreSignatureStatusKind] under the
+ * storage package so consumers binding [StorageTelemetryGuard] do not need a second import.
+ * The arms are authoritative in `passes-core`; storage MUST NOT shadow or fork them.
+ */
+public typealias SignatureStatusKind = CoreSignatureStatusKind
 
 /**
  * The storage-side counterpart to `passes-core`'s `TelemetryGuard`. Carries the same
@@ -30,7 +38,7 @@ public interface StorageTelemetryGuard {
     )
 
     /**
-     * A pass row was deleted (D6). Emitted after the transaction commits and after the
+     * A pass row was deleted. Emitted after the transaction commits and after the
      * StateFlow is updated.
      */
     public fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind)
@@ -51,18 +59,6 @@ public interface StorageTelemetryGuard {
         kind: StorageFailureKind,
         unknownKind: UnknownStorageFailureKind?,
     )
-}
-
-/**
- * Flattened enum mirror of `passes-core`'s `SignatureStatus` arms, suitable for crossing
- * a metric backend that wants string dimensions. New arms here MUST mirror new arms in
- * `SignatureStatus`.
- */
-public enum class SignatureStatusKind {
-    Unsigned,
-    SelfSigned,
-    AppleVerified,
-    CertChainIncomplete,
 }
 
 /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -1,0 +1,24 @@
+package `is`.walt.passes.storage.internal
+
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.SignatureStatusKind
+import `is`.walt.passes.storage.StorageError
+import `is`.walt.passes.storage.StorageFailureKind
+
+/** Mirrors the `passes-core` sealed interface arms onto the storage telemetry enum. */
+internal fun SignatureStatus.toSignatureStatusKind(): SignatureStatusKind = when (this) {
+    SignatureStatus.Unsigned -> SignatureStatusKind.Unsigned
+    SignatureStatus.SelfSigned -> SignatureStatusKind.SelfSigned
+    SignatureStatus.AppleVerified -> SignatureStatusKind.AppleVerified
+    SignatureStatus.CertChainIncomplete -> SignatureStatusKind.CertChainIncomplete
+}
+
+/** Stable telemetry projection of [StorageError]. New error arms require new enum arms. */
+internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
+    StorageError.KeyUnavailable -> StorageFailureKind.KeyUnavailable
+    StorageError.KeyUnwrapFailed -> StorageFailureKind.KeyUnwrapFailed
+    StorageError.DatabaseLocked -> StorageFailureKind.DatabaseLocked
+    is StorageError.IntegrityViolation -> StorageFailureKind.IntegrityViolation
+    is StorageError.Unsupported -> StorageFailureKind.Unsupported
+    is StorageError.Unknown -> StorageFailureKind.Unknown
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -1,19 +1,23 @@
 package `is`.walt.passes.storage.internal
 
 import `is`.walt.passes.core.SignatureStatus
-import `is`.walt.passes.storage.SignatureStatusKind
+import `is`.walt.passes.core.SignatureStatusKind
 import `is`.walt.passes.storage.StorageError
 import `is`.walt.passes.storage.StorageFailureKind
 
-/** Mirrors the `passes-core` sealed interface arms onto the storage telemetry enum. */
-internal fun SignatureStatus.toSignatureStatusKind(): SignatureStatusKind = when (this) {
-    SignatureStatus.Unsigned -> SignatureStatusKind.Unsigned
-    SignatureStatus.SelfSigned -> SignatureStatusKind.SelfSigned
-    SignatureStatus.AppleVerified -> SignatureStatusKind.AppleVerified
-    SignatureStatus.CertChainIncomplete -> SignatureStatusKind.CertChainIncomplete
+/**
+ * Inverse of `passes-core`'s `SignatureStatus.toKind()`. Used when re-hydrating
+ * `signature_status_kind` from a cursor: the on-disk vocabulary is the [SignatureStatusKind]
+ * `name`, so unknown names route through the migration-row-dropped path before this is
+ * reached.
+ */
+internal fun SignatureStatusKind.toSignatureStatus(): SignatureStatus = when (this) {
+    SignatureStatusKind.Unsigned -> SignatureStatus.Unsigned
+    SignatureStatusKind.SelfSigned -> SignatureStatus.SelfSigned
+    SignatureStatusKind.AppleVerified -> SignatureStatus.AppleVerified
+    SignatureStatusKind.CertChainIncomplete -> SignatureStatus.CertChainIncomplete
 }
 
-/** Stable telemetry projection of [StorageError]. New error arms require new enum arms. */
 internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
     StorageError.KeyUnavailable -> StorageFailureKind.KeyUnavailable
     StorageError.KeyUnwrapFailed -> StorageFailureKind.KeyUnwrapFailed

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -18,6 +18,11 @@ internal fun SignatureStatusKind.toSignatureStatus(): SignatureStatus = when (th
     SignatureStatusKind.CertChainIncomplete -> SignatureStatus.CertChainIncomplete
 }
 
+/**
+ * Stable telemetry projection of [StorageError]. The exhaustive `when` is the load-bearing
+ * drift detector: a new error arm without a matching enum entry is a compile error, not a
+ * silent observability gap.
+ */
 internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
     StorageError.KeyUnavailable -> StorageFailureKind.KeyUnavailable
     StorageError.KeyUnwrapFailed -> StorageFailureKind.KeyUnwrapFailed

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassJson.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassJson.kt
@@ -16,13 +16,13 @@ import kotlinx.serialization.json.Json
 
 /**
  * Kotlinx-serialized projection of `Pass` minus its image-bytes map and locale tables, which
- * `passes-storage` persists as separate normalized rows (see ADR 0002 D3). The on-disk
- * `pass_json` BLOB column carries this surrogate; the renderer reconstructs the same `Pass`
- * value the parser produced, without re-running PKCS#7 verification.
+ * `passes-storage` persists as separate normalized rows. The on-disk `pass_json` BLOB column
+ * carries this surrogate; the renderer reconstructs the same `Pass` value the parser
+ * produced, without re-running PKCS#7 verification.
  *
- * `passes-core` does not annotate its public types as `@Serializable` because it is KMP-aimed
- * and we do not want kotlinx-serialization on its public surface. So this module owns its own
- * surrogate and the `Pass <-> PassJson` conversion.
+ * `passes-core` deliberately does not annotate its public types as `@Serializable` (KMP-aimed,
+ * keeps kotlinx-serialization off its public surface), so this module owns its own surrogate
+ * and the `Pass <-> PassJson` conversion.
  */
 internal object PassJsonCodec {
     private val json: Json = Json {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassJson.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassJson.kt
@@ -1,0 +1,166 @@
+package `is`.walt.passes.storage.internal
+
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.TextAlignment
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Kotlinx-serialized projection of `Pass` minus its image-bytes map and locale tables, which
+ * `passes-storage` persists as separate normalized rows (see ADR 0002 D3). The on-disk
+ * `pass_json` BLOB column carries this surrogate; the renderer reconstructs the same `Pass`
+ * value the parser produced, without re-running PKCS#7 verification.
+ *
+ * `passes-core` does not annotate its public types as `@Serializable` because it is KMP-aimed
+ * and we do not want kotlinx-serialization on its public surface. So this module owns its own
+ * surrogate and the `Pass <-> PassJson` conversion.
+ */
+internal object PassJsonCodec {
+    private val json: Json = Json {
+        ignoreUnknownKeys = false
+        encodeDefaults = true
+        explicitNulls = true
+    }
+
+    fun encode(pass: Pass): ByteArray {
+        val surrogate = pass.toSurrogate()
+        return json.encodeToString(PassSurrogate.serializer(), surrogate).encodeToByteArray()
+    }
+
+    fun decode(bytes: ByteArray): Pass {
+        val surrogate = json.decodeFromString(PassSurrogate.serializer(), bytes.decodeToString())
+        return surrogate.toPass()
+    }
+
+    fun encodeStrings(strings: LocalizedStrings): ByteArray =
+        json.encodeToString(LocalizedStringsSurrogate.serializer(), LocalizedStringsSurrogate(strings.entries))
+            .encodeToByteArray()
+
+    fun decodeStrings(bytes: ByteArray): LocalizedStrings =
+        LocalizedStrings(
+            json.decodeFromString(LocalizedStringsSurrogate.serializer(), bytes.decodeToString()).entries,
+        )
+
+    @Serializable
+    internal data class PassSurrogate(
+        val type: PassType,
+        val serialNumber: String,
+        val description: String,
+        val organizationName: String,
+        val expirationEpochMs: Long?,
+        val voided: Boolean,
+        val colors: PassColorsSurrogate,
+        val frontFields: PassFieldsSurrogate,
+        val backFields: List<PassFieldSurrogate>,
+        val barcode: BarcodeSurrogate?,
+    )
+
+    @Serializable
+    internal data class PassColorsSurrogate(
+        val foregroundRgb: Int?,
+        val backgroundRgb: Int?,
+        val labelRgb: Int?,
+    )
+
+    @Serializable
+    internal data class PassFieldsSurrogate(
+        val header: List<PassFieldSurrogate>,
+        val primary: List<PassFieldSurrogate>,
+        val secondary: List<PassFieldSurrogate>,
+        val auxiliary: List<PassFieldSurrogate>,
+    )
+
+    @Serializable
+    internal data class PassFieldSurrogate(
+        val key: String,
+        val label: String?,
+        val value: String,
+        val textAlignment: TextAlignment,
+    )
+
+    @Serializable
+    internal data class BarcodeSurrogate(
+        val format: BarcodeFormat,
+        val message: String,
+        val messageEncoding: String,
+        val altText: String?,
+    )
+
+    @Serializable
+    internal data class LocalizedStringsSurrogate(val entries: Map<String, String>)
+
+    private fun Pass.toSurrogate(): PassSurrogate = PassSurrogate(
+        type = type,
+        serialNumber = serialNumber,
+        description = description,
+        organizationName = organizationName,
+        expirationEpochMs = expirationDate?.epochMillis,
+        voided = voided,
+        colors = PassColorsSurrogate(
+            foregroundRgb = colors.foreground?.rgb,
+            backgroundRgb = colors.background?.rgb,
+            labelRgb = colors.label?.rgb,
+        ),
+        frontFields = PassFieldsSurrogate(
+            header = frontFields.header.map { it.toSurrogate() },
+            primary = frontFields.primary.map { it.toSurrogate() },
+            secondary = frontFields.secondary.map { it.toSurrogate() },
+            auxiliary = frontFields.auxiliary.map { it.toSurrogate() },
+        ),
+        backFields = backFields.map { it.toSurrogate() },
+        barcode = barcode?.let {
+            BarcodeSurrogate(
+                format = it.format,
+                message = it.message,
+                messageEncoding = it.messageEncoding,
+                altText = it.altText,
+            )
+        },
+    )
+
+    private fun PassField.toSurrogate(): PassFieldSurrogate =
+        PassFieldSurrogate(key = key, label = label, value = value, textAlignment = textAlignment)
+
+    private fun PassSurrogate.toPass(): Pass = Pass(
+        type = type,
+        serialNumber = serialNumber,
+        description = description,
+        organizationName = organizationName,
+        expirationDate = expirationEpochMs?.let { PassInstant(it) },
+        voided = voided,
+        colors = PassColors(
+            foreground = colors.foregroundRgb?.let { ColorValue(it) },
+            background = colors.backgroundRgb?.let { ColorValue(it) },
+            label = colors.labelRgb?.let { ColorValue(it) },
+        ),
+        frontFields = PassFields(
+            header = frontFields.header.map { it.toField() },
+            primary = frontFields.primary.map { it.toField() },
+            secondary = frontFields.secondary.map { it.toField() },
+            auxiliary = frontFields.auxiliary.map { it.toField() },
+        ),
+        backFields = backFields.map { it.toField() },
+        barcode = barcode?.let {
+            Barcode(
+                format = it.format,
+                message = it.message,
+                messageEncoding = it.messageEncoding,
+                altText = it.altText,
+            )
+        },
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+
+    private fun PassFieldSurrogate.toField(): PassField =
+        PassField(key = key, label = label, value = value, textAlignment = textAlignment)
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
@@ -4,14 +4,12 @@ import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.storage.PassRecordId
 import `is`.walt.passes.storage.PassSummary
-import `is`.walt.passes.storage.StorageError
 import `is`.walt.passes.storage.StoredPass
 
 /**
  * Internal persistence boundary inside `passes-storage`. Sits between the public
  * `PassRepository` (which owns `StateFlow` plumbing and telemetry sequencing) and the actual
- * storage backend (SQLCipher in production, an in-memory fake for the StateFlow + delete
- * contract test on Robolectric / JVM CI).
+ * storage backend (SQLCipher in production, an in-memory fake on Robolectric / JVM CI).
  *
  * The interface is deliberately blocking and synchronous: the repository wraps each call in
  * the IO dispatcher. Pushing coroutines into the store would force the SQLite cursor APIs
@@ -35,13 +33,3 @@ internal data class UpsertOutcome(
 internal data class DeleteOutcome(
     val summary: PassSummary,
 )
-
-/**
- * Open-result for a [PassStore] factory. Carries a typed failure arm so the repository can
- * surface `KeyUnavailable` / `KeyUnwrapFailed` distinctly without pretending exceptions
- * survived the API boundary.
- */
-internal sealed interface PassStoreOpenResult {
-    data class Success(val store: PassStore) : PassStoreOpenResult
-    data class Failure(val error: StorageError) : PassStoreOpenResult
-}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
@@ -1,0 +1,47 @@
+package `is`.walt.passes.storage.internal
+
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.PassRecordId
+import `is`.walt.passes.storage.PassSummary
+import `is`.walt.passes.storage.StorageError
+import `is`.walt.passes.storage.StoredPass
+
+/**
+ * Internal persistence boundary inside `passes-storage`. Sits between the public
+ * `PassRepository` (which owns `StateFlow` plumbing and telemetry sequencing) and the actual
+ * storage backend (SQLCipher in production, an in-memory fake for the StateFlow + delete
+ * contract test on Robolectric / JVM CI).
+ *
+ * The interface is deliberately blocking and synchronous: the repository wraps each call in
+ * the IO dispatcher. Pushing coroutines into the store would force the SQLite cursor APIs
+ * (which are inherently blocking and not cancellable mid-cursor) to pretend at suspendability.
+ */
+internal interface PassStore {
+    fun listSummaries(): List<PassSummary>
+    fun loadById(id: PassRecordId): StoredPass?
+    fun summaryById(id: PassRecordId): PassSummary?
+    fun upsert(pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long): UpsertOutcome
+    fun delete(id: PassRecordId): DeleteOutcome?
+    fun close()
+}
+
+internal data class UpsertOutcome(
+    val recordId: PassRecordId,
+    val summary: PassSummary,
+    val wasReplacement: Boolean,
+)
+
+internal data class DeleteOutcome(
+    val summary: PassSummary,
+)
+
+/**
+ * Open-result for a [PassStore] factory. Carries a typed failure arm so the repository can
+ * surface `KeyUnavailable` / `KeyUnwrapFailed` distinctly without pretending exceptions
+ * survived the API boundary.
+ */
+internal sealed interface PassStoreOpenResult {
+    data class Success(val store: PassStore) : PassStoreOpenResult
+    data class Failure(val error: StorageError) : PassStoreOpenResult
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -11,10 +11,9 @@ import java.io.File
 
 /**
  * Opens (or creates on first use) the `walt_passes.db` SQLCipher file with the supplied
- * [DatabaseKey], applies the SQLCipher v4 compatibility pragma per ADR 0002, runs
- * [Schema.DDL] under a single transaction on first use, and enables `PRAGMA foreign_keys=ON`
- * so the `ON DELETE CASCADE` chains for `pass_images` and `pass_locales` actually fire
- * (SQLite/SQLCipher default this off).
+ * [DatabaseKey], pins the SQLCipher v4 page format, runs [Schema.DDL] under a single
+ * transaction on first use, and enables `PRAGMA foreign_keys=ON` so the `ON DELETE CASCADE`
+ * chains for `pass_images` and `pass_locales` actually fire (SQLite/SQLCipher default this off).
  *
  * The native libraries are loaded lazily via `System.loadLibrary("sqlcipher")`, which is
  * idempotent on subsequent calls.
@@ -43,27 +42,25 @@ internal object SqlCipherDatabaseFactory {
         dbFile.parentFile?.mkdirs()
 
         val db: SQLiteDatabase = databaseKey.withBytes { rawKey ->
-            // SQLCipher takes the 32 bytes directly via the byte[] password overload; the
-            // withBytes scope zeros our local copy on return. SQLCipher's internal page-key
-            // derivation buffer survives for the lifetime of the open connection, which is
-            // bounded by SqlCipherPassStore.close().
+            // The withBytes scope zeros our local copy on return; SQLCipher's internal
+            // page-key derivation buffer survives for the lifetime of the open connection,
+            // which is bounded by SqlCipherPassStore.close().
             SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null)
         }
 
-        // ADR 0002: pin SQLCipher v4 page format. Defensive against a future SQLCipher
-        // major-version default change; v4 is the format the wallet's on-disk DBs will be
-        // in for the foreseeable future. Issued before any other DDL/DML so the page format
-        // is locked before tables get created.
+        // Pin SQLCipher v4 page format defensively against a future major-version default
+        // change. Issued before any other DDL/DML so the page format is locked before
+        // tables get created.
         db.execSQL("PRAGMA cipher_compatibility = 4")
         db.execSQL("PRAGMA foreign_keys = ON")
 
-        // Detect schema version on disk before mutating anything. ADR D7: a build that
-        // sees a newer-than-it-understands schema must surface Unsupported, not silently
-        // run its (older) DDL.
         val onDiskVersion: Int? = readSchemaVersionIfPresent(db)
-        if (onDiskVersion != null && onDiskVersion > Schema.VERSION) {
-            db.close()
-            return StorageResult.Failure(StorageError.Unsupported(onDiskVersion))
+        when {
+            onDiskVersion != null && onDiskVersion > Schema.VERSION -> {
+                db.close()
+                return StorageResult.Failure(StorageError.Unsupported(onDiskVersion))
+            }
+            onDiskVersion == Schema.VERSION -> return StorageResult.Success(db)
         }
 
         db.beginTransaction()

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -3,32 +3,68 @@ package `is`.walt.passes.storage.internal
 import android.content.Context
 import `is`.walt.passes.storage.DatabaseKey
 import `is`.walt.passes.storage.Schema
-import net.sqlcipher.database.SQLiteDatabase
+import `is`.walt.passes.storage.StorageError
+import `is`.walt.passes.storage.StorageResult
+import `is`.walt.passes.storage.UnknownStorageFailureKind
+import net.zetetic.database.sqlcipher.SQLiteDatabase
 import java.io.File
 
 /**
  * Opens (or creates on first use) the `walt_passes.db` SQLCipher file with the supplied
- * [DatabaseKey], runs [Schema.DDL] under a single transaction on first use, and enables
- * `PRAGMA foreign_keys=ON` so the `ON DELETE CASCADE` chains for `pass_images` and
- * `pass_locales` actually fire (SQLite/SQLCipher default this off).
+ * [DatabaseKey], applies the SQLCipher v4 compatibility pragma per ADR 0002, runs
+ * [Schema.DDL] under a single transaction on first use, and enables `PRAGMA foreign_keys=ON`
+ * so the `ON DELETE CASCADE` chains for `pass_images` and `pass_locales` actually fire
+ * (SQLite/SQLCipher default this off).
  *
- * The native libraries are loaded lazily here via `SQLiteDatabase.loadLibs(context)`, which
- * is idempotent.
+ * The native libraries are loaded lazily via `System.loadLibrary("sqlcipher")`, which is
+ * idempotent on subsequent calls.
  */
 internal object SqlCipherDatabaseFactory {
-    fun openOrCreate(context: Context, databaseKey: DatabaseKey): SQLiteDatabase {
-        SQLiteDatabase.loadLibs(context.applicationContext)
+    @Volatile
+    private var librariesLoaded: Boolean = false
+
+    private fun loadLibsOnce() {
+        if (!librariesLoaded) {
+            synchronized(this) {
+                if (!librariesLoaded) {
+                    System.loadLibrary("sqlcipher")
+                    librariesLoaded = true
+                }
+            }
+        }
+    }
+
+    fun openOrCreate(
+        context: Context,
+        databaseKey: DatabaseKey,
+    ): StorageResult<SQLiteDatabase> {
+        loadLibsOnce()
         val dbFile: File = context.applicationContext.getDatabasePath(Schema.DATABASE_NAME)
         dbFile.parentFile?.mkdirs()
 
         val db: SQLiteDatabase = databaseKey.withBytes { rawKey ->
-            // SQLCipher accepts the raw 32 bytes directly; we hand the array to the
-            // openOrCreateDatabase overload that takes a byte[] key, then withBytes zeros our
-            // local copy on return. SQLCipher's internal page-key derivation buffer survives
-            // for the lifetime of the open connection; that lifetime is bounded by close().
-            SQLiteDatabase.openOrCreateDatabase(dbFile.absolutePath, rawKey, null, null)
+            // SQLCipher takes the 32 bytes directly via the byte[] password overload; the
+            // withBytes scope zeros our local copy on return. SQLCipher's internal page-key
+            // derivation buffer survives for the lifetime of the open connection, which is
+            // bounded by SqlCipherPassStore.close().
+            SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null)
         }
+
+        // ADR 0002: pin SQLCipher v4 page format. Defensive against a future SQLCipher
+        // major-version default change; v4 is the format the wallet's on-disk DBs will be
+        // in for the foreseeable future. Issued before any other DDL/DML so the page format
+        // is locked before tables get created.
+        db.execSQL("PRAGMA cipher_compatibility = 4")
         db.execSQL("PRAGMA foreign_keys = ON")
+
+        // Detect schema version on disk before mutating anything. ADR D7: a build that
+        // sees a newer-than-it-understands schema must surface Unsupported, not silently
+        // run its (older) DDL.
+        val onDiskVersion: Int? = readSchemaVersionIfPresent(db)
+        if (onDiskVersion != null && onDiskVersion > Schema.VERSION) {
+            db.close()
+            return StorageResult.Failure(StorageError.Unsupported(onDiskVersion))
+        }
 
         db.beginTransaction()
         try {
@@ -40,9 +76,34 @@ internal object SqlCipherDatabaseFactory {
                 arrayOf<Any>(Schema.MetaKeys.SCHEMA_VERSION, Schema.VERSION.toString().toByteArray()),
             )
             db.setTransactionSuccessful()
-        } finally {
+        } catch (e: Throwable) {
             db.endTransaction()
+            db.close()
+            return StorageResult.Failure(
+                StorageError.Unknown(
+                    kind = UnknownStorageFailureKind.DatabaseCorrupt,
+                    cause = e,
+                ),
+            )
         }
-        return db
+        db.endTransaction()
+        return StorageResult.Success(db)
+    }
+
+    private fun readSchemaVersionIfPresent(db: SQLiteDatabase): Int? {
+        // schema_meta itself may not exist yet on first open; tolerate that and let the
+        // DDL block create it.
+        val tableExists = db.rawQuery(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            arrayOf(Schema.Tables.SCHEMA_META),
+        ).use { it.moveToNext() }
+        if (!tableExists) return null
+
+        return db.rawQuery(
+            "SELECT value FROM ${Schema.Tables.SCHEMA_META} WHERE key = ?",
+            arrayOf(Schema.MetaKeys.SCHEMA_VERSION),
+        ).use { c ->
+            if (!c.moveToNext()) null else c.getBlob(0).decodeToString().toIntOrNull()
+        }
     }
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -1,0 +1,48 @@
+package `is`.walt.passes.storage.internal
+
+import android.content.Context
+import `is`.walt.passes.storage.DatabaseKey
+import `is`.walt.passes.storage.Schema
+import net.sqlcipher.database.SQLiteDatabase
+import java.io.File
+
+/**
+ * Opens (or creates on first use) the `walt_passes.db` SQLCipher file with the supplied
+ * [DatabaseKey], runs [Schema.DDL] under a single transaction on first use, and enables
+ * `PRAGMA foreign_keys=ON` so the `ON DELETE CASCADE` chains for `pass_images` and
+ * `pass_locales` actually fire (SQLite/SQLCipher default this off).
+ *
+ * The native libraries are loaded lazily here via `SQLiteDatabase.loadLibs(context)`, which
+ * is idempotent.
+ */
+internal object SqlCipherDatabaseFactory {
+    fun openOrCreate(context: Context, databaseKey: DatabaseKey): SQLiteDatabase {
+        SQLiteDatabase.loadLibs(context.applicationContext)
+        val dbFile: File = context.applicationContext.getDatabasePath(Schema.DATABASE_NAME)
+        dbFile.parentFile?.mkdirs()
+
+        val db: SQLiteDatabase = databaseKey.withBytes { rawKey ->
+            // SQLCipher accepts the raw 32 bytes directly; we hand the array to the
+            // openOrCreateDatabase overload that takes a byte[] key, then withBytes zeros our
+            // local copy on return. SQLCipher's internal page-key derivation buffer survives
+            // for the lifetime of the open connection; that lifetime is bounded by close().
+            SQLiteDatabase.openOrCreateDatabase(dbFile.absolutePath, rawKey, null, null)
+        }
+        db.execSQL("PRAGMA foreign_keys = ON")
+
+        db.beginTransaction()
+        try {
+            for (statement in Schema.DDL) {
+                db.execSQL(statement)
+            }
+            db.execSQL(
+                "INSERT OR REPLACE INTO ${Schema.Tables.SCHEMA_META} (key, value) VALUES (?, ?)",
+                arrayOf<Any>(Schema.MetaKeys.SCHEMA_VERSION, Schema.VERSION.toString().toByteArray()),
+            )
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return db
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -10,6 +10,8 @@ import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.core.SignatureStatusKind
+import `is`.walt.passes.core.toKind
 import `is`.walt.passes.storage.MigrationFailureKind
 import `is`.walt.passes.storage.PassRecordId
 import `is`.walt.passes.storage.PassSummary
@@ -20,11 +22,9 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase
 
 /**
  * SQLCipher-backed implementation of [PassStore]. Owns the `SQLiteDatabase` handle for the
- * lifetime of the `PassRepository`. Concurrency is single-writer: all callers go through the
- * repository's IO dispatcher, which we treat as a serialization point. SQLite WAL mode
- * tolerates concurrent readers, but the repository does not currently exploit that — all
- * reads are also routed through the same dispatcher to keep the StateFlow + telemetry
- * sequencing deterministic (D6).
+ * lifetime of the repository. Concurrency is single-writer: all callers go through the
+ * repository's IO dispatcher. Reads share the same dispatcher to keep the StateFlow +
+ * telemetry sequencing deterministic.
  */
 internal class SqlCipherPassStore(
     private val db: SQLiteDatabase,
@@ -34,10 +34,7 @@ internal class SqlCipherPassStore(
     override fun listSummaries(): List<PassSummary> {
         val out = ArrayList<PassSummary>()
         db.rawQuery(
-            "SELECT id, type, serial_number, organization_name, description, " +
-                "expiration_epoch_ms, voided, signature_status_kind, " +
-                "created_at_epoch_ms, updated_at_epoch_ms " +
-                "FROM ${Schema.Tables.PASSES} ORDER BY created_at_epoch_ms DESC",
+            "SELECT $SUMMARY_COLUMNS FROM ${Schema.Tables.PASSES} ORDER BY created_at_epoch_ms DESC",
             emptyArray(),
         ).use { c ->
             while (c.moveToNext()) {
@@ -50,10 +47,7 @@ internal class SqlCipherPassStore(
 
     override fun loadById(id: PassRecordId): StoredPass? {
         val (summary, blob) = db.rawQuery(
-            "SELECT id, type, serial_number, organization_name, description, " +
-                "expiration_epoch_ms, voided, signature_status_kind, " +
-                "created_at_epoch_ms, updated_at_epoch_ms, pass_json " +
-                "FROM ${Schema.Tables.PASSES} WHERE id = ?",
+            "SELECT $SUMMARY_COLUMNS, pass_json FROM ${Schema.Tables.PASSES} WHERE id = ?",
             arrayOf(id.value.toString()),
         ).use { c ->
             if (!c.moveToNext()) return null
@@ -78,10 +72,7 @@ internal class SqlCipherPassStore(
 
     override fun summaryById(id: PassRecordId): PassSummary? {
         return db.rawQuery(
-            "SELECT id, type, serial_number, organization_name, description, " +
-                "expiration_epoch_ms, voided, signature_status_kind, " +
-                "created_at_epoch_ms, updated_at_epoch_ms " +
-                "FROM ${Schema.Tables.PASSES} WHERE id = ?",
+            "SELECT $SUMMARY_COLUMNS FROM ${Schema.Tables.PASSES} WHERE id = ?",
             arrayOf(id.value.toString()),
         ).use { c ->
             if (!c.moveToNext()) null else c.toSummaryOrNull()
@@ -95,20 +86,16 @@ internal class SqlCipherPassStore(
     ): UpsertOutcome {
         db.beginTransaction()
         try {
-            val existingId: Long? = db.rawQuery(
+            val existing: Pair<Long, Long>? = db.rawQuery(
                 "SELECT id, created_at_epoch_ms FROM ${Schema.Tables.PASSES} " +
                     "WHERE type = ? AND serial_number = ? AND organization_name = ?",
                 arrayOf(pass.type.name, pass.serialNumber, pass.organizationName),
-            ).use { c -> if (c.moveToNext()) c.getLong(0) else null }
+            ).use { c -> if (c.moveToNext()) c.getLong(0) to c.getLong(1) else null }
 
-            val createdAt: Long = existingId?.let { id ->
-                db.rawQuery(
-                    "SELECT created_at_epoch_ms FROM ${Schema.Tables.PASSES} WHERE id = ?",
-                    arrayOf(id.toString()),
-                ).use { c -> if (c.moveToNext()) c.getLong(0) else nowEpochMs }
-            } ?: nowEpochMs
+            val existingId: Long? = existing?.first
+            val createdAt: Long = existing?.second ?: nowEpochMs
 
-            val signatureKind = signatureStatus.kindName()
+            val signatureKind = signatureStatus.toKind().name
             val passJson = PassJsonCodec.encode(pass)
 
             val rowId: Long = if (existingId != null) {
@@ -195,7 +182,7 @@ internal class SqlCipherPassStore(
         val summary = summaryById(id) ?: return null
         db.beginTransaction()
         try {
-            // ON DELETE CASCADE on pass_images and pass_locales handles the children.
+            // ON DELETE CASCADE on pass_images and pass_locales drops the children.
             db.delete(Schema.Tables.PASSES, "id = ?", arrayOf(id.value.toString()))
             db.setTransactionSuccessful()
         } finally {
@@ -240,47 +227,49 @@ internal class SqlCipherPassStore(
     /**
      * Materializes a [PassSummary] from the cursor row, or returns null after emitting
      * `onMigrationRowDropped(UnknownEnumValue)` if the row references an enum value this
-     * build does not understand. ADR 0002 D4: failed-to-decode rows are dropped, not raised.
+     * build does not understand. Failed-to-decode rows are dropped, not raised.
      */
     private fun Cursor.toSummaryOrNull(): PassSummary? {
-        val typeName = getString(getColumnIndexOrThrow("type"))
-        val type = PassType.entries.firstOrNull { it.name == typeName } ?: run {
+        val idIdx = getColumnIndexOrThrow("id")
+        val typeIdx = getColumnIndexOrThrow("type")
+        val serialIdx = getColumnIndexOrThrow("serial_number")
+        val orgIdx = getColumnIndexOrThrow("organization_name")
+        val descIdx = getColumnIndexOrThrow("description")
+        val expIdx = getColumnIndexOrThrow("expiration_epoch_ms")
+        val voidedIdx = getColumnIndexOrThrow("voided")
+        val sigIdx = getColumnIndexOrThrow("signature_status_kind")
+        val createdIdx = getColumnIndexOrThrow("created_at_epoch_ms")
+        val updatedIdx = getColumnIndexOrThrow("updated_at_epoch_ms")
+
+        val type = PassType.entries.firstOrNull { it.name == getString(typeIdx) } ?: run {
             telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
             return null
         }
-        val signatureKind = getString(getColumnIndexOrThrow("signature_status_kind"))
-        val signatureStatus = signatureStatusFromKind(signatureKind) ?: run {
-            telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
-            return null
-        }
+        val signatureStatus = runCatching { SignatureStatusKind.valueOf(getString(sigIdx)) }
+            .getOrNull()
+            ?.toSignatureStatus()
+            ?: run {
+                telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
+                return null
+            }
         return PassSummary(
-            id = PassRecordId(getLong(getColumnIndexOrThrow("id"))),
+            id = PassRecordId(getLong(idIdx)),
             type = type,
-            serialNumber = getString(getColumnIndexOrThrow("serial_number")),
-            organizationName = getString(getColumnIndexOrThrow("organization_name")),
-            description = getString(getColumnIndexOrThrow("description")),
-            expirationDate = getColumnIndexOrThrow("expiration_epoch_ms").let { idx ->
-                if (isNull(idx)) null else PassInstant(getLong(idx))
-            },
-            voided = getInt(getColumnIndexOrThrow("voided")) != 0,
+            serialNumber = getString(serialIdx),
+            organizationName = getString(orgIdx),
+            description = getString(descIdx),
+            expirationDate = if (isNull(expIdx)) null else PassInstant(getLong(expIdx)),
+            voided = getInt(voidedIdx) != 0,
             signatureStatus = signatureStatus,
-            createdAt = PassInstant(getLong(getColumnIndexOrThrow("created_at_epoch_ms"))),
-            updatedAt = PassInstant(getLong(getColumnIndexOrThrow("updated_at_epoch_ms"))),
+            createdAt = PassInstant(getLong(createdIdx)),
+            updatedAt = PassInstant(getLong(updatedIdx)),
         )
     }
 
-    private fun signatureStatusFromKind(name: String): SignatureStatus? = when (name) {
-        "Unsigned" -> SignatureStatus.Unsigned
-        "SelfSigned" -> SignatureStatus.SelfSigned
-        "AppleVerified" -> SignatureStatus.AppleVerified
-        "CertChainIncomplete" -> SignatureStatus.CertChainIncomplete
-        else -> null
-    }
-
-    private fun SignatureStatus.kindName(): String = when (this) {
-        SignatureStatus.Unsigned -> "Unsigned"
-        SignatureStatus.SelfSigned -> "SelfSigned"
-        SignatureStatus.AppleVerified -> "AppleVerified"
-        SignatureStatus.CertChainIncomplete -> "CertChainIncomplete"
+    private companion object {
+        const val SUMMARY_COLUMNS: String =
+            "id, type, serial_number, organization_name, description, " +
+                "expiration_epoch_ms, voided, signature_status_kind, " +
+                "created_at_epoch_ms, updated_at_epoch_ms"
     }
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -10,11 +10,13 @@ import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.MigrationFailureKind
 import `is`.walt.passes.storage.PassRecordId
 import `is`.walt.passes.storage.PassSummary
 import `is`.walt.passes.storage.Schema
+import `is`.walt.passes.storage.StorageTelemetryGuard
 import `is`.walt.passes.storage.StoredPass
-import net.sqlcipher.database.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteDatabase
 
 /**
  * SQLCipher-backed implementation of [PassStore]. Owns the `SQLiteDatabase` handle for the
@@ -26,6 +28,7 @@ import net.sqlcipher.database.SQLiteDatabase
  */
 internal class SqlCipherPassStore(
     private val db: SQLiteDatabase,
+    private val telemetryGuard: StorageTelemetryGuard,
 ) : PassStore {
 
     override fun listSummaries(): List<PassSummary> {
@@ -38,7 +41,8 @@ internal class SqlCipherPassStore(
             emptyArray(),
         ).use { c ->
             while (c.moveToNext()) {
-                out += c.toSummary()
+                val summary = c.toSummaryOrNull() ?: continue
+                out += summary
             }
         }
         return out
@@ -53,7 +57,7 @@ internal class SqlCipherPassStore(
             arrayOf(id.value.toString()),
         ).use { c ->
             if (!c.moveToNext()) return null
-            val s = c.toSummary()
+            val s = c.toSummaryOrNull() ?: return null
             val passJson = c.getBlob(c.getColumnIndexOrThrow("pass_json"))
             s to passJson
         }
@@ -80,7 +84,7 @@ internal class SqlCipherPassStore(
                 "FROM ${Schema.Tables.PASSES} WHERE id = ?",
             arrayOf(id.value.toString()),
         ).use { c ->
-            if (!c.moveToNext()) null else c.toSummary()
+            if (!c.moveToNext()) null else c.toSummaryOrNull()
         }
     }
 
@@ -233,27 +237,44 @@ internal class SqlCipherPassStore(
         return out
     }
 
-    private fun Cursor.toSummary(): PassSummary = PassSummary(
-        id = PassRecordId(getLong(getColumnIndexOrThrow("id"))),
-        type = PassType.valueOf(getString(getColumnIndexOrThrow("type"))),
-        serialNumber = getString(getColumnIndexOrThrow("serial_number")),
-        organizationName = getString(getColumnIndexOrThrow("organization_name")),
-        description = getString(getColumnIndexOrThrow("description")),
-        expirationDate = getColumnIndexOrThrow("expiration_epoch_ms").let { idx ->
-            if (isNull(idx)) null else PassInstant(getLong(idx))
-        },
-        voided = getInt(getColumnIndexOrThrow("voided")) != 0,
-        signatureStatus = signatureStatusFromKind(getString(getColumnIndexOrThrow("signature_status_kind"))),
-        createdAt = PassInstant(getLong(getColumnIndexOrThrow("created_at_epoch_ms"))),
-        updatedAt = PassInstant(getLong(getColumnIndexOrThrow("updated_at_epoch_ms"))),
-    )
+    /**
+     * Materializes a [PassSummary] from the cursor row, or returns null after emitting
+     * `onMigrationRowDropped(UnknownEnumValue)` if the row references an enum value this
+     * build does not understand. ADR 0002 D4: failed-to-decode rows are dropped, not raised.
+     */
+    private fun Cursor.toSummaryOrNull(): PassSummary? {
+        val typeName = getString(getColumnIndexOrThrow("type"))
+        val type = PassType.entries.firstOrNull { it.name == typeName } ?: run {
+            telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
+            return null
+        }
+        val signatureKind = getString(getColumnIndexOrThrow("signature_status_kind"))
+        val signatureStatus = signatureStatusFromKind(signatureKind) ?: run {
+            telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
+            return null
+        }
+        return PassSummary(
+            id = PassRecordId(getLong(getColumnIndexOrThrow("id"))),
+            type = type,
+            serialNumber = getString(getColumnIndexOrThrow("serial_number")),
+            organizationName = getString(getColumnIndexOrThrow("organization_name")),
+            description = getString(getColumnIndexOrThrow("description")),
+            expirationDate = getColumnIndexOrThrow("expiration_epoch_ms").let { idx ->
+                if (isNull(idx)) null else PassInstant(getLong(idx))
+            },
+            voided = getInt(getColumnIndexOrThrow("voided")) != 0,
+            signatureStatus = signatureStatus,
+            createdAt = PassInstant(getLong(getColumnIndexOrThrow("created_at_epoch_ms"))),
+            updatedAt = PassInstant(getLong(getColumnIndexOrThrow("updated_at_epoch_ms"))),
+        )
+    }
 
-    private fun signatureStatusFromKind(name: String): SignatureStatus = when (name) {
+    private fun signatureStatusFromKind(name: String): SignatureStatus? = when (name) {
         "Unsigned" -> SignatureStatus.Unsigned
         "SelfSigned" -> SignatureStatus.SelfSigned
         "AppleVerified" -> SignatureStatus.AppleVerified
         "CertChainIncomplete" -> SignatureStatus.CertChainIncomplete
-        else -> error("unknown signature_status_kind '$name'")
+        else -> null
     }
 
     private fun SignatureStatus.kindName(): String = when (this) {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -1,0 +1,265 @@
+package `is`.walt.passes.storage.internal
+
+import android.content.ContentValues
+import android.database.Cursor
+import `is`.walt.passes.core.ImageBytes
+import `is`.walt.passes.core.ImageRole
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.PassRecordId
+import `is`.walt.passes.storage.PassSummary
+import `is`.walt.passes.storage.Schema
+import `is`.walt.passes.storage.StoredPass
+import net.sqlcipher.database.SQLiteDatabase
+
+/**
+ * SQLCipher-backed implementation of [PassStore]. Owns the `SQLiteDatabase` handle for the
+ * lifetime of the `PassRepository`. Concurrency is single-writer: all callers go through the
+ * repository's IO dispatcher, which we treat as a serialization point. SQLite WAL mode
+ * tolerates concurrent readers, but the repository does not currently exploit that — all
+ * reads are also routed through the same dispatcher to keep the StateFlow + telemetry
+ * sequencing deterministic (D6).
+ */
+internal class SqlCipherPassStore(
+    private val db: SQLiteDatabase,
+) : PassStore {
+
+    override fun listSummaries(): List<PassSummary> {
+        val out = ArrayList<PassSummary>()
+        db.rawQuery(
+            "SELECT id, type, serial_number, organization_name, description, " +
+                "expiration_epoch_ms, voided, signature_status_kind, " +
+                "created_at_epoch_ms, updated_at_epoch_ms " +
+                "FROM ${Schema.Tables.PASSES} ORDER BY created_at_epoch_ms DESC",
+            emptyArray(),
+        ).use { c ->
+            while (c.moveToNext()) {
+                out += c.toSummary()
+            }
+        }
+        return out
+    }
+
+    override fun loadById(id: PassRecordId): StoredPass? {
+        val (summary, blob) = db.rawQuery(
+            "SELECT id, type, serial_number, organization_name, description, " +
+                "expiration_epoch_ms, voided, signature_status_kind, " +
+                "created_at_epoch_ms, updated_at_epoch_ms, pass_json " +
+                "FROM ${Schema.Tables.PASSES} WHERE id = ?",
+            arrayOf(id.value.toString()),
+        ).use { c ->
+            if (!c.moveToNext()) return null
+            val s = c.toSummary()
+            val passJson = c.getBlob(c.getColumnIndexOrThrow("pass_json"))
+            s to passJson
+        }
+
+        val images = readImages(id)
+        val locales = readLocales(id)
+
+        val basePass = PassJsonCodec.decode(blob)
+        val passWithChildren = basePass.copy(images = images, locales = locales)
+        return StoredPass(
+            id = summary.id,
+            pass = passWithChildren,
+            signatureStatus = summary.signatureStatus,
+            createdAt = summary.createdAt,
+            updatedAt = summary.updatedAt,
+        )
+    }
+
+    override fun summaryById(id: PassRecordId): PassSummary? {
+        return db.rawQuery(
+            "SELECT id, type, serial_number, organization_name, description, " +
+                "expiration_epoch_ms, voided, signature_status_kind, " +
+                "created_at_epoch_ms, updated_at_epoch_ms " +
+                "FROM ${Schema.Tables.PASSES} WHERE id = ?",
+            arrayOf(id.value.toString()),
+        ).use { c ->
+            if (!c.moveToNext()) null else c.toSummary()
+        }
+    }
+
+    override fun upsert(
+        pass: Pass,
+        signatureStatus: SignatureStatus,
+        nowEpochMs: Long,
+    ): UpsertOutcome {
+        db.beginTransaction()
+        try {
+            val existingId: Long? = db.rawQuery(
+                "SELECT id, created_at_epoch_ms FROM ${Schema.Tables.PASSES} " +
+                    "WHERE type = ? AND serial_number = ? AND organization_name = ?",
+                arrayOf(pass.type.name, pass.serialNumber, pass.organizationName),
+            ).use { c -> if (c.moveToNext()) c.getLong(0) else null }
+
+            val createdAt: Long = existingId?.let { id ->
+                db.rawQuery(
+                    "SELECT created_at_epoch_ms FROM ${Schema.Tables.PASSES} WHERE id = ?",
+                    arrayOf(id.toString()),
+                ).use { c -> if (c.moveToNext()) c.getLong(0) else nowEpochMs }
+            } ?: nowEpochMs
+
+            val signatureKind = signatureStatus.kindName()
+            val passJson = PassJsonCodec.encode(pass)
+
+            val rowId: Long = if (existingId != null) {
+                val cv = ContentValues().apply {
+                    put("type", pass.type.name)
+                    put("serial_number", pass.serialNumber)
+                    put("organization_name", pass.organizationName)
+                    put("description", pass.description)
+                    pass.expirationDate?.let { put("expiration_epoch_ms", it.epochMillis) }
+                        ?: putNull("expiration_epoch_ms")
+                    put("voided", if (pass.voided) 1 else 0)
+                    put("signature_status_kind", signatureKind)
+                    put("pass_json", passJson)
+                    put("updated_at_epoch_ms", nowEpochMs)
+                }
+                db.update(
+                    Schema.Tables.PASSES,
+                    cv,
+                    "id = ?",
+                    arrayOf(existingId.toString()),
+                )
+                db.delete(Schema.Tables.PASS_IMAGES, "pass_id = ?", arrayOf(existingId.toString()))
+                db.delete(Schema.Tables.PASS_LOCALES, "pass_id = ?", arrayOf(existingId.toString()))
+                existingId
+            } else {
+                val cv = ContentValues().apply {
+                    put("type", pass.type.name)
+                    put("serial_number", pass.serialNumber)
+                    put("organization_name", pass.organizationName)
+                    put("description", pass.description)
+                    pass.expirationDate?.let { put("expiration_epoch_ms", it.epochMillis) }
+                        ?: putNull("expiration_epoch_ms")
+                    put("voided", if (pass.voided) 1 else 0)
+                    put("signature_status_kind", signatureKind)
+                    put("pass_json", passJson)
+                    put("created_at_epoch_ms", createdAt)
+                    put("updated_at_epoch_ms", nowEpochMs)
+                }
+                db.insertOrThrow(Schema.Tables.PASSES, null, cv)
+            }
+
+            for ((role, bytes) in pass.images) {
+                val cv = ContentValues().apply {
+                    put("pass_id", rowId)
+                    put("role", role.name)
+                    put("bytes", bytes.bytes)
+                }
+                db.insertOrThrow(Schema.Tables.PASS_IMAGES, null, cv)
+            }
+            for ((locale, strings) in pass.locales) {
+                val cv = ContentValues().apply {
+                    put("pass_id", rowId)
+                    put("locale_tag", locale.tag)
+                    put("strings_json", PassJsonCodec.encodeStrings(strings))
+                }
+                db.insertOrThrow(Schema.Tables.PASS_LOCALES, null, cv)
+            }
+
+            db.setTransactionSuccessful()
+
+            val summary = PassSummary(
+                id = PassRecordId(rowId),
+                type = pass.type,
+                serialNumber = pass.serialNumber,
+                organizationName = pass.organizationName,
+                description = pass.description,
+                expirationDate = pass.expirationDate,
+                voided = pass.voided,
+                signatureStatus = signatureStatus,
+                createdAt = PassInstant(createdAt),
+                updatedAt = PassInstant(nowEpochMs),
+            )
+            return UpsertOutcome(
+                recordId = PassRecordId(rowId),
+                summary = summary,
+                wasReplacement = existingId != null,
+            )
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    override fun delete(id: PassRecordId): DeleteOutcome? {
+        val summary = summaryById(id) ?: return null
+        db.beginTransaction()
+        try {
+            // ON DELETE CASCADE on pass_images and pass_locales handles the children.
+            db.delete(Schema.Tables.PASSES, "id = ?", arrayOf(id.value.toString()))
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return DeleteOutcome(summary)
+    }
+
+    override fun close() {
+        db.close()
+    }
+
+    private fun readImages(id: PassRecordId): Map<ImageRole, ImageBytes> {
+        val out = HashMap<ImageRole, ImageBytes>()
+        db.rawQuery(
+            "SELECT role, bytes FROM ${Schema.Tables.PASS_IMAGES} WHERE pass_id = ?",
+            arrayOf(id.value.toString()),
+        ).use { c ->
+            while (c.moveToNext()) {
+                val role = ImageRole.valueOf(c.getString(0))
+                out[role] = ImageBytes(c.getBlob(1))
+            }
+        }
+        return out
+    }
+
+    private fun readLocales(id: PassRecordId): Map<PassLocale, LocalizedStrings> {
+        val out = HashMap<PassLocale, LocalizedStrings>()
+        db.rawQuery(
+            "SELECT locale_tag, strings_json FROM ${Schema.Tables.PASS_LOCALES} WHERE pass_id = ?",
+            arrayOf(id.value.toString()),
+        ).use { c ->
+            while (c.moveToNext()) {
+                val tag = c.getString(0)
+                val bytes = c.getBlob(1)
+                out[PassLocale(tag)] = PassJsonCodec.decodeStrings(bytes)
+            }
+        }
+        return out
+    }
+
+    private fun Cursor.toSummary(): PassSummary = PassSummary(
+        id = PassRecordId(getLong(getColumnIndexOrThrow("id"))),
+        type = PassType.valueOf(getString(getColumnIndexOrThrow("type"))),
+        serialNumber = getString(getColumnIndexOrThrow("serial_number")),
+        organizationName = getString(getColumnIndexOrThrow("organization_name")),
+        description = getString(getColumnIndexOrThrow("description")),
+        expirationDate = getColumnIndexOrThrow("expiration_epoch_ms").let { idx ->
+            if (isNull(idx)) null else PassInstant(getLong(idx))
+        },
+        voided = getInt(getColumnIndexOrThrow("voided")) != 0,
+        signatureStatus = signatureStatusFromKind(getString(getColumnIndexOrThrow("signature_status_kind"))),
+        createdAt = PassInstant(getLong(getColumnIndexOrThrow("created_at_epoch_ms"))),
+        updatedAt = PassInstant(getLong(getColumnIndexOrThrow("updated_at_epoch_ms"))),
+    )
+
+    private fun signatureStatusFromKind(name: String): SignatureStatus = when (name) {
+        "Unsigned" -> SignatureStatus.Unsigned
+        "SelfSigned" -> SignatureStatus.SelfSigned
+        "AppleVerified" -> SignatureStatus.AppleVerified
+        "CertChainIncomplete" -> SignatureStatus.CertChainIncomplete
+        else -> error("unknown signature_status_kind '$name'")
+    }
+
+    private fun SignatureStatus.kindName(): String = when (this) {
+        SignatureStatus.Unsigned -> "Unsigned"
+        SignatureStatus.SelfSigned -> "SelfSigned"
+        SignatureStatus.AppleVerified -> "AppleVerified"
+        SignatureStatus.CertChainIncomplete -> "CertChainIncomplete"
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
@@ -21,7 +21,14 @@ import `is`.walt.passes.storage.KeyBacking
  */
 internal interface WrappedKeyStorage {
     fun read(): WrappedKeyEnvelope?
-    fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking)
+
+    /**
+     * Persists [envelope] synchronously and durably. Returns true on success, false if the
+     * underlying storage rejected the write. Callers MUST treat a false return as a hard
+     * failure: the brick scenario from the ADR class-of-bugs notes is "DB encrypted with a
+     * key whose envelope never made it to disk".
+     */
+    fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking): Boolean
 
     companion object {
         fun sharedPreferences(context: Context): WrappedKeyStorage =
@@ -70,13 +77,18 @@ private class SharedPrefsWrappedKeyStorage(
         )
     }
 
-    override fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking) {
-        prefs.edit()
+    override fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking): Boolean {
+        // Synchronous write. The envelope MUST be on disk before we hand the unwrapped
+        // database key to SQLCipher: a crash between an async apply() and the disk flush
+        // would leave the SQLCipher pages encrypted with a key whose envelope was never
+        // persisted, bricking the wallet's at-rest data on next launch. commit() blocks
+        // until the SharedPreferences XML is fsync'd.
+        return prefs.edit()
             .putString(KEY_CIPHERTEXT, Base64.encodeToString(envelope.ciphertext, Base64.NO_WRAP))
             .putString(KEY_IV, Base64.encodeToString(envelope.iv, Base64.NO_WRAP))
             .putString(KEY_ALIAS, envelope.keyAlias)
             .putString(KEY_BACKING, backing.name)
-            .apply()
+            .commit()
     }
 
     private companion object {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
@@ -1,0 +1,88 @@
+package `is`.walt.passes.storage.internal
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import `is`.walt.passes.storage.KeyBacking
+
+/**
+ * Persists the AES-GCM-wrapped database-key envelope. ADR 0002 D2 places this in the
+ * `schema_meta` table; in practice schema_meta lives inside the SQLCipher-encrypted
+ * database, so the bootstrap envelope (which IS the key to the DB) must live outside it.
+ *
+ * Implementation: a private SharedPreferences file scoped to the wallet's package.
+ * The envelope is itself ciphertext (AES-GCM wrapped by a Keystore-resident master key),
+ * so plain SharedPreferences is acceptable storage; the threat model is "physical recovery
+ * of disk bytes," and the wrapping defends against that without help from the prefs file.
+ *
+ * The envelope is excluded from Auto Backup via the same `walt_passes_backup_rules.xml` /
+ * `walt_passes_data_extraction_rules.xml` files (the SharedPreferences file is opted out
+ * by domain).
+ */
+internal interface WrappedKeyStorage {
+    fun read(): WrappedKeyEnvelope?
+    fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking)
+
+    companion object {
+        fun sharedPreferences(context: Context): WrappedKeyStorage =
+            SharedPrefsWrappedKeyStorage(
+                context.applicationContext.getSharedPreferences(
+                    PREFS_NAME,
+                    Context.MODE_PRIVATE,
+                ),
+            )
+
+        const val PREFS_NAME: String = "is.walt.passes.storage.key_envelope"
+    }
+}
+
+internal data class WrappedKeyEnvelope(
+    val ciphertext: ByteArray,
+    val iv: ByteArray,
+    val keyAlias: String,
+) {
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is WrappedKeyEnvelope &&
+            ciphertext.contentEquals(other.ciphertext) &&
+            iv.contentEquals(other.iv) &&
+            keyAlias == other.keyAlias)
+
+    override fun hashCode(): Int {
+        var r = ciphertext.contentHashCode()
+        r = 31 * r + iv.contentHashCode()
+        r = 31 * r + keyAlias.hashCode()
+        return r
+    }
+}
+
+private class SharedPrefsWrappedKeyStorage(
+    private val prefs: SharedPreferences,
+) : WrappedKeyStorage {
+
+    override fun read(): WrappedKeyEnvelope? {
+        val ct = prefs.getString(KEY_CIPHERTEXT, null) ?: return null
+        val iv = prefs.getString(KEY_IV, null) ?: return null
+        val alias = prefs.getString(KEY_ALIAS, null) ?: return null
+        return WrappedKeyEnvelope(
+            ciphertext = Base64.decode(ct, Base64.NO_WRAP),
+            iv = Base64.decode(iv, Base64.NO_WRAP),
+            keyAlias = alias,
+        )
+    }
+
+    override fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking) {
+        prefs.edit()
+            .putString(KEY_CIPHERTEXT, Base64.encodeToString(envelope.ciphertext, Base64.NO_WRAP))
+            .putString(KEY_IV, Base64.encodeToString(envelope.iv, Base64.NO_WRAP))
+            .putString(KEY_ALIAS, envelope.keyAlias)
+            .putString(KEY_BACKING, backing.name)
+            .apply()
+    }
+
+    private companion object {
+        const val KEY_CIPHERTEXT = "ciphertext"
+        const val KEY_IV = "iv"
+        const val KEY_ALIAS = "alias"
+        const val KEY_BACKING = "backing"
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/WrappedKeyStorage.kt
@@ -15,9 +15,12 @@ import `is`.walt.passes.storage.KeyBacking
  * so plain SharedPreferences is acceptable storage; the threat model is "physical recovery
  * of disk bytes," and the wrapping defends against that without help from the prefs file.
  *
- * The envelope is excluded from Auto Backup via the same `walt_passes_backup_rules.xml` /
- * `walt_passes_data_extraction_rules.xml` files (the SharedPreferences file is opted out
- * by domain).
+ * The envelope's SharedPreferences file is opted out of Auto Backup and device-to-device
+ * transfer via explicit `<exclude domain="sharedpref" .../>` entries in both
+ * `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml`. (Backed-up
+ * envelope ciphertext would be undecryptable on a restored device anyway, since the
+ * Keystore master is non-exportable, but the trust claim covers the envelope file
+ * alongside the encrypted DB.)
  */
 internal interface WrappedKeyStorage {
     fun read(): WrappedKeyEnvelope?

--- a/passes-storage/src/main/res/xml/walt_passes_backup_rules.xml
+++ b/passes-storage/src/main/res/xml/walt_passes_backup_rules.xml
@@ -15,4 +15,11 @@
     <exclude domain="database" path="walt_passes.db-journal" />
     <exclude domain="database" path="walt_passes.db-wal" />
     <exclude domain="database" path="walt_passes.db-shm" />
+    <!--
+      The wrapped DB-key envelope (AES-GCM ciphertext under a non-exportable Keystore
+      master). Backed-up envelope is undecryptable on a restored device, but the trust
+      claim "pass-related at-rest data is excluded from cloud backup" covers the
+      envelope file alongside the encrypted DB.
+    -->
+    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
 </full-backup-content>

--- a/passes-storage/src/main/res/xml/walt_passes_backup_rules.xml
+++ b/passes-storage/src/main/res/xml/walt_passes_backup_rules.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Auto Backup exclusions for API 23-30. ADR 0002 D5.
+
+  The walt_passes.db SQLCipher file (and SQLite's WAL/journal sidecars) is excluded
+  from cloud Auto Backup. Even though the file is page-encrypted with a Keystore-wrapped
+  key that the backup blob cannot decrypt, exclusion is the load-bearing control: cloud
+  blobs of opaque ciphertext still represent a future-decryption risk if the key store
+  on a restored device ever lines up by accident.
+
+  The trust claim "pass data is excluded from cloud backup" is delivered by these rules.
+-->
+<full-backup-content>
+    <exclude domain="database" path="walt_passes.db" />
+    <exclude domain="database" path="walt_passes.db-journal" />
+    <exclude domain="database" path="walt_passes.db-wal" />
+    <exclude domain="database" path="walt_passes.db-shm" />
+</full-backup-content>

--- a/passes-storage/src/main/res/xml/walt_passes_data_extraction_rules.xml
+++ b/passes-storage/src/main/res/xml/walt_passes_data_extraction_rules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Data extraction rules for API 31+ (Android 12 and later). ADR 0002 D5.
+
+  Covers both cloud backup and device-to-device transfer. The walt_passes.db SQLCipher
+  file (and its WAL/journal sidecars) is excluded from both surfaces. Pass data is
+  not portable across devices through the system transfer flow; users re-import passes
+  on a new device, which keeps the Keystore-wrapped key custody story intact.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="database" path="walt_passes.db" />
+        <exclude domain="database" path="walt_passes.db-journal" />
+        <exclude domain="database" path="walt_passes.db-wal" />
+        <exclude domain="database" path="walt_passes.db-shm" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="database" path="walt_passes.db" />
+        <exclude domain="database" path="walt_passes.db-journal" />
+        <exclude domain="database" path="walt_passes.db-wal" />
+        <exclude domain="database" path="walt_passes.db-shm" />
+    </device-transfer>
+</data-extraction-rules>

--- a/passes-storage/src/main/res/xml/walt_passes_data_extraction_rules.xml
+++ b/passes-storage/src/main/res/xml/walt_passes_data_extraction_rules.xml
@@ -13,11 +13,13 @@
         <exclude domain="database" path="walt_passes.db-journal" />
         <exclude domain="database" path="walt_passes.db-wal" />
         <exclude domain="database" path="walt_passes.db-shm" />
+        <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
     </cloud-backup>
     <device-transfer>
         <exclude domain="database" path="walt_passes.db" />
         <exclude domain="database" path="walt_passes.db-journal" />
         <exclude domain="database" path="walt_passes.db-wal" />
         <exclude domain="database" path="walt_passes.db-shm" />
+        <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
     </device-transfer>
 </data-extraction-rules>

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProviderTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/AndroidKeystorePassKeyProviderTest.kt
@@ -1,0 +1,60 @@
+package `is`.walt.passes.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.storage.internal.WrappedKeyEnvelope
+import `is`.walt.passes.storage.internal.WrappedKeyStorage
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Behavioral tests for the bootstrap branches of [AndroidKeystorePassKeyProvider] that do
+ * not require Keystore — driven through a fake [WrappedKeyStorage] and a constructed
+ * provider so the file-existence guard from review item (3) is reachable on the JVM CI
+ * host.
+ *
+ * The Keystore-touching paths (master key generation, AES-GCM wrap/unwrap, StrongBox vs
+ * TEE detection) are exercised on-device by the follow-on `wpass-x5l` instrumentation
+ * suite; this file only locks the orchestration around the wrapped storage.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class AndroidKeystorePassKeyProviderTest {
+
+    @Test
+    fun missingEnvelopeWithExistingDatabaseFileSurfacesKeyUnavailable() {
+        val storage = FakeWrappedKeyStorage(initial = null)
+        val provider = AndroidKeystorePassKeyProvider(
+            masterKey = NoOpSecretKey,
+            keyBacking = KeyBacking.Tee,
+            wrappedKeyStorage = storage,
+            databaseFileExists = { true },
+        )
+        val result = provider.provideDatabaseKey()
+        check(result is StorageResult.Failure)
+        assertThat(result.error).isEqualTo(StorageError.KeyUnavailable)
+        // No fresh envelope was written; the existing-but-unrecoverable DB is left
+        // untouched for the wallet's "secure storage was reset" remediation flow.
+        assertThat(storage.writeCount).isEqualTo(0)
+    }
+
+    private class FakeWrappedKeyStorage(initial: WrappedKeyEnvelope?) : WrappedKeyStorage {
+        private var envelope: WrappedKeyEnvelope? = initial
+        var writeCount: Int = 0
+            private set
+
+        override fun read(): WrappedKeyEnvelope? = envelope
+        override fun write(envelope: WrappedKeyEnvelope, backing: KeyBacking): Boolean {
+            this.envelope = envelope
+            writeCount++
+            return true
+        }
+    }
+
+    private object NoOpSecretKey : javax.crypto.SecretKey {
+        override fun getAlgorithm(): String = "AES"
+        override fun getFormat(): String = "RAW"
+        override fun getEncoded(): ByteArray = ByteArray(32)
+    }
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -114,7 +114,7 @@ class PassRepositoryContractTest {
     }
 
     @Test
-    fun deleteOfUnknownIdReturnsIntegrityViolationAndEmitsNoDeleteEvent() = runTest {
+    fun deleteOfUnknownIdReturnsIntegrityViolationAndEmitsFailureNotDeleteEvent() = runTest {
         val store = FakePassStore()
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
@@ -129,7 +129,37 @@ class PassRepositoryContractTest {
 
         check(result is StorageResult.Failure)
         check(result.error is StorageError.IntegrityViolation)
-        assertThat(telemetry.events).containsExactly("init:StrongBox")
+        // No delete event (the row didn't go anywhere); ONE storage-failure event so the
+        // observability discipline survives the early return path.
+        assertThat(telemetry.events).containsExactly(
+            "init:StrongBox",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
+    fun closeMakesSubsequentCallsReturnDatabaseLockedAndEmitsFailure() = runTest {
+        val store = FakePassStore(initial = listOf(sampleSummary(id = 1L)))
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.Tee,
+        )
+        repo.close()
+        // close() is idempotent.
+        repo.close()
+        assertThat(store.closeCount).isEqualTo(1)
+
+        val result = repo.summaryOf(PassRecordId(1L))
+        check(result is StorageResult.Failure)
+        check(result.error == StorageError.DatabaseLocked)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "failure:DatabaseLocked:n/a",
+        ).inOrder()
     }
 
     @Test
@@ -217,7 +247,12 @@ class PassRepositoryContractTest {
             return DeleteOutcome(summary)
         }
 
-        override fun close() = Unit
+        var closeCount: Int = 0
+            private set
+
+        override fun close() {
+            closeCount++
+        }
     }
 
     private class RecordingGuard : StorageTelemetryGuard {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -27,11 +27,11 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /**
- * Robolectric-runner-backed verification of the StateFlow + delete sequencing contract from
- * ADR 0002 D6. The repository is constructed against an in-memory fake [PassStore] so we
- * exercise the public contract without touching SQLCipher native libraries.
+ * Robolectric-runner-backed verification of the StateFlow + delete sequencing contract.
+ * The repository is constructed against an in-memory fake [PassStore] so we exercise the
+ * public contract without touching SQLCipher native libraries.
  *
- * The properties locked here:
+ * Properties locked here:
  *
  *  1. The `passes` StateFlow seeds from `store.listSummaries()` at construction time.
  *  2. After `upsert`, the StateFlow reflects the new row (insert OR replace).
@@ -103,10 +103,8 @@ class PassRepositoryContractTest {
 
         assertThat(repo.passes.value).isEmpty()
 
-        // Sequencing: the StateFlow update happens BEFORE the telemetry event. We can verify
-        // this by inspecting the recorded transcript: telemetry was recorded after delete()
-        // returned, by which point the StateFlow value is already empty. The telemetry guard
-        // is not invoked from inside the store, so a pre-state-update event would be a bug.
+        // Sequencing: telemetry fires after the StateFlow update. The recorded transcript
+        // observes only the post-delete() state, by which point the value is already empty.
         assertThat(telemetry.events).containsExactly(
             "init:Software",
             "delete:BoardingPass:AppleVerified",
@@ -129,8 +127,6 @@ class PassRepositoryContractTest {
 
         check(result is StorageResult.Failure)
         check(result.error is StorageError.IntegrityViolation)
-        // No delete event (the row didn't go anywhere); ONE storage-failure event so the
-        // observability discipline survives the early return path.
         assertThat(telemetry.events).containsExactly(
             "init:StrongBox",
             "failure:IntegrityViolation:n/a",
@@ -165,8 +161,7 @@ class PassRepositoryContractTest {
     @Test
     fun deleteIsIrreversibleNoUndoArmOnPublicSurface() {
         // Compile-time lock: the only mutating method on PassRepository for an existing row
-        // is `delete(id)`. There is no `undelete`, `restore`, `softDelete`, or `archive` on
-        // the contract. Adding one would force a re-read of ADR 0002 D6.
+        // is `delete(id)`. No `undelete`, `restore`, `softDelete`, or `archive` arms exist.
         val methods = PassRepository::class.java.declaredMethods.map { it.name }.toSet()
         assertThat(methods).doesNotContain("undelete")
         assertThat(methods).doesNotContain("restore")

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -1,0 +1,289 @@
+package `is`.walt.passes.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.ImageBytes
+import `is`.walt.passes.core.ImageRole
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.DeleteOutcome
+import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.UpsertOutcome
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-runner-backed verification of the StateFlow + delete sequencing contract from
+ * ADR 0002 D6. The repository is constructed against an in-memory fake [PassStore] so we
+ * exercise the public contract without touching SQLCipher native libraries.
+ *
+ * The properties locked here:
+ *
+ *  1. The `passes` StateFlow seeds from `store.listSummaries()` at construction time.
+ *  2. After `upsert`, the StateFlow reflects the new row (insert OR replace).
+ *  3. After `delete(id)` the StateFlow no longer carries that id.
+ *  4. `onPassDeleted(type, signatureStatus)` is emitted AFTER the StateFlow update.
+ *  5. `onPassDeleted` is NOT emitted for an unknown id; that surfaces as
+ *     `IntegrityViolation` instead.
+ *  6. Deletion is irreversible at the repository surface: there is no `undelete` /
+ *     `restore` / soft-delete arm reachable from the public API.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class PassRepositoryContractTest {
+
+    @Test
+    fun stateFlowSeedsFromStoreOnConstruction() = runTest {
+        val seed = listOf(sampleSummary(id = 1L), sampleSummary(id = 2L))
+        val store = FakePassStore(initial = seed)
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_000L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+        assertThat(repo.passes.value.map { it.id.value }).containsExactly(1L, 2L).inOrder()
+        assertThat(telemetry.events).containsExactly("init:StrongBox")
+    }
+
+    @Test
+    fun upsertUpdatesStateFlowAndEmitsTelemetryAfter() = runTest {
+        val store = FakePassStore()
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_000L },
+            keyBacking = KeyBacking.Tee,
+        )
+
+        val pass = samplePass(serial = "S1")
+        val result = repo.upsert(pass, SignatureStatus.AppleVerified)
+
+        check(result is StorageResult.Success)
+        assertThat(repo.passes.value.map { it.serialNumber }).containsExactly("S1")
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "upsert:BoardingPass:AppleVerified:false",
+        ).inOrder()
+    }
+
+    @Test
+    fun deleteUpdatesStateFlowAndEmitsTelemetryAfterTransaction() = runTest {
+        val store = FakePassStore(initial = listOf(sampleSummary(id = 7L)))
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_000L },
+            keyBacking = KeyBacking.Software,
+        )
+
+        val result = repo.delete(PassRecordId(7L))
+        check(result is StorageResult.Success)
+
+        assertThat(repo.passes.value).isEmpty()
+
+        // Sequencing: the StateFlow update happens BEFORE the telemetry event. We can verify
+        // this by inspecting the recorded transcript: telemetry was recorded after delete()
+        // returned, by which point the StateFlow value is already empty. The telemetry guard
+        // is not invoked from inside the store, so a pre-state-update event would be a bug.
+        assertThat(telemetry.events).containsExactly(
+            "init:Software",
+            "delete:BoardingPass:AppleVerified",
+        ).inOrder()
+    }
+
+    @Test
+    fun deleteOfUnknownIdReturnsIntegrityViolationAndEmitsNoDeleteEvent() = runTest {
+        val store = FakePassStore()
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+
+        val result = repo.delete(PassRecordId(404L))
+
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.IntegrityViolation)
+        assertThat(telemetry.events).containsExactly("init:StrongBox")
+    }
+
+    @Test
+    fun deleteIsIrreversibleNoUndoArmOnPublicSurface() {
+        // Compile-time lock: the only mutating method on PassRepository for an existing row
+        // is `delete(id)`. There is no `undelete`, `restore`, `softDelete`, or `archive` on
+        // the contract. Adding one would force a re-read of ADR 0002 D6.
+        val methods = PassRepository::class.java.declaredMethods.map { it.name }.toSet()
+        assertThat(methods).doesNotContain("undelete")
+        assertThat(methods).doesNotContain("restore")
+        assertThat(methods).doesNotContain("softDelete")
+        assertThat(methods).doesNotContain("archive")
+    }
+
+    /**
+     * In-memory [PassStore] that exercises the same surface area as `SqlCipherPassStore` but
+     * works in JVM. Sequence is single-threaded; tests use [UnconfinedTestDispatcher] so
+     * `withContext(ioDispatcher)` runs in the calling test thread.
+     */
+    private class FakePassStore(initial: List<PassSummary> = emptyList()) : PassStore {
+        private val rows: LinkedHashMap<Long, StoredPass> = LinkedHashMap()
+        private val summaries: LinkedHashMap<Long, PassSummary> = LinkedHashMap()
+        private var nextId: Long = 0L
+
+        init {
+            for (s in initial) {
+                summaries[s.id.value] = s
+                rows[s.id.value] = StoredPass(
+                    id = s.id,
+                    pass = samplePass(serial = s.serialNumber),
+                    signatureStatus = s.signatureStatus,
+                    createdAt = s.createdAt,
+                    updatedAt = s.updatedAt,
+                )
+                nextId = maxOf(nextId, s.id.value)
+            }
+        }
+
+        override fun listSummaries(): List<PassSummary> = summaries.values.toList()
+        override fun loadById(id: PassRecordId): StoredPass? = rows[id.value]
+        override fun summaryById(id: PassRecordId): PassSummary? = summaries[id.value]
+
+        override fun upsert(
+            pass: Pass,
+            signatureStatus: SignatureStatus,
+            nowEpochMs: Long,
+        ): UpsertOutcome {
+            val existing = summaries.values.firstOrNull {
+                it.type == pass.type &&
+                    it.serialNumber == pass.serialNumber &&
+                    it.organizationName == pass.organizationName
+            }
+            val id = existing?.id ?: PassRecordId(++nextId)
+            val createdAt = existing?.createdAt ?: PassInstant(nowEpochMs)
+            val summary = PassSummary(
+                id = id,
+                type = pass.type,
+                serialNumber = pass.serialNumber,
+                organizationName = pass.organizationName,
+                description = pass.description,
+                expirationDate = pass.expirationDate,
+                voided = pass.voided,
+                signatureStatus = signatureStatus,
+                createdAt = createdAt,
+                updatedAt = PassInstant(nowEpochMs),
+            )
+            summaries[id.value] = summary
+            rows[id.value] = StoredPass(
+                id = id,
+                pass = pass,
+                signatureStatus = signatureStatus,
+                createdAt = createdAt,
+                updatedAt = PassInstant(nowEpochMs),
+            )
+            return UpsertOutcome(
+                recordId = id,
+                summary = summary,
+                wasReplacement = existing != null,
+            )
+        }
+
+        override fun delete(id: PassRecordId): DeleteOutcome? {
+            val summary = summaries.remove(id.value) ?: return null
+            rows.remove(id.value)
+            return DeleteOutcome(summary)
+        }
+
+        override fun close() = Unit
+    }
+
+    private class RecordingGuard : StorageTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+        override fun onKeyProviderInitialized(backing: KeyBacking) {
+            events += "init:${backing.name}"
+        }
+        override fun onPassUpserted(
+            type: PassType,
+            signatureStatus: SignatureStatusKind,
+            wasReplacement: Boolean,
+        ) {
+            events += "upsert:${type.name}:${signatureStatus.name}:$wasReplacement"
+        }
+        override fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind) {
+            events += "delete:${type.name}:${signatureStatus.name}"
+        }
+        override fun onMigrationRowDropped(kind: MigrationFailureKind) {
+            events += "drop:${kind.name}"
+        }
+        override fun onStorageFailure(
+            kind: StorageFailureKind,
+            unknownKind: UnknownStorageFailureKind?,
+        ) {
+            events += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
+        }
+    }
+
+    private companion object {
+        fun sampleSummary(id: Long): PassSummary = PassSummary(
+            id = PassRecordId(id),
+            type = PassType.BoardingPass,
+            serialNumber = "S$id",
+            organizationName = "AcmeAir",
+            description = "Boarding Pass",
+            expirationDate = null,
+            voided = false,
+            signatureStatus = SignatureStatus.AppleVerified,
+            createdAt = PassInstant(1L),
+            updatedAt = PassInstant(1L),
+        )
+
+        fun samplePass(serial: String): Pass = Pass(
+            type = PassType.BoardingPass,
+            serialNumber = serial,
+            description = "Boarding Pass",
+            organizationName = "AcmeAir",
+            expirationDate = null,
+            voided = false,
+            colors = PassColors(
+                foreground = ColorValue(0xFFFFFF),
+                background = ColorValue(0x000000),
+                label = null,
+            ),
+            frontFields = PassFields(
+                primary = listOf(PassField(key = "p", label = null, value = "v")),
+            ),
+            backFields = emptyList(),
+            barcode = Barcode(
+                format = BarcodeFormat.QR,
+                message = "data",
+                messageEncoding = "iso-8859-1",
+                altText = null,
+            ),
+            images = mapOf(ImageRole.Logo to ImageBytes(byteArrayOf(0x01, 0x02))),
+            locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("k" to "v"))),
+        )
+    }
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
@@ -1,0 +1,131 @@
+package `is`.walt.passes.storage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.sql.DriverManager
+import java.sql.SQLException
+
+/**
+ * JVM-side verification that [Schema.DDL] executes cleanly on a stock SQLite engine. The
+ * Android implementation runs the same DDL through SQLCipher; SQLCipher is wire-compatible
+ * with SQLite, so a JVM-side green here is a strong signal that the schema is well-formed
+ * before instrumentation tests get involved. Backed by xerial `sqlite-jdbc`.
+ *
+ * These tests deliberately do NOT depend on Android, SQLCipher, or any native library.
+ */
+class SchemaDdlTest {
+
+    private fun openMemoryDb() = DriverManager.getConnection("jdbc:sqlite::memory:")
+
+    private fun applyDdl(): java.sql.Connection {
+        val conn = openMemoryDb()
+        conn.createStatement().use { stmt ->
+            stmt.execute("PRAGMA foreign_keys = ON")
+            for (sql in Schema.DDL) {
+                stmt.execute(sql)
+            }
+        }
+        return conn
+    }
+
+    @Test
+    fun ddlExecutesCleanlyAndCreatesTheFourDocumentedTables() {
+        applyDdl().use { conn ->
+            val tables = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT name FROM sqlite_master WHERE type='table'")
+                while (rs.next()) tables.add(rs.getString(1))
+            }
+            assertThat(tables).containsAtLeast(
+                Schema.Tables.SCHEMA_META,
+                Schema.Tables.PASSES,
+                Schema.Tables.PASS_IMAGES,
+                Schema.Tables.PASS_LOCALES,
+            )
+        }
+    }
+
+    @Test
+    fun ddlCreatesTheThreeDocumentedIndexes() {
+        applyDdl().use { conn ->
+            val indexes = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+                )
+                while (rs.next()) indexes.add(rs.getString(1))
+            }
+            assertThat(indexes).containsAtLeast(
+                "idx_passes_type",
+                "idx_passes_expiration",
+                "idx_passes_identity",
+            )
+        }
+    }
+
+    @Test
+    fun uniqueIdentityIndexRejectsDuplicateImports() {
+        applyDdl().use { conn ->
+            val insert = conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?)",
+            )
+            fun insertSample(serial: String) {
+                insert.setString(1, "BoardingPass")
+                insert.setString(2, serial)
+                insert.setString(3, "AcmeAir")
+                insert.setString(4, "AcmeAir Boarding Pass")
+                insert.setString(5, "AppleVerified")
+                insert.setBytes(6, byteArrayOf(0))
+                insert.setLong(7, 1L)
+                insert.setLong(8, 1L)
+                insert.executeUpdate()
+            }
+            insertSample("AAA")
+            try {
+                insertSample("AAA")
+                error("expected uniqueness violation")
+            } catch (expected: SQLException) {
+                assertThat(expected.message).contains("UNIQUE")
+            }
+        }
+    }
+
+    @Test
+    fun foreignKeyCascadeDropsImageAndLocaleRowsWithTheParentPass() {
+        applyDdl().use { conn ->
+            conn.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (1, 'BoardingPass', 'S1', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASS_IMAGES} (pass_id, role, bytes) " +
+                    "VALUES (1, 'Logo', x'00')",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASS_LOCALES} (pass_id, locale_tag, strings_json) " +
+                    "VALUES (1, 'en', x'00')",
+            ).use { it.executeUpdate() }
+
+            conn.prepareStatement("DELETE FROM ${Schema.Tables.PASSES} WHERE id = 1")
+                .use { it.executeUpdate() }
+
+            conn.createStatement().use { stmt ->
+                val imageRows = stmt.executeQuery(
+                    "SELECT COUNT(*) FROM ${Schema.Tables.PASS_IMAGES}",
+                ).also { it.next() }.getInt(1)
+                val localeRows = stmt.executeQuery(
+                    "SELECT COUNT(*) FROM ${Schema.Tables.PASS_LOCALES}",
+                ).also { it.next() }.getInt(1)
+                assertThat(imageRows).isEqualTo(0)
+                assertThat(localeRows).isEqualTo(0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implementation follow-on to `wpass-9vv.3` (design) closing `wpass-fpj`. Wires AGP onto `passes-storage` and lands the trust-claim-bearing storage layer behind the contract from ADR 0002.

- AGP 9.0.1 + SQLCipher 4.5.4, minSdk 28, matching `passes-ui`.
- `AndroidKeystorePassKeyProvider`: AES-256 master in AndroidKeyStore (StrongBox preferred, TEE fallback, Software last), AES-GCM-wrapped 32-byte DB key. `KeyBacking` reported through `StorageTelemetryGuard.onKeyProviderInitialized` (ADR D2).
- Wrapped key envelope persists in a private `SharedPreferences` file. Note: ADR D2 specified `schema_meta` for envelope storage, but `schema_meta` is itself inside the SQLCipher-encrypted DB the envelope unlocks; storing the envelope outside the DB resolves the chicken-and-egg without weakening the trust claim (the envelope is itself ciphertext under a non-exportable Keystore master).
- Library-merged `res/xml/walt_passes_backup_rules.xml` + `walt_passes_data_extraction_rules.xml`, wired via the library `AndroidManifest.xml`'s `android:fullBackupContent` and `android:dataExtractionRules` (ADR D5).
- `BackupRulesAssertion.assertBackupRulesApplied(context)`: consumer-side check the merge actually applied. Uses reflection on `ApplicationInfo.fullBackupContent` / `dataExtractionRulesRes` since both are hidden public-API fields in recent SDKs.
- `SqlCipherPassRepository`: StateFlow seeded from disk; upsert/delete serialized through a write mutex; delete updates the StateFlow inside the same critical section, then emits `onPassDeleted` (ADR D6 — no undo, no soft-delete, no VACUUM).
- Internal `PassStore` boundary lets the public-surface contract tests run on Robolectric without SQLCipher native libs.

## Tests

- `PublicApiSurfaceTest`: still passes; no public surface changes.
- `SchemaDdlTest` (JVM, xerial sqlite-jdbc): verifies DDL creates the four tables + three indexes, the unique identity index rejects duplicate imports, and `ON DELETE CASCADE` removes child rows in `pass_images` / `pass_locales`.
- `PassRepositoryContractTest` (Robolectric): StateFlow seeds from disk; upsert / delete reflect in StateFlow; telemetry fires after the StateFlow update; unknown-id delete returns `IntegrityViolation` and emits no `onPassDeleted`; the public surface has no `undelete` / `restore` / `softDelete` / `archive` method.

`./gradlew check` green across `passes-core`, `passes-storage`, `passes-ui`.

## Test plan

- [ ] Walk the merged manifest in a consumer (`assembleRelease`) and confirm `android:fullBackupContent` / `android:dataExtractionRules` reference the walt resources.
- [ ] Confirm `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml` ship in the AAR.
- [ ] Smoke-test `SqlCipherPassRepository.create(context, AndroidKeystorePassKeyProvider.create(context).value, telemetryGuard)` against a real device under wpass-x5l.

## Follow-ups

- `wpass-x5l` — device-required `connectedAndroidTest` suite: bmgr Auto Backup verification, StrongBox/TEE matrix on emulator + physical device, work-profile install, KeyUnavailable surface across app-data clear.

Closes wpass-fpj.