### PR TITLE
Fix three AutoBackup/KeyUnavailable test failures (wpass-cb9)

### DIFF
--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/AutoBackupBmgrTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/AutoBackupBmgrTest.kt
@@ -3,12 +3,16 @@ package `is`.walt.passes.storage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.storage.internal.WrappedKeyStorage
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * Drives `bmgr` end-to-end against the test APK and asserts that the Auto Backup pipeline
@@ -73,8 +77,14 @@ class AutoBackupBmgrTest {
         precreatePassesDatabaseInTestApp()
         val canary = dropCanary()
 
+        // Capture a wall-clock baseline for logcat -T BEFORE invoking bmgr. Logcat is a
+        // shared ring buffer that persists across test methods and across runs on the same
+        // boot; without a baseline, awaitBackupCompletion would race against stale completion
+        // lines from prior runs and return before this run's backup actually finished.
+        val logcatBaseline = captureLogcatBaseline()
+
         InstrumentationShell.run("bmgr backupnow $packageName")
-        awaitBackupCompletion(packageName)
+        awaitBackupCompletion(logcatBaseline)
 
         val transportDir = File("/data/data/com.android.localtransport/files/$packageName")
         assumeTrue(
@@ -95,12 +105,13 @@ class AutoBackupBmgrTest {
         assertThat(listing).contains(canary.name)
 
         // The trust claim: the encrypted database, its sidecars, and the wrapped-key
-        // envelope must not appear in the blob.
-        assertThat(listing).doesNotContain("walt_passes.db")
-        assertThat(listing).doesNotContain("walt_passes.db-journal")
-        assertThat(listing).doesNotContain("walt_passes.db-wal")
-        assertThat(listing).doesNotContain("walt_passes.db-shm")
-        assertThat(listing).doesNotContain("is.walt.passes.storage.key_envelope")
+        // envelope must not appear in the blob. Reference the production constants so a
+        // rename in the implementation cannot drift these into vacuous absence assertions.
+        assertThat(listing).doesNotContain(Schema.DATABASE_NAME)
+        assertThat(listing).doesNotContain("${Schema.DATABASE_NAME}-journal")
+        assertThat(listing).doesNotContain("${Schema.DATABASE_NAME}-wal")
+        assertThat(listing).doesNotContain("${Schema.DATABASE_NAME}-shm")
+        assertThat(listing).doesNotContain(WrappedKeyStorage.PREFS_NAME)
     }
 
     /**
@@ -151,6 +162,13 @@ class AutoBackupBmgrTest {
     }
 
     /**
+     * Returns a logcat-compatible timestamp for the current wall-clock moment. Pair with
+     * `logcat -T '<timestamp>'` to read only entries strictly after this point.
+     */
+    private fun captureLogcatBaseline(): String =
+        SimpleDateFormat(LOGCAT_BASELINE_FORMAT, Locale.US).format(Date())
+
+    /**
      * `bmgr backupnow` queues the backup and returns before the per-package result is
      * known; on API 28 it returns immediately with "Running incremental backup for 1
      * requested packages.", and on newer APIs it sometimes blocks for several seconds but
@@ -158,26 +176,28 @@ class AutoBackupBmgrTest {
      * once the transport has accepted the data, so polling logcat for that tag is the
      * reliable signal across API 28-36.
      *
+     * Match shape: every candidate line must contain [packageName] AND a completion-marker
+     * substring (`result:`, `succeeded`, etc.). Requiring [packageName] on every line keeps
+     * a backup driven by another package on the same emulator from satisfying the wait.
+     *
      * Times out cleanly so a wedged framework on a flaky emulator surfaces as a test
      * failure rather than a hung instrumentation run.
      */
-    @Suppress("ReturnCount")
-    private fun awaitBackupCompletion(packageName: String) {
+    private fun awaitBackupCompletion(logcatBaseline: String) {
         val deadlineMillis = System.currentTimeMillis() + BACKUP_COMPLETION_TIMEOUT_MILLIS
         while (System.currentTimeMillis() < deadlineMillis) {
             val logcat = InstrumentationShell.run(
-                "logcat -d -s BackupManagerService:* PerformBackupTask:*",
+                "logcat -d -T '$logcatBaseline' -s BackupManagerService:* PerformBackupTask:*",
             ).output
-            val finished = logcat.lineSequence().any { line ->
-                (line.contains(packageName) && line.contains("result:")) ||
-                    line.contains("Backup pass finished")
+            val completed = logcat.lineSequence().any { line ->
+                line.contains(packageName) && BACKUP_COMPLETION_MARKERS.any(line::contains)
             }
-            if (finished) return
+            if (completed) return
             Thread.sleep(BACKUP_COMPLETION_POLL_INTERVAL_MILLIS)
         }
         error(
             "BackupManagerService did not log a completion line for $packageName " +
-                "within ${BACKUP_COMPLETION_TIMEOUT_MILLIS}ms",
+                "within ${BACKUP_COMPLETION_TIMEOUT_MILLIS}ms (baseline $logcatBaseline)",
         )
     }
 
@@ -185,5 +205,20 @@ class AutoBackupBmgrTest {
         const val CANARY_FILE_NAME: String = "wpass_cb9_backup_canary.txt"
         const val BACKUP_COMPLETION_TIMEOUT_MILLIS: Long = 30_000
         const val BACKUP_COMPLETION_POLL_INTERVAL_MILLIS: Long = 500
+        const val LOGCAT_BASELINE_FORMAT: String = "MM-dd HH:mm:ss.SSS"
+
+        /**
+         * Substrings that mark a per-package completion line emitted by
+         * `BackupManagerService` across API 28-36. The polling loop also requires the
+         * candidate line to contain the package name, so these markers can be liberal
+         * without producing cross-package false positives.
+         */
+        val BACKUP_COMPLETION_MARKERS: List<String> = listOf(
+            "result:",
+            "succeeded",
+            "Success",
+            "Failure",
+            "failed",
+        )
     }
 }

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/AutoBackupBmgrTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/AutoBackupBmgrTest.kt
@@ -3,6 +3,7 @@ package `is`.walt.passes.storage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
+import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
@@ -26,14 +27,27 @@ import java.io.File
  *    [BackupRulesAssertionInstrumentationTest] (content-check of the merged rules) is
  *    sufficient for the trust claim.
  *
+ * Why a canary file: Auto Backup's exclude-only rules apply only when there is something
+ * to back up. If every file the test creates is excluded, the framework decides the package
+ * has no eligible data and the resulting blob is empty. A `doesNotContain("walt_passes.db")`
+ * assertion against an empty blob is vacuously true, so the test would pass even if the
+ * exclusion rules were missing or wrong. The canary is an unrestricted file in the app's
+ * `filesDir` whose presence in the blob is asserted before the exclusion assertions run.
+ * That makes the absence of `walt_passes.db` a load-bearing claim rather than an artifact
+ * of an empty blob.
+ *
  * The bmgr invocation choice: `bmgr backupnow <pkg>` is preferred over `bmgr fullbackup`
- * because the former returns a structured "Result: Success" line that a test can parse
- * deterministically across API 28-36. `bmgr fullbackup` writes a tarfile via
- * `adb backup` plumbing that has been progressively restricted since API 31 and is no
- * longer reliable from instrumentation. The local transport's blob layout is read from
- * `/data/data/com.android.localtransport/files/` when accessible; that path requires
- * privileged shell on most devices, so the file-listing assertion is gated behind
- * `assumeTrue` and skipped cleanly when the path is opaque.
+ * because `bmgr fullbackup` writes a tarfile via `adb backup` plumbing that has been
+ * progressively restricted since API 31 and is no longer reliable from instrumentation.
+ * `bmgr backupnow` queues the backup and returns before completion; the actual completion
+ * is logged by `BackupManagerService` later, so [awaitBackupCompletion] polls logcat for
+ * the per-package result line rather than parsing bmgr's own stdout.
+ *
+ * The local transport's blob layout is read from `/data/data/com.android.localtransport/files/`
+ * when accessible; that path requires privileged shell on most devices, so the file-listing
+ * assertion (and the canary inclusion check that gates it) is held behind `assumeTrue` and
+ * skipped cleanly when the path is opaque. On those devices [BackupRulesAssertionInstrumentationTest]
+ * carries the trust-claim assertion via the merged rules XML.
  */
 @RunWith(AndroidJUnit4::class)
 class AutoBackupBmgrTest {
@@ -49,27 +63,39 @@ class AutoBackupBmgrTest {
         InstrumentationShell.run("bmgr transport com.android.localtransport/.LocalTransport")
     }
 
-    @Test
-    fun bmgrBackupNowSucceedsAndExcludesPassesDatabase() {
-        precreatePassesDatabaseInTestApp()
+    @After
+    fun removeCanary() {
+        canaryFile().delete()
+    }
 
-        val backup = InstrumentationShell.run("bmgr backupnow $packageName")
-        // bmgr emits a per-package result line like:
-        //   "Package com.example.pkg with result: Success"
-        // older releases use "Backup finished with result: Success". Either form contains
-        // the substring "Success" only on the success path; "no data to backup" surfaces
-        // as a different terminal line.
-        assertThat(backup.output).contains("Success")
+    @Test
+    fun passesDataExcludedFromBackupBlob() {
+        precreatePassesDatabaseInTestApp()
+        val canary = dropCanary()
+
+        InstrumentationShell.run("bmgr backupnow $packageName")
+        awaitBackupCompletion(packageName)
 
         val transportDir = File("/data/data/com.android.localtransport/files/$packageName")
         assumeTrue(
             "Local transport blob layout is not readable from the shell user on this " +
-                "device. The bmgr success line above is the load-bearing signal here; the " +
-                "blob-listing assertion is best-effort and only fires on userdebug builds.",
+                "device. The doesNotContain assertions below depend on inspecting the blob " +
+                "directly; on devices without that access this test runs as a smoke check " +
+                "that bmgr accepts the merged manifest, and BackupRulesAssertionInstrumentationTest " +
+                "carries the trust-claim assertion via the merged rules XML.",
             transportDir.canRead(),
         )
 
         val listing = InstrumentationShell.run("ls -laR ${transportDir.absolutePath}").output
+
+        // Sanity: the canary file (placed in the app's filesDir, not covered by any
+        // <exclude> rule) must appear in the blob. Without this presence check the
+        // exclusion assertions below would be vacuously true on an empty-blob run, e.g.
+        // when the framework decides nothing is eligible to back up.
+        assertThat(listing).contains(canary.name)
+
+        // The trust claim: the encrypted database, its sidecars, and the wrapped-key
+        // envelope must not appear in the blob.
         assertThat(listing).doesNotContain("walt_passes.db")
         assertThat(listing).doesNotContain("walt_passes.db-journal")
         assertThat(listing).doesNotContain("walt_passes.db-wal")
@@ -103,5 +129,61 @@ class AutoBackupBmgrTest {
         check(dbFile.exists()) {
             "Pre-backup precondition failed: $dbFile was not created."
         }
+    }
+
+    private fun canaryFile(): File =
+        File(
+            InstrumentationRegistry.getInstrumentation().targetContext.filesDir,
+            CANARY_FILE_NAME,
+        )
+
+    private fun dropCanary(): File {
+        val canary = canaryFile()
+        canary.writeText(
+            "wpass-cb9 backup canary; presence in the local-transport blob asserts that " +
+                "the framework produced a non-empty backup, which makes the doesNotContain " +
+                "assertions for walt_passes.db non-vacuous.",
+        )
+        check(canary.exists()) {
+            "Canary precondition failed: $canary was not created."
+        }
+        return canary
+    }
+
+    /**
+     * `bmgr backupnow` queues the backup and returns before the per-package result is
+     * known; on API 28 it returns immediately with "Running incremental backup for 1
+     * requested packages.", and on newer APIs it sometimes blocks for several seconds but
+     * not always until completion. The completion line is logged by `BackupManagerService`
+     * once the transport has accepted the data, so polling logcat for that tag is the
+     * reliable signal across API 28-36.
+     *
+     * Times out cleanly so a wedged framework on a flaky emulator surfaces as a test
+     * failure rather than a hung instrumentation run.
+     */
+    @Suppress("ReturnCount")
+    private fun awaitBackupCompletion(packageName: String) {
+        val deadlineMillis = System.currentTimeMillis() + BACKUP_COMPLETION_TIMEOUT_MILLIS
+        while (System.currentTimeMillis() < deadlineMillis) {
+            val logcat = InstrumentationShell.run(
+                "logcat -d -s BackupManagerService:* PerformBackupTask:*",
+            ).output
+            val finished = logcat.lineSequence().any { line ->
+                (line.contains(packageName) && line.contains("result:")) ||
+                    line.contains("Backup pass finished")
+            }
+            if (finished) return
+            Thread.sleep(BACKUP_COMPLETION_POLL_INTERVAL_MILLIS)
+        }
+        error(
+            "BackupManagerService did not log a completion line for $packageName " +
+                "within ${BACKUP_COMPLETION_TIMEOUT_MILLIS}ms",
+        )
+    }
+
+    private companion object {
+        const val CANARY_FILE_NAME: String = "wpass_cb9_backup_canary.txt"
+        const val BACKUP_COMPLETION_TIMEOUT_MILLIS: Long = 30_000
+        const val BACKUP_COMPLETION_POLL_INTERVAL_MILLIS: Long = 500
     }
 }

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/KeyUnavailableAcrossDataClearTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/KeyUnavailableAcrossDataClearTest.kt
@@ -66,7 +66,7 @@ class KeyUnavailableAcrossDataClearTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val dbFile = context.getDatabasePath(Schema.DATABASE_NAME)
         check(dbFile.exists()) { "Test setup left no DB file at $dbFile" }
-        deleteEnvelopeFile(context)
+        clearEnvelopePrefs(context)
 
         val keyResult = AndroidKeystorePassKeyProvider.create(context)
         check(keyResult is StorageResult.Success) {
@@ -142,7 +142,7 @@ class KeyUnavailableAcrossDataClearTest {
         repo.close()
     }
 
-    private fun deleteEnvelopeFile(context: Context) {
+    private fun clearEnvelopePrefs(context: Context) {
         // Clear through the SharedPreferences API rather than deleting the underlying XML.
         // SharedPreferences is a process-singleton with in-memory caching: a file-level
         // delete leaves stale data in the cache, so subsequent reads return the old
@@ -185,7 +185,7 @@ class KeyUnavailableAcrossDataClearTest {
             File(db.absolutePath + "-wal").delete()
             File(db.absolutePath + "-shm").delete()
         }
-        deleteEnvelopeFile(context)
+        clearEnvelopePrefs(context)
         deleteKeystoreMasterAlias()
     }
 

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/KeyUnavailableAcrossDataClearTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/KeyUnavailableAcrossDataClearTest.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.storage
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
@@ -14,6 +15,7 @@ import `is`.walt.passes.core.PassFields
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.WrappedKeyStorage
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -140,16 +142,27 @@ class KeyUnavailableAcrossDataClearTest {
         repo.close()
     }
 
-    private fun deleteEnvelopeFile(context: android.content.Context) {
-        // SharedPreferences XMLs live at /data/data/<pkg>/shared_prefs/<name>.xml.
-        // Direct file removal is the cleanest reproduction of the "envelope vanished"
-        // scenario; clearing the prefs through the SharedPreferences API would emit
-        // listeners and could leave the file on disk (even if empty).
-        val prefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
-        val envelope = File(prefsDir, "is.walt.passes.storage.key_envelope.xml")
-        envelope.delete()
-        check(!envelope.exists()) {
-            "Envelope file at $envelope was not deletable; cannot run failure-closed assertion"
+    private fun deleteEnvelopeFile(context: Context) {
+        // Clear through the SharedPreferences API rather than deleting the underlying XML.
+        // SharedPreferences is a process-singleton with in-memory caching: a file-level
+        // delete leaves stale data in the cache, so subsequent reads return the old
+        // wrapped envelope. After a Keystore master regeneration that envelope can no
+        // longer be unwrapped, surfacing as KeyUnwrapFailed rather than the
+        // KeyUnavailable this test is pinning. Clearing through the API matches what
+        // production code observes after a `pm clear`-style wipe (which kills the
+        // process and empties the cache anyway), and the implementation reads via the
+        // same API surface so the wipe is consistent with how the envelope is consumed.
+        val prefs = context.getSharedPreferences(
+            WrappedKeyStorage.PREFS_NAME,
+            Context.MODE_PRIVATE,
+        )
+        val cleared = prefs.edit().clear().commit()
+        check(cleared) {
+            "Envelope prefs ${WrappedKeyStorage.PREFS_NAME} were not cleared; " +
+                "cannot run failure-closed assertion"
+        }
+        check(prefs.all.isEmpty()) {
+            "Envelope prefs ${WrappedKeyStorage.PREFS_NAME} still contain entries after clear()"
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes three failures tracked under **wpass-cb9** that the wpass-ym0 emulator-matrix CI surfaced. All three were latent test-side defects that passed static gates but had not been run end-to-end on a real Android instance.

## Failure 1: \`AutoBackupBmgrTest\`

Two structural problems addressed:

### \`bmgr backupnow\` is asynchronous

The original test asserted \`backup.output\` contained \`"Success"\`. \`bmgr backupnow\` does not work that way:

- On API 28 it returns immediately with \`"Running incremental backup for 1 requested packages."\`. Clean assertion failure.
- On API 31/34/36 it sometimes blocks for a few seconds but not until completion; the test process crashed mid-run on every emulator we tried.

The completion line lands in logcat from \`BackupManagerService\`, not in bmgr's stdout. Fix polls logcat for the per-package result line (\`"Package <pkg> with result: ..."\`) or the overall \`"Backup pass finished"\` line, with a 30s timeout.

### Absence assertions were vacuous

The library's \`<full-backup-content>\` and \`<data-extraction-rules>\` are exclude-only and cover exactly the files the test creates (\`walt_passes.db\` + sidecars + envelope sharedpref). After exclusion the test APK has nothing eligible to back up, so the framework produces an empty blob and \`doesNotContain("walt_passes.db")\` is trivially true. The original test would also pass if the exclusion rules were entirely missing.

Fix: drop a canary file (\`wpass_cb9_backup_canary.txt\`) in \`targetContext.filesDir\` (not covered by any \`<exclude>\` rule) before invoking bmgr, then assert the local-transport listing **both** contains the canary **and** does not contain \`walt_passes.db\`/sidecars/envelope. The canary's presence makes the absence assertions load-bearing.

The \`assumeTrue(transportDir.canRead(), ...)\` gate stays. On emulators where the local-transport blob is opaque to the shell user (the typical case), this test runs as a smoke check that bmgr accepts the merged manifest. The trust-claim assertion is still carried by \`BackupRulesAssertionInstrumentationTest\`, which walks the merged rules XML directly.

The renamed test method \`passesDataExcludedFromBackupBlob\` describes the new contract.

## Failures 2 & 3: \`KeyUnavailableAcrossDataClearTest\`

Both tests failed at \`@Before\` bootstrap with \`KeyUnwrapFailed\` when run after a prior test in the same JVM.

### Root cause

\`deleteEnvelopeFile()\` removed the underlying \`shared_prefs/is.walt.passes.storage.key_envelope.xml\` directly. \`SharedPreferences\` is a process-singleton with in-memory caching: the file delete does **not** invalidate the cached singleton. After \`@Before\`'s \`deleteKeystoreMasterAlias()\` regenerated the master, the next bootstrap's \`provideDatabaseKey()\` called \`wrappedKeyStorage.read()\`, got the cached old wrapped envelope (still in memory), and failed the AES-GCM tag check when unwrapping it under the new master - surfacing as \`KeyUnwrapFailed\` rather than the \`KeyUnavailable\` the test is pinning.

The original comment in the test even acknowledged the choice (\"clearing the prefs through the SharedPreferences API would emit listeners and could leave the file on disk\") but the implementation does not register a listener and does not care whether the empty XML file remains, so neither concern is load-bearing.

### Fix

Clear through the \`SharedPreferences\` API (\`prefs.edit().clear().commit()\`). The implementation reads via the same API, so clearing through the API matches what production code observes after a \`pm clear\`-style wipe (which kills the process and empties the cache anyway). Reference \`WrappedKeyStorage.PREFS_NAME\` directly rather than hardcoding the prefs name, so a rename in the implementation cannot drift this test silently.

## Out of scope

\`BackupRulesAssertionInstrumentationTest.mergedManifestRulesAreApplied\` was also FAILED on API 28 in the wpass-ym0 run; that needs separate diagnosis and is left tracked under wpass-cb9.

## Validation

- \`./gradlew :passes-storage:detekt :passes-storage:ktlintCheck --rerun-tasks\` - passes.
- The full \`:check\` build is exercised by the existing CI \`build\` job.
- End-to-end emulator validation depends on the wpass-ym0 matrix landing or being rebased onto this PR.

## Test plan

- [ ] CI \`Build & quality\` job passes.
- [ ] After wpass-ym0's matrix lands (or is rebased onto this PR), all three tests run cleanly across API 28/31/34/36.

Refs: wpass-cb9 (parent: wpass-ym0).