### PR TITLE
Wire CI, dependabot, and build-logic plugins (wpass-9vv.6)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+# `is.walt.passes.*` uses Kotlin's reserved word `is` as a package segment, which is
+# legal Kotlin (with backticks at use-sites) and matches the `is.walt.*` namespace
+# walt-android publishes under. Disable ktlint's package-name rule so the namespace
+# stays consistent across the trust-claim boundary.
+ktlint_standard_package-name = disabled
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "automated"
+    # passes-android is the trust-claim repo. Major-version bumps to AGP, Kotlin,
+    # AndroidX core, SQLCipher, BouncyCastle, and Compose all warrant manual review;
+    # let dependabot handle minor/patch and surface majors as separate PRs.
+    ignore:
+      - dependency-name: "com.android.tools.build:gradle"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.jetbrains.kotlin:*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "androidx.core:core-ktx"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "net.zetetic:sqlcipher-android"
+        update-types: ["version-update:semver-major"]
+    groups:
+      kotlin-and-agp:
+        patterns:
+          - "org.jetbrains.kotlin:*"
+          - "com.android.tools.build:*"
+        update-types:
+          - "minor"
+          - "patch"
+      compose:
+        patterns:
+          - "androidx.compose.*:*"
+          - "androidx.compose.material3:*"
+        update-types:
+          - "minor"
+          - "patch"
+      androidx:
+        patterns:
+          - "androidx.*"
+        update-types:
+          - "minor"
+          - "patch"
+      testing:
+        patterns:
+          - "junit:*"
+          - "com.google.truth:*"
+          - "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+          - "org.robolectric:*"
+          - "org.xerial:*"
+        update-types:
+          - "minor"
+          - "patch"
+      quality:
+        patterns:
+          - "io.gitlab.arturbosch.detekt:*"
+          - "org.jlleitschuh.gradle:*"
+        update-types:
+          - "minor"
+          - "patch"
+      other:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # build-logic is a separate composite build with its own Gradle plugin classpath.
+  - package-ecosystem: "gradle"
+    directory: "/build-logic"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "build-logic"
+      - "automated"
+    commit-message:
+      prefix: "deps(build-logic)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "automated"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ["**/*.md", "docs/**", ".github/ISSUE_TEMPLATE/**"]
   push:
     branches: [main]
+    paths-ignore: ["**/*.md", "docs/**", ".github/ISSUE_TEMPLATE/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,21 +21,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
         with:
           packages: "platforms;android-36 build-tools;36.0.0"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
         with:
           # Forks must not be able to write to the build cache.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: reports
           path: |
@@ -60,9 +60,9 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Dependency review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,17 @@ jobs:
           java-version: "17"
           distribution: "temurin"
 
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
-        with:
-          packages: "platforms;android-36 build-tools;36.0.0"
+      # Use the Android SDK preinstalled on ubuntu-latest. Top up the
+      # specific platform / build-tools the modules need via sdkmanager. We
+      # cannot use android-actions/setup-android because the publisher org
+      # is not on the repo's verified-actions allowlist.
+      - name: Top up Android SDK packages
+        run: |
+          set -eu
+          yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" \
+            "platforms;android-36" \
+            "build-tools;36.0.0"
+          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & quality
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: "platforms;android-36 build-tools;36.0.0"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          # Forks must not be able to write to the build cache.
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+      - name: Build, test, lint
+        run: ./gradlew check assemble --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: reports
+          path: |
+            **/build/reports/tests/
+            **/build/reports/detekt/
+            **/build/reports/ktlint/
+          if-no-files-found: ignore
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,47 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    `kotlin-dsl`
+}
+
+group = "is.walt.passes.buildlogic"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
+    }
+}
+
+dependencies {
+    compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
+    compileOnly(libs.compose.gradlePlugin)
+    implementation(libs.detekt.gradlePlugin)
+    implementation(libs.ktlint.gradlePlugin)
+}
+
+gradlePlugin {
+    plugins {
+        register("kotlinLibrary") {
+            id = "is.walt.passes.kotlin.library"
+            implementationClass = "KotlinLibraryConventionPlugin"
+        }
+        register("androidLibrary") {
+            id = "is.walt.passes.android.library"
+            implementationClass = "AndroidLibraryConventionPlugin"
+        }
+        register("androidCompose") {
+            id = "is.walt.passes.android.compose"
+            implementationClass = "ComposeConventionPlugin"
+        }
+        register("quality") {
+            id = "is.walt.passes.quality"
+            implementationClass = "QualityConventionPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -10,13 +10,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 /**
  * Convention for Android library modules (passes-storage, passes-ui).
  *
- * Mirrors walt-android's AndroidLibraryConventionPlugin with two passes-specific tweaks:
- * - minSdk 28 instead of 26. StrongBox-backed Keystore (passes-storage) and
- *   ImageDecoder.setOnHeaderDecodedListener (passes-ui) both land at API 28; aligning
- *   the whole repo at minSdk 28 keeps the trust-claim story consistent across modules.
- * - explicitApi + -Xjvm-default=all enforced via Kotlin compiler options.
- *
- * AGP 9 has built-in Kotlin support, so org.jetbrains.kotlin.android is not applied.
+ * minSdk 28: StrongBox-backed Keystore and ImageDecoder.setOnHeaderDecodedListener
+ * both land at API 28, so the whole repo aligns there.
  */
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -29,6 +24,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 defaultConfig {
                     minSdk = 28
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                    consumerProguardFiles("consumer-rules.pro")
                 }
 
                 compileOptions {
@@ -39,6 +35,10 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                 buildFeatures {
                     aidl = false
                     shaders = false
+                }
+
+                lint {
+                    checkReleaseBuilds = false
                 }
 
                 testOptions {

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,0 +1,61 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+
+/**
+ * Convention for Android library modules (passes-storage, passes-ui).
+ *
+ * Mirrors walt-android's AndroidLibraryConventionPlugin with two passes-specific tweaks:
+ * - minSdk 28 instead of 26. StrongBox-backed Keystore (passes-storage) and
+ *   ImageDecoder.setOnHeaderDecodedListener (passes-ui) both land at API 28; aligning
+ *   the whole repo at minSdk 28 keeps the trust-claim story consistent across modules.
+ * - explicitApi + -Xjvm-default=all enforced via Kotlin compiler options.
+ *
+ * AGP 9 has built-in Kotlin support, so org.jetbrains.kotlin.android is not applied.
+ */
+class AndroidLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("com.android.library")
+
+            extensions.configure<LibraryExtension> {
+                compileSdk = 36
+
+                defaultConfig {
+                    minSdk = 28
+                    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                }
+
+                compileOptions {
+                    sourceCompatibility = JavaVersion.VERSION_17
+                    targetCompatibility = JavaVersion.VERSION_17
+                }
+
+                buildFeatures {
+                    aidl = false
+                    shaders = false
+                }
+
+                testOptions {
+                    unitTests {
+                        isIncludeAndroidResources = true
+                        isReturnDefaultValues = true
+                    }
+                }
+            }
+
+            extensions.configure<KotlinAndroidProjectExtension> {
+                explicitApi = ExplicitApiMode.Strict
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_17)
+                    freeCompilerArgs.addAll("-Xjvm-default=all")
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
@@ -1,0 +1,46 @@
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByType
+
+/**
+ * Convention for Android modules using Jetpack Compose (passes-ui).
+ *
+ * Diverges from walt-android's ComposeConventionPlugin by NOT auto-adding Compose BOM
+ * or core Compose libraries. passes-ui exposes its Compose surface to walt-android via
+ * `api(...)` rather than `implementation(...)`, so dependency strength is module-specific
+ * and stays in the module's build.gradle.kts.
+ *
+ * Must be applied after walt.passes.android.library.
+ *
+ * Usage:
+ * ```
+ * plugins {
+ *     alias(libs.plugins.walt.passes.android.library)
+ *     alias(libs.plugins.walt.passes.android.compose)
+ * }
+ * ```
+ */
+class ComposeConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            pluginManager.apply(libs.findPlugin("kotlin-compose").get().get().pluginId)
+
+            val androidExtension = extensions.findByType(LibraryExtension::class.java)
+                ?: error(
+                    "is.walt.passes.android.compose must be applied after " +
+                        "is.walt.passes.android.library (Android Library plugin not found)."
+                )
+
+            androidExtension.apply {
+                buildFeatures {
+                    compose = true
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ComposeConventionPlugin.kt
@@ -1,44 +1,24 @@
 import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.findByType
-import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.configure
 
 /**
  * Convention for Android modules using Jetpack Compose (passes-ui).
  *
- * Diverges from walt-android's ComposeConventionPlugin by NOT auto-adding Compose BOM
- * or core Compose libraries. passes-ui exposes its Compose surface to walt-android via
- * `api(...)` rather than `implementation(...)`, so dependency strength is module-specific
- * and stays in the module's build.gradle.kts.
- *
- * Must be applied after walt.passes.android.library.
- *
- * Usage:
- * ```
- * plugins {
- *     alias(libs.plugins.walt.passes.android.library)
- *     alias(libs.plugins.walt.passes.android.compose)
- * }
- * ```
+ * Does NOT auto-add the Compose BOM or core Compose libraries; passes-ui exposes its
+ * Compose surface via `api(...)` so dependency strength stays in the module file.
  */
 class ComposeConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
-            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+            pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
 
-            pluginManager.apply(libs.findPlugin("kotlin-compose").get().get().pluginId)
-
-            val androidExtension = extensions.findByType(LibraryExtension::class.java)
-                ?: error(
-                    "is.walt.passes.android.compose must be applied after " +
-                        "is.walt.passes.android.library (Android Library plugin not found)."
-                )
-
-            androidExtension.apply {
-                buildFeatures {
-                    compose = true
+            pluginManager.withPlugin("com.android.library") {
+                extensions.configure<LibraryExtension> {
+                    buildFeatures {
+                        compose = true
+                    }
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
@@ -1,0 +1,46 @@
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+/**
+ * Convention for pure Kotlin/JVM library modules (passes-core).
+ *
+ * Mirrors walt-android's KotlinLibraryConventionPlugin and adds the two trust-claim-relevant
+ * defaults the passes repo enforces everywhere: explicit API mode and -Xjvm-default=all.
+ *
+ * Usage:
+ * ```
+ * plugins {
+ *     alias(libs.plugins.walt.passes.kotlin.library)
+ * }
+ * ```
+ */
+class KotlinLibraryConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.jvm")
+                apply("java-library")
+            }
+
+            extensions.configure<JavaPluginExtension> {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+
+            extensions.configure<KotlinJvmProjectExtension> {
+                explicitApi = ExplicitApiMode.Strict
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_17)
+                    progressiveMode.set(true)
+                    freeCompilerArgs.addAll("-Xjvm-default=all")
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
@@ -10,15 +10,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 /**
  * Convention for pure Kotlin/JVM library modules (passes-core).
  *
- * Mirrors walt-android's KotlinLibraryConventionPlugin and adds the two trust-claim-relevant
- * defaults the passes repo enforces everywhere: explicit API mode and -Xjvm-default=all.
- *
- * Usage:
- * ```
- * plugins {
- *     alias(libs.plugins.walt.passes.kotlin.library)
- * }
- * ```
+ * Enforces explicit API mode and `-Xjvm-default=all` for the trust-claim surface.
  */
 class KotlinLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {

--- a/build-logic/convention/src/main/kotlin/QualityConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/QualityConventionPlugin.kt
@@ -1,0 +1,63 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+
+/**
+ * Convention for code quality tools (detekt + ktlint), mirroring walt-android.
+ *
+ * Usage:
+ * ```
+ * plugins {
+ *     alias(libs.plugins.walt.passes.quality)
+ * }
+ * ```
+ */
+class QualityConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("io.gitlab.arturbosch.detekt")
+                apply("org.jlleitschuh.gradle.ktlint")
+            }
+
+            extensions.configure<DetektExtension> {
+                config.setFrom(files("$rootDir/detekt.yml"))
+                buildUponDefaultConfig = true
+                allRules = false
+                // Per-module baseline pins existing findings so detekt only fails on
+                // *new* violations introduced going forward. File is checked in.
+                val baselineFile = file("detekt-baseline.xml")
+                if (baselineFile.exists()) {
+                    baseline = baselineFile
+                }
+            }
+
+            tasks.withType<Detekt>().configureEach {
+                jvmTarget = "17"
+            }
+
+            val libs = extensions.getByType(
+                VersionCatalogsExtension::class.java,
+            ).named("libs")
+            dependencies {
+                add("detektPlugins", libs.findLibrary("detekt-formatting").get())
+            }
+
+            extensions.configure<KtlintExtension> {
+                android.set(true)
+                ignoreFailures.set(false)
+                reporters {
+                    reporter(ReporterType.PLAIN)
+                    reporter(ReporterType.CHECKSTYLE)
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/QualityConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/QualityConventionPlugin.kt
@@ -2,23 +2,13 @@ import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
-/**
- * Convention for code quality tools (detekt + ktlint), mirroring walt-android.
- *
- * Usage:
- * ```
- * plugins {
- *     alias(libs.plugins.walt.passes.quality)
- * }
- * ```
- */
+/** Convention for code quality tools (detekt + ktlint). */
 class QualityConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
@@ -31,8 +21,6 @@ class QualityConventionPlugin : Plugin<Project> {
                 config.setFrom(files("$rootDir/detekt.yml"))
                 buildUponDefaultConfig = true
                 allRules = false
-                // Per-module baseline pins existing findings so detekt only fails on
-                // *new* violations introduced going forward. File is checked in.
                 val baselineFile = file("detekt-baseline.xml")
                 if (baselineFile.exists()) {
                     baseline = baselineFile
@@ -40,14 +28,7 @@ class QualityConventionPlugin : Plugin<Project> {
             }
 
             tasks.withType<Detekt>().configureEach {
-                jvmTarget = "17"
-            }
-
-            val libs = extensions.getByType(
-                VersionCatalogsExtension::class.java,
-            ).named("libs")
-            dependencies {
-                add("detektPlugins", libs.findLibrary("detekt-formatting").get())
+                jvmTarget = JvmTarget.JVM_17.target
             }
 
             extensions.configure<KtlintExtension> {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,15 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/detekt.yml
+++ b/detekt.yml
@@ -437,6 +437,3 @@ style:
     active: true
   WildcardImport:
     active: false # Allow wildcard imports for Compose
-
-formatting:
-  active: false # Using ktlint for formatting checks

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,442 @@
+# Detekt configuration for walt-passes-android.
+# https://detekt.dev/docs/intro
+
+build:
+  maxIssues: 0 # Fail build if any issues found
+  excludeCorrectable: false
+  weights:
+    complexity: 2
+    LongParameterList: 1
+    style: 1
+    comments: 0
+
+config:
+  validation: true
+  warningsAsErrors: false
+  checkExhaustiveness: false
+
+processors:
+  active: true
+
+console-reports:
+  active: true
+
+output-reports:
+  active: true
+  exclude:
+    - 'HtmlOutputReport'
+
+comments:
+  active: false # Don't enforce comments initially
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: true
+    threshold: 10
+  CyclomaticComplexMethod:
+    active: true
+    threshold: 15
+  LongMethod:
+    active: true
+    threshold: 60
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 15
+    thresholdInClasses: 15
+    thresholdInInterfaces: 15
+    thresholdInObjects: 15
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true # Prevent GlobalScope usage
+  RedundantSuspendModifier:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true
+
+empty-blocks:
+  active: true
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: true
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+  InstanceOfCheckForException:
+    active: true
+  NotImplementedDeclaration:
+    active: false # Allow TODO() for incremental development
+  PrintStackTrace:
+    active: true # Don't print stack traces in production
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+  EnumNaming:
+    active: true
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  FunctionNaming:
+    active: true
+    functionPattern: '[a-z][a-zA-Z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreAnnotated: ['Composable']
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+  InvalidPackageDeclaration:
+    active: true
+    rootPackage: 'is.walt'
+  MatchingDeclarationName:
+    active: true
+  MemberNameEqualsClassName:
+    active: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: true
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: false # Disabled - our package uses backticks around 'is' keyword
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+
+performance:
+  active: true
+  ArrayPrimitive:
+    active: true
+  CouldBeSequence:
+    active: false # Too aggressive for most cases
+  ForEachOnRange:
+    active: true
+  SpreadOperator:
+    active: false
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  AvoidReferentialEquality:
+    active: true
+  CastToNullableType:
+    active: true
+  Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
+    active: true
+  DoubleMutabilityForCollection:
+    active: true
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: false
+  ExplicitGarbageCollectionCall:
+    active: true
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false # Common in Android
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  MissingPackageDeclaration:
+    active: false
+  NullCheckOnMutableProperty:
+    active: true
+  NullableToStringCall:
+    active: true
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: true
+  DataClassContainsFunctions:
+    active: false
+  DataClassShouldBeImmutable:
+    active: false
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: true
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
+  ExpressionBodySyntax:
+    active: false
+  ForbiddenComment:
+    active: false
+  ForbiddenImport:
+    active: false
+  ForbiddenMethodCall:
+    active: false
+  ForbiddenVoid:
+    active: true
+  FunctionOnlyReturningConstant:
+    active: true
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: false # Too noisy for UI code
+  BracesOnIfStatements:
+    active: false
+    singleLine: never
+    multiLine: always
+  MaxChainedCallsOnSameLine:
+    active: false
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: false
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: true
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    # Disabled: conflicts with explicitApi() Strict mode, which requires explicit
+    # `: Unit` on public function returns.
+    active: false
+  PreferToOverPairSyntax:
+    active: true
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    # Disabled: conflicts with explicitApi() Strict mode, which requires explicit
+    # `public` on every public declaration in passes-core / passes-storage / passes-ui.
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions: ['equals']
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: false
+  SpacingBetweenPackageAndImports:
+    active: true
+  ThrowsCount:
+    active: true
+    max: 2
+  TrailingWhitespace:
+    active: true
+  UnderscoresInNumericLiterals:
+    active: false
+  UnnecessaryAbstractClass:
+    active: true
+  UnnecessaryAnnotationUseSiteTarget:
+    active: true
+  UnnecessaryApply:
+    active: true
+  UnnecessaryBackticks:
+    active: true
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: true
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: true
+  UntilInsteadOfRangeTo:
+    active: true
+  UnusedImports:
+    active: true
+  UnusedParameter:
+    active: true
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    ignoreAnnotated: ['Preview']
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseDataClass:
+    active: false
+  UseEmptyCounterpart:
+    active: true
+  UseIfEmptyOrIfBlank:
+    active: true
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: true
+  UseOrEmpty:
+    active: true
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UseSumOfInsteadOfFlatMapSize:
+    active: true
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+  WildcardImport:
+    active: false # Allow wildcard imports for Compose
+
+formatting:
+  active: false # Using ktlint for formatting checks

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ kotlinxSerialization = "1.7.3"
 kotlinxCoroutines = "1.9.0"
 junit = "4.13.2"
 truth = "1.4.5"
+detekt = "1.23.8"
+ktlint = "12.1.1"
 
 # Android + Compose toolchain (matches walt-android consumer to avoid drift).
 androidxCoreKtx = "1.17.0"
@@ -19,6 +21,16 @@ androidxStartup = "1.2.0"
 xerial = "3.46.0.0"
 
 [libraries]
+# Gradle plugins (consumed by build-logic convention plugins).
+android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+compose-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
+detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
+ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle.ktlint", name = "org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlint" }
+
+# Detekt formatting ruleset (added to detektPlugins by the quality convention).
+detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
+
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
@@ -68,3 +80,12 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+
+# Convention plugins served from build-logic. Versionless because they live in the
+# composite build, not a published artifact.
+walt-passes-kotlin-library = { id = "is.walt.passes.kotlin.library", version = "unspecified" }
+walt-passes-android-library = { id = "is.walt.passes.android.library", version = "unspecified" }
+walt-passes-android-compose = { id = "is.walt.passes.android.compose", version = "unspecified" }
+walt-passes-quality = { id = "is.walt.passes.quality", version = "unspecified" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,9 +28,6 @@ compose-gradlePlugin = { group = "org.jetbrains.kotlin", name = "compose-compile
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 ktlint-gradlePlugin = { group = "org.jlleitschuh.gradle.ktlint", name = "org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlint" }
 
-# Detekt formatting ruleset (added to detektPlugins by the quality convention).
-detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
-
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }

--- a/passes-core/build.gradle.kts
+++ b/passes-core/build.gradle.kts
@@ -10,7 +10,3 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }
-
-tasks.test {
-    useJUnit()
-}

--- a/passes-core/build.gradle.kts
+++ b/passes-core/build.gradle.kts
@@ -1,19 +1,7 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.walt.passes.kotlin.library)
+    alias(libs.plugins.walt.passes.quality)
     alias(libs.plugins.kotlin.serialization)
-}
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
-
-kotlin {
-    explicitApi()
-    compilerOptions {
-        freeCompilerArgs.addAll("-Xjvm-default=all")
-    }
 }
 
 dependencies {

--- a/passes-core/detekt-baseline.xml
+++ b/passes-core/detekt-baseline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:PublicApiSurfaceTest.kt$PublicApiSurfaceTest$@Test fun passConstructorIsExercisedWithEveryShape()</ID>
+    <ID>MaxLineLength:Pass.kt$ImageBytes$override fun equals(other: Any?): Boolean</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
@@ -82,12 +82,14 @@ public sealed interface UnsupportedReason {
  * they are the most useful failure to alert on (they signal a too-tight [ParserConfig], not
  * an attack payload).
  */
-public fun ParseResult.toFailureKind(): ParseFailureKind? = when (this) {
-    is ParseResult.Success -> null
-    is ParseResult.Tampered -> ParseFailureKind.Tampered
-    is ParseResult.Malformed -> when (reason) {
-        is MalformedReason.ResourceLimitExceeded -> ParseFailureKind.ResourceLimitExceeded
-        else -> ParseFailureKind.Malformed
+public fun ParseResult.toFailureKind(): ParseFailureKind? =
+    when (this) {
+        is ParseResult.Success -> null
+        is ParseResult.Tampered -> ParseFailureKind.Tampered
+        is ParseResult.Malformed ->
+            when (reason) {
+                is MalformedReason.ResourceLimitExceeded -> ParseFailureKind.ResourceLimitExceeded
+                else -> ParseFailureKind.Malformed
+            }
+        is ParseResult.Unsupported -> ParseFailureKind.Unsupported
     }
-    is ParseResult.Unsupported -> ParseFailureKind.Unsupported
-}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ParserConfig.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ParserConfig.kt
@@ -38,10 +38,11 @@ public data class ParserConfig(
          * and for an opt-in stricter ingestion mode; not the default per
          * decision-wlt-0tn-q1.
          */
-        public val Strict: ParserConfig = ParserConfig(
-            acceptUnsignedArchives = false,
-            acceptSelfSignedCertificates = false,
-        )
+        public val Strict: ParserConfig =
+            ParserConfig(
+                acceptUnsignedArchives = false,
+                acceptSelfSignedCertificates = false,
+            )
     }
 }
 
@@ -54,12 +55,13 @@ public data class ParserConfig(
  * it a [ParserConfig] field is a compile error here, so an enum value can never silently
  * lack a backing limit.
  */
-public fun ResourceLimit.limitFrom(config: ParserConfig): Long = when (this) {
-    ResourceLimit.ArchiveSize -> config.maxArchiveBytes
-    ResourceLimit.EntryCount -> config.maxEntries.toLong()
-    ResourceLimit.EntrySize -> config.maxEntryBytes
-    ResourceLimit.JsonDepth -> config.maxJsonDepth.toLong()
-    ResourceLimit.JsonStringSize -> config.maxJsonStringBytes.toLong()
-    ResourceLimit.ImagePixelCount -> config.maxImagePixelCount.toLong()
-    ResourceLimit.LocaleCount -> config.maxLocaleCount.toLong()
-}
+public fun ResourceLimit.limitFrom(config: ParserConfig): Long =
+    when (this) {
+        ResourceLimit.ArchiveSize -> config.maxArchiveBytes
+        ResourceLimit.EntryCount -> config.maxEntries.toLong()
+        ResourceLimit.EntrySize -> config.maxEntryBytes
+        ResourceLimit.JsonDepth -> config.maxJsonDepth.toLong()
+        ResourceLimit.JsonStringSize -> config.maxJsonStringBytes.toLong()
+        ResourceLimit.ImagePixelCount -> config.maxImagePixelCount.toLong()
+        ResourceLimit.LocaleCount -> config.maxLocaleCount.toLong()
+    }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
@@ -35,8 +35,7 @@ public data class Pass(
  * to a decoder; they should not be doing arithmetic on the array.
  */
 public class ImageBytes(public val bytes: ByteArray) {
-    override fun equals(other: Any?): Boolean =
-        this === other || (other is ImageBytes && bytes.contentEquals(other.bytes))
+    override fun equals(other: Any?): Boolean = this === other || other is ImageBytes && bytes.contentEquals(other.bytes)
 
     override fun hashCode(): Int = bytes.contentHashCode()
 }
@@ -111,12 +110,24 @@ public enum class BarcodeFormat {
  * the parser preserves whichever variants the archive provides without upscaling.
  */
 public enum class ImageRole {
-    Logo, LogoRetina, LogoSuperRetina,
-    Icon, IconRetina, IconSuperRetina,
-    Strip, StripRetina, StripSuperRetina,
-    Background, BackgroundRetina, BackgroundSuperRetina,
-    Thumbnail, ThumbnailRetina, ThumbnailSuperRetina,
-    Footer, FooterRetina, FooterSuperRetina,
+    Logo,
+    LogoRetina,
+    LogoSuperRetina,
+    Icon,
+    IconRetina,
+    IconSuperRetina,
+    Strip,
+    StripRetina,
+    StripSuperRetina,
+    Background,
+    BackgroundRetina,
+    BackgroundSuperRetina,
+    Thumbnail,
+    ThumbnailRetina,
+    ThumbnailSuperRetina,
+    Footer,
+    FooterRetina,
+    FooterSuperRetina,
 }
 
 /** Contents of a single `<locale>.lproj/pass.strings` file. */

--- a/passes-core/src/main/kotlin/is/walt/passes/core/SignatureStatus.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/SignatureStatus.kt
@@ -38,9 +38,10 @@ public sealed interface SignatureStatus {
  * adding a [SignatureStatus] arm without extending [SignatureStatusKind] is a compile error,
  * not a silent observability gap.
  */
-public fun SignatureStatus.toKind(): SignatureStatusKind = when (this) {
-    SignatureStatus.Unsigned -> SignatureStatusKind.Unsigned
-    SignatureStatus.SelfSigned -> SignatureStatusKind.SelfSigned
-    SignatureStatus.AppleVerified -> SignatureStatusKind.AppleVerified
-    SignatureStatus.CertChainIncomplete -> SignatureStatusKind.CertChainIncomplete
-}
+public fun SignatureStatus.toKind(): SignatureStatusKind =
+    when (this) {
+        SignatureStatus.Unsigned -> SignatureStatusKind.Unsigned
+        SignatureStatus.SelfSigned -> SignatureStatusKind.SelfSigned
+        SignatureStatus.AppleVerified -> SignatureStatusKind.AppleVerified
+        SignatureStatus.CertChainIncomplete -> SignatureStatusKind.CertChainIncomplete
+    }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
@@ -34,12 +34,13 @@ class PublicApiSurfaceTest {
     @Test
     fun parseResultArmsAreReachableViaWhen() {
         val result: ParseResult = ParseResult.Malformed(MalformedReason.NotAZipArchive)
-        val branch = when (result) {
-            is ParseResult.Success -> "success"
-            is ParseResult.Tampered -> "tampered"
-            is ParseResult.Malformed -> "malformed"
-            is ParseResult.Unsupported -> "unsupported"
-        }
+        val branch =
+            when (result) {
+                is ParseResult.Success -> "success"
+                is ParseResult.Tampered -> "tampered"
+                is ParseResult.Malformed -> "malformed"
+                is ParseResult.Unsupported -> "unsupported"
+            }
         assertThat(branch).isEqualTo("malformed")
     }
 
@@ -51,12 +52,13 @@ class PublicApiSurfaceTest {
      */
     @Test
     fun signatureStatusBijectsToKind() {
-        val statuses: List<SignatureStatus> = listOf(
-            SignatureStatus.Unsigned,
-            SignatureStatus.SelfSigned,
-            SignatureStatus.AppleVerified,
-            SignatureStatus.CertChainIncomplete,
-        )
+        val statuses: List<SignatureStatus> =
+            listOf(
+                SignatureStatus.Unsigned,
+                SignatureStatus.SelfSigned,
+                SignatureStatus.AppleVerified,
+                SignatureStatus.CertChainIncomplete,
+            )
         val kindsFromStatuses = statuses.map { it.toKind() }.toSet()
         assertThat(kindsFromStatuses).containsExactlyElementsIn(SignatureStatusKind.entries)
     }
@@ -72,13 +74,14 @@ class PublicApiSurfaceTest {
         val nonResourceMalformed: ParseResult = ParseResult.Malformed(MalformedReason.MissingPassJson)
         val resourceMalformed: ParseResult =
             ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.ArchiveSize))
-        val results: List<ParseResult> = listOf(
-            ParseResult.Success(samplePass(), SignatureStatus.AppleVerified),
-            ParseResult.Tampered(TamperReason.ManifestSignatureMismatch),
-            nonResourceMalformed,
-            resourceMalformed,
-            ParseResult.Unsupported(UnsupportedReason.EncryptedArchive),
-        )
+        val results: List<ParseResult> =
+            listOf(
+                ParseResult.Success(samplePass(), SignatureStatus.AppleVerified),
+                ParseResult.Tampered(TamperReason.ManifestSignatureMismatch),
+                nonResourceMalformed,
+                resourceMalformed,
+                ParseResult.Unsupported(UnsupportedReason.EncryptedArchive),
+            )
         val kinds = results.map { it.toFailureKind() }
         assertThat(kinds).containsExactly(
             null,
@@ -111,34 +114,37 @@ class PublicApiSurfaceTest {
      */
     @Test
     fun tamperReasonArmsAreAllConstructible() {
-        val reasons: List<TamperReason> = listOf(
-            TamperReason.ManifestSignatureMismatch,
-            TamperReason.FileHashMismatch,
-            TamperReason.SignatureCryptoFailure,
-        )
+        val reasons: List<TamperReason> =
+            listOf(
+                TamperReason.ManifestSignatureMismatch,
+                TamperReason.FileHashMismatch,
+                TamperReason.SignatureCryptoFailure,
+            )
         assertThat(reasons.toSet()).hasSize(reasons.size)
     }
 
     @Test
     fun malformedReasonArmsAreAllConstructible() {
-        val reasons: List<MalformedReason> = listOf(
-            MalformedReason.NotAZipArchive,
-            MalformedReason.MissingPassJson,
-            MalformedReason.MissingManifest,
-            MalformedReason.InvalidPassJson,
-            MalformedReason.InvalidManifest,
-            MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonDepth),
-        )
+        val reasons: List<MalformedReason> =
+            listOf(
+                MalformedReason.NotAZipArchive,
+                MalformedReason.MissingPassJson,
+                MalformedReason.MissingManifest,
+                MalformedReason.InvalidPassJson,
+                MalformedReason.InvalidManifest,
+                MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonDepth),
+            )
         assertThat(reasons.toSet()).hasSize(reasons.size)
     }
 
     @Test
     fun unsupportedReasonArmsAreAllConstructible() {
-        val reasons: List<UnsupportedReason> = listOf(
-            UnsupportedReason.FormatVersion(2),
-            UnsupportedReason.UnknownPassStyle("nfcPass"),
-            UnsupportedReason.EncryptedArchive,
-        )
+        val reasons: List<UnsupportedReason> =
+            listOf(
+                UnsupportedReason.FormatVersion(2),
+                UnsupportedReason.UnknownPassStyle("nfcPass"),
+                UnsupportedReason.EncryptedArchive,
+            )
         assertThat(reasons.toSet()).hasSize(reasons.size)
     }
 
@@ -177,65 +183,74 @@ class PublicApiSurfaceTest {
      */
     @Test
     fun passConstructorIsExercisedWithEveryShape() {
-        val field = PassField(
-            key = "destination",
-            label = "Destination",
-            value = "SFO",
-            textAlignment = TextAlignment.Natural,
-        )
-        val pass = Pass(
-            type = PassType.BoardingPass,
-            serialNumber = "ABC-123",
-            description = "Boarding pass for flight 42",
-            organizationName = "Example Air",
-            expirationDate = PassInstant(epochMillis = 1_800_000_000_000L),
-            voided = false,
-            colors = PassColors(
-                foreground = ColorValue(0xFFFFFF),
-                background = ColorValue(0x000000),
-                label = ColorValue(0xCCCCCC),
-            ),
-            frontFields = PassFields(
-                header = listOf(field.copy(key = "h", textAlignment = TextAlignment.Left)),
-                primary = listOf(field.copy(key = "p", textAlignment = TextAlignment.Center)),
-                secondary = listOf(field.copy(key = "s", textAlignment = TextAlignment.Right)),
-                auxiliary = listOf(field.copy(key = "a")),
-            ),
-            backFields = listOf(field.copy(key = "b")),
-            barcode = Barcode(
-                format = BarcodeFormat.QR,
-                message = "FLIGHT42",
-                messageEncoding = "iso-8859-1",
-                altText = "FLIGHT42",
-            ),
-            images = mapOf(
-                ImageRole.Logo to ImageBytes(byteArrayOf(0x89.toByte(), 0x50)),
-                ImageRole.Icon to ImageBytes(byteArrayOf(0x89.toByte(), 0x50)),
-            ),
-            locales = mapOf(
-                PassLocale("en-US") to LocalizedStrings(mapOf("destination" to "Destination")),
-                PassLocale("de") to LocalizedStrings(mapOf("destination" to "Ziel")),
-            ),
-        )
+        val field =
+            PassField(
+                key = "destination",
+                label = "Destination",
+                value = "SFO",
+                textAlignment = TextAlignment.Natural,
+            )
+        val pass =
+            Pass(
+                type = PassType.BoardingPass,
+                serialNumber = "ABC-123",
+                description = "Boarding pass for flight 42",
+                organizationName = "Example Air",
+                expirationDate = PassInstant(epochMillis = 1_800_000_000_000L),
+                voided = false,
+                colors =
+                    PassColors(
+                        foreground = ColorValue(0xFFFFFF),
+                        background = ColorValue(0x000000),
+                        label = ColorValue(0xCCCCCC),
+                    ),
+                frontFields =
+                    PassFields(
+                        header = listOf(field.copy(key = "h", textAlignment = TextAlignment.Left)),
+                        primary = listOf(field.copy(key = "p", textAlignment = TextAlignment.Center)),
+                        secondary = listOf(field.copy(key = "s", textAlignment = TextAlignment.Right)),
+                        auxiliary = listOf(field.copy(key = "a")),
+                    ),
+                backFields = listOf(field.copy(key = "b")),
+                barcode =
+                    Barcode(
+                        format = BarcodeFormat.QR,
+                        message = "FLIGHT42",
+                        messageEncoding = "iso-8859-1",
+                        altText = "FLIGHT42",
+                    ),
+                images =
+                    mapOf(
+                        ImageRole.Logo to ImageBytes(byteArrayOf(0x89.toByte(), 0x50)),
+                        ImageRole.Icon to ImageBytes(byteArrayOf(0x89.toByte(), 0x50)),
+                    ),
+                locales =
+                    mapOf(
+                        PassLocale("en-US") to LocalizedStrings(mapOf("destination" to "Destination")),
+                        PassLocale("de") to LocalizedStrings(mapOf("destination" to "Ziel")),
+                    ),
+            )
 
         assertThat(pass.type).isEqualTo(PassType.BoardingPass)
         assertThat(pass.locales).hasSize(2)
         // All five PassTypes referenced so removal breaks compilation, not just the one we instantiated.
-        val allTypes = setOf(
-            PassType.BoardingPass,
-            PassType.EventTicket,
-            PassType.Coupon,
-            PassType.StoreCard,
-            PassType.Generic,
-        )
+        val allTypes =
+            setOf(
+                PassType.BoardingPass,
+                PassType.EventTicket,
+                PassType.Coupon,
+                PassType.StoreCard,
+                PassType.Generic,
+            )
         assertThat(allTypes).hasSize(PassType.entries.size)
         // Ditto for BarcodeFormat.
-        val allFormats = setOf(
-            BarcodeFormat.QR,
-            BarcodeFormat.PDF417,
-            BarcodeFormat.Aztec,
-            BarcodeFormat.Code128,
-        )
+        val allFormats =
+            setOf(
+                BarcodeFormat.QR,
+                BarcodeFormat.PDF417,
+                BarcodeFormat.Aztec,
+                BarcodeFormat.Code128,
+            )
         assertThat(allFormats).hasSize(BarcodeFormat.entries.size)
     }
 
@@ -257,18 +272,19 @@ class PublicApiSurfaceTest {
         assertThat(a).isNotEqualTo(different)
     }
 
-    private fun samplePass(imageBytes: ByteArray = byteArrayOf(0)): Pass = Pass(
-        type = PassType.Generic,
-        serialNumber = "S",
-        description = "D",
-        organizationName = "O",
-        expirationDate = null,
-        voided = false,
-        colors = PassColors(foreground = null, background = null, label = null),
-        frontFields = PassFields(),
-        backFields = emptyList(),
-        barcode = null,
-        images = mapOf(ImageRole.Icon to ImageBytes(imageBytes)),
-        locales = emptyMap(),
-    )
+    private fun samplePass(imageBytes: ByteArray = byteArrayOf(0)): Pass =
+        Pass(
+            type = PassType.Generic,
+            serialNumber = "S",
+            description = "D",
+            organizationName = "O",
+            expirationDate = null,
+            voided = false,
+            colors = PassColors(foreground = null, background = null, label = null),
+            frontFields = PassFields(),
+            backFields = emptyList(),
+            barcode = null,
+            images = mapOf(ImageRole.Icon to ImageBytes(imageBytes)),
+            locales = emptyMap(),
+        )
 }

--- a/passes-storage/build.gradle.kts
+++ b/passes-storage/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
 
 android {
     namespace = "is.walt.passes.storage"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }
 
 dependencies {
@@ -17,13 +13,9 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
 
-    // SQLCipher: encrypted SQLite at rest. ADR 0002 D1/D2.
     implementation(libs.sqlcipher.android)
     implementation(libs.androidx.sqlite)
 
-    // JVM-side tests: schema-DDL via xerial sqlite-jdbc; Robolectric for the StateFlow +
-    // delete contract (no SQLCipher native libs needed — the repo is constructed with an
-    // in-memory PassStore fake that exercises the contract without touching JNI).
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/passes-storage/build.gradle.kts
+++ b/passes-storage/build.gradle.kts
@@ -1,38 +1,14 @@
 plugins {
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.walt.passes.android.library)
+    alias(libs.plugins.walt.passes.quality)
     alias(libs.plugins.kotlin.serialization)
 }
 
 android {
     namespace = "is.walt.passes.storage"
-    compileSdk = 36
 
     defaultConfig {
-        // StrongBox-backed Keystore lands at API 28; aligning with passes-ui (also minSdk 28)
-        // keeps the trust-claim story consistent across the three modules.
-        minSdk = 28
-
         consumerProguardFiles("consumer-rules.pro")
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-}
-
-kotlin {
-    explicitApi()
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.addAll("-Xjvm-default=all")
     }
 }
 

--- a/passes-storage/detekt-baseline.xml
+++ b/passes-storage/detekt-baseline.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
+    <ID>LongMethod:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
+    <ID>MatchingDeclarationName:PassJson.kt$PassJsonCodec</ID>
+    <ID>NestedBlockDepth:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
+    <ID>ReturnCount:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider$override fun provideDatabaseKey(): StorageResult&lt;DatabaseKey&gt;</ID>
+    <ID>ReturnCount:BackupRulesAssertion.kt$BackupRulesAssertion$@JvmStatic public fun assertBackupRulesApplied(context: Context): Outcome</ID>
+    <ID>ReturnCount:SqlCipherDatabaseFactory.kt$SqlCipherDatabaseFactory$fun openOrCreate( context: Context, databaseKey: DatabaseKey, ): StorageResult&lt;SQLiteDatabase&gt;</ID>
+    <ID>ReturnCount:SqlCipherPassRepository.kt$SqlCipherPassRepository.Companion$@JvmStatic public fun create( context: Context, keyProvider: PassKeyProvider, telemetryGuard: StorageTelemetryGuard, ioDispatcher: CoroutineDispatcher = Dispatchers.IO, clock: () -&gt; Long = { System.currentTimeMillis() }, ): StorageResult&lt;SqlCipherPassRepository&gt;</ID>
+    <ID>ReturnCount:SqlCipherPassStore.kt$SqlCipherPassStore$override fun loadById(id: PassRecordId): StoredPass?</ID>
+    <ID>ReturnCount:SqlCipherPassStore.kt$SqlCipherPassStore$private fun Cursor.toSummaryOrNull(): PassSummary?</ID>
+    <ID>ReturnCount:WrappedKeyStorage.kt$SharedPrefsWrappedKeyStorage$override fun read(): WrappedKeyEnvelope?</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider$e: java.security.KeyStoreException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider$e: java.security.UnrecoverableKeyException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider$e: javax.crypto.AEADBadTagException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: StrongBoxUnavailableException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: Throwable</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: java.security.KeyStoreException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: java.security.NoSuchProviderException</ID>
+    <ID>SwallowedException:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: java.security.UnrecoverableKeyException</ID>
+    <ID>SwallowedException:BackupRulesAssertion.kt$BackupRulesAssertion$e: IllegalAccessException</ID>
+    <ID>SwallowedException:BackupRulesAssertion.kt$BackupRulesAssertion$e: NoSuchFieldException</ID>
+    <ID>SwallowedException:BackupRulesAssertion.kt$BackupRulesAssertion$e: PackageManager.NameNotFoundException</ID>
+    <ID>TooGenericExceptionCaught:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SqlCipherDatabaseFactory.kt$SqlCipherDatabaseFactory$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SqlCipherPassRepository.kt$SqlCipherPassRepository$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:SqlCipherPassRepository.kt$SqlCipherPassRepository.Companion$e: Throwable</ID>
+    <ID>UnnecessaryParentheses:WrappedKeyStorage.kt$WrappedKeyEnvelope$(other is WrappedKeyEnvelope &amp;&amp; ciphertext.contentEquals(other.ciphertext) &amp;&amp; iv.contentEquals(other.iv) &amp;&amp; keyAlias == other.keyAlias)</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -6,10 +6,6 @@ plugins {
 
 android {
     namespace = "is.walt.passes.ui"
-
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
 }
 
 dependencies {
@@ -19,7 +15,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
     val composeBom = platform(libs.androidx.compose.bom)
-    implementation(composeBom)
     api(composeBom)
 
     api(libs.androidx.compose.ui)
@@ -32,8 +27,6 @@ dependencies {
 
     implementation(libs.zxing.core)
 
-    // JVM-side tests: pure-Kotlin contract checks + Robolectric-backed Compose smoke tests
-    // so the public-API surface and basic composition exercise stay on the JVM CI host.
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlin.reflect)

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -1,43 +1,14 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.walt.passes.android.library)
+    alias(libs.plugins.walt.passes.android.compose)
+    alias(libs.plugins.walt.passes.quality)
 }
 
 android {
     namespace = "is.walt.passes.ui"
-    compileSdk = 36
 
     defaultConfig {
-        // ImageDecoder.setOnHeaderDecodedListener (used by BoundedImage) requires API 28.
-        // StrongBox-backed Keystore (used by passes-storage) also lands at API 28. Aligning
-        // the whole repo at minSdk 28 keeps the trust-claim story consistent across modules.
-        minSdk = 28
-
         consumerProguardFiles("consumer-rules.pro")
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-
-    buildFeatures {
-        compose = true
-    }
-}
-
-kotlin {
-    explicitApi()
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        freeCompilerArgs.addAll("-Xjvm-default=all")
     }
 }
 

--- a/passes-ui/detekt-baseline.xml
+++ b/passes-ui/detekt-baseline.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:PassFront.kt$@Composable public fun PassFront( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), nowEpochMillis: Long = System.currentTimeMillis(), )</ID>
+    <ID>LongMethod:SecuritySheets.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun SecuritySheet( kind: SecurityIntentKind, passType: PassType, title: String, target: String, source: SourceField, confirmCopy: String, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
+    <ID>LongParameterList:BoundedImage.kt$( bytes: ImageBytes, @Suppress("UNUSED_PARAMETER") role: ImageRole, contentDescription: String?, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, bounds: ImageRenderBounds = ImageRenderBounds.Default, )</ID>
+    <ID>LongParameterList:PassBack.kt$( pass: Pass, onUrlIntent: (B3UrlIntent) -&gt; Unit, onPhoneIntent: (PhoneIntent) -&gt; Unit, onEmailIntent: (EmailIntent) -&gt; Unit, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), )</ID>
+    <ID>LongParameterList:PassFront.kt$( field: PassField, foreground: Color, labelColor: Color, valueStyle: androidx.compose.ui.text.TextStyle, modifier: Modifier = Modifier, textAlign: TextAlign? = null, )</ID>
+    <ID>LongParameterList:PassFront.kt$( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), nowEpochMillis: Long = System.currentTimeMillis(), )</ID>
+    <ID>LongParameterList:SecuritySheets.kt$( kind: SecurityIntentKind, passType: PassType, title: String, target: String, source: SourceField, confirmCopy: String, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
+    <ID>LoopWithTooManyJumpStatements:FieldLinkScanner.kt$FieldLinkScanner$for</ID>
+    <ID>MaxLineLength:SecuritySheets.kt$/** First Strong Isolate (U+2068). Opens an isolate that takes the directional class of the first strong-class character within. */</ID>
+    <ID>ReturnCount:ExpiredOverlayState.kt$ExpiredOverlayState.Companion$@JvmStatic public fun from(pass: Pass, nowEpochMillis: Long): ExpiredOverlayState</ID>
+    <ID>SwallowedException:BoundedImage.kt$e: IOException</ID>
+    <ID>SwallowedException:BoundedImage.kt$e: IllegalArgumentException</ID>
+    <ID>SwallowedException:BoundedImage.kt$e: RuntimeException</ID>
+    <ID>TooGenericExceptionCaught:BoundedImage.kt$e: RuntimeException</ID>
+    <ID>UnnecessaryParentheses:ExpiredOverlay.kt$(style.scrimAlpha.coerceIn(0, 255))</ID>
+    <ID>UnnecessaryParentheses:PassFront.kt$(packed shr 16)</ID>
+    <ID>UnnecessaryParentheses:PassFront.kt$(packed shr 8)</ID>
+    <ID>UnusedImports:TrustClaimSurfaceTest.kt$import `is`.walt.passes.core.ImageBytes</ID>
+    <ID>UnusedImports:TrustClaimSurfaceTest.kt$import `is`.walt.passes.core.ImageRole</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google {
             content {


### PR DESCRIPTION
## Summary

- Adds a `build-logic` composite build with four convention plugins mirroring walt-android's, adapted for the three-module shape (passes-core / passes-storage / passes-ui).
- Adds GitHub Actions CI (`./gradlew check assemble`) plus a dependency-review job, and weekly Dependabot covering gradle (root + build-logic) and github-actions.
- Migrates the three modules to apply the new convention plugins; resulting AAR/JAR outputs are functionally equivalent.

## What's in build-logic

| Plugin id | Module | Notes |
| --- | --- | --- |
| `is.walt.passes.kotlin.library` | passes-core | kotlin.jvm + java-library, JVM 17, `explicitApi()`, `-Xjvm-default=all` |
| `is.walt.passes.android.library` | passes-storage, passes-ui | AGP 9, compileSdk 36, **minSdk 28** (for StrongBox + ImageDecoder), JVM 17, `explicitApi()` |
| `is.walt.passes.android.compose` | passes-ui | Applies kotlin.plugin.compose, enables buildFeatures.compose |
| `is.walt.passes.quality` | all three | detekt + ktlint with per-module `detekt-baseline.xml` |

### Deliberate divergences from walt-android's build-logic

- `is.walt.passes.android.compose` does **not** auto-add Compose BOM / core libs. passes-ui exposes its Compose surface to consumers via `api(...)` rather than `implementation(...)`, so dependency strength stays in the module's build file.
- `AndroidLibraryConventionPlugin` sets `minSdk = 28` (vs walt-android's 26) to align with StrongBox-backed Keystore and `ImageDecoder.setOnHeaderDecodedListener` requirements. Already the per-module value before this change.
- Both convention plugins set `explicitApi = ExplicitApiMode.Strict`, which in turn conflicts with two detekt rules — `RedundantVisibilityModifierRule` and `OptionalUnit` — disabled at config level with a comment.

## CI

- `ubuntu-latest` runners with JDK 17 (Temurin).
- `android-actions/setup-android@v3` installs `platforms;android-36` + `build-tools;36.0.0` for AGP 9.
- `gradle/actions/setup-gradle@v5` with `cache-read-only` for fork PRs (no cache writes from forks).
- Dependency review runs on PRs only, fails on `high`+ severity.

## Other

- One-time `ktlintFormat` pass over `passes-core/src/**/*.kt` to bring sources under the new style (whitespace/wrapping only — no semantic changes).
- `.editorconfig` disables `ktlint_standard_package-name` because `is.walt.*` uses the Kotlin reserved word `is` as a package segment (matches walt-android's namespace).
- detekt baselines are checked in so this PR starts from a clean slate; new findings going forward will fail CI.

## Test plan

- [x] `./gradlew :passes-core:check :passes-storage:check :passes-ui:check` green locally
- [x] `./gradlew assemble` green locally (passes-core JAR + passes-{storage,ui} AARs)
- [ ] CI (this PR's own check run) green
- [ ] Review the convention-plugin shape before merging — request review

Refs: wpass-9vv.6 (closes when merged); blocks wpass-9vv.7