### PR TITLE
BackupRulesAssertion: manifest-XML fallback for blocklisted reflection (wpass-2zv)

### DIFF
--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/BackupRulesAssertionInstrumentationTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/BackupRulesAssertionInstrumentationTest.kt
@@ -1,10 +1,8 @@
 package `is`.walt.passes.storage
 
-import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -25,36 +23,17 @@ import org.junit.runner.RunWith
  * `walt_passes_backup_rules.xml` and `walt_passes_data_extraction_rules.xml` resources
  * directly. ADR 0002 D5's "Mirror" posture (the walt-android consumer's posture) is
  * exercised separately by walt-android's own instrumentation suite.
+ *
+ * Runs on every API in the matrix (28, 31, 34, 36). On API 31+, hidden-API reflection on
+ * `ApplicationInfo.dataExtractionRulesRes` is blocklisted for our target SDK and
+ * collapses to `null`; the manifest-XML fallback path then opens the on-device APK via
+ * `ApkAssets.loadFromPath` and reads the same resource ids from the merged manifest.
  */
 @RunWith(AndroidJUnit4::class)
 class BackupRulesAssertionInstrumentationTest {
 
     @Test
     fun mergedManifestRulesAreApplied() {
-        // BackupRulesAssertion reads ApplicationInfo.fullBackupContent and
-        // ApplicationInfo.dataExtractionRulesRes by reflection (the comment in
-        // BackupRulesAssertion.kt explains why). On API 31+ with the test APK targeting
-        // a recent SDK, dataExtractionRulesRes is on the hidden-API blocklist and
-        // getDeclaredField throws NoSuchFieldException, collapsing to
-        // Outcome.FieldUnavailable. The author anticipated this in the production-code
-        // docstring: "a manifest-XML fallback is the expected mitigation."
-        //
-        // Tracked as a follow-up bead (see wpass-cb9 status notes). Until the fallback
-        // is implemented, skip on API 31+; the Robolectric counterpart in
-        // BackupRulesAssertionTest covers the same code paths against synthetic
-        // ApplicationInfo without hidden-API exposure, so the trust claim is verified
-        // on the JVM side regardless.
-        assumeTrue(
-            "BackupRulesAssertion uses hidden-API reflection on " +
-                "ApplicationInfo.dataExtractionRulesRes, which is blocklisted on " +
-                "API ${Build.VERSION_CODES.S}+ for our target SDK. The instrumentation " +
-                "assertion will collapse to FieldUnavailable until the manifest-XML " +
-                "fallback in BackupRulesAssertion is implemented; the JVM-side " +
-                "BackupRulesAssertionTest carries the same coverage against synthetic " +
-                "ApplicationInfo in the meantime.",
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.S,
-        )
-
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val outcome = BackupRulesAssertion.assertBackupRulesApplied(context)
         assertThat(outcome).isEqualTo(BackupRulesAssertion.Outcome.Applied)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -29,12 +29,46 @@ private const val PACKAGE_ATTRIBUTE = "package"
 private const val MAX_MANIFEST_COOKIE_PROBE = 32
 
 /**
- * Manifest-XML fallback path. The running [AssetManager] already has the app's own
+ * Tier 1: read resource ids from the merged-manifest values cached on `ApplicationInfo`.
+ * Direct, but reaches greylisted hidden-API fields. Returns `null` for either field that
+ * the platform's hidden-API policy now blocks (notably `dataExtractionRulesRes` on API
+ * 31+ for our target SDK).
+ */
+private fun readResourceIdsViaReflection(
+    appInfo: ApplicationInfo,
+): BackupRulesAssertion.ResourceIds? {
+    val full = readIntField(appInfo, "fullBackupContent")
+    val dxr = readDxrResId(appInfo)
+    return if (full != null && dxr != null) {
+        BackupRulesAssertion.ResourceIds(fullBackup = full, dxr = dxr)
+    } else {
+        null
+    }
+}
+
+private fun readDxrResId(appInfo: ApplicationInfo): Int? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        readIntField(appInfo, "dataExtractionRulesRes")
+    } else {
+        0
+    }
+
+private fun readIntField(target: Any, name: String): Int? = try {
+    val field = target.javaClass.getDeclaredField(name).also { it.isAccessible = true }
+    field.getInt(target)
+} catch (_: NoSuchFieldException) {
+    null
+} catch (_: IllegalAccessException) {
+    null
+}
+
+/**
+ * Tier 2: manifest-XML fallback. The running [AssetManager] already has the app's own
  * `AndroidManifest.xml` loaded; the only unknown is which cookie it sits behind (varies
  * by Android version and presence of split APKs / resource loaders). Iterate cookies
  * 1..[MAX_MANIFEST_COOKIE_PROBE] and pick the first parser whose
- * `<manifest package="...">` matches [packageName] — that's the merged manifest the
- * trust claim cares about. Reads `android:fullBackupContent` /
+ * `<manifest package="...">` matches the running package — that's the merged manifest
+ * the trust claim cares about. Reads `android:fullBackupContent` /
  * `android:dataExtractionRules` off the `<application>` element using only public
  * AssetManager API ([AssetManager.openXmlResourceParser], since API 1).
  *
@@ -43,11 +77,11 @@ private const val MAX_MANIFEST_COOKIE_PROBE = 32
  *  - Loading or parsing the manifest throws IO / XML errors.
  *  - The merged manifest has no `<application>` tag (defensive; should not happen).
  */
-private fun readManifestResourceIds(
-    assets: AssetManager,
-    packageName: String,
+private fun readResourceIdsFromManifestXml(
+    appInfo: ApplicationInfo,
+    resources: Resources,
 ): BackupRulesAssertion.ResourceIds? {
-    val parser = openOwnManifestParser(assets, packageName) ?: return null
+    val parser = openOwnManifestParser(resources.assets, appInfo.packageName) ?: return null
     return try {
         parseApplicationAttributes(parser)
     } catch (_: XmlPullParserException) {
@@ -316,39 +350,6 @@ public object BackupRulesAssertion {
     @VisibleForTesting
     internal data class ResourceIds(val fullBackup: Int, val dxr: Int)
 
-    private fun readResourceIdsViaReflection(appInfo: ApplicationInfo): ResourceIds? {
-        val full = readIntField(appInfo, "fullBackupContent")
-        val dxr = readDxrResId(appInfo)
-        return if (full != null && dxr != null) ResourceIds(fullBackup = full, dxr = dxr) else null
-    }
-
-    private fun readDxrResId(appInfo: ApplicationInfo): Int? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            readIntField(appInfo, "dataExtractionRulesRes")
-        } else {
-            0
-        }
-
-    /**
-     * Manifest-XML fallback path. The running `AssetManager` already has the app's own
-     * `AndroidManifest.xml` loaded; the only unknown is which cookie it sits behind
-     * (varies by Android version and presence of split APKs / resource loaders).
-     * Iterate cookies 1..N and pick the first parser whose `<manifest package="...">`
-     * matches the running package — that's the merged manifest the trust claim cares
-     * about. Reads `android:fullBackupContent` / `android:dataExtractionRules` off the
-     * `<application>` element using only public AssetManager API (`openXmlResourceParser`,
-     * since API 1).
-     *
-     * Returns null when:
-     *  - No cookie in the probed range yields a parser whose package matches.
-     *  - Loading or parsing the manifest throws IO / XML errors.
-     *  - The merged manifest has no `<application>` tag (defensive; should not happen).
-     */
-    private fun readResourceIdsFromManifestXml(
-        appInfo: ApplicationInfo,
-        resources: Resources,
-    ): ResourceIds? = readManifestResourceIds(resources.assets, appInfo.packageName)
-
     private sealed interface ValidationResult {
         data class Ok(val problems: List<MissingSection>) : ValidationResult
         data class Unreadable(val outcome: Outcome.RulesResourceUnreadable) : ValidationResult
@@ -401,15 +402,6 @@ public object BackupRulesAssertion {
     private fun loadApplicationInfo(context: Context): ApplicationInfo? = try {
         context.packageManager.getApplicationInfo(context.packageName, 0)
     } catch (_: PackageManager.NameNotFoundException) {
-        null
-    }
-
-    private fun readIntField(target: Any, name: String): Int? = try {
-        val field = target.javaClass.getDeclaredField(name).also { it.isAccessible = true }
-        field.getInt(target)
-    } catch (_: NoSuchFieldException) {
-        null
-    } catch (_: IllegalAccessException) {
         null
     }
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/BackupRulesAssertion.kt
@@ -3,15 +3,156 @@ package `is`.walt.passes.storage
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import android.content.res.AssetManager
 import android.content.res.Resources
 import android.content.res.XmlResourceParser
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import `is`.walt.passes.storage.BackupRulesContract.REQUIRED_EXCLUDES
 import `is`.walt.passes.storage.BackupRulesContract.RequiredExclude
 import `is`.walt.passes.storage.BackupRulesContract.Section
+import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import java.io.IOException
+
+private const val MANIFEST_FILE_NAME = "AndroidManifest.xml"
+private const val APPLICATION_ELEMENT = "application"
+private const val MANIFEST_ELEMENT = "manifest"
+private const val PACKAGE_ATTRIBUTE = "package"
+
+// AssetManager assigns a cookie per loaded ApkAssets. The running app's main APK
+// usually lands at cookie 1 or 2 (framework loads first); split APKs and dynamically
+// loaded resource providers may push it higher. 32 is a generous upper bound that
+// covers every shipping Android configuration without making the search expensive
+// (each iteration is a JNI call that returns immediately for unknown cookies).
+private const val MAX_MANIFEST_COOKIE_PROBE = 32
+
+/**
+ * Manifest-XML fallback path. The running [AssetManager] already has the app's own
+ * `AndroidManifest.xml` loaded; the only unknown is which cookie it sits behind (varies
+ * by Android version and presence of split APKs / resource loaders). Iterate cookies
+ * 1..[MAX_MANIFEST_COOKIE_PROBE] and pick the first parser whose
+ * `<manifest package="...">` matches [packageName] — that's the merged manifest the
+ * trust claim cares about. Reads `android:fullBackupContent` /
+ * `android:dataExtractionRules` off the `<application>` element using only public
+ * AssetManager API ([AssetManager.openXmlResourceParser], since API 1).
+ *
+ * Returns null when:
+ *  - No cookie in the probed range yields a parser whose package matches.
+ *  - Loading or parsing the manifest throws IO / XML errors.
+ *  - The merged manifest has no `<application>` tag (defensive; should not happen).
+ */
+private fun readManifestResourceIds(
+    assets: AssetManager,
+    packageName: String,
+): BackupRulesAssertion.ResourceIds? {
+    val parser = openOwnManifestParser(assets, packageName) ?: return null
+    return try {
+        parseApplicationAttributes(parser)
+    } catch (_: XmlPullParserException) {
+        null
+    } catch (_: IOException) {
+        null
+    } finally {
+        parser.close()
+    }
+}
+
+private fun openOwnManifestParser(
+    assets: AssetManager,
+    packageName: String,
+): XmlResourceParser? {
+    for (cookie in 1..MAX_MANIFEST_COOKIE_PROBE) {
+        val candidate = openManifestAt(assets, cookie) ?: continue
+        if (advanceToOwnManifestStartTag(candidate, packageName)) {
+            return candidate
+        }
+        candidate.close()
+    }
+    return null
+}
+
+private fun openManifestAt(assets: AssetManager, cookie: Int): XmlResourceParser? = try {
+    assets.openXmlResourceParser(cookie, MANIFEST_FILE_NAME)
+} catch (_: IOException) {
+    null
+} catch (_: RuntimeException) {
+    // Native side raises IllegalArgumentException / IndexOutOfBoundsException for
+    // cookies that don't map to a loaded ApkAssets. Treat as "not this one" and
+    // keep probing.
+    null
+}
+
+/**
+ * Advances [parser] to the `<manifest>` start tag and returns true iff its `package`
+ * attribute matches [expectedPackage]. Leaves the parser positioned at that start tag
+ * so the caller can keep walking into `<application>`. A single return path keeps the
+ * detekt ReturnCount budget small without sacrificing the IO/XML error short-circuit.
+ */
+private fun advanceToOwnManifestStartTag(
+    parser: XmlResourceParser,
+    expectedPackage: String,
+): Boolean = try {
+    var matched = false
+    var event = parser.eventType
+    while (event != XmlPullParser.END_DOCUMENT) {
+        if (event == XmlPullParser.START_TAG && parser.name == MANIFEST_ELEMENT) {
+            matched = parser.getAttributeValue(null, PACKAGE_ATTRIBUTE) == expectedPackage
+            break
+        }
+        event = parser.next()
+    }
+    matched
+} catch (_: XmlPullParserException) {
+    false
+} catch (_: IOException) {
+    false
+}
+
+/**
+ * Walks the manifest's binary AXML to the first `<application>` start tag and reads
+ * the resource ids of the two attributes the trust claim cares about. Returns null if
+ * the document has no `<application>` element at all (a malformed manifest).
+ */
+private fun parseApplicationAttributes(
+    parser: XmlResourceParser,
+): BackupRulesAssertion.ResourceIds? {
+    var event = parser.eventType
+    while (event != XmlPullParser.END_DOCUMENT) {
+        if (event == XmlPullParser.START_TAG && parser.name == APPLICATION_ELEMENT) {
+            return readApplicationAttributes(parser)
+        }
+        event = parser.next()
+    }
+    return null
+}
+
+private fun readApplicationAttributes(parser: XmlResourceParser): BackupRulesAssertion.ResourceIds {
+    var fullBackup = 0
+    for (i in 0 until parser.attributeCount) {
+        if (parser.getAttributeNameResource(i) == android.R.attr.fullBackupContent) {
+            fullBackup = parser.getAttributeResourceValue(i, 0)
+            break
+        }
+    }
+    val dxr = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        readDataExtractionRulesAttribute(parser)
+    } else {
+        0
+    }
+    return BackupRulesAssertion.ResourceIds(fullBackup = fullBackup, dxr = dxr)
+}
+
+@RequiresApi(Build.VERSION_CODES.S)
+private fun readDataExtractionRulesAttribute(parser: XmlResourceParser): Int {
+    for (i in 0 until parser.attributeCount) {
+        if (parser.getAttributeNameResource(i) == android.R.attr.dataExtractionRules) {
+            return parser.getAttributeResourceValue(i, 0)
+        }
+    }
+    return 0
+}
 
 /**
  * Verifies that the trust claim "pass data is excluded from cloud backup" holds in the
@@ -40,11 +181,24 @@ import java.io.IOException
  * If the consumer has set `android:allowBackup="false"` app-wide, the trust claim is
  * trivially satisfied and the assertion returns [Outcome.Applied] without parsing rules.
  *
- * Reflection on `ApplicationInfo.fullBackupContent` and
- * `ApplicationInfo.dataExtractionRulesRes` is intentional: those greylisted hidden-API
- * fields are the most reliable read of the merged manifest. They may be moved to the
- * blocklist in a future Android release; if that happens, [Outcome.FieldUnavailable] is
- * the surface for triage and a manifest-XML fallback is the expected mitigation.
+ * The resource-id read is two-tier:
+ *
+ *  1. **Reflection on `ApplicationInfo.fullBackupContent` and
+ *     `ApplicationInfo.dataExtractionRulesRes`** — the most direct read of the merged
+ *     manifest, but those fields are greylisted hidden-API. On platforms where either
+ *     field has been moved to the blocklist (observed on API 31+ for our target SDK,
+ *     where `dataExtractionRulesRes` collapses to `NoSuchFieldException`), reflection
+ *     returns no value.
+ *  2. **Manifest-XML fallback** — when reflection fails, the assertion opens the running
+ *     app's already-loaded `AndroidManifest.xml` through the running `AssetManager`
+ *     (`AssetManager.openXmlResourceParser`, public since API 1) and reads
+ *     `android:fullBackupContent` / `android:dataExtractionRules` off the `<application>`
+ *     element. Slower than reflection, but uses only stable public API.
+ *
+ * [Outcome.FieldUnavailable] is reserved for the case where both tiers fail (reflection
+ * blocked AND the manifest read errors out, e.g. AXML malformed or no cookie in the
+ * probed range matches the running package). It is the triage surface for genuinely
+ * incompatible OS-side changes.
  */
 public object BackupRulesAssertion {
 
@@ -103,18 +257,32 @@ public object BackupRulesAssertion {
     /**
      * Test seam. Lets unit tests construct a fresh [ApplicationInfo] (e.g., via Parcel
      * round-trip) and pass it directly, avoiding mutation of the Robolectric-shared
-     * `ApplicationInfo` returned by `Context.applicationInfo`.
+     * `ApplicationInfo` returned by `Context.applicationInfo`. The two reader parameters
+     * let JVM tests drive each tier of the read order independently — useful because
+     * Robolectric cannot easily simulate hidden-API blocklist failures on
+     * `ApplicationInfo` reflection.
      */
     @VisibleForTesting
-    internal fun assertBackupRulesApplied(appInfo: ApplicationInfo, resources: Resources): Outcome =
+    internal fun assertBackupRulesApplied(
+        appInfo: ApplicationInfo,
+        resources: Resources,
+        reflectionReader: (ApplicationInfo) -> ResourceIds? = ::readResourceIdsViaReflection,
+        manifestFallbackReader: (ApplicationInfo, Resources) -> ResourceIds? =
+            ::readResourceIdsFromManifestXml,
+    ): Outcome =
         if (appInfo.flags and ApplicationInfo.FLAG_ALLOW_BACKUP == 0) {
             Outcome.Applied
         } else {
-            evaluateRules(appInfo, resources)
+            evaluateRules(appInfo, resources, reflectionReader, manifestFallbackReader)
         }
 
-    private fun evaluateRules(appInfo: ApplicationInfo, resources: Resources): Outcome {
-        val resIds = readResourceIds(appInfo)
+    private fun evaluateRules(
+        appInfo: ApplicationInfo,
+        resources: Resources,
+        reflectionReader: (ApplicationInfo) -> ResourceIds?,
+        manifestFallbackReader: (ApplicationInfo, Resources) -> ResourceIds?,
+    ): Outcome {
+        val resIds = reflectionReader(appInfo) ?: manifestFallbackReader(appInfo, resources)
         return when {
             resIds == null -> Outcome.FieldUnavailable
             resIds.fullBackup == 0 && resIds.dxr == 0 -> Outcome.NoBackupRulesConfigured
@@ -145,9 +313,10 @@ public object BackupRulesAssertion {
         return if (problems.isEmpty()) Outcome.Applied else Outcome.MissingExcludes(problems)
     }
 
-    private data class ResourceIds(val fullBackup: Int, val dxr: Int)
+    @VisibleForTesting
+    internal data class ResourceIds(val fullBackup: Int, val dxr: Int)
 
-    private fun readResourceIds(appInfo: ApplicationInfo): ResourceIds? {
+    private fun readResourceIdsViaReflection(appInfo: ApplicationInfo): ResourceIds? {
         val full = readIntField(appInfo, "fullBackupContent")
         val dxr = readDxrResId(appInfo)
         return if (full != null && dxr != null) ResourceIds(fullBackup = full, dxr = dxr) else null
@@ -159,6 +328,26 @@ public object BackupRulesAssertion {
         } else {
             0
         }
+
+    /**
+     * Manifest-XML fallback path. The running `AssetManager` already has the app's own
+     * `AndroidManifest.xml` loaded; the only unknown is which cookie it sits behind
+     * (varies by Android version and presence of split APKs / resource loaders).
+     * Iterate cookies 1..N and pick the first parser whose `<manifest package="...">`
+     * matches the running package — that's the merged manifest the trust claim cares
+     * about. Reads `android:fullBackupContent` / `android:dataExtractionRules` off the
+     * `<application>` element using only public AssetManager API (`openXmlResourceParser`,
+     * since API 1).
+     *
+     * Returns null when:
+     *  - No cookie in the probed range yields a parser whose package matches.
+     *  - Loading or parsing the manifest throws IO / XML errors.
+     *  - The merged manifest has no `<application>` tag (defensive; should not happen).
+     */
+    private fun readResourceIdsFromManifestXml(
+        appInfo: ApplicationInfo,
+        resources: Resources,
+    ): ResourceIds? = readManifestResourceIds(resources.assets, appInfo.packageName)
 
     private sealed interface ValidationResult {
         data class Ok(val problems: List<MissingSection>) : ValidationResult

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -242,6 +242,69 @@ class BackupRulesAssertionTest {
     }
 
     @Test
+    fun reflectionSucceedsAndManifestFallbackIsNotInvoked() {
+        // First tier of the read order: when reflection on ApplicationInfo returns a
+        // valid ResourceIds, the assertion must pass through to validateResource without
+        // invoking the manifest-XML fallback. Pins the documented "reflection first,
+        // manifest second" order so a future refactor cannot accidentally promote the
+        // (slower) fallback to primary.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val ids = BackupRulesAssertion.ResourceIds(
+            fullBackup = R.xml.walt_passes_backup_rules,
+            dxr = R.xml.walt_passes_data_extraction_rules,
+        )
+        var manifestCalls = 0
+        val outcome = BackupRulesAssertion.assertBackupRulesApplied(
+            appInfo = context.applicationInfo,
+            resources = context.resources,
+            reflectionReader = { ids },
+            manifestFallbackReader = { _, _ -> manifestCalls++; null },
+        )
+
+        assertThat(outcome).isEqualTo(Outcome.Applied)
+        assertThat(manifestCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun reflectionUnavailableTriggersManifestFallbackAndReturnsApplied() {
+        // Realises the simulated state PR #20 surfaced on real hardware: reflection on
+        // ApplicationInfo.dataExtractionRulesRes throws NoSuchFieldException under the
+        // hidden-API blocklist, so the first-tier reader returns null. The second-tier
+        // manifest-XML reader resolves the same resource ids and the assertion returns
+        // Applied — "degrade from broken to slower, not broken to manual review."
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val ids = BackupRulesAssertion.ResourceIds(
+            fullBackup = R.xml.walt_passes_backup_rules,
+            dxr = R.xml.walt_passes_data_extraction_rules,
+        )
+        val outcome = BackupRulesAssertion.assertBackupRulesApplied(
+            appInfo = context.applicationInfo,
+            resources = context.resources,
+            reflectionReader = { null },
+            manifestFallbackReader = { _, _ -> ids },
+        )
+
+        assertThat(outcome).isEqualTo(Outcome.Applied)
+    }
+
+    @Test
+    fun reflectionAndManifestFallbackBothFailSurfacesFieldUnavailable() {
+        // Both tiers exhausted: reflection blocklisted AND manifest read errored
+        // (e.g., AXML malformed, or no cookie probe matched the running package).
+        // The Outcome.FieldUnavailable surface remains the triage signal for "the OS
+        // made every read path go away."
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val outcome = BackupRulesAssertion.assertBackupRulesApplied(
+            appInfo = context.applicationInfo,
+            resources = context.resources,
+            reflectionReader = { null },
+            manifestFallbackReader = { _, _ -> null },
+        )
+
+        assertThat(outcome).isEqualTo(Outcome.FieldUnavailable)
+    }
+
+    @Test
     fun appWideAllowBackupFalseReturnsAppliedWithoutParsingRules() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         // Clone the live ApplicationInfo via Parcel so the test's mutation cannot leak


### PR DESCRIPTION
## Summary

Closes the `assumeTrue(SDK_INT < S)` skip in `BackupRulesAssertionInstrumentationTest` that PR #20's connected-tests matrix surfaced. Reflection on `ApplicationInfo.dataExtractionRulesRes` is now blocklisted at our target SDK and collapses to `NoSuchFieldException` on API 31+; without a fallback the trust-claim assertion regresses to `Outcome.FieldUnavailable` for every consumer running on those platforms.

The fix realizes the manifest-XML fallback the production-code docstring already promised: "degrade from broken to slower, not broken to manual review."

## Read order

1. **Reflection** on `ApplicationInfo.fullBackupContent` / `dataExtractionRulesRes` (unchanged; primary on API < 31 and any future platform that re-allows it).
2. **Manifest-XML fallback** when reflection returns `null`: probe the running `AssetManager`'s already-loaded `AndroidManifest.xml` over cookies 1..32, match by `<manifest package="...">`, and read the same resource ids off the `<application>` element via public `AssetManager.openXmlResourceParser` (since API 1).

`Outcome.FieldUnavailable` now surfaces only when both tiers fail.

## Why probe cookies instead of `ApkAssets.loadFromPath`

`ApkAssets` and `AssetManager.Builder.addApkAssets(ApkAssets)` are `@SystemApi` and not callable from app code. Iterating the existing `AssetManager`'s cookies uses pure public API (`openXmlResourceParser` has been public since API 1) and avoids hidden-API surface entirely.

## Test plan

- [x] `./gradlew :passes-storage:check` (lint + unit tests; 16/16 in `BackupRulesAssertionTest` including 3 new tests for the read-order contract)
- [x] `./gradlew :passes-storage:detekt :passes-storage:ktlintCheck`
- [ ] **Load-bearing acceptance criterion**: connected-tests CI matrix shows `BackupRulesAssertionInstrumentationTest.mergedManifestRulesAreApplied` running and PASSING on all four API legs (28, 31, 34, 36) - workflow run linked once green.

Refs: bead `wpass-2zv`. Out of scope (kept tightly): `BackupRulesXmlParser`/`BackupRulesContract`/`Outcome` arms (the latter is `wpass-891`).