### PR TITLE
Composite Gradle build setup + GitHub Packages migration plan (wpass-9vv.7)

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -18,6 +18,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
         with(target) {
             pluginManager.apply("com.android.library")
 
+            group = providers.gradleProperty("walt.passes.group").get()
+            version = providers.gradleProperty("walt.passes.version").get()
+
             extensions.configure<LibraryExtension> {
                 compileSdk = 36
 

--- a/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
@@ -20,6 +20,9 @@ class KotlinLibraryConventionPlugin : Plugin<Project> {
                 apply("java-library")
             }
 
+            group = providers.gradleProperty("walt.passes.group").get()
+            version = providers.gradleProperty("walt.passes.version").get()
+
             extensions.configure<JavaPluginExtension> {
                 sourceCompatibility = JavaVersion.VERSION_17
                 targetCompatibility = JavaVersion.VERSION_17

--- a/docs/adr/0004-distribution-and-github-packages.md
+++ b/docs/adr/0004-distribution-and-github-packages.md
@@ -1,0 +1,245 @@
+# ADR 0004: distribution mechanism and GitHub Packages migration plan
+
+- Status: Accepted (v1 composite build); Proposed (v1.5 GitHub Packages cutover)
+- Date: 2026-05-05
+- Tracks: parent epic `wpass-9vv`; bead `wpass-9vv.7`
+- Decision context: `decision-wlt-0tn-q4` (separate repo, Apache 2.0, composite
+  Gradle build for v1, GitHub Packages later)
+- Related: [`docs/composite-build.md`](../composite-build.md)
+
+## Context
+
+Two questions have to be answered together for `walt-passes-android`:
+
+1. How does walt-android (closed source) consume the three library modules
+   (`passes-core`, `passes-storage`, `passes-ui`) shipped by this repository?
+2. How can a third-party auditor or open-source reuser consume them without
+   needing access to walt-android's local-checkout topology?
+
+The brainstorming-phase decision (`decision-wlt-0tn-q4`) said: composite Gradle
+build for v1, GitHub Packages later. v1 is now real, and the producer side of
+the composite build has to land before walt-android can wire it up
+(`wlt-4pg` in the consumer repo). At the same time, the project has accumulated
+enough of an audit posture that "later" needs to be more than a hand-wave — a
+follow-up bead has to be cheap to spawn, with the version strategy and
+publishing surface already settled.
+
+This ADR fixes both halves: the v1 mechanism (already in effect after this
+bead lands) and the v1.5+ migration plan (gated on a yet-to-be-filed bead).
+
+## Decisions
+
+### D1. v1 distribution: composite Gradle build, sibling checkouts
+
+walt-android adds `includeBuild("../../passes-android/passes-android-main")` in
+its `settings.gradle.kts`. Module dependencies are declared as
+`implementation("is.walt:passes-core")` and so on; Gradle's dependency
+substitution matches on `(group, module-name)` and resolves the coordinate to
+the included project at configuration time.
+
+This is documented operationally in [`docs/composite-build.md`](../composite-build.md);
+the rest of this section is the rationale for choosing this over the
+alternatives.
+
+**Rejected alternatives:**
+
+- *Monorepo*: would put the trust-claim-bearing code in the closed repo and
+  break the audit story (the central decisive constraint in `wpass-9vv`).
+- *Local Maven publish*: forces every contributor on the consumer side to run
+  `./gradlew publishToMavenLocal` before each build, easy to forget, hard to
+  validate in CI without a wrapper script that this ADR would still have to
+  describe. Composite build subsumes the workflow with one Gradle line.
+- *git submodule*: orthogonal to dependency resolution. Consumers still have to
+  point the build at the submodule path, and submodules add their own UX
+  problems (detached HEAD, two-step pulls). Not worth the extra moving piece.
+- *Maven Central from day one*: committing to Maven Central before we know the
+  API is stable creates a graveyard of `0.x` artifacts under the `is.walt`
+  group that we cannot retract. The audit posture does not yet need it; the
+  reusers we would attract are a v1.5+ concern.
+
+**Coordinates** are pinned in `gradle.properties` (`walt.passes.group=is.walt`,
+`walt.passes.version=...`), and the convention plugins in `build-logic/` stamp
+those onto every library module. There is no per-module `group =` / `version =`
+line for any contributor to forget.
+
+### D2. v1.5+ distribution: GitHub Packages with Maven Publish
+
+The follow-up cutover publishes the same three coordinates to GitHub Packages
+(`https://maven.pkg.github.com/walt-app/walt-passes-android`). Composite build
+remains supported as a development-time mode for engineers working on both
+repos at once; GitHub Packages is the published mode that decouples the
+consumer from a sibling-checkout assumption and lets third-party auditors
+depend on a published artifact without negotiating a local layout.
+
+GitHub Packages was chosen over Maven Central for v1.5 because:
+
+- The org already has a `walt-app` GitHub presence and credentials there, with
+  no separate Sonatype OSSRH account to provision.
+- Token-based consumer auth fits the closed walt-android workflow without
+  exposing an API key broadly.
+- It lets us iterate on the publishing pipeline (signing, version strategy,
+  release workflow) before promoting any artifact to Maven Central, which is
+  effectively unretractable.
+
+Maven Central is not ruled out as a v2 destination; the publishing pipeline
+designed below is portable to it (the Sonatype publishing plugin and Maven
+Central differ only in the repository URL and the staging steps).
+
+#### D2.1 Plugin surface
+
+Each library module applies `maven-publish` and `signing` (the latter gated on
+release builds; SNAPSHOTs publish unsigned). The convention plugins gain a
+small `PublishingConventionPlugin` that wires both, so contributors do not
+duplicate the publication block per module.
+
+Sketch of what the publishing plugin does on a module:
+
+```kotlin
+// build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+class PublishingConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("maven-publish")
+        pluginManager.apply("signing")
+
+        // Android library modules expose a `release` software component once
+        // singleVariant("release") { withSourcesJar(); withJavadocJar() } is
+        // declared in the android { publishing { ... } } block. Pure-JVM
+        // modules expose `java`. The plugin picks the right one.
+        afterEvaluate {
+            extensions.configure<PublishingExtension> {
+                publications.create<MavenPublication>("release") {
+                    from(components[componentName()])
+                    pom {
+                        name.set(provider { "${rootProject.name}:${project.name}" })
+                        description.set("Walt's open pass-handling kernel — ${project.name}")
+                        url.set("https://github.com/walt-app/walt-passes-android")
+                        licenses { license { name.set("Apache-2.0") } }
+                    }
+                }
+                repositories {
+                    maven {
+                        name = "GitHubPackages"
+                        url = uri("https://maven.pkg.github.com/walt-app/walt-passes-android")
+                        credentials {
+                            username = providers.gradleProperty("gpr.user")
+                                .orElse(providers.environmentVariable("GITHUB_ACTOR")).get()
+                            password = providers.gradleProperty("gpr.token")
+                                .orElse(providers.environmentVariable("GITHUB_TOKEN")).get()
+                        }
+                    }
+                }
+            }
+
+            extensions.configure<SigningExtension> {
+                isRequired = isReleaseVersion()  // SNAPSHOTs publish unsigned
+                useInMemoryPgpKeys(
+                    providers.environmentVariable("SIGNING_KEY").orNull,
+                    providers.environmentVariable("SIGNING_PASSPHRASE").orNull,
+                )
+                sign(extensions.getByType<PublishingExtension>().publications)
+            }
+        }
+    }
+}
+```
+
+The implementing bead must, additionally:
+
+- Add `singleVariant("release") { withSourcesJar(); withJavadocJar() }` to the
+  Android library convention plugin's `LibraryExtension.publishing { ... }`
+  block, and `withSourcesJar()` + `withJavadocJar()` for the JVM library
+  convention plugin.
+- Decide whether to publish `-sources.jar` for `passes-storage` (the encrypted
+  storage module is the most security-sensitive surface and the audit story
+  benefits from sources being on Packages, not just on GitHub). Default
+  recommendation: yes, ship sources for all three modules.
+
+#### D2.2 Versioning and release workflow
+
+- **Branch trunk**: `0.X.Y-SNAPSHOT` in `gradle.properties`. Pushes to `main`
+  publish a SNAPSHOT to GitHub Packages on every successful CI run on
+  `main` (a separate workflow from the PR-validation workflow already in
+  `.github/workflows/ci.yml`).
+- **Release**: a tagged commit (`v0.X.Y` annotated tag) triggers
+  `.github/workflows/release.yml`. The workflow:
+  1. checks out the tagged ref,
+  2. asserts `gradle.properties` `walt.passes.version` matches the tag (no
+     `-SNAPSHOT`),
+  3. runs `./gradlew :passes-core:publish :passes-storage:publish :passes-ui:publish`
+     against the `GitHubPackages` repository with `SIGNING_KEY` /
+     `SIGNING_PASSPHRASE` from repository secrets,
+  4. creates a GitHub Release with auto-generated notes from the tag's commit
+     range.
+- **Post-release**: a separate PR bumps `walt.passes.version` to the next
+  `-SNAPSHOT`. This is the only place in the repo a version literal lives, so
+  the bump is one line.
+
+SemVer applies, with the strict constraint: any change to a module's public
+API (`explicitApi = ExplicitApiMode.Strict` is already on for both convention
+plugins; the surface that escapes the module is exactly what `dump-api`-style
+tooling would catch) is a major bump until 1.0.0, and a minor bump after.
+
+#### D2.3 Consumer auth for GitHub Packages
+
+GitHub Packages requires authentication even for public packages. Consumers
+add to their `~/.gradle/gradle.properties` (or set the equivalent environment
+variables in CI):
+
+```properties
+gpr.user=<github-username>
+gpr.token=<personal-access-token-with-read:packages>
+```
+
+The token requires only `read:packages`. walt-android's CI uses the
+`GITHUB_TOKEN` injected into Actions runs; no new secret is needed.
+
+The walt-android-side change to consume from GitHub Packages — declaring the
+repository in `dependencyResolutionManagement.repositories` and dropping the
+`includeBuild` line — is the cutover work item, tracked by a yet-to-be-filed
+bead in the consumer repo. That bead replaces (does not extend)
+`wlt-4pg`-equivalent composite-build wiring.
+
+#### D2.4 Cutover plan from composite build to artifact resolution
+
+The transition is staged so that the consumer can switch one module at a time
+and roll back without coordinating a producer-side change:
+
+1. **Producer**: ship the publishing pipeline. SNAPSHOTs land in GitHub
+   Packages on each `main` push. The composite-build path stays supported.
+2. **Consumer (preview)**: an opt-in flag (`waltPasses.useArtifacts=true` in
+   `~/.gradle/gradle.properties`) routes the consumer's settings to declare
+   the GitHub Packages repository instead of `includeBuild(...)`. Engineers
+   sanity-check the SNAPSHOT path locally.
+3. **Producer**: cut a `0.1.0` tagged release. Versions in walt-android
+   switch from "no version specified" to "0.1.0".
+4. **Consumer (default)**: flip the default for `waltPasses.useArtifacts` to
+   `true`. Composite build remains an opt-in mode for engineers actively
+   developing both repos.
+5. **Producer (long-term)**: composite build stays in the matrix indefinitely.
+   It is the right tool for active cross-repo development; the artifact path
+   is the right tool for steady-state consumption.
+
+### D3. Out of scope for this ADR / for the bead implementing it
+
+- Maven Central. Designed for portability; not pursued in v1.5.
+- Snapshots-on-PR. Only `main` SNAPSHOTs publish; PR builds remain validation-
+  only. Avoiding fork-PR security exposure to publish credentials.
+- Reproducible builds. Worth pursuing later but not part of this ADR.
+- Per-module independent versioning. All three modules ship at the same
+  version, locked through `walt.passes.version`. Independent versioning is
+  reconsidered if `passes-core` ever stabilizes much faster than the Android
+  modules (which is plausible — the JVM module is the smallest API surface).
+
+## Consequences
+
+- The producer-side composite-build coordinates are stable for v1, and the
+  shape of `is.walt:passes-{core,storage,ui}` already matches what the
+  GitHub Packages migration will publish.
+- The version literal lives in exactly one place (`gradle.properties`), so
+  the eventual release-workflow assertion in §D2.2 is one grep.
+- The publishing pipeline is sketched but not written. The implementing bead
+  is in scope for a v1.5 milestone; until it lands, third parties are asked
+  to read the source on GitHub or use composite build at their own risk.
+- ADRs 0001–0003 fix the API and theming contracts; this ADR fixes how those
+  contracts are *delivered*. A future ADR may revisit the publishing target
+  if Maven Central or another registry becomes a better fit.

--- a/docs/composite-build.md
+++ b/docs/composite-build.md
@@ -1,0 +1,114 @@
+# Consuming walt-passes-android via composite Gradle build (v1)
+
+Status: current for v1. This is the supported way for a consumer Gradle build to
+depend on the three `walt-passes-android` library modules until the GitHub
+Packages migration described in [ADR 0004](adr/0004-distribution-and-github-packages.md)
+ships.
+
+The DECISIVE CONSTRAINT recorded against the parent epic `wpass-9vv` is that
+trust-claim-bearing logic lives only in this repository: walt-android consumes
+the implementations directly rather than parallel-implementing them. Composite
+build is what makes "directly" cheap in the Gradle sense — the consumer's
+compiler reads the same source files that any auditor reads on GitHub.
+
+## Coordinates
+
+The three modules publish under group `is.walt`. The artifactId of each module
+equals its Gradle project name. Versioning follows ADR 0004: the trunk carries
+a `-SNAPSHOT` suffix; tagged releases drop it.
+
+| Coordinate                                 | Module             | Origin                              |
+|--------------------------------------------|--------------------|-------------------------------------|
+| `is.walt:passes-core:0.1.0-SNAPSHOT`       | `:passes-core`     | Pure Kotlin/JVM library (jar)       |
+| `is.walt:passes-storage:0.1.0-SNAPSHOT`    | `:passes-storage`  | Android library (aar)               |
+| `is.walt:passes-ui:0.1.0-SNAPSHOT`         | `:passes-ui`       | Android + Compose library (aar)     |
+
+Group, version, and artifactId are stamped on every module by the convention
+plugins (`KotlinLibraryConventionPlugin`, `AndroidLibraryConventionPlugin`).
+The single source of truth is `gradle.properties` keys `walt.passes.group` and
+`walt.passes.version`. To bump the trunk version, edit those — never set
+`group` or `version` in a module's `build.gradle.kts`.
+
+## Consumer setup
+
+The consumer is expected to check out `walt-passes-android` as a sibling of its
+own repo:
+
+```
+~/workspace/walt/
+  android/                       ← consumer repo
+    android-main/
+  passes-android/                ← producer repo (this one)
+    passes-android-main/
+```
+
+In the consumer's `settings.gradle.kts`, register an included build that points
+at the producer's checkout:
+
+```kotlin
+// android/android-main/settings.gradle.kts
+includeBuild("../../passes-android/passes-android-main")
+```
+
+Then declare normal Gradle dependencies in any module that needs the kernel.
+Gradle's composite-build dependency substitution matches `(group, name)` and
+swaps the external coordinate for the included project at configuration time,
+so the consumer never resolves these from a Maven repository:
+
+```kotlin
+// android/android-main/core/data-passes/build.gradle.kts
+dependencies {
+    implementation("is.walt:passes-core")
+    implementation("is.walt:passes-storage")
+}
+
+// android/android-main/feature/passes/build.gradle.kts
+dependencies {
+    implementation("is.walt:passes-core")
+    implementation("is.walt:passes-ui")
+}
+```
+
+A version is not required on the dependency declaration; substitution ignores
+it. A version may be supplied for documentation, in which case it should match
+the trunk's `walt.passes.version` so a future cutover to artifact resolution
+(see ADR 0004) keeps working without edits to call sites.
+
+## Caveats and constraints
+
+1. **Sibling-checkout assumption.** The `includeBuild(...)` path is filesystem-
+   relative. Consumers that put repos in non-sibling locations adjust the path
+   themselves; producer-side guidance assumes the layout above to match how
+   walt-android operators are already set up.
+2. **No third-party use of composite build is supported.** The trust-claim
+   audience is reading source on GitHub; the build-mode audience is walt-
+   android. Third parties that want to depend on `walt-passes-android` are
+   welcomed but should wait for the v1.5 GitHub Packages release described in
+   ADR 0004 instead of replicating the composite-build workflow.
+3. **Build-logic does not get composed.** The producer's `build-logic/`
+   convention plugins are scoped to the producer and do not become available
+   to the consumer's modules. The consumer keeps its own conventions; the
+   `is.walt.passes.*` plugin IDs are an internal contract here.
+4. **Version catalogs are independent.** The consumer's `libs.versions.toml`
+   and the producer's are separate. `:passes-core` does not export third-
+   party deps it does not `api(...)`; the consumer pulls in its own copies of
+   shared transitives the same way it does for any other Maven dependency.
+5. **CI must check out both repos.** Consumer CI (the closed walt-android
+   repo) must clone `walt-passes-android` next to itself before running
+   Gradle. Without the included build present on disk, configuration fails
+   with "Project ... not found" before any compilation happens.
+
+## Trust-claim framing
+
+This file exists in the open repo on purpose. A reader investigating "what does
+Walt actually run when it parses my pass" finds:
+
+- a `wallet` app (closed source) that imports `is.walt:passes-core`,
+- a path on disk that resolves to source files in this repository, and
+- a chain of build-logic plugins, written in this repository, that compile
+  those files.
+
+The chain is short and uniform across the three modules; nothing is renamed,
+relocated, or rewritten on the way into walt-android. That is the property the
+audit story trades on, and composite build is what preserves it cheaply during
+v1.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,15 @@ kotlin.code.style=official
 # Android Gradle Plugin settings (passes-ui).
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+# Single source of truth for the Maven coordinates the three library modules
+# (passes-core, passes-storage, passes-ui) publish under. Convention plugins read
+# these and stamp every module with `group = walt.passes.group` and
+# `version = walt.passes.version`. Consumers that compose this build (see
+# docs/composite-build.md) match on (group, module-name); the module-name is the
+# Gradle project name (e.g. "passes-core").
+#
+# Version stays on the SNAPSHOT track until ADR 0004's GitHub Packages cutover,
+# at which point tagged releases drop the suffix.
+walt.passes.group=is.walt
+walt.passes.version=0.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Closes the producer side of the v1 distribution story for `walt-passes-android` (bead `wpass-9vv.7`, the last open child of epic `wpass-9vv`):

- **Coordinates stamped on every library module.** Convention plugins (`KotlinLibraryConventionPlugin`, `AndroidLibraryConventionPlugin`) now set `group` and `version` on each module from `gradle.properties` (`walt.passes.group=is.walt`, `walt.passes.version=0.1.0-SNAPSHOT`). Result: `is.walt:passes-core:0.1.0-SNAPSHOT`, `is.walt:passes-storage:0.1.0-SNAPSHOT`, `is.walt:passes-ui:0.1.0-SNAPSHOT`. Single source of truth for the version literal.
- **Composite-build contract documented** in `docs/composite-build.md`. A consumer adds `includeBuild("../../passes-android/passes-android-main")` in `settings.gradle.kts`, then declares `implementation("is.walt:passes-core")` etc; Gradle substitution matches `(group, name)` and resolves to the included project. Sibling-checkout assumption documented; the v1 mode is for walt-android, not third parties.
- **ADR 0004 (`docs/adr/0004-distribution-and-github-packages.md`)** captures the v1.5+ GitHub Packages migration plan: `maven-publish` + `signing` plugin sketch, tag-triggered release workflow shape, SemVer + SNAPSHOT scheme, consumer auth via `read:packages` PAT, and a staged cutover that keeps composite-build supported as a development-time mode after artifacts ship.

This unblocks the consumer-side wiring tracked as `wlt-4pg` in the (closed) walt-android repo. Closing this bead closes epic `wpass-9vv`.

Sanity-checked the contract by including this build from a scratch consumer (`/tmp/walt-passes-composite-test/`, removed after verification): `implementation("is.walt:passes-core")` resolved to the included project's `passes-core/build/classes/...` with no Maven repository involvement.

## Test plan

- [x] `./gradlew :passes-core:assemble :passes-storage:assemble :passes-ui:assemble` — green
- [x] `./gradlew :passes-core:check :passes-storage:check :passes-ui:check` — green
- [x] `./gradlew :passes-storage:detekt :passes-storage:ktlintCheck` — green
- [x] `./gradlew -q :passes-{core,storage,ui}:properties` reports group/name/version match `is.walt:passes-{core,storage,ui}:0.1.0-SNAPSHOT`
- [x] Scratch consumer with `includeBuild(...)` + `implementation("is.walt:passes-core")` resolves to the included project's classes (verified, then deleted)
- [ ] `wlt-4pg` (consumer side, closed repo) wires `includeBuild` against the coordinates documented in `docs/composite-build.md`