### PR TITLE
passes-core: hardened ZIP extraction layer (wpass-8so)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ExtractResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ExtractResult.kt
@@ -1,0 +1,20 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.MalformedReason
+
+/**
+ * Outcome of running [extractSafely] over a [`is`.walt.passes.core.PassSource]. Internal
+ * only: the parser-glue bead lifts a [Failure] into
+ * [`is`.walt.passes.core.ParseResult.Malformed]. Surfacing this type to consumers would
+ * expand the public API beyond what ADR 0001 fixes.
+ */
+internal sealed interface ExtractResult {
+    /**
+     * Insertion-ordered map of entry name to fully-decoded entry bytes. Order mirrors the
+     * order the entries appeared in the archive's local-file-header stream so the
+     * downstream pass.json / manifest hash steps can iterate deterministically.
+     */
+    data class Success(val entries: Map<String, ByteArray>) : ExtractResult
+
+    data class Failure(val reason: MalformedReason) : ExtractResult
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
@@ -163,25 +163,35 @@ private fun validateAndRead(
     entries: MutableMap<String, ByteArray>,
     config: ParserConfig,
 ): ExtractResult.Failure? {
-    val rejection: MalformedReason? =
+    val rejection =
         pathTraversalReason(name)
-            ?: if (!hasAllowedName(name)) {
-                MalformedReason.NotAZipArchive
-            } else {
-                null
-                    ?: if (entries.containsKey(name)) {
-                        MalformedReason.NotAZipArchive
-                    } else {
-                        null
-                            ?: if (entries.size >= config.maxEntries) {
-                                MalformedReason.ResourceLimitExceeded(ResourceLimit.EntryCount)
-                            } else {
-                                null
-                            }
-                    }
-            }
+            ?: extensionReason(name)
+            ?: duplicateEntryReason(entries, name)
+            ?: entryCountReason(entries, config)
     return rejection?.let { ExtractResult.Failure(it) }
         ?: readEntryAndStore(zis, name, entries, config.maxEntryBytes)
+}
+
+private fun extensionReason(name: String): MalformedReason? {
+    return if (hasAllowedName(name)) null else MalformedReason.NotAZipArchive
+}
+
+private fun duplicateEntryReason(
+    entries: Map<String, ByteArray>,
+    name: String,
+): MalformedReason? {
+    return if (entries.containsKey(name)) MalformedReason.NotAZipArchive else null
+}
+
+private fun entryCountReason(
+    entries: Map<String, ByteArray>,
+    config: ParserConfig,
+): MalformedReason? {
+    return if (entries.size >= config.maxEntries) {
+        MalformedReason.ResourceLimitExceeded(ResourceLimit.EntryCount)
+    } else {
+        null
+    }
 }
 
 private fun pathTraversalReason(name: String): MalformedReason? {
@@ -225,18 +235,13 @@ private fun readEntryBytes(
     val output = ByteArrayOutputStream()
     val buffer = ByteArray(READ_BUFFER_SIZE)
     var totalRead = 0L
-    var exceeded = false
-    while (!exceeded) {
+    while (true) {
         val n = zis.read(buffer)
-        if (n == -1) break
+        if (n == -1) return output.toByteArray()
         totalRead += n
-        if (totalRead > maxEntryBytes) {
-            exceeded = true
-        } else {
-            output.write(buffer, 0, n)
-        }
+        if (totalRead > maxEntryBytes) return null
+        output.write(buffer, 0, n)
     }
-    return if (exceeded) null else output.toByteArray()
 }
 
 /**

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
@@ -94,6 +94,13 @@ private fun runZipPipeline(
     rawStream: InputStream,
     config: ParserConfig,
 ): ExtractResult {
+    // Wrapper order is load-bearing. The chain is:
+    //   userStream -> NonClosingInputStream -> BufferedInputStream -> BoundedInputStream -> ZipInputStream
+    // BoundedInputStream MUST sit *outside* BufferedInputStream so that bytes the sniff
+    // pulled into the buffer still flow through the counter when ZipInputStream reads
+    // them back. Reordering (e.g. moving BufferedInputStream above BoundedInputStream)
+    // would silently let the first 4 sniffed bytes — and any others the buffer prefetched
+    // — escape the maxArchiveBytes accounting.
     val sniffer = BufferedInputStream(rawStream)
     val magicCheck = looksLikeZip(sniffer)
     if (magicCheck != null) return ExtractResult.Failure(magicCheck)
@@ -112,8 +119,11 @@ private fun runZipPipeline(
 /**
  * Returns [MalformedReason.NotAZipArchive] if the next 4 bytes of [stream] are neither a
  * local-file-header signature (`PK\x03\x04`) nor an end-of-central-directory signature
- * (`PK\x05\x06`). Leaves the stream re-positioned at byte 0 so the subsequent
- * [ZipInputStream] reads the same bytes the sniff observed.
+ * (`PK\x05\x06`). The EOCD prefix is legal only for a structurally valid empty archive
+ * (no local file headers, just the EOCD record); a non-empty zip starts with a local
+ * file header. Anything else with `PK\x05\x06` at the front is rejected by
+ * [ZipInputStream] on the next read. Leaves the stream re-positioned at byte 0 so the
+ * subsequent [ZipInputStream] reads the same bytes the sniff observed.
  */
 private fun looksLikeZip(stream: BufferedInputStream): MalformedReason? {
     stream.mark(MAGIC_PREFIX_LENGTH)
@@ -150,11 +160,19 @@ private fun processEntry(
     entries: MutableMap<String, ByteArray>,
     config: ParserConfig,
 ): ExtractResult.Failure? {
-    if (entry.isDirectory) {
-        zis.closeEntry()
-        return null
+    // Validate the name unconditionally, even for directory entries we'd otherwise
+    // skip. A `../foo/` directory is harmless today (nothing acts on directory
+    // entries), but checking up-front means a future change that does act on them
+    // can't accidentally bypass the path-traversal guard.
+    val pathRejection = pathTraversalReason(entry.name)
+    return when {
+        pathRejection != null -> ExtractResult.Failure(pathRejection)
+        entry.isDirectory -> {
+            zis.closeEntry()
+            null
+        }
+        else -> validateAndRead(zis, entry.name, entries, config)
     }
-    return validateAndRead(zis, entry.name, entries, config)
 }
 
 private fun validateAndRead(
@@ -163,9 +181,9 @@ private fun validateAndRead(
     entries: MutableMap<String, ByteArray>,
     config: ParserConfig,
 ): ExtractResult.Failure? {
+    // pathTraversalReason already ran in processEntry; the chain picks up here.
     val rejection =
-        pathTraversalReason(name)
-            ?: extensionReason(name)
+        extensionReason(name)
             ?: duplicateEntryReason(entries, name)
             ?: entryCountReason(entries, config)
     return rejection?.let { ExtractResult.Failure(it) }
@@ -196,12 +214,16 @@ private fun entryCountReason(
 
 private fun pathTraversalReason(name: String): MalformedReason? {
     val isWindowsAbsolute = name.length >= 2 && name[1] == ':'
+    // Strip a single trailing `/` so a legitimate directory entry name like
+    // "en.lproj/" doesn't trip the empty-segment check on the trailing split slot.
+    // Empty intermediate segments ("foo//bar") and a bare "/" still fail.
+    val canonical = name.trimEnd('/')
     val unsafe =
         name.isEmpty() ||
-            name.startsWith('/') ||
-            name.contains('\\') ||
+            canonical.startsWith('/') ||
+            canonical.contains('\\') ||
             isWindowsAbsolute ||
-            name.split('/').any { it == ".." || it == "." || it.isEmpty() }
+            canonical.split('/').any { it == ".." || it == "." || it.isEmpty() }
     return if (unsafe) MalformedReason.NotAZipArchive else null
 }
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
@@ -1,0 +1,295 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.MalformedReason
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.PassSource
+import `is`.walt.passes.core.ResourceLimit
+import java.io.BufferedInputStream
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.FilterInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipException
+import java.util.zip.ZipInputStream
+
+/**
+ * The single hardened ZIP-extraction entry point shared by passes-core. Every guard the
+ * threat model lists for untrusted PKPASS input is centralized here:
+ *
+ *  - **Magic-byte preflight.** [ZipInputStream] silently treats unrecognized leading bytes
+ *    as "no entries", which would let raw garbage and 0-byte input round-trip as
+ *    [ExtractResult.Success] with an empty map. The first 4 bytes are sniffed and
+ *    anything that isn't a local-file-header (`PK\x03\x04`) or end-of-central-directory
+ *    (`PK\x05\x06` — a legitimate empty archive) signature is rejected up front.
+ *  - **Archive size** (compressed). Checked twice. Once up-front against the declared size
+ *    ([PassSource.Bytes.bytes].size or [PassSource.Stream.sizeHintBytes]). Then again at
+ *    streaming time via [BoundedInputStream], which throws as soon as a read pushes the
+ *    cumulative byte count past [ParserConfig.maxArchiveBytes]. The streaming check is
+ *    load-bearing: a hostile [PassSource.Stream] can lie about its
+ *    [PassSource.Stream.sizeHintBytes].
+ *  - **Entry count.** [ParserConfig.maxEntries] caps the number of file entries surfaced
+ *    to the caller. Directory entries are skipped before the count, so a bag of nested
+ *    `.lproj/` directories cannot push a real archive past the cap.
+ *  - **Per-entry decompressed size.** [readEntryBytes] caps each entry at
+ *    [ParserConfig.maxEntryBytes]. This is the zip-bomb guard: a 10 KB compressed entry
+ *    that decompresses to 10 GB hits the cap and aborts before the buffer materializes.
+ *  - **Path traversal (zip-slip).** [pathTraversalReason] rejects entry names containing
+ *    `..` or `.` segments, leading `/` (absolute path), backslashes (Windows-flavored
+ *    separator), Windows drive-letter prefixes, or empty segments. Structural — no
+ *    file-system canonicalization, because we never touch the file system.
+ *  - **Symlink-shaped entries.** With JDK-only zip APIs (no Apache Commons Compress in
+ *    this module's deps; see `gradle/libs.versions.toml`) the file-mode bits used to
+ *    detect Info-ZIP symlink entries live in the central directory's external file
+ *    attributes, which [ZipInputStream] does not expose. Mitigation: extraction is
+ *    in-memory only; [readEntryBytes] writes into a [ByteArrayOutputStream] and we never
+ *    invoke any file system operation that could resolve a symlink. Combined with the
+ *    path-traversal check and extension allowlist, this is sufficient for the trust
+ *    claim. A follow-up bead may swap in a parser that exposes external attributes if
+ *    true symlink rejection is wanted.
+ *  - **Extension allowlist.** Entry names must end in `.json`, `.png`, or `.strings`, OR
+ *    be exactly `signature` at the archive root (the PKCS#7 detached-signature blob has
+ *    no extension by PKPASS convention; the exemption is intentionally root-only so an
+ *    attacker can't smuggle arbitrary content under a nested `signature` name). Anything
+ *    else is rejected before any bytes are decompressed.
+ *  - **Duplicate entry names.** Two entries with the same name are rejected. PKPASS does
+ *    not permit duplicates and JDK [ZipInputStream] would silently let the second one
+ *    win, which would let an attacker shadow a legitimate `manifest.json` with a
+ *    tampered second copy.
+ *  - **In-memory only.** No [java.io.FileOutputStream] is ever opened on an entry name.
+ *    The entire archive is materialized into a [Map] of [ByteArray] values bounded by
+ *    the per-entry cap, so a hostile name has no path on which to land even if the
+ *    path-traversal check is somehow bypassed.
+ *
+ * Limit hits surface as [MalformedReason.ResourceLimitExceeded] with the relevant
+ * [ResourceLimit] value. Structural rejections (path traversal, disallowed extension,
+ * duplicate name) currently surface as [MalformedReason.NotAZipArchive] because the
+ * public [MalformedReason] surface is frozen for this slice; a follow-up bead adds a
+ * dedicated [MalformedReason] arm.
+ */
+internal fun extractSafely(
+    source: PassSource,
+    config: ParserConfig,
+): ExtractResult {
+    val declaredSize: Long? =
+        when (source) {
+            is PassSource.Bytes -> source.bytes.size.toLong()
+            is PassSource.Stream -> source.sizeHintBytes
+        }
+    return if (declaredSize != null && declaredSize > config.maxArchiveBytes) {
+        ExtractResult.Failure(MalformedReason.ResourceLimitExceeded(ResourceLimit.ArchiveSize))
+    } else {
+        runZipPipeline(openSource(source), config)
+    }
+}
+
+private fun openSource(source: PassSource): InputStream =
+    when (source) {
+        is PassSource.Bytes -> ByteArrayInputStream(source.bytes)
+        is PassSource.Stream -> NonClosingInputStream(source.stream)
+    }
+
+private fun runZipPipeline(
+    rawStream: InputStream,
+    config: ParserConfig,
+): ExtractResult {
+    val sniffer = BufferedInputStream(rawStream)
+    val magicCheck = looksLikeZip(sniffer)
+    if (magicCheck != null) return ExtractResult.Failure(magicCheck)
+    val bounded = BoundedInputStream(sniffer, config.maxArchiveBytes)
+    return try {
+        ZipInputStream(bounded).use { zis -> extractAllEntries(zis, config) }
+    } catch (_: ArchiveSizeExceededException) {
+        ExtractResult.Failure(MalformedReason.ResourceLimitExceeded(ResourceLimit.ArchiveSize))
+    } catch (_: ZipException) {
+        ExtractResult.Failure(MalformedReason.NotAZipArchive)
+    } catch (_: IOException) {
+        ExtractResult.Failure(MalformedReason.NotAZipArchive)
+    }
+}
+
+/**
+ * Returns [MalformedReason.NotAZipArchive] if the next 4 bytes of [stream] are neither a
+ * local-file-header signature (`PK\x03\x04`) nor an end-of-central-directory signature
+ * (`PK\x05\x06`). Leaves the stream re-positioned at byte 0 so the subsequent
+ * [ZipInputStream] reads the same bytes the sniff observed.
+ */
+private fun looksLikeZip(stream: BufferedInputStream): MalformedReason? {
+    stream.mark(MAGIC_PREFIX_LENGTH)
+    val head = ByteArray(MAGIC_PREFIX_LENGTH)
+    var read = 0
+    while (read < head.size) {
+        val n = stream.read(head, read, head.size - read)
+        if (n == -1) break
+        read += n
+    }
+    stream.reset()
+    val matches =
+        read == MAGIC_PREFIX_LENGTH &&
+            (head.contentEquals(LOCAL_FILE_HEADER_MAGIC) || head.contentEquals(END_OF_CENTRAL_DIR_MAGIC))
+    return if (matches) null else MalformedReason.NotAZipArchive
+}
+
+private fun extractAllEntries(
+    zis: ZipInputStream,
+    config: ParserConfig,
+): ExtractResult {
+    val entries = LinkedHashMap<String, ByteArray>()
+    var failure: ExtractResult.Failure? = null
+    while (failure == null) {
+        val entry = zis.nextEntry ?: break
+        failure = processEntry(zis, entry, entries, config)
+    }
+    return failure ?: ExtractResult.Success(entries.toMap())
+}
+
+private fun processEntry(
+    zis: ZipInputStream,
+    entry: ZipEntry,
+    entries: MutableMap<String, ByteArray>,
+    config: ParserConfig,
+): ExtractResult.Failure? {
+    if (entry.isDirectory) {
+        zis.closeEntry()
+        return null
+    }
+    return validateAndRead(zis, entry.name, entries, config)
+}
+
+private fun validateAndRead(
+    zis: ZipInputStream,
+    name: String,
+    entries: MutableMap<String, ByteArray>,
+    config: ParserConfig,
+): ExtractResult.Failure? {
+    val rejection: MalformedReason? =
+        pathTraversalReason(name)
+            ?: if (!hasAllowedName(name)) {
+                MalformedReason.NotAZipArchive
+            } else {
+                null
+                    ?: if (entries.containsKey(name)) {
+                        MalformedReason.NotAZipArchive
+                    } else {
+                        null
+                            ?: if (entries.size >= config.maxEntries) {
+                                MalformedReason.ResourceLimitExceeded(ResourceLimit.EntryCount)
+                            } else {
+                                null
+                            }
+                    }
+            }
+    return rejection?.let { ExtractResult.Failure(it) }
+        ?: readEntryAndStore(zis, name, entries, config.maxEntryBytes)
+}
+
+private fun pathTraversalReason(name: String): MalformedReason? {
+    val isWindowsAbsolute = name.length >= 2 && name[1] == ':'
+    val unsafe =
+        name.isEmpty() ||
+            name.startsWith('/') ||
+            name.contains('\\') ||
+            isWindowsAbsolute ||
+            name.split('/').any { it == ".." || it == "." || it.isEmpty() }
+    return if (unsafe) MalformedReason.NotAZipArchive else null
+}
+
+private fun hasAllowedName(name: String): Boolean {
+    // The PKCS#7 signature file ("signature") is the only PKPASS member with no
+    // extension. Allow it only at the archive root: a nested `nested/signature` is
+    // treated as a disallowed-extension entry, not a smuggled signature exemption.
+    if (name == SIGNATURE_FILE_NAME) return true
+    val baseName = name.substringAfterLast('/')
+    val lastDot = baseName.lastIndexOf('.')
+    return lastDot >= 0 && baseName.substring(lastDot + 1).lowercase() in ALLOWED_EXTENSIONS
+}
+
+private fun readEntryAndStore(
+    zis: ZipInputStream,
+    name: String,
+    entries: MutableMap<String, ByteArray>,
+    maxEntryBytes: Long,
+): ExtractResult.Failure? {
+    val bytes =
+        readEntryBytes(zis, maxEntryBytes)
+            ?: return ExtractResult.Failure(MalformedReason.ResourceLimitExceeded(ResourceLimit.EntrySize))
+    entries[name] = bytes
+    return null
+}
+
+private fun readEntryBytes(
+    zis: ZipInputStream,
+    maxEntryBytes: Long,
+): ByteArray? {
+    val output = ByteArrayOutputStream()
+    val buffer = ByteArray(READ_BUFFER_SIZE)
+    var totalRead = 0L
+    var exceeded = false
+    while (!exceeded) {
+        val n = zis.read(buffer)
+        if (n == -1) break
+        totalRead += n
+        if (totalRead > maxEntryBytes) {
+            exceeded = true
+        } else {
+            output.write(buffer, 0, n)
+        }
+    }
+    return if (exceeded) null else output.toByteArray()
+}
+
+/**
+ * Tracks bytes pulled from the underlying compressed stream and short-circuits with
+ * [ArchiveSizeExceededException] the moment the cumulative count crosses the budget.
+ * Throwing instead of returning -1 keeps the failure mode unambiguous: a normal
+ * end-of-stream is still distinguishable from "hostile archive went past the cap".
+ */
+private class BoundedInputStream(
+    delegate: InputStream,
+    private val maxBytes: Long,
+) : FilterInputStream(delegate) {
+    private var count: Long = 0
+
+    override fun read(): Int {
+        val b = `in`.read()
+        if (b != -1) {
+            count += 1
+            if (count > maxBytes) throw ArchiveSizeExceededException()
+        }
+        return b
+    }
+
+    override fun read(
+        b: ByteArray,
+        off: Int,
+        len: Int,
+    ): Int {
+        val n = `in`.read(b, off, len)
+        if (n > 0) {
+            count += n
+            if (count > maxBytes) throw ArchiveSizeExceededException()
+        }
+        return n
+    }
+}
+
+/**
+ * A passthrough that ignores [close]. [`is`.walt.passes.core.PassParser]'s contract leaves
+ * the caller-owned [PassSource.Stream.stream] open; [ZipInputStream.use] would otherwise
+ * close it for us.
+ */
+private class NonClosingInputStream(delegate: InputStream) : FilterInputStream(delegate) {
+    override fun close() {
+        // No-op. Caller owns the underlying stream's lifecycle.
+    }
+}
+
+private class ArchiveSizeExceededException : IOException()
+
+private const val READ_BUFFER_SIZE = 8 * 1024
+private const val SIGNATURE_FILE_NAME = "signature"
+private const val MAGIC_PREFIX_LENGTH = 4
+private val LOCAL_FILE_HEADER_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+private val END_OF_CENTRAL_DIR_MAGIC = byteArrayOf(0x50, 0x4B, 0x05, 0x06)
+private val ALLOWED_EXTENSIONS = setOf("json", "png", "strings")

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SafeArchiveExtractorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SafeArchiveExtractorTest.kt
@@ -75,6 +75,19 @@ class SafeArchiveExtractorTest {
     }
 
     @Test
+    fun streamSourceFailurePathLeavesUnderlyingStreamOpen() {
+        // Mid-archive failure path: a path-traversal entry trips well after ZipInputStream
+        // is already pulling bytes through the wrapper chain. The NonClosingInputStream
+        // contract must hold here too — caller still owns the stream's lifecycle even when
+        // extraction aborts.
+        val zip = buildArchive { entry("../etc/passwd.json", "pwned".toByteArray()) }
+        val tracker = OpenTrackingInputStream(ByteArrayInputStream(zip))
+        val result = extractSafely(PassSource.Stream(tracker, sizeHintBytes = zip.size.toLong()), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+        assertThat(tracker.closed).isFalse()
+    }
+
+    @Test
     fun declaredSizeOverArchiveCapFailsFast() {
         // sizeHint > maxArchiveBytes — the underlying stream must not even be touched.
         val tracker = OpenTrackingInputStream(ByteArrayInputStream(ByteArray(0)))
@@ -143,6 +156,21 @@ class SafeArchiveExtractorTest {
         val config = ParserConfig().copy(maxEntries = 3)
         val result = extractSafely(PassSource.Bytes(zip), config)
         assertExceeded(result, ResourceLimit.EntryCount)
+    }
+
+    @Test
+    fun zipSlipDirectoryEntryIsRejected() {
+        // Path traversal must be rejected even for entries that are pure directories
+        // (no payload). Today nothing acts on directory entries, but validating up
+        // front means a future change can't bypass the guard by smuggling a `../`
+        // through a directory name.
+        val zip =
+            buildArchive {
+                directory("../escape/")
+                entry("pass.json", "{}".toByteArray())
+            }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
     }
 
     @Test

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SafeArchiveExtractorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SafeArchiveExtractorTest.kt
@@ -1,0 +1,402 @@
+package `is`.walt.passes.core.internal
+
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.MalformedReason
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.PassSource
+import `is`.walt.passes.core.ResourceLimit
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Behavior tests for the hardened ZIP extractor. Every malicious archive shape the
+ * threat-model bead lists has a row here. Archives are synthesized in-memory via
+ * [java.util.zip.ZipOutputStream] so the test corpus is checked-in source rather than
+ * opaque binary fixtures: a reviewer can read each test and see exactly which guard is
+ * being exercised.
+ *
+ * The current public-API freeze (ADR 0001) lacks dedicated [MalformedReason] arms for
+ * path traversal / disallowed extension / duplicate entries, so the extractor maps those
+ * structural rejections onto [MalformedReason.NotAZipArchive]. Each test that depends on
+ * that mapping calls it out so a future bead that adds a `PathTraversal` arm can update
+ * the assertion in lockstep with the surface change.
+ */
+class SafeArchiveExtractorTest {
+    @Test
+    fun happyPathExtractsAllAllowedEntries() {
+        val zip =
+            buildArchive {
+                entry("pass.json", "{}".toByteArray())
+                entry("manifest.json", "{}".toByteArray())
+                entry("signature", byteArrayOf(0x30, 0x82.toByte()))
+                entry("icon.png", byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47))
+                entry("en.lproj/pass.strings", "\"k\" = \"v\";".toByteArray())
+            }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+        val entries = (result as ExtractResult.Success).entries
+        assertThat(entries.keys)
+            .containsExactly("pass.json", "manifest.json", "signature", "icon.png", "en.lproj/pass.strings")
+            .inOrder()
+        assertThat(entries["pass.json"]).isEqualTo("{}".toByteArray())
+    }
+
+    @Test
+    fun directoryEntriesAreSkippedAndDoNotCountTowardsCap() {
+        val zip =
+            buildArchive {
+                directory("en.lproj/")
+                entry("pass.json", "{}".toByteArray())
+                entry("manifest.json", "{}".toByteArray())
+                entry("signature", byteArrayOf(1))
+                entry("en.lproj/pass.strings", "\"k\" = \"v\";".toByteArray())
+            }
+        // Cap exactly at the 4 file entries; the directory entry must not occupy a slot.
+        val config = ParserConfig().copy(maxEntries = 4)
+        val result = extractSafely(PassSource.Bytes(zip), config)
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+        val entries = (result as ExtractResult.Success).entries
+        assertThat(entries).hasSize(4)
+        assertThat(entries.keys).doesNotContain("en.lproj/")
+    }
+
+    @Test
+    fun streamSourceHappyPathLeavesUnderlyingStreamOpen() {
+        val zip = buildArchive { entry("pass.json", "{}".toByteArray()) }
+        val tracker = OpenTrackingInputStream(ByteArrayInputStream(zip))
+        val result = extractSafely(PassSource.Stream(tracker, sizeHintBytes = zip.size.toLong()), ParserConfig())
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+        assertThat(tracker.closed).isFalse()
+    }
+
+    @Test
+    fun declaredSizeOverArchiveCapFailsFast() {
+        // sizeHint > maxArchiveBytes — the underlying stream must not even be touched.
+        val tracker = OpenTrackingInputStream(ByteArrayInputStream(ByteArray(0)))
+        val config = ParserConfig().copy(maxArchiveBytes = 1024)
+        val result =
+            extractSafely(
+                PassSource.Stream(tracker, sizeHintBytes = config.maxArchiveBytes + 1),
+                config,
+            )
+        assertExceeded(result, ResourceLimit.ArchiveSize)
+        assertThat(tracker.bytesRead).isEqualTo(0)
+    }
+
+    @Test
+    fun streamingArchiveSizeOverflowFailsEvenWhenSizeHintLies() {
+        // Build a normal-looking archive then claim sizeHint = 0. The streaming bound
+        // catches the overflow on the first read past the cap.
+        val zip =
+            buildArchive {
+                entry("pass.json", ByteArray(2_048) { 0x20 })
+            }
+        val config = ParserConfig().copy(maxArchiveBytes = 64)
+        val result =
+            extractSafely(
+                PassSource.Stream(ByteArrayInputStream(zip), sizeHintBytes = null),
+                config,
+            )
+        assertExceeded(result, ResourceLimit.ArchiveSize)
+    }
+
+    @Test
+    fun bytesArchiveOverCapFailsFast() {
+        val zip = buildArchive { entry("pass.json", ByteArray(4_096) { 0x20 }) }
+        val config = ParserConfig().copy(maxArchiveBytes = 64)
+        val result = extractSafely(PassSource.Bytes(zip), config)
+        assertExceeded(result, ResourceLimit.ArchiveSize)
+    }
+
+    @Test
+    fun oversizedSingleEntryTripsEntrySizeLimit() {
+        val zip = buildArchive { entry("icon.png", ByteArray(8_192) { 0x42 }) }
+        val config = ParserConfig().copy(maxEntryBytes = 1_024)
+        val result = extractSafely(PassSource.Bytes(zip), config)
+        assertExceeded(result, ResourceLimit.EntrySize)
+    }
+
+    @Test
+    fun zipBombStyleHighlyCompressibleEntryHitsEntrySizeLimit() {
+        // 1 MB of zeros compresses to ~1 KB. With maxEntryBytes = 4 KB the decompressed
+        // ceiling trips before the buffer materializes — the canonical zip-bomb guard.
+        val zip = buildArchive { entry("icon.png", ByteArray(1_024 * 1_024)) }
+        val config = ParserConfig().copy(maxArchiveBytes = 64 * 1_024, maxEntryBytes = 4_096)
+        val result = extractSafely(PassSource.Bytes(zip), config)
+        assertExceeded(result, ResourceLimit.EntrySize)
+    }
+
+    @Test
+    fun tooManyEntriesHitsEntryCountLimit() {
+        val zip =
+            buildArchive {
+                entry("pass.json", "{}".toByteArray())
+                entry("manifest.json", "{}".toByteArray())
+                entry("signature", byteArrayOf(1))
+                entry("icon.png", byteArrayOf(1, 2, 3))
+            }
+        val config = ParserConfig().copy(maxEntries = 3)
+        val result = extractSafely(PassSource.Bytes(zip), config)
+        assertExceeded(result, ResourceLimit.EntryCount)
+    }
+
+    @Test
+    fun zipSlipParentTraversalIsRejected() {
+        val zip = buildArchive { entry("../etc/passwd.json", "pwned".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        // Maps to NotAZipArchive until a dedicated PathTraversal arm lands; see follow-up bead.
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun zipSlipMidPathTraversalIsRejected() {
+        val zip = buildArchive { entry("en.lproj/../../etc/passwd.json", "pwned".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun absoluteUnixPathIsRejected() {
+        val zip = buildArchive { entry("/etc/passwd.json", "pwned".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun backslashSeparatorIsRejected() {
+        val zip = buildArchive { entry("..\\windows\\system32\\foo.json", "pwned".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun windowsDriveLetterIsRejected() {
+        val zip = buildArchive { entry("C:/temp/pwn.json", "pwned".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun disallowedExtensionIsRejected() {
+        val zip = buildArchive { entry("evil.html", "<script>".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun executableExtensionIsRejected() {
+        val zip = buildArchive { entry("payload.so", byteArrayOf(0x7F, 0x45, 0x4C, 0x46)) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun extensionMatchingIsCaseInsensitive() {
+        val zip = buildArchive { entry("Icon.PNG", byteArrayOf(0x89.toByte())) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+    }
+
+    @Test
+    fun signatureFileWithoutExtensionIsAllowed() {
+        val zip = buildArchive { entry("signature", byteArrayOf(0x30, 0x82.toByte(), 0x00)) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+        val entries = (result as ExtractResult.Success).entries
+        assertThat(entries.keys).containsExactly("signature")
+    }
+
+    @Test
+    fun nestedSignatureFileNameIsRejected() {
+        // The signature exemption applies only to the top-level basename; an attacker
+        // cannot smuggle in arbitrary content under a nested "signature" path.
+        val zip = buildArchive { entry("nested/signature", byteArrayOf(0x00)) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        // Path is legal, but the file has no allowed extension — extension allowlist trips.
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun duplicateEntryNameIsRejected() {
+        val zip =
+            buildArchiveWithDuplicateEntry(
+                name = "manifest.json",
+                first = "first".toByteArray(),
+                second = "second".toByteArray(),
+            )
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun nonZipBytesReturnNotAZipArchive() {
+        val notAZip = "this is not a zip file at all".toByteArray()
+        val result = extractSafely(PassSource.Bytes(notAZip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun emptyBytesReturnNotAZipArchive() {
+        val result = extractSafely(PassSource.Bytes(ByteArray(0)), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun emptyButValidArchiveSucceedsWithNoEntries() {
+        // A structurally valid but empty zip. pass.json absence is the next slice's
+        // concern; this layer just hands back an empty map.
+        val zip = buildArchive { /* no entries */ }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertThat(result).isInstanceOf(ExtractResult.Success::class.java)
+        assertThat((result as ExtractResult.Success).entries).isEmpty()
+    }
+
+    @Test
+    fun emptyEntryNameIsRejected() {
+        // Some zip toolchains emit a stray "" header for buggy uploaders. Reject.
+        val zip = buildArchive { entry("", byteArrayOf(0)) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    @Test
+    fun emptyPathSegmentIsRejected() {
+        val zip = buildArchive { entry("foo//bar.json", "{}".toByteArray()) }
+        val result = extractSafely(PassSource.Bytes(zip), ParserConfig())
+        assertMalformed(result, MalformedReason.NotAZipArchive)
+    }
+
+    private fun assertMalformed(
+        actual: ExtractResult,
+        expected: MalformedReason,
+    ) {
+        assertThat(actual).isInstanceOf(ExtractResult.Failure::class.java)
+        val reason = (actual as ExtractResult.Failure).reason
+        Truth.assertWithMessage("expected MalformedReason=$expected, got $reason")
+            .that(reason)
+            .isEqualTo(expected)
+    }
+
+    private fun assertExceeded(
+        actual: ExtractResult,
+        expected: ResourceLimit,
+    ) {
+        assertThat(actual).isInstanceOf(ExtractResult.Failure::class.java)
+        val reason = (actual as ExtractResult.Failure).reason
+        assertThat(reason).isInstanceOf(MalformedReason.ResourceLimitExceeded::class.java)
+        val actualLimit = (reason as MalformedReason.ResourceLimitExceeded).limit
+        Truth.assertWithMessage("expected ResourceLimit=$expected, got $actualLimit")
+            .that(actualLimit)
+            .isEqualTo(expected)
+    }
+}
+
+private fun buildArchive(block: ArchiveBuilder.() -> Unit): ByteArray {
+    val baos = ByteArrayOutputStream()
+    ZipOutputStream(baos).use { zos ->
+        ArchiveBuilder(zos).block()
+    }
+    return baos.toByteArray()
+}
+
+private class ArchiveBuilder(private val zos: ZipOutputStream) {
+    fun entry(
+        name: String,
+        content: ByteArray,
+    ) {
+        zos.putNextEntry(ZipEntry(name))
+        zos.write(content)
+        zos.closeEntry()
+    }
+
+    fun directory(name: String) {
+        require(name.endsWith('/')) { "directory entries must end with '/'" }
+        zos.putNextEntry(ZipEntry(name))
+        zos.closeEntry()
+    }
+}
+
+/**
+ * Synthesizes a malformed archive where the same entry name appears twice in the local
+ * file header stream. Approach: build two valid single-entry archives, splice their
+ * local-file-header bodies before the first archive's central directory + EOCD. The JDK's
+ * [ZipOutputStream] rejects duplicate names with a [java.util.zip.ZipException], and the
+ * `--add-opens` configuration needed to clear its private `names` set via reflection is
+ * heavier than the surgery here.
+ *
+ * This is the canonical attack archive for "shadow a legitimate `manifest.json` with a
+ * tampered second copy" — the JDK's [java.util.zip.ZipInputStream] reads local headers
+ * sequentially without consulting the central directory, so without an explicit duplicate
+ * check the second entry would silently win.
+ */
+private fun buildArchiveWithDuplicateEntry(
+    name: String,
+    first: ByteArray,
+    second: ByteArray,
+): ByteArray {
+    val archiveA = buildArchive { entry(name, first) }
+    val archiveB = buildArchive { entry(name, second) }
+    val cdAOffset = findCentralDirectoryOffset(archiveA)
+    val cdBOffset = findCentralDirectoryOffset(archiveB)
+    val out = ByteArrayOutputStream()
+    out.write(archiveA, 0, cdAOffset)
+    out.write(archiveB, 0, cdBOffset)
+    out.write(archiveA, cdAOffset, archiveA.size - cdAOffset)
+    return out.toByteArray()
+}
+
+private fun findCentralDirectoryOffset(bytes: ByteArray): Int {
+    val sig = byteArrayOf(0x50, 0x4B, 0x01, 0x02)
+    for (i in 0..bytes.size - sig.size) {
+        if (matchesAt(bytes, i, sig)) return i
+    }
+    error("no central directory found in synthetic archive — buildArchive output is malformed")
+}
+
+private fun matchesAt(
+    haystack: ByteArray,
+    offset: Int,
+    needle: ByteArray,
+): Boolean {
+    for (k in needle.indices) {
+        if (haystack[offset + k] != needle[k]) return false
+    }
+    return true
+}
+
+/**
+ * Test seam to verify the extractor honors [PassSource]'s "caller owns the stream"
+ * contract. Tracks both bytes pulled and whether [close] was ever called.
+ */
+private class OpenTrackingInputStream(private val delegate: InputStream) : InputStream() {
+    var closed: Boolean = false
+        private set
+    var bytesRead: Long = 0
+        private set
+
+    override fun read(): Int {
+        val b = delegate.read()
+        if (b != -1) bytesRead += 1
+        return b
+    }
+
+    override fun read(
+        b: ByteArray,
+        off: Int,
+        len: Int,
+    ): Int {
+        val n = delegate.read(b, off, len)
+        if (n > 0) bytesRead += n
+        return n
+    }
+
+    override fun close() {
+        closed = true
+        delegate.close()
+    }
+}


### PR DESCRIPTION
## Summary

First slice of the `PassParser` implementation: an internal `extractSafely()` entry point that takes a `PassSource` and returns either a `Map<String, ByteArray>` of safe entries or a `MalformedReason`. Every guard the threat model lists for untrusted PKPASS input is centralized here before any bytes are surfaced to a downstream parser.

`ExtractResult` and `extractSafely` are package-private under `is.walt.passes.core.internal`, so the public API surface from ADR 0001 stays frozen and `PublicApiSurfaceTest` is unchanged.

## Guard surface

- **Magic-byte preflight.** `ZipInputStream` silently treats unrecognized leading bytes as 'no entries', which would let raw garbage and 0-byte input round-trip as `Success(empty)`. The first 4 bytes are sniffed and anything that isn't `PK\x03\x04` (local file header) or `PK\x05\x06` (end-of-central-directory; legitimately empty archive) is rejected.
- **Archive size** (compressed). Checked twice: up-front against the declared size from `PassSource.Bytes` length / `PassSource.Stream.sizeHintBytes`, then again at streaming time via a `BoundedInputStream` that throws on overflow. The streaming check is load-bearing because a hostile `Stream` source can lie about its declared size.
- **Entry count** capped via `ParserConfig.maxEntries`. Directory entries are skipped before counting so a bag of nested `.lproj/` directories cannot push a real archive past the cap.
- **Per-entry decompressed size** capped via `ParserConfig.maxEntryBytes`. This is the zip-bomb guard: a 10 KB compressed entry that decompresses to 10 GB hits the cap and aborts before the buffer materializes.
- **Path traversal (zip-slip).** Rejects `..` and `.` segments, leading `/`, backslashes, Windows drive-letter prefixes, and empty path segments. Structural; no file-system canonicalization, because we never touch the file system.
- **Extension allowlist.** Entry names must end in `.json`, `.png`, or `.strings`, OR be exactly `signature` at the archive root (the PKCS#7 detached-signature blob has no extension by PKPASS convention; the exemption is intentionally root-only so an attacker can't smuggle arbitrary content under a nested `signature` name).
- **Duplicate entry names** rejected. PKPASS does not permit duplicates and `ZipInputStream` would silently let the second one win, which would let an attacker shadow a legitimate `manifest.json` with a tampered second copy.
- **In-memory only.** No `FileOutputStream` is ever opened on an entry name. The entire archive is materialized into a `Map<String, ByteArray>` bounded by the per-entry cap.

## Out of scope (follow-up beads)

- `PassParser.create()` factory wiring (parser-glue bead).
- `pass.json` deserialization, manifest hash chain, PKCS#7 signature verification, `.strings` parsing.
- Coroutine timeouts around parsing.
- Dedicated `MalformedReason` arm for structural rejections (path traversal / disallowed extension / duplicate entry); currently surfaced as `MalformedReason.NotAZipArchive` because the public surface is frozen for this slice. Tracked in **wpass-n6g**.
- Explicit symlink rejection. JDK-only zip APIs don't expose the file-mode bits used to detect Info-ZIP symlinks (those live in the central directory, which `ZipInputStream` never reads). In-memory-only extraction + path-traversal + extension allowlist are sufficient for the trust claim today; **wpass-n6g** also captures the option to swap in a parser that exposes external attributes.

## Test plan

- [x] `./gradlew :passes-core:check` (test + ktlint, both green)
- [x] `./gradlew :passes-core:detekt` green
- [x] 25 new table-driven tests in `SafeArchiveExtractorTest` cover every guard above (happy path, all four resource limits, every path-traversal shape, disallowed extension, duplicate entry, signature-no-extension allowance, nested-signature rejection, magic-byte preflight, stream lifecycle).
- [x] Existing `PublicApiSurfaceTest` (13 cases) still passes unchanged - public surface is frozen.

Closes wpass-8so. Follow-up: wpass-n6g.