### PR TITLE
BackupRulesAssertion: validate by content, support tools:replace consumers (wpass-edb)

### DIFF
--- a/docs/adr/0002-passes-storage.md
+++ b/docs/adr/0002-passes-storage.md
@@ -110,6 +110,13 @@ The library does NOT set `android:allowBackup="false"` on the consumer, because 
 
 A consumer-side `assertBackupRulesApplied()` helper is exposed from `passes-storage` for use in instrumentation tests, so the trust claim is checkable in CI rather than relying on documentation review.
 
+Two consumer postures are valid and the assertion accepts both:
+
+1. **Inherit.** The consumer lets the library's manifest contributions reach the merged manifest unchanged. `ApplicationInfo.fullBackupContent` and `ApplicationInfo.dataExtractionRulesRes` then reference `walt_passes_backup_rules` and `walt_passes_data_extraction_rules` directly.
+2. **Mirror.** The consumer overrides the library contributions with `tools:replace="android:fullBackupContent,android:dataExtractionRules"` and points the manifest at a consumer-owned XML resource that mirrors the library's required `<exclude>` entries (and optionally adds its own). Walt-android takes this posture so it can manage backup posture for the whole app from a single resource.
+
+The assertion validates by content, not resource identity. It opens whichever XML resource the merged manifest points at and checks that every entry in `BackupRulesAssertion.REQUIRED_EXCLUDES` is present in every backup-relevant section of that resource (`<full-backup-content>` for the API 23 - 30 path; both `<cloud-backup>` and `<device-transfer>` for the API 31+ path). Consumers may add additional excludes; only the pass-related entries are required for the trust claim. Setting `android:allowBackup="false"` app-wide trivially satisfies the claim and short-circuits the assertion.
+
 ### D6. Deletion is items 1+3+4+5+6 from `decision-wlt-0tn-q3-4`
 
 `PassRepository.delete(id)`:

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -3,73 +3,281 @@ package `is`.walt.passes.storage
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.content.res.Resources
+import android.content.res.XmlResourceParser
 import android.os.Build
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.io.IOException
 
 /**
- * Verifies that the consumer's merged `AndroidManifest.xml` actually carries the
- * library-shipped backup-exclusion rules from ADR 0002 D5. Intended for the consumer's
- * instrumentation test suite; the trust claim "pass data is excluded from cloud backup"
- * becomes checkable in CI rather than relying on manifest review.
+ * Verifies that the trust claim "pass data is excluded from cloud backup" holds in the
+ * consumer's merged manifest. Intended for the consumer's instrumentation test suite so
+ * that the claim is checkable in CI rather than relying on manifest review.
  *
- * The assertion only checks that the consumer's `<application>` references rule resources
- * named `walt_passes_backup_rules` (API 23-30) and `walt_passes_data_extraction_rules`
- * (API 31+). It does NOT parse the rules XML. Combined with the resources we ship, this
- * narrows the consumer-side risk to "the consumer overrode our rules with a non-walt
- * resource of the same name," which is a deliberate act, not an oversight.
+ * The library ships `walt_passes_backup_rules.xml` (API 23 - 30) and
+ * `walt_passes_data_extraction_rules.xml` (API 31+). Two consumer postures are valid:
  *
- * The two ApplicationInfo fields we check (`fullBackupContent` and `dataExtractionRulesRes`)
- * are hidden public-API fields in recent Android SDKs (greylisted, accessible via
- * reflection). Using reflection here is intentional: the alternative is parsing the
- * merged manifest XML by hand, which is more brittle than a hidden-API field whose
- * semantics have not changed since the feature shipped.
+ *  1. **Inherit.** The consumer lets the library's manifest contributions reach the
+ *     merged manifest unchanged. The merged `ApplicationInfo` then references the
+ *     library's resource directly.
+ *  2. **Mirror.** The consumer overrides the library's contributions with `tools:replace`
+ *     on `android:fullBackupContent` and/or `android:dataExtractionRules`, pointing at a
+ *     consumer-owned XML resource that **mirrors** the required `<exclude>` entries.
+ *     Walt-android does this so it can manage backup posture for the whole app from a
+ *     single resource.
+ *
+ * Both postures satisfy the trust claim. The assertion validates by **content**, not
+ * resource identity: it opens whichever XML resource the merged manifest points at and
+ * confirms every entry in [REQUIRED_EXCLUDES] is present in every backup-relevant
+ * section of that resource. A consumer is free to add their own additional excludes;
+ * only the pass-related entries are required.
+ *
+ * If the consumer has set `android:allowBackup="false"` app-wide, the trust claim is
+ * trivially satisfied (no surface for pass data to leak through) and the assertion
+ * returns [Outcome.Applied] without parsing rules.
+ *
+ * Reflection on `ApplicationInfo.fullBackupContent` and `ApplicationInfo.dataExtractionRulesRes`
+ * is intentional: the alternative is parsing the merged manifest XML by hand, which is
+ * more brittle than greylisted hidden-API fields whose semantics have not changed since
+ * the feature shipped.
  */
 public object BackupRulesAssertion {
+
+    /** Backup rule sections the assertion validates. */
+    public enum class Section { FullBackupContent, CloudBackup, DeviceTransfer }
+
+    /** A single `<exclude domain="..." path="..."/>` entry. */
+    public data class RequiredExclude(public val domain: String, public val path: String)
+
+    /** A section that is missing one or more required excludes. */
+    public data class MissingSection(
+        public val resourceId: Int,
+        public val section: Section,
+        public val missing: List<RequiredExclude>,
+    )
+
     public sealed interface Outcome {
+        /**
+         * Trust claim holds: every required exclude is present in every relevant
+         * section, or the consumer disabled backup app-wide.
+         */
         public data object Applied : Outcome
-        public data class FullBackupContentMismatch(public val actualResId: Int) : Outcome
-        public data class DataExtractionRulesMissing(public val actualResId: Int) : Outcome
+
+        /**
+         * One or more sections of the consumer's rules resource(s) are missing required
+         * excludes. The list contains every gap discovered.
+         */
+        public data class MissingExcludes(public val problems: List<MissingSection>) : Outcome
+
+        /**
+         * Manifest declares no backup rules resource at all (and `allowBackup` is true).
+         * The default Auto Backup policy would include the passes database.
+         */
+        public data object NoBackupRulesConfigured : Outcome
+
+        /** A rules resource referenced by the manifest could not be opened or parsed. */
+        public data class RulesResourceUnreadable(
+            public val resourceId: Int,
+            public val reason: String,
+        ) : Outcome
+
+        /**
+         * `PackageManager` could not find the running package. Should not happen in
+         * normal app or instrumentation contexts; surfaced for defensive completeness.
+         */
         public data object PackageInfoUnavailable : Outcome
+
+        /**
+         * A required `ApplicationInfo` field is not reachable via reflection on the
+         * current platform. Indicates an incompatible OS-side change; surface for triage
+         * rather than masquerading as a content failure.
+         */
         public data object FieldUnavailable : Outcome
     }
 
+    /** Entries the library requires every consumer rules resource to carry. */
+    public val REQUIRED_EXCLUDES: List<RequiredExclude> = listOf(
+        RequiredExclude(domain = "database", path = "walt_passes.db"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-journal"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-wal"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-shm"),
+        RequiredExclude(domain = "sharedpref", path = "is.walt.passes.storage.key_envelope.xml"),
+    )
+
     @JvmStatic
     public fun assertBackupRulesApplied(context: Context): Outcome {
-        val pm = context.packageManager
-        val appInfo: ApplicationInfo = try {
-            pm.getApplicationInfo(context.packageName, 0)
-        } catch (e: PackageManager.NameNotFoundException) {
-            return Outcome.PackageInfoUnavailable
+        val appInfo = loadApplicationInfo(context) ?: return Outcome.PackageInfoUnavailable
+
+        if (appInfo.flags and ApplicationInfo.FLAG_ALLOW_BACKUP == 0) {
+            return Outcome.Applied
         }
 
-        val expectedFullBackup = context.resources
-            .getIdentifier(FULL_BACKUP_CONTENT_RES_NAME, "xml", context.packageName)
-        val actualFullBackup = readIntField(appInfo, "fullBackupContent")
+        val fullBackupResId = readIntField(appInfo, "fullBackupContent")
             ?: return Outcome.FieldUnavailable
-        if (actualFullBackup != expectedFullBackup) {
-            return Outcome.FullBackupContentMismatch(actualFullBackup)
+        val dxrResId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            readIntField(appInfo, "dataExtractionRulesRes") ?: return Outcome.FieldUnavailable
+        } else {
+            0
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val expectedDxr = context.resources
-                .getIdentifier(DATA_EXTRACTION_RULES_RES_NAME, "xml", context.packageName)
-            val actualDxr = readIntField(appInfo, "dataExtractionRulesRes")
-                ?: return Outcome.FieldUnavailable
-            if (actualDxr != expectedDxr) {
-                return Outcome.DataExtractionRulesMissing(actualDxr)
+        if (fullBackupResId == 0 && dxrResId == 0) {
+            return Outcome.NoBackupRulesConfigured
+        }
+
+        val problems = mutableListOf<MissingSection>()
+        validateResource(
+            context = context,
+            resId = fullBackupResId,
+            sections = listOf(Section.FullBackupContent),
+            problems = problems,
+        )?.let { return it }
+        validateResource(
+            context = context,
+            resId = dxrResId,
+            sections = listOf(Section.CloudBackup, Section.DeviceTransfer),
+            problems = problems,
+        )?.let { return it }
+
+        return if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems.toList())
+    }
+
+    private fun loadApplicationInfo(context: Context): ApplicationInfo? = try {
+        context.packageManager.getApplicationInfo(context.packageName, 0)
+    } catch (_: PackageManager.NameNotFoundException) {
+        null
+    }
+
+    /**
+     * Parses [resId] (if non-zero) and appends a [MissingSection] for every entry in
+     * [sections] that is missing a required exclude. Returns a short-circuit
+     * [Outcome.RulesResourceUnreadable] if the resource cannot be opened or parsed.
+     */
+    private fun validateResource(
+        context: Context,
+        resId: Int,
+        sections: List<Section>,
+        problems: MutableList<MissingSection>,
+    ): Outcome? {
+        if (resId != 0) {
+            val parsed = parseResource(context, resId)
+                ?: return Outcome.RulesResourceUnreadable(resId, "parse failed")
+            for (section in sections) {
+                val excludes = parsed[section].orEmpty()
+                val missing = REQUIRED_EXCLUDES.filterNot { it in excludes }
+                if (missing.isNotEmpty()) {
+                    problems += MissingSection(resId, section, missing)
+                }
             }
         }
-        return Outcome.Applied
+        return null
+    }
+
+    private fun parseResource(context: Context, resId: Int): Map<Section, Set<RequiredExclude>>? {
+        val parser: XmlResourceParser = try {
+            context.resources.getXml(resId)
+        } catch (_: Resources.NotFoundException) {
+            return null
+        }
+        return try {
+            parseRulesXml(parser)
+        } catch (_: XmlPullParserException) {
+            null
+        } catch (_: IOException) {
+            null
+        } catch (_: IllegalStateException) {
+            null
+        } finally {
+            parser.close()
+        }
+    }
+
+    /**
+     * Walks a backup-rules XML document and returns the `<exclude>` entries grouped by
+     * section. Accepts both legacy `<full-backup-content>` documents (single implicit
+     * section) and modern `<data-extraction-rules>` documents (with `<cloud-backup>` and
+     * `<device-transfer>` children). `<include>` entries and unknown elements are
+     * ignored; only the `<exclude>` discipline is load-bearing for the trust claim.
+     */
+    @JvmStatic
+    internal fun parseRulesXml(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
+        val state = ParseState()
+        var event = parser.eventType
+        while (event != XmlPullParser.END_DOCUMENT) {
+            when (event) {
+                XmlPullParser.START_TAG -> handleStartTag(parser, state)
+                XmlPullParser.END_TAG -> handleEndTag(parser, state)
+            }
+            event = parser.next()
+        }
+        return state.sections
+    }
+
+    private fun handleStartTag(parser: XmlPullParser, state: ParseState) {
+        val name = parser.name
+        when {
+            !state.rootSeen -> openRoot(name, state)
+            !state.rootIsFullBackup && name == "cloud-backup" -> state.enter(Section.CloudBackup)
+            !state.rootIsFullBackup && name == "device-transfer" -> state.enter(Section.DeviceTransfer)
+            name == "exclude" -> recordExclude(parser, state)
+        }
+    }
+
+    private fun handleEndTag(parser: XmlPullParser, state: ParseState) {
+        if (state.rootIsFullBackup) return
+        val name = parser.name
+        if (name == "cloud-backup" || name == "device-transfer") {
+            state.leave()
+        }
+    }
+
+    private fun openRoot(name: String, state: ParseState) {
+        state.rootSeen = true
+        when (name) {
+            "full-backup-content" -> {
+                state.rootIsFullBackup = true
+                state.enter(Section.FullBackupContent)
+            }
+            "data-extraction-rules" -> Unit
+            else -> error("unexpected root element: $name")
+        }
+    }
+
+    private fun recordExclude(parser: XmlPullParser, state: ParseState) {
+        val sect = state.currentSection
+        val domain = parser.getAttributeValue(null, "domain")
+        val path = parser.getAttributeValue(null, "path")
+        if (sect != null && domain != null && path != null) {
+            state.add(sect, RequiredExclude(domain, path))
+        }
+    }
+
+    private class ParseState {
+        val sections: MutableMap<Section, MutableSet<RequiredExclude>> = mutableMapOf()
+        var currentSection: Section? = null
+        var rootIsFullBackup: Boolean = false
+        var rootSeen: Boolean = false
+
+        fun enter(section: Section) {
+            currentSection = section
+            sections.getOrPut(section) { mutableSetOf() }
+        }
+
+        fun leave() {
+            currentSection = null
+        }
+
+        fun add(section: Section, exclude: RequiredExclude) {
+            sections.getValue(section).add(exclude)
+        }
     }
 
     private fun readIntField(target: Any, name: String): Int? = try {
         val field = target.javaClass.getDeclaredField(name).also { it.isAccessible = true }
         field.getInt(target)
-    } catch (e: NoSuchFieldException) {
+    } catch (_: NoSuchFieldException) {
         null
-    } catch (e: IllegalAccessException) {
+    } catch (_: IllegalAccessException) {
         null
     }
-
-    internal const val FULL_BACKUP_CONTENT_RES_NAME: String = "walt_passes_backup_rules"
-    internal const val DATA_EXTRACTION_RULES_RES_NAME: String = "walt_passes_data_extraction_rules"
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -133,14 +133,13 @@ public object BackupRulesAssertion {
         }
     }
 
-    private fun reduce(fullBackup: ValidationResult, dxr: ValidationResult): Outcome = when {
-        fullBackup is ValidationResult.Unreadable -> fullBackup.outcome
-        dxr is ValidationResult.Unreadable -> dxr.outcome
-        else -> {
-            val problems = (fullBackup as ValidationResult.Ok).problems +
-                (dxr as ValidationResult.Ok).problems
-            if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems)
-        }
+    private fun reduce(fullBackup: ValidationResult, dxr: ValidationResult): Outcome {
+        val unreadable = fullBackup as? ValidationResult.Unreadable
+            ?: dxr as? ValidationResult.Unreadable
+        if (unreadable != null) return unreadable.outcome
+        val problems = (fullBackup as ValidationResult.Ok).problems +
+            (dxr as ValidationResult.Ok).problems
+        return if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems)
     }
 
     private data class ResourceIds(val fullBackup: Int, val dxr: Int)
@@ -195,8 +194,8 @@ public object BackupRulesAssertion {
             return ParseAttempt.Failed(e.message ?: "resource not found")
         }
         return try {
-            ParseAttempt.Success(parseRulesXml(parser))
-        } catch (e: BackupRulesParseException) {
+            ParseAttempt.Success(BackupRulesXmlParser.parseRulesXml(parser))
+        } catch (e: BackupRulesXmlParser.ParseException) {
             ParseAttempt.Failed(e.message ?: "malformed rules document")
         } catch (e: XmlPullParserException) {
             ParseAttempt.Failed(e.message ?: "xml parse error")

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -6,14 +6,18 @@ import android.content.pm.PackageManager
 import android.content.res.Resources
 import android.content.res.XmlResourceParser
 import android.os.Build
-import org.xmlpull.v1.XmlPullParser
+import androidx.annotation.VisibleForTesting
+import `is`.walt.passes.storage.BackupRulesContract.REQUIRED_EXCLUDES
+import `is`.walt.passes.storage.BackupRulesContract.RequiredExclude
+import `is`.walt.passes.storage.BackupRulesContract.Section
 import org.xmlpull.v1.XmlPullParserException
 import java.io.IOException
 
 /**
  * Verifies that the trust claim "pass data is excluded from cloud backup" holds in the
- * consumer's merged manifest. Intended for the consumer's instrumentation test suite so
- * that the claim is checkable in CI rather than relying on manifest review.
+ * consumer's merged manifest. Intended for the consumer's test suite (Robolectric or
+ * on-device instrumentation) so that the claim is checkable in CI rather than relying
+ * on manifest review.
  *
  * The library ships `walt_passes_backup_rules.xml` (API 23 - 30) and
  * `walt_passes_data_extraction_rules.xml` (API 31+). Two consumer postures are valid:
@@ -29,26 +33,20 @@ import java.io.IOException
  *
  * Both postures satisfy the trust claim. The assertion validates by **content**, not
  * resource identity: it opens whichever XML resource the merged manifest points at and
- * confirms every entry in [REQUIRED_EXCLUDES] is present in every backup-relevant
- * section of that resource. A consumer is free to add their own additional excludes;
- * only the pass-related entries are required.
+ * confirms every entry in [BackupRulesContract.REQUIRED_EXCLUDES] is present in every
+ * backup-relevant section. Consumers may add additional excludes; only the pass-related
+ * entries are required.
  *
  * If the consumer has set `android:allowBackup="false"` app-wide, the trust claim is
- * trivially satisfied (no surface for pass data to leak through) and the assertion
- * returns [Outcome.Applied] without parsing rules.
+ * trivially satisfied and the assertion returns [Outcome.Applied] without parsing rules.
  *
- * Reflection on `ApplicationInfo.fullBackupContent` and `ApplicationInfo.dataExtractionRulesRes`
- * is intentional: the alternative is parsing the merged manifest XML by hand, which is
- * more brittle than greylisted hidden-API fields whose semantics have not changed since
- * the feature shipped.
+ * Reflection on `ApplicationInfo.fullBackupContent` and
+ * `ApplicationInfo.dataExtractionRulesRes` is intentional: those greylisted hidden-API
+ * fields are the most reliable read of the merged manifest. They may be moved to the
+ * blocklist in a future Android release; if that happens, [Outcome.FieldUnavailable] is
+ * the surface for triage and a manifest-XML fallback is the expected mitigation.
  */
 public object BackupRulesAssertion {
-
-    /** Backup rule sections the assertion validates. */
-    public enum class Section { FullBackupContent, CloudBackup, DeviceTransfer }
-
-    /** A single `<exclude domain="..." path="..."/>` entry. */
-    public data class RequiredExclude(public val domain: String, public val path: String)
 
     /** A section that is missing one or more required excludes. */
     public data class MissingSection(
@@ -96,180 +94,123 @@ public object BackupRulesAssertion {
         public data object FieldUnavailable : Outcome
     }
 
-    /** Entries the library requires every consumer rules resource to carry. */
-    public val REQUIRED_EXCLUDES: List<RequiredExclude> = listOf(
-        RequiredExclude(domain = "database", path = "walt_passes.db"),
-        RequiredExclude(domain = "database", path = "walt_passes.db-journal"),
-        RequiredExclude(domain = "database", path = "walt_passes.db-wal"),
-        RequiredExclude(domain = "database", path = "walt_passes.db-shm"),
-        RequiredExclude(domain = "sharedpref", path = "is.walt.passes.storage.key_envelope.xml"),
-    )
-
     @JvmStatic
     public fun assertBackupRulesApplied(context: Context): Outcome {
         val appInfo = loadApplicationInfo(context) ?: return Outcome.PackageInfoUnavailable
+        return assertBackupRulesApplied(appInfo, context.resources)
+    }
 
+    /**
+     * Test seam. Lets unit tests construct a fresh [ApplicationInfo] (e.g., via Parcel
+     * round-trip) and pass it directly, avoiding mutation of the Robolectric-shared
+     * `ApplicationInfo` returned by `Context.applicationInfo`.
+     */
+    @VisibleForTesting
+    internal fun assertBackupRulesApplied(appInfo: ApplicationInfo, resources: Resources): Outcome =
         if (appInfo.flags and ApplicationInfo.FLAG_ALLOW_BACKUP == 0) {
-            return Outcome.Applied
+            Outcome.Applied
+        } else {
+            evaluateRules(appInfo, resources)
         }
 
-        val fullBackupResId = readIntField(appInfo, "fullBackupContent")
-            ?: return Outcome.FieldUnavailable
-        val dxrResId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            readIntField(appInfo, "dataExtractionRulesRes") ?: return Outcome.FieldUnavailable
+    private fun evaluateRules(appInfo: ApplicationInfo, resources: Resources): Outcome {
+        val resIds = readResourceIds(appInfo)
+        return when {
+            resIds == null -> Outcome.FieldUnavailable
+            resIds.fullBackup == 0 && resIds.dxr == 0 -> Outcome.NoBackupRulesConfigured
+            else -> reduce(
+                fullBackup = validateResource(
+                    resources = resources,
+                    resId = resIds.fullBackup,
+                    sections = listOf(Section.FullBackupContent),
+                ),
+                dxr = validateResource(
+                    resources = resources,
+                    resId = resIds.dxr,
+                    sections = listOf(Section.CloudBackup, Section.DeviceTransfer),
+                ),
+            )
+        }
+    }
+
+    private fun reduce(fullBackup: ValidationResult, dxr: ValidationResult): Outcome = when {
+        fullBackup is ValidationResult.Unreadable -> fullBackup.outcome
+        dxr is ValidationResult.Unreadable -> dxr.outcome
+        else -> {
+            val problems = (fullBackup as ValidationResult.Ok).problems +
+                (dxr as ValidationResult.Ok).problems
+            if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems)
+        }
+    }
+
+    private data class ResourceIds(val fullBackup: Int, val dxr: Int)
+
+    private fun readResourceIds(appInfo: ApplicationInfo): ResourceIds? {
+        val full = readIntField(appInfo, "fullBackupContent")
+        val dxr = readDxrResId(appInfo)
+        return if (full != null && dxr != null) ResourceIds(fullBackup = full, dxr = dxr) else null
+    }
+
+    private fun readDxrResId(appInfo: ApplicationInfo): Int? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            readIntField(appInfo, "dataExtractionRulesRes")
         } else {
             0
         }
 
-        if (fullBackupResId == 0 && dxrResId == 0) {
-            return Outcome.NoBackupRulesConfigured
+    private sealed interface ValidationResult {
+        data class Ok(val problems: List<MissingSection>) : ValidationResult
+        data class Unreadable(val outcome: Outcome.RulesResourceUnreadable) : ValidationResult
+    }
+
+    private fun validateResource(
+        resources: Resources,
+        resId: Int,
+        sections: List<Section>,
+    ): ValidationResult {
+        if (resId == 0) return ValidationResult.Ok(emptyList())
+        return when (val attempt = parseResource(resources, resId)) {
+            is ParseAttempt.Failed ->
+                ValidationResult.Unreadable(Outcome.RulesResourceUnreadable(resId, attempt.reason))
+            is ParseAttempt.Success -> {
+                val problems = sections.mapNotNull { section ->
+                    val excludes = attempt.sections[section].orEmpty()
+                    val missing = REQUIRED_EXCLUDES.filterNot { it in excludes }
+                    if (missing.isEmpty()) null else MissingSection(resId, section, missing)
+                }
+                ValidationResult.Ok(problems)
+            }
         }
+    }
 
-        val problems = mutableListOf<MissingSection>()
-        validateResource(
-            context = context,
-            resId = fullBackupResId,
-            sections = listOf(Section.FullBackupContent),
-            problems = problems,
-        )?.let { return it }
-        validateResource(
-            context = context,
-            resId = dxrResId,
-            sections = listOf(Section.CloudBackup, Section.DeviceTransfer),
-            problems = problems,
-        )?.let { return it }
+    private sealed interface ParseAttempt {
+        data class Success(val sections: Map<Section, Set<RequiredExclude>>) : ParseAttempt
+        data class Failed(val reason: String) : ParseAttempt
+    }
 
-        return if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems.toList())
+    private fun parseResource(resources: Resources, resId: Int): ParseAttempt {
+        val parser: XmlResourceParser = try {
+            resources.getXml(resId)
+        } catch (e: Resources.NotFoundException) {
+            return ParseAttempt.Failed(e.message ?: "resource not found")
+        }
+        return try {
+            ParseAttempt.Success(parseRulesXml(parser))
+        } catch (e: BackupRulesParseException) {
+            ParseAttempt.Failed(e.message ?: "malformed rules document")
+        } catch (e: XmlPullParserException) {
+            ParseAttempt.Failed(e.message ?: "xml parse error")
+        } catch (e: IOException) {
+            ParseAttempt.Failed(e.message ?: "io error")
+        } finally {
+            parser.close()
+        }
     }
 
     private fun loadApplicationInfo(context: Context): ApplicationInfo? = try {
         context.packageManager.getApplicationInfo(context.packageName, 0)
     } catch (_: PackageManager.NameNotFoundException) {
         null
-    }
-
-    /**
-     * Parses [resId] (if non-zero) and appends a [MissingSection] for every entry in
-     * [sections] that is missing a required exclude. Returns a short-circuit
-     * [Outcome.RulesResourceUnreadable] if the resource cannot be opened or parsed.
-     */
-    private fun validateResource(
-        context: Context,
-        resId: Int,
-        sections: List<Section>,
-        problems: MutableList<MissingSection>,
-    ): Outcome? {
-        if (resId != 0) {
-            val parsed = parseResource(context, resId)
-                ?: return Outcome.RulesResourceUnreadable(resId, "parse failed")
-            for (section in sections) {
-                val excludes = parsed[section].orEmpty()
-                val missing = REQUIRED_EXCLUDES.filterNot { it in excludes }
-                if (missing.isNotEmpty()) {
-                    problems += MissingSection(resId, section, missing)
-                }
-            }
-        }
-        return null
-    }
-
-    private fun parseResource(context: Context, resId: Int): Map<Section, Set<RequiredExclude>>? {
-        val parser: XmlResourceParser = try {
-            context.resources.getXml(resId)
-        } catch (_: Resources.NotFoundException) {
-            return null
-        }
-        return try {
-            parseRulesXml(parser)
-        } catch (_: XmlPullParserException) {
-            null
-        } catch (_: IOException) {
-            null
-        } catch (_: IllegalStateException) {
-            null
-        } finally {
-            parser.close()
-        }
-    }
-
-    /**
-     * Walks a backup-rules XML document and returns the `<exclude>` entries grouped by
-     * section. Accepts both legacy `<full-backup-content>` documents (single implicit
-     * section) and modern `<data-extraction-rules>` documents (with `<cloud-backup>` and
-     * `<device-transfer>` children). `<include>` entries and unknown elements are
-     * ignored; only the `<exclude>` discipline is load-bearing for the trust claim.
-     */
-    @JvmStatic
-    internal fun parseRulesXml(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
-        val state = ParseState()
-        var event = parser.eventType
-        while (event != XmlPullParser.END_DOCUMENT) {
-            when (event) {
-                XmlPullParser.START_TAG -> handleStartTag(parser, state)
-                XmlPullParser.END_TAG -> handleEndTag(parser, state)
-            }
-            event = parser.next()
-        }
-        return state.sections
-    }
-
-    private fun handleStartTag(parser: XmlPullParser, state: ParseState) {
-        val name = parser.name
-        when {
-            !state.rootSeen -> openRoot(name, state)
-            !state.rootIsFullBackup && name == "cloud-backup" -> state.enter(Section.CloudBackup)
-            !state.rootIsFullBackup && name == "device-transfer" -> state.enter(Section.DeviceTransfer)
-            name == "exclude" -> recordExclude(parser, state)
-        }
-    }
-
-    private fun handleEndTag(parser: XmlPullParser, state: ParseState) {
-        if (state.rootIsFullBackup) return
-        val name = parser.name
-        if (name == "cloud-backup" || name == "device-transfer") {
-            state.leave()
-        }
-    }
-
-    private fun openRoot(name: String, state: ParseState) {
-        state.rootSeen = true
-        when (name) {
-            "full-backup-content" -> {
-                state.rootIsFullBackup = true
-                state.enter(Section.FullBackupContent)
-            }
-            "data-extraction-rules" -> Unit
-            else -> error("unexpected root element: $name")
-        }
-    }
-
-    private fun recordExclude(parser: XmlPullParser, state: ParseState) {
-        val sect = state.currentSection
-        val domain = parser.getAttributeValue(null, "domain")
-        val path = parser.getAttributeValue(null, "path")
-        if (sect != null && domain != null && path != null) {
-            state.add(sect, RequiredExclude(domain, path))
-        }
-    }
-
-    private class ParseState {
-        val sections: MutableMap<Section, MutableSet<RequiredExclude>> = mutableMapOf()
-        var currentSection: Section? = null
-        var rootIsFullBackup: Boolean = false
-        var rootSeen: Boolean = false
-
-        fun enter(section: Section) {
-            currentSection = section
-            sections.getOrPut(section) { mutableSetOf() }
-        }
-
-        fun leave() {
-            currentSection = null
-        }
-
-        fun add(section: Section, exclude: RequiredExclude) {
-            sections.getValue(section).add(exclude)
-        }
     }
 
     private fun readIntField(target: Any, name: String): Int? = try {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -134,6 +134,9 @@ public object BackupRulesAssertion {
     }
 
     private fun reduce(fullBackup: ValidationResult, dxr: ValidationResult): Outcome {
+        // If both arms are unreadable, only the first is reported. The Outcome shape
+        // (single resourceId + reason) does not model simultaneous failures; a consumer
+        // fixing the first surfaces the second on the next run.
         val unreadable = fullBackup as? ValidationResult.Unreadable
             ?: dxr as? ValidationResult.Unreadable
         if (unreadable != null) return unreadable.outcome

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesContract.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesContract.kt
@@ -1,0 +1,32 @@
+package `is`.walt.passes.storage
+
+/**
+ * Backup-rules trust contract for `passes-storage`. Encodes what the trust claim
+ * "pass data is excluded from cloud backup" means as data the assertion can verify
+ * against the consumer's merged manifest.
+ *
+ * This object is the audit-facing entry point. A security researcher reading the trust
+ * claim should land on [REQUIRED_EXCLUDES] to see exactly which files the library
+ * insists are excluded from Auto Backup and device-to-device transfer.
+ */
+public object BackupRulesContract {
+
+    /** Backup rule sections the assertion validates. */
+    public enum class Section(public val xmlElement: String) {
+        FullBackupContent("full-backup-content"),
+        CloudBackup("cloud-backup"),
+        DeviceTransfer("device-transfer"),
+    }
+
+    /** A single `<exclude domain="..." path="..."/>` entry. */
+    public data class RequiredExclude(public val domain: String, public val path: String)
+
+    /** Entries the library requires every consumer rules resource to carry. */
+    public val REQUIRED_EXCLUDES: List<RequiredExclude> = listOf(
+        RequiredExclude(domain = "database", path = "walt_passes.db"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-journal"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-wal"),
+        RequiredExclude(domain = "database", path = "walt_passes.db-shm"),
+        RequiredExclude(domain = "sharedpref", path = "is.walt.passes.storage.key_envelope.xml"),
+    )
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
@@ -69,7 +69,7 @@ internal object BackupRulesXmlParser {
     ) {
         val section = sectionByElementName(parser.name) ?: return
         val collected = collectExcludesUntil(parser, parser.name)
-        sections[section] = sections[section]?.let { it + collected } ?: collected
+        sections.merge(section, collected, Set<RequiredExclude>::plus)
     }
 
     /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
@@ -11,85 +11,105 @@ import org.xmlpull.v1.XmlPullParser
  * `<device-transfer>` children). `<include>` entries and unknown elements are ignored;
  * only the `<exclude>` discipline is load-bearing for the trust claim.
  *
- * Throws [BackupRulesParseException] when the document does not have a recognized
- * backup-rules root element. Other XML or IO errors propagate as
+ * Throws [ParseException] when the document does not have a recognized backup-rules
+ * root element. Other XML or IO errors propagate as
  * [org.xmlpull.v1.XmlPullParserException] / [java.io.IOException] for the caller to
  * translate into [BackupRulesAssertion.Outcome.RulesResourceUnreadable].
+ *
+ * Two deliberate tolerances:
+ *
+ *  - **Depth-blind exclude collection.** An `<exclude>` nested below the expected level
+ *    (e.g., inside an unexpected wrapper element) is still captured into the enclosing
+ *    section. The Android backup-rules schema does not permit such nesting, so a
+ *    consumer who writes one is shipping a document Android itself would reject; the
+ *    assertion does not try to second-guess that.
+ *  - **Duplicate-section union.** A malformed document that declares `<cloud-backup>`
+ *    twice has its excludes unioned rather than overwritten, so a missing entry in the
+ *    first block is not masked by its presence in the second.
  */
-internal fun parseRulesXml(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
-    advanceToFirstStartTag(parser)
-    return when (val name = parser.name) {
-        Section.FullBackupContent.xmlElement ->
-            mapOf(Section.FullBackupContent to collectExcludesUntil(parser, name))
-        DATA_EXTRACTION_RULES_ELEMENT -> parseDataExtractionRules(parser)
-        else -> throw BackupRulesParseException("unexpected root element: $name")
-    }
-}
+internal object BackupRulesXmlParser {
 
-internal class BackupRulesParseException(message: String) : RuntimeException(message)
-
-private const val DATA_EXTRACTION_RULES_ELEMENT = "data-extraction-rules"
-private const val EXCLUDE_ELEMENT = "exclude"
-private const val DOMAIN_ATTRIBUTE = "domain"
-private const val PATH_ATTRIBUTE = "path"
-
-private fun advanceToFirstStartTag(parser: XmlPullParser) {
-    var event = parser.eventType
-    while (event != XmlPullParser.START_TAG && event != XmlPullParser.END_DOCUMENT) {
-        event = parser.next()
-    }
-    if (event != XmlPullParser.START_TAG) {
-        throw BackupRulesParseException("empty rules document")
-    }
-}
-
-private fun parseDataExtractionRules(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
-    val sections = mutableMapOf<Section, Set<RequiredExclude>>()
-    var event = parser.next()
-    while (!isEndOfDataExtractionRules(event, parser)) {
-        if (event == XmlPullParser.START_TAG) {
-            val section = sectionByElementName(parser.name)
-            if (section != null) {
-                sections[section] = collectExcludesUntil(parser, parser.name)
-            }
+    fun parseRulesXml(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
+        advanceToFirstStartTag(parser)
+        return when (val name = parser.name) {
+            Section.FullBackupContent.xmlElement ->
+                mapOf(Section.FullBackupContent to collectExcludesUntil(parser, name))
+            DATA_EXTRACTION_RULES_ELEMENT -> parseDataExtractionRules(parser)
+            else -> throw ParseException("unexpected root element: $name")
         }
-        event = parser.next()
     }
-    return sections
-}
 
-/**
- * Reads `<exclude>` children of the element currently positioned at START_TAG. Returns
- * once the matching END_TAG (named [closingElement]) is consumed.
- */
-private fun collectExcludesUntil(
-    parser: XmlPullParser,
-    closingElement: String,
-): Set<RequiredExclude> {
-    val excludes = mutableSetOf<RequiredExclude>()
-    var event = parser.next()
-    while (!isClosingEvent(event, parser, closingElement)) {
-        if (event == XmlPullParser.START_TAG && parser.name == EXCLUDE_ELEMENT) {
-            val domain = parser.getAttributeValue(null, DOMAIN_ATTRIBUTE)
-            val path = parser.getAttributeValue(null, PATH_ATTRIBUTE)
-            if (domain != null && path != null) {
-                excludes.add(RequiredExclude(domain, path))
-            }
+    class ParseException(message: String) : RuntimeException(message)
+
+    private fun advanceToFirstStartTag(parser: XmlPullParser) {
+        var event = parser.eventType
+        while (event != XmlPullParser.START_TAG && event != XmlPullParser.END_DOCUMENT) {
+            event = parser.next()
         }
-        event = parser.next()
+        if (event != XmlPullParser.START_TAG) {
+            throw ParseException("empty rules document")
+        }
     }
-    return excludes
-}
 
-private fun isClosingEvent(event: Int, parser: XmlPullParser, closingElement: String): Boolean {
-    if (event == XmlPullParser.END_DOCUMENT) return true
-    return event == XmlPullParser.END_TAG && parser.name == closingElement
-}
+    private fun parseDataExtractionRules(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
+        val sections = mutableMapOf<Section, Set<RequiredExclude>>()
+        var event = parser.next()
+        while (!isEndOfDataExtractionRules(event, parser)) {
+            if (event == XmlPullParser.START_TAG) {
+                handleDxrChildSection(parser, sections)
+            }
+            event = parser.next()
+        }
+        return sections
+    }
 
-private fun isEndOfDataExtractionRules(event: Int, parser: XmlPullParser): Boolean {
-    if (event == XmlPullParser.END_DOCUMENT) return true
-    return event == XmlPullParser.END_TAG && parser.name == DATA_EXTRACTION_RULES_ELEMENT
-}
+    private fun handleDxrChildSection(
+        parser: XmlPullParser,
+        sections: MutableMap<Section, Set<RequiredExclude>>,
+    ) {
+        val section = sectionByElementName(parser.name) ?: return
+        val collected = collectExcludesUntil(parser, parser.name)
+        sections[section] = sections[section]?.let { it + collected } ?: collected
+    }
 
-private fun sectionByElementName(name: String): Section? =
-    Section.entries.firstOrNull { it.xmlElement == name }
+    /**
+     * Reads `<exclude>` children of the element currently positioned at START_TAG.
+     * Returns once the matching END_TAG (named [closingElement]) is consumed.
+     */
+    private fun collectExcludesUntil(
+        parser: XmlPullParser,
+        closingElement: String,
+    ): Set<RequiredExclude> {
+        val excludes = mutableSetOf<RequiredExclude>()
+        var event = parser.next()
+        while (!isClosingEvent(event, parser, closingElement)) {
+            if (event == XmlPullParser.START_TAG && parser.name == EXCLUDE_ELEMENT) {
+                val domain = parser.getAttributeValue(null, DOMAIN_ATTRIBUTE)
+                val path = parser.getAttributeValue(null, PATH_ATTRIBUTE)
+                if (domain != null && path != null) {
+                    excludes.add(RequiredExclude(domain, path))
+                }
+            }
+            event = parser.next()
+        }
+        return excludes
+    }
+
+    private fun isClosingEvent(event: Int, parser: XmlPullParser, closingElement: String): Boolean {
+        if (event == XmlPullParser.END_DOCUMENT) return true
+        return event == XmlPullParser.END_TAG && parser.name == closingElement
+    }
+
+    private fun isEndOfDataExtractionRules(event: Int, parser: XmlPullParser): Boolean {
+        if (event == XmlPullParser.END_DOCUMENT) return true
+        return event == XmlPullParser.END_TAG && parser.name == DATA_EXTRACTION_RULES_ELEMENT
+    }
+
+    private fun sectionByElementName(name: String): Section? =
+        Section.entries.firstOrNull { it.xmlElement == name }
+
+    private const val DATA_EXTRACTION_RULES_ELEMENT = "data-extraction-rules"
+    private const val EXCLUDE_ELEMENT = "exclude"
+    private const val DOMAIN_ATTRIBUTE = "domain"
+    private const val PATH_ATTRIBUTE = "path"
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesXmlParser.kt
@@ -1,0 +1,95 @@
+package `is`.walt.passes.storage
+
+import `is`.walt.passes.storage.BackupRulesContract.RequiredExclude
+import `is`.walt.passes.storage.BackupRulesContract.Section
+import org.xmlpull.v1.XmlPullParser
+
+/**
+ * Walks a backup-rules XML document and returns the `<exclude>` entries grouped by
+ * section. Accepts both legacy `<full-backup-content>` documents (single implicit
+ * section) and modern `<data-extraction-rules>` documents (`<cloud-backup>` and
+ * `<device-transfer>` children). `<include>` entries and unknown elements are ignored;
+ * only the `<exclude>` discipline is load-bearing for the trust claim.
+ *
+ * Throws [BackupRulesParseException] when the document does not have a recognized
+ * backup-rules root element. Other XML or IO errors propagate as
+ * [org.xmlpull.v1.XmlPullParserException] / [java.io.IOException] for the caller to
+ * translate into [BackupRulesAssertion.Outcome.RulesResourceUnreadable].
+ */
+internal fun parseRulesXml(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
+    advanceToFirstStartTag(parser)
+    return when (val name = parser.name) {
+        Section.FullBackupContent.xmlElement ->
+            mapOf(Section.FullBackupContent to collectExcludesUntil(parser, name))
+        DATA_EXTRACTION_RULES_ELEMENT -> parseDataExtractionRules(parser)
+        else -> throw BackupRulesParseException("unexpected root element: $name")
+    }
+}
+
+internal class BackupRulesParseException(message: String) : RuntimeException(message)
+
+private const val DATA_EXTRACTION_RULES_ELEMENT = "data-extraction-rules"
+private const val EXCLUDE_ELEMENT = "exclude"
+private const val DOMAIN_ATTRIBUTE = "domain"
+private const val PATH_ATTRIBUTE = "path"
+
+private fun advanceToFirstStartTag(parser: XmlPullParser) {
+    var event = parser.eventType
+    while (event != XmlPullParser.START_TAG && event != XmlPullParser.END_DOCUMENT) {
+        event = parser.next()
+    }
+    if (event != XmlPullParser.START_TAG) {
+        throw BackupRulesParseException("empty rules document")
+    }
+}
+
+private fun parseDataExtractionRules(parser: XmlPullParser): Map<Section, Set<RequiredExclude>> {
+    val sections = mutableMapOf<Section, Set<RequiredExclude>>()
+    var event = parser.next()
+    while (!isEndOfDataExtractionRules(event, parser)) {
+        if (event == XmlPullParser.START_TAG) {
+            val section = sectionByElementName(parser.name)
+            if (section != null) {
+                sections[section] = collectExcludesUntil(parser, parser.name)
+            }
+        }
+        event = parser.next()
+    }
+    return sections
+}
+
+/**
+ * Reads `<exclude>` children of the element currently positioned at START_TAG. Returns
+ * once the matching END_TAG (named [closingElement]) is consumed.
+ */
+private fun collectExcludesUntil(
+    parser: XmlPullParser,
+    closingElement: String,
+): Set<RequiredExclude> {
+    val excludes = mutableSetOf<RequiredExclude>()
+    var event = parser.next()
+    while (!isClosingEvent(event, parser, closingElement)) {
+        if (event == XmlPullParser.START_TAG && parser.name == EXCLUDE_ELEMENT) {
+            val domain = parser.getAttributeValue(null, DOMAIN_ATTRIBUTE)
+            val path = parser.getAttributeValue(null, PATH_ATTRIBUTE)
+            if (domain != null && path != null) {
+                excludes.add(RequiredExclude(domain, path))
+            }
+        }
+        event = parser.next()
+    }
+    return excludes
+}
+
+private fun isClosingEvent(event: Int, parser: XmlPullParser, closingElement: String): Boolean {
+    if (event == XmlPullParser.END_DOCUMENT) return true
+    return event == XmlPullParser.END_TAG && parser.name == closingElement
+}
+
+private fun isEndOfDataExtractionRules(event: Int, parser: XmlPullParser): Boolean {
+    if (event == XmlPullParser.END_DOCUMENT) return true
+    return event == XmlPullParser.END_TAG && parser.name == DATA_EXTRACTION_RULES_ELEMENT
+}
+
+private fun sectionByElementName(name: String): Section? =
+    Section.entries.firstOrNull { it.xmlElement == name }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -225,9 +225,20 @@ class BackupRulesAssertionTest {
         // Pre-S devices use full-backup-content, not data-extraction-rules. This test
         // pins that the legacy path of the trust claim works end-to-end on Android 11
         // and earlier, where ApplicationInfo.dataExtractionRulesRes does not exist.
+        // Hardened the same way as the API 34 endToEnd test so a future allowBackup
+        // flip surfaces here regardless of which Android version regresses first.
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
-        assertThat(outcome).isEqualTo(Outcome.Applied)
+        assertThat(context.applicationInfo.flags and ApplicationInfo.FLAG_ALLOW_BACKUP)
+            .isNotEqualTo(0)
+
+        val publicOutcome = BackupRulesAssertion.assertBackupRulesApplied(context)
+        val seamOutcome = BackupRulesAssertion.assertBackupRulesApplied(
+            context.applicationInfo,
+            context.resources,
+        )
+
+        assertThat(publicOutcome).isEqualTo(Outcome.Applied)
+        assertThat(seamOutcome).isEqualTo(publicOutcome)
     }
 
     @Test

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -152,11 +152,34 @@ class BackupRulesAssertionTest {
         val xml = "<wrong-root><exclude domain=\"database\" path=\"x\" /></wrong-root>"
         try {
             parse(xml)
-            error("expected BackupRulesParseException")
-        } catch (expected: BackupRulesParseException) {
+            error("expected BackupRulesXmlParser.ParseException")
+        } catch (expected: BackupRulesXmlParser.ParseException) {
             assertThat(expected.message).contains("unexpected root element")
             assertThat(expected.message).contains("wrong-root")
         }
+    }
+
+    @Test
+    fun duplicateSectionsAreUnioned() {
+        // Defensive: a malformed document repeating <cloud-backup> must not mask a
+        // missing entry in the first block by its presence in the second.
+        val xml = """
+            <data-extraction-rules>
+                <cloud-backup>
+                    <exclude domain="database" path="walt_passes.db" />
+                </cloud-backup>
+                <cloud-backup>
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                </cloud-backup>
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.getValue(Section.CloudBackup)).containsExactly(
+            RequiredExclude("database", "walt_passes.db"),
+            RequiredExclude("database", "walt_passes.db-journal"),
+        )
     }
 
     @Test
@@ -175,6 +198,33 @@ class BackupRulesAssertionTest {
 
     @Test
     fun endToEndAgainstLibraryOwnRulesReturnsApplied() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // The test must exercise the parser path, not the allowBackup=false short-circuit.
+        // If the library's manifest is ever changed to flip this flag, this assertion
+        // surfaces the change rather than the test silently passing for the wrong reason.
+        assertThat(context.applicationInfo.flags and ApplicationInfo.FLAG_ALLOW_BACKUP)
+            .isNotEqualTo(0)
+
+        val publicOutcome = BackupRulesAssertion.assertBackupRulesApplied(context)
+        // Cross-check: the public entry point and the test seam must agree on the same
+        // unmutated context. Catches divergence between Context.applicationInfo and
+        // packageManager.getApplicationInfo(packageName) under any future Robolectric
+        // configuration.
+        val seamOutcome = BackupRulesAssertion.assertBackupRulesApplied(
+            context.applicationInfo,
+            context.resources,
+        )
+
+        assertThat(publicOutcome).isEqualTo(Outcome.Applied)
+        assertThat(seamOutcome).isEqualTo(publicOutcome)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun endToEndOnPreSReturnsAppliedFromFullBackupContentAlone() {
+        // Pre-S devices use full-backup-content, not data-extraction-rules. This test
+        // pins that the legacy path of the trust claim works end-to-end on Android 11
+        // and earlier, where ApplicationInfo.dataExtractionRulesRes does not exist.
         val context = ApplicationProvider.getApplicationContext<Context>()
         val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
         assertThat(outcome).isEqualTo(Outcome.Applied)
@@ -236,6 +286,11 @@ class BackupRulesAssertionTest {
         ).inOrder()
     }
 
+    /**
+     * Same project convention as [outcomeArmsAreReachableViaWhen] (and
+     * `PublicApiSurfaceTest`): pin the enum surface so additions or removals require a
+     * compile-time conversation here.
+     */
     @Test
     fun sectionEnumeratesTheThreeKnownSectionsWithXmlElementNames() {
         assertThat(Section.entries.map { it.name }).containsExactly(
@@ -252,7 +307,7 @@ class BackupRulesAssertionTest {
         val factory = XmlPullParserFactory.newInstance().apply { isNamespaceAware = false }
         val parser = factory.newPullParser()
         parser.setInput(StringReader(xml))
-        return parseRulesXml(parser)
+        return BackupRulesXmlParser.parseRulesXml(parser)
     }
 
     private fun cloneApplicationInfo(source: ApplicationInfo): ApplicationInfo {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -1,13 +1,16 @@
 package `is`.walt.passes.storage
 
+import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.os.Parcel
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.storage.BackupRulesAssertion.MissingSection
 import `is`.walt.passes.storage.BackupRulesAssertion.Outcome
-import `is`.walt.passes.storage.BackupRulesAssertion.RequiredExclude
-import `is`.walt.passes.storage.BackupRulesAssertion.Section
+import `is`.walt.passes.storage.BackupRulesContract.REQUIRED_EXCLUDES
+import `is`.walt.passes.storage.BackupRulesContract.RequiredExclude
+import `is`.walt.passes.storage.BackupRulesContract.Section
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -15,16 +18,16 @@ import org.xmlpull.v1.XmlPullParserFactory
 import java.io.StringReader
 
 /**
- * Behavioral tests for [BackupRulesAssertion]. The XML parsing logic is exercised
- * directly via [BackupRulesAssertion.parseRulesXml] against hand-crafted strings, which
- * lets us cover both consumer postures (inherit vs mirror), missing-entry diagnostics,
- * and malformed-input handling without needing test-only Android resources.
+ * Behavioral tests for [BackupRulesAssertion]. The XML parser is exercised directly
+ * against hand-crafted strings, which lets us cover both consumer postures (inherit vs
+ * mirror), missing-entry diagnostics, and malformed-input handling without needing
+ * test-only Android resources.
  *
  * The end-to-end Context-driven path is exercised against the library's own
  * `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml`, which
  * Robolectric loads via the library's manifest contributions. The on-device path
- * (StrongBox vs TEE matrix, bmgr backup-blob inspection) is covered by the
- * `wpass-x5l` instrumentation suite; this file stays JVM-only.
+ * (StrongBox vs TEE matrix, bmgr backup-blob inspection) is covered by the `wpass-x5l`
+ * instrumentation suite; this file stays JVM-only.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -46,7 +49,7 @@ class BackupRulesAssertionTest {
 
         assertThat(parsed.keys).containsExactly(Section.FullBackupContent)
         assertThat(parsed.getValue(Section.FullBackupContent))
-            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+            .containsExactlyElementsIn(REQUIRED_EXCLUDES)
     }
 
     @Test
@@ -74,9 +77,9 @@ class BackupRulesAssertionTest {
 
         assertThat(parsed.keys).containsExactly(Section.CloudBackup, Section.DeviceTransfer)
         assertThat(parsed.getValue(Section.CloudBackup))
-            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+            .containsExactlyElementsIn(REQUIRED_EXCLUDES)
         assertThat(parsed.getValue(Section.DeviceTransfer))
-            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+            .containsExactlyElementsIn(REQUIRED_EXCLUDES)
     }
 
     @Test
@@ -100,7 +103,7 @@ class BackupRulesAssertionTest {
     }
 
     @Test
-    fun mirroredResourceWithExtraExcludesStillPasses() {
+    fun mirroredResourceWithExtraExcludesStillCarriesRequired() {
         // Walt-android's posture: own resource that mirrors required entries plus its own.
         val xml = """
             <data-extraction-rules>
@@ -126,22 +129,15 @@ class BackupRulesAssertionTest {
         val parsed = parse(xml)
 
         assertThat(parsed.getValue(Section.CloudBackup))
-            .containsAtLeastElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+            .containsAtLeastElementsIn(REQUIRED_EXCLUDES)
     }
 
     @Test
-    fun missingDeviceTransferSectionIsReportedByCallerLogic() {
-        // The parser itself doesn't synthesize sections; it only returns what's there.
-        // The assertion treats absent sections as empty, which lets the assertion
-        // surface them as missing-required-excludes.
+    fun absentSectionIsReportedAsAbsentByParser() {
         val xml = """
             <data-extraction-rules>
                 <cloud-backup>
                     <exclude domain="database" path="walt_passes.db" />
-                    <exclude domain="database" path="walt_passes.db-journal" />
-                    <exclude domain="database" path="walt_passes.db-wal" />
-                    <exclude domain="database" path="walt_passes.db-shm" />
-                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
                 </cloud-backup>
             </data-extraction-rules>
         """.trimIndent()
@@ -152,19 +148,20 @@ class BackupRulesAssertionTest {
     }
 
     @Test
-    fun unknownRootElementThrows() {
+    fun unknownRootElementThrowsTypedException() {
         val xml = "<wrong-root><exclude domain=\"database\" path=\"x\" /></wrong-root>"
         try {
             parse(xml)
-            error("expected IllegalStateException")
-        } catch (expected: IllegalStateException) {
+            error("expected BackupRulesParseException")
+        } catch (expected: BackupRulesParseException) {
             assertThat(expected.message).contains("unexpected root element")
+            assertThat(expected.message).contains("wrong-root")
         }
     }
 
     @Test
     fun excludeOutsideAnySectionIsIgnored() {
-        // Defensive: an <exclude> directly under <data-extraction-rules> with no
+        // Defensive: a stray <exclude> directly under <data-extraction-rules> with no
         // <cloud-backup>/<device-transfer> wrapper has no semantics and is dropped.
         val xml = """
             <data-extraction-rules>
@@ -178,25 +175,29 @@ class BackupRulesAssertionTest {
 
     @Test
     fun endToEndAgainstLibraryOwnRulesReturnsApplied() {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
         assertThat(outcome).isEqualTo(Outcome.Applied)
     }
 
     @Test
     fun appWideAllowBackupFalseReturnsAppliedWithoutParsingRules() {
-        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
-        val info: ApplicationInfo = context.packageManager.getApplicationInfo(context.packageName, 0)
-        val originalFlags = info.flags
-        try {
-            info.flags = info.flags and ApplicationInfo.FLAG_ALLOW_BACKUP.inv()
-            val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
-            assertThat(outcome).isEqualTo(Outcome.Applied)
-        } finally {
-            info.flags = originalFlags
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // Clone the live ApplicationInfo via Parcel so the test's mutation cannot leak
+        // into Robolectric's shared package state for sibling tests.
+        val freshInfo = cloneApplicationInfo(context.applicationInfo).apply {
+            flags = flags and ApplicationInfo.FLAG_ALLOW_BACKUP.inv()
         }
+        val outcome = BackupRulesAssertion.assertBackupRulesApplied(freshInfo, context.resources)
+        assertThat(outcome).isEqualTo(Outcome.Applied)
     }
 
+    /**
+     * Locks the [Outcome] surface against silent additions or removals. Matches the
+     * project convention from `PublicApiSurfaceTest`: every sealed arm is reached via
+     * an exhaustive `when` so that adding or removing an arm forces a compile-time
+     * conversation here, before any consumer sees it.
+     */
     @Test
     fun outcomeArmsAreReachableViaWhen() {
         val outcomes: List<Outcome> = listOf(
@@ -236,18 +237,32 @@ class BackupRulesAssertionTest {
     }
 
     @Test
-    fun sectionEnumeratesTheThreeKnownSections() {
+    fun sectionEnumeratesTheThreeKnownSectionsWithXmlElementNames() {
         assertThat(Section.entries.map { it.name }).containsExactly(
             "FullBackupContent",
             "CloudBackup",
             "DeviceTransfer",
         ).inOrder()
+        assertThat(Section.FullBackupContent.xmlElement).isEqualTo("full-backup-content")
+        assertThat(Section.CloudBackup.xmlElement).isEqualTo("cloud-backup")
+        assertThat(Section.DeviceTransfer.xmlElement).isEqualTo("device-transfer")
     }
 
     private fun parse(xml: String): Map<Section, Set<RequiredExclude>> {
         val factory = XmlPullParserFactory.newInstance().apply { isNamespaceAware = false }
         val parser = factory.newPullParser()
         parser.setInput(StringReader(xml))
-        return BackupRulesAssertion.parseRulesXml(parser)
+        return parseRulesXml(parser)
+    }
+
+    private fun cloneApplicationInfo(source: ApplicationInfo): ApplicationInfo {
+        val parcel = Parcel.obtain()
+        return try {
+            source.writeToParcel(parcel, 0)
+            parcel.setDataPosition(0)
+            ApplicationInfo.CREATOR.createFromParcel(parcel)
+        } finally {
+            parcel.recycle()
+        }
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -1,0 +1,253 @@
+package `is`.walt.passes.storage
+
+import android.content.pm.ApplicationInfo
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.storage.BackupRulesAssertion.MissingSection
+import `is`.walt.passes.storage.BackupRulesAssertion.Outcome
+import `is`.walt.passes.storage.BackupRulesAssertion.RequiredExclude
+import `is`.walt.passes.storage.BackupRulesAssertion.Section
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.StringReader
+
+/**
+ * Behavioral tests for [BackupRulesAssertion]. The XML parsing logic is exercised
+ * directly via [BackupRulesAssertion.parseRulesXml] against hand-crafted strings, which
+ * lets us cover both consumer postures (inherit vs mirror), missing-entry diagnostics,
+ * and malformed-input handling without needing test-only Android resources.
+ *
+ * The end-to-end Context-driven path is exercised against the library's own
+ * `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml`, which
+ * Robolectric loads via the library's manifest contributions. The on-device path
+ * (StrongBox vs TEE matrix, bmgr backup-blob inspection) is covered by the
+ * `wpass-x5l` instrumentation suite; this file stays JVM-only.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class BackupRulesAssertionTest {
+
+    @Test
+    fun parsesFullBackupContentEntries() {
+        val xml = """
+            <full-backup-content>
+                <exclude domain="database" path="walt_passes.db" />
+                <exclude domain="database" path="walt_passes.db-journal" />
+                <exclude domain="database" path="walt_passes.db-wal" />
+                <exclude domain="database" path="walt_passes.db-shm" />
+                <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+            </full-backup-content>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.keys).containsExactly(Section.FullBackupContent)
+        assertThat(parsed.getValue(Section.FullBackupContent))
+            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+    }
+
+    @Test
+    fun parsesDataExtractionRulesIntoBothSections() {
+        val xml = """
+            <data-extraction-rules>
+                <cloud-backup>
+                    <exclude domain="database" path="walt_passes.db" />
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                    <exclude domain="database" path="walt_passes.db-wal" />
+                    <exclude domain="database" path="walt_passes.db-shm" />
+                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+                </cloud-backup>
+                <device-transfer>
+                    <exclude domain="database" path="walt_passes.db" />
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                    <exclude domain="database" path="walt_passes.db-wal" />
+                    <exclude domain="database" path="walt_passes.db-shm" />
+                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+                </device-transfer>
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.keys).containsExactly(Section.CloudBackup, Section.DeviceTransfer)
+        assertThat(parsed.getValue(Section.CloudBackup))
+            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+        assertThat(parsed.getValue(Section.DeviceTransfer))
+            .containsExactlyElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+    }
+
+    @Test
+    fun ignoresIncludeEntriesAndUnknownElements() {
+        val xml = """
+            <data-extraction-rules>
+                <cloud-backup>
+                    <include domain="database" path="other.db" />
+                    <exclude domain="database" path="walt_passes.db" />
+                    <unknown-element foo="bar" />
+                </cloud-backup>
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.getValue(Section.CloudBackup)).containsExactly(
+            RequiredExclude("database", "walt_passes.db"),
+        )
+        assertThat(parsed.keys).doesNotContain(Section.DeviceTransfer)
+    }
+
+    @Test
+    fun mirroredResourceWithExtraExcludesStillPasses() {
+        // Walt-android's posture: own resource that mirrors required entries plus its own.
+        val xml = """
+            <data-extraction-rules>
+                <cloud-backup>
+                    <exclude domain="database" path="walt_passes.db" />
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                    <exclude domain="database" path="walt_passes.db-wal" />
+                    <exclude domain="database" path="walt_passes.db-shm" />
+                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+                    <exclude domain="database" path="transactions.db" />
+                    <exclude domain="sharedpref" path="walt_secrets.xml" />
+                </cloud-backup>
+                <device-transfer>
+                    <exclude domain="database" path="walt_passes.db" />
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                    <exclude domain="database" path="walt_passes.db-wal" />
+                    <exclude domain="database" path="walt_passes.db-shm" />
+                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+                </device-transfer>
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.getValue(Section.CloudBackup))
+            .containsAtLeastElementsIn(BackupRulesAssertion.REQUIRED_EXCLUDES)
+    }
+
+    @Test
+    fun missingDeviceTransferSectionIsReportedByCallerLogic() {
+        // The parser itself doesn't synthesize sections; it only returns what's there.
+        // The assertion treats absent sections as empty, which lets the assertion
+        // surface them as missing-required-excludes.
+        val xml = """
+            <data-extraction-rules>
+                <cloud-backup>
+                    <exclude domain="database" path="walt_passes.db" />
+                    <exclude domain="database" path="walt_passes.db-journal" />
+                    <exclude domain="database" path="walt_passes.db-wal" />
+                    <exclude domain="database" path="walt_passes.db-shm" />
+                    <exclude domain="sharedpref" path="is.walt.passes.storage.key_envelope.xml" />
+                </cloud-backup>
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+
+        assertThat(parsed.keys).containsExactly(Section.CloudBackup)
+    }
+
+    @Test
+    fun unknownRootElementThrows() {
+        val xml = "<wrong-root><exclude domain=\"database\" path=\"x\" /></wrong-root>"
+        try {
+            parse(xml)
+            error("expected IllegalStateException")
+        } catch (expected: IllegalStateException) {
+            assertThat(expected.message).contains("unexpected root element")
+        }
+    }
+
+    @Test
+    fun excludeOutsideAnySectionIsIgnored() {
+        // Defensive: an <exclude> directly under <data-extraction-rules> with no
+        // <cloud-backup>/<device-transfer> wrapper has no semantics and is dropped.
+        val xml = """
+            <data-extraction-rules>
+                <exclude domain="database" path="stray.db" />
+            </data-extraction-rules>
+        """.trimIndent()
+
+        val parsed = parse(xml)
+        assertThat(parsed).isEmpty()
+    }
+
+    @Test
+    fun endToEndAgainstLibraryOwnRulesReturnsApplied() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
+        assertThat(outcome).isEqualTo(Outcome.Applied)
+    }
+
+    @Test
+    fun appWideAllowBackupFalseReturnsAppliedWithoutParsingRules() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val info: ApplicationInfo = context.packageManager.getApplicationInfo(context.packageName, 0)
+        val originalFlags = info.flags
+        try {
+            info.flags = info.flags and ApplicationInfo.FLAG_ALLOW_BACKUP.inv()
+            val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
+            assertThat(outcome).isEqualTo(Outcome.Applied)
+        } finally {
+            info.flags = originalFlags
+        }
+    }
+
+    @Test
+    fun outcomeArmsAreReachableViaWhen() {
+        val outcomes: List<Outcome> = listOf(
+            Outcome.Applied,
+            Outcome.MissingExcludes(
+                listOf(
+                    MissingSection(
+                        resourceId = 0x7f0e0001,
+                        section = Section.CloudBackup,
+                        missing = listOf(RequiredExclude("database", "walt_passes.db")),
+                    ),
+                ),
+            ),
+            Outcome.NoBackupRulesConfigured,
+            Outcome.RulesResourceUnreadable(resourceId = 0x7f0e0002, reason = "io"),
+            Outcome.PackageInfoUnavailable,
+            Outcome.FieldUnavailable,
+        )
+        val labels = outcomes.map { outcome ->
+            when (outcome) {
+                Outcome.Applied -> "applied"
+                is Outcome.MissingExcludes -> "missing:${outcome.problems.size}"
+                Outcome.NoBackupRulesConfigured -> "no-rules"
+                is Outcome.RulesResourceUnreadable -> "unreadable:${outcome.reason}"
+                Outcome.PackageInfoUnavailable -> "no-package"
+                Outcome.FieldUnavailable -> "no-field"
+            }
+        }
+        assertThat(labels).containsExactly(
+            "applied",
+            "missing:1",
+            "no-rules",
+            "unreadable:io",
+            "no-package",
+            "no-field",
+        ).inOrder()
+    }
+
+    @Test
+    fun sectionEnumeratesTheThreeKnownSections() {
+        assertThat(Section.entries.map { it.name }).containsExactly(
+            "FullBackupContent",
+            "CloudBackup",
+            "DeviceTransfer",
+        ).inOrder()
+    }
+
+    private fun parse(xml: String): Map<Section, Set<RequiredExclude>> {
+        val factory = XmlPullParserFactory.newInstance().apply { isNamespaceAware = false }
+        val parser = factory.newPullParser()
+        parser.setInput(StringReader(xml))
+        return BackupRulesAssertion.parseRulesXml(parser)
+    }
+}


### PR DESCRIPTION
## Summary

- `BackupRulesAssertion` now validates by **content**, not resource identity. Opens whichever XML resource the merged manifest points at and confirms every entry in `REQUIRED_EXCLUDES` is present in every backup-relevant section. Fixes the assertion for consumers (walt-android included) that use `tools:replace` and mirror the library's required `<exclude>` entries into a consumer-owned XML.
- Outcome surface widened: `Applied | MissingExcludes | NoBackupRulesConfigured | RulesResourceUnreadable | PackageInfoUnavailable | FieldUnavailable`. `MissingExcludes` enumerates every section/entry gap. `allowBackup=false` short-circuits to `Applied`.
- ADR 0002 D5 documents the inherit-vs-mirror consumer postures and the content-not-identity validation contract.

Refs: `wpass-edb`. Unblocks `wpass-x5l` (device-instrumentation tests) which depends on the post-fix assertion shape.

## Test plan

- [x] Parser unit tests: full-backup-content, data-extraction-rules with both sections, mirror-with-extras, ignored `<include>` and unknown elements, unknown root error, stray `<exclude>` outside any section.
- [x] End-to-end Robolectric test against the library's own `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml` returns `Applied`.
- [x] `allowBackup=false` short-circuit returns `Applied` without parsing rules.
- [x] Exhaustive `when` over every `Outcome` arm (compile-lock against silent surface drift).
- [x] `./gradlew check` green across all three modules (test, detekt, ktlint, lint).
- [ ] On-device verification (StrongBox/TEE matrix, bmgr backup-blob inspection): deferred to `wpass-x5l`.