### PR TITLE
passes-core: pass.json deserialization slice (wpass-7sl)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/JsonLimitTokenizer.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/JsonLimitTokenizer.kt
@@ -1,0 +1,98 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.ParserConfig
+
+/**
+ * Defensive ceiling check the kotlinx parser does not natively enforce. Iterates
+ * source bytes once, tracking nesting depth and the byte length of in-progress JSON
+ * string tokens. ASCII-byte scanning is safe over UTF-8: continuation bytes
+ * (`0x80..0xBF`) cannot collide with `{`, `}`, `[`, `]`, `"`, or `\`.
+ *
+ * String byte-counting uses source bytes (overcount by escape-sequence shrinkage),
+ * not decoded character bytes — the guard's intent is to bound JSON-bomb expansion
+ * before allocation, and the overcount is conservative (never lets an over-budget
+ * string through). Returns `null` on success, or the first arm that tripped. JSON
+ * well-formedness is intentionally not verified here — kotlinx.serialization handles
+ * that downstream — so an unbalanced bracket pair sails through here and surfaces as
+ * [PassJsonFailure.InvalidJson] from the typed parse.
+ */
+internal fun enforceJsonLimits(
+    bytes: ByteArray,
+    config: ParserConfig,
+): PassJsonFailure? {
+    val state =
+        JsonLimitTokenizer(
+            maxDepth = config.maxJsonDepth,
+            maxStringBytes = config.maxJsonStringBytes,
+        )
+    var i = 0
+    while (i < bytes.size && state.failure == null) {
+        state.consume(bytes[i])
+        i++
+    }
+    return state.failure
+}
+
+private class JsonLimitTokenizer(
+    private val maxDepth: Int,
+    private val maxStringBytes: Int,
+) {
+    var failure: PassJsonFailure? = null
+        private set
+
+    private var depth = 0
+    private var inString = false
+    private var stringByteCount = 0
+    private var escape = false
+
+    fun consume(b: Byte) {
+        if (inString) consumeInString(b) else consumeOutsideString(b)
+    }
+
+    private fun consumeInString(b: Byte) {
+        when {
+            escape -> {
+                escape = false
+                bumpStringByte()
+            }
+            b == BACKSLASH -> {
+                escape = true
+                bumpStringByte()
+            }
+            b == DOUBLE_QUOTE -> inString = false
+            else -> bumpStringByte()
+        }
+    }
+
+    private fun consumeOutsideString(b: Byte) {
+        when (b) {
+            DOUBLE_QUOTE -> {
+                inString = true
+                stringByteCount = 0
+            }
+            LBRACE, LBRACKET -> {
+                depth++
+                if (depth > maxDepth) failure = PassJsonFailure.JsonDepthExceeded
+            }
+            // Clamp at zero. A payload with stray leading closers (`}}}{...`) would
+            // otherwise drive depth negative, then climb back, leaving the in-flight
+            // peak at `maxDepth + leadingClosers` rather than `maxDepth`. kotlinx
+            // rejects the mismatched JSON downstream and the entry-size cap bounds
+            // it in practice, but the invariant `0 <= depth <= maxDepth` is cheap
+            // to keep and removes any reliance on those downstream bounds.
+            RBRACE, RBRACKET -> if (depth > 0) depth--
+        }
+    }
+
+    private fun bumpStringByte() {
+        stringByteCount++
+        if (stringByteCount > maxStringBytes) failure = PassJsonFailure.JsonStringTooLong
+    }
+}
+
+private const val DOUBLE_QUOTE: Byte = 0x22
+private const val BACKSLASH: Byte = 0x5C
+private const val LBRACE: Byte = 0x7B
+private const val RBRACE: Byte = 0x7D
+private const val LBRACKET: Byte = 0x5B
+private const val RBRACKET: Byte = 0x5D

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecodeResult.kt
@@ -5,18 +5,14 @@ import `is`.walt.passes.core.Pass
 /**
  * Outcome of running [decodePassJson] over the entries map produced by [extractSafely].
  * Internal only: the parser-glue bead lifts a [Failed] into the right
- * [`is`.walt.passes.core.ParseResult] arm. The arm split is finer-grained than the
- * frozen public [`is`.walt.passes.core.MalformedReason] surface so the resource-limit
- * arms (`JsonDepthExceeded`, `JsonStringTooLong`) can route to
- * [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded] with the right
- * [`is`.walt.passes.core.ResourceLimit] without re-deriving it from a stringy reason,
- * and the unsupported arms (`UnknownFormatVersion`, `UnknownPassStyle`) can route to
- * [`is`.walt.passes.core.ParseResult.Unsupported] without collapsing onto malformedness.
+ * [`is`.walt.passes.core.ParseResult] arm. The arm split on [PassJsonFailure] is finer
+ * than the public surface so each failure routes independently — see [PassJsonFailure]
+ * for the routing rationale.
  *
  * [Ok.pass] is constructed with `images = emptyMap()` and `locales = emptyMap()` —
  * pass.json carries no image bytes and no per-locale `.strings` files. The parser-glue
- * bead populates those from the entries map at the same layer that owns image bounding
- * and `.strings` parsing, so this slice does not have to know about them.
+ * bead populates those at the same layer that owns image bounding and `.strings`
+ * parsing.
  */
 internal sealed interface PassJsonDecodeResult {
     data class Ok(val pass: Pass) : PassJsonDecodeResult
@@ -25,34 +21,16 @@ internal sealed interface PassJsonDecodeResult {
 }
 
 /**
- * Why [decodePassJson] rejected a `pass.json` payload. The arms partition along the
- * same trust / structural / unsupported axis the public
- * [`is`.walt.passes.core.ParseResult] uses, but at finer granularity so the parser-glue
- * bead can route each arm independently:
- *
- *  - [Missing] / [InvalidJson] / [InvalidShape] are structural — pass.json is absent or
- *    its bytes are not parseable as the expected object shape. The parser-glue bead
- *    routes [Missing] to [`is`.walt.passes.core.MalformedReason.MissingPassJson] and the
- *    other two to [`is`.walt.passes.core.MalformedReason.InvalidPassJson].
- *  - [JsonDepthExceeded] / [JsonStringTooLong] are resource-limit hits — pass.json is
- *    syntactically reasonable but exceeds [`is`.walt.passes.core.ParserConfig] guards.
- *    The parser-glue bead routes them to
- *    [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded] with
- *    [`is`.walt.passes.core.ResourceLimit.JsonDepth] /
- *    [`is`.walt.passes.core.ResourceLimit.JsonStringSize].
- *  - [UnknownFormatVersion] / [UnknownPassStyle] are unsupported — pass.json is well
- *    formed but uses a feature this parser does not implement. The parser-glue bead
- *    routes them to [`is`.walt.passes.core.ParseResult.Unsupported] with
- *    [`is`.walt.passes.core.UnsupportedReason.FormatVersion] /
- *    [`is`.walt.passes.core.UnsupportedReason.UnknownPassStyle].
- *
- * Why split the resource-limit arms here rather than collapsing them onto [InvalidShape]
- * and inferring later: the parser-glue bead has no visibility into which limit tripped
- * once the bytes have been discarded. Surfacing the arm here lets it map straight onto
- * the public [`is`.walt.passes.core.ResourceLimit] enum without reparse heuristics.
+ * Why [decodePassJson] rejected a `pass.json` payload. Arms are deliberately finer-
+ * grained than the public [`is`.walt.passes.core.MalformedReason] /
+ * [`is`.walt.passes.core.UnsupportedReason] surface so the parser-glue bead can route
+ * each failure independently without re-deriving it from a stringy reason once the
+ * bytes have been discarded — in particular, the resource-limit arms surface which
+ * [`is`.walt.passes.core.ResourceLimit] tripped, and the unsupported arms stay out of
+ * the malformedness bucket.
  */
 internal sealed interface PassJsonFailure {
-    /** The entries map handed back by [extractSafely] does not contain `pass.json`. */
+    /** No `pass.json` entry in the entries map. */
     data object Missing : PassJsonFailure
 
     /** `pass.json` is present but its bytes are not parseable as JSON. */
@@ -60,50 +38,35 @@ internal sealed interface PassJsonFailure {
 
     /**
      * `pass.json` parses but is structurally not a PKPASS pass: top-level is not an
-     * object, a required field is missing, or a typed field carries the wrong JSON
-     * kind (e.g. a field-row entry is a string instead of an object).
+     * object, a required field is missing, two pass-style keys are present, or a
+     * typed field carries the wrong JSON kind.
      */
     data object InvalidShape : PassJsonFailure
 
     /**
-     * The pre-pass JSON tokenizer observed an open-bracket nesting level greater than
-     * [`is`.walt.passes.core.ParserConfig.maxJsonDepth]. Surfaced here rather than from
-     * the kotlinx.serialization decoder because the kotlinx parser does not enforce a
-     * depth limit natively, and post-validating the parsed tree is too late — a
-     * deeply-nested adversarial payload has already been allocated by the time the
-     * tree is constructed.
+     * Pre-pass tokenizer observed nesting deeper than
+     * [`is`.walt.passes.core.ParserConfig.maxJsonDepth].
      */
     data object JsonDepthExceeded : PassJsonFailure
 
     /**
-     * The pre-pass tokenizer observed a JSON string token whose source-byte length
-     * exceeded [`is`.walt.passes.core.ParserConfig.maxJsonStringBytes]. Source-byte
-     * length is a slight overcount of the decoded value (escape sequences expand to
-     * fewer bytes), but the guard's intent is to bound JSON-bomb expansion, and the
-     * overcount is conservative — never letting an over-budget string through. Same
-     * pre-pass rationale as [JsonDepthExceeded].
+     * Pre-pass tokenizer observed a string token longer than
+     * [`is`.walt.passes.core.ParserConfig.maxJsonStringBytes].
      */
     data object JsonStringTooLong : PassJsonFailure
 
     /**
-     * `pass.json` declares a `formatVersion` that is not `1`. PKPASS has only ever
-     * defined version 1; surfaced as a distinct arm so a future spec bump shows up
-     * as an unsupported feature, not as malformedness.
-     *
-     * [version] is `0` if `formatVersion` was missing or non-integer — pass.json is
-     * malformed in that case, but a missing version is operationally a "format we
-     * cannot understand", which is the same UI surface as a future version we do not
-     * implement. The parser-glue bead can choose to coalesce missing-version onto
-     * `InvalidPassJson` if that fits the UI better; the failure is preserved here.
+     * `formatVersion` is not `1`. [version] is `0` if `formatVersion` was missing or
+     * non-integer; the parser-glue bead can choose to coalesce that onto
+     * `InvalidPassJson` if the UI calls for it.
      */
     data class UnknownFormatVersion(val version: Int) : PassJsonFailure
 
     /**
-     * `pass.json` does not declare any of the five known top-level pass styles
-     * (`boardingPass`, `eventTicket`, `coupon`, `storeCard`, `generic`). [raw] is the
-     * first object-valued top-level key that is not in the known-style or
-     * known-non-style allowlist, or `""` when no plausible-shape candidate is
-     * present.
+     * No known top-level pass style (`boardingPass`, `eventTicket`, `coupon`,
+     * `storeCard`, `generic`) is declared. [raw] is the first object-valued top-level
+     * key not on the known-style or known-non-style allowlist, or `""` when no
+     * plausible candidate is present.
      */
     data class UnknownPassStyle(val raw: String) : PassJsonFailure
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecodeResult.kt
@@ -1,0 +1,109 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.Pass
+
+/**
+ * Outcome of running [decodePassJson] over the entries map produced by [extractSafely].
+ * Internal only: the parser-glue bead lifts a [Failed] into the right
+ * [`is`.walt.passes.core.ParseResult] arm. The arm split is finer-grained than the
+ * frozen public [`is`.walt.passes.core.MalformedReason] surface so the resource-limit
+ * arms (`JsonDepthExceeded`, `JsonStringTooLong`) can route to
+ * [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded] with the right
+ * [`is`.walt.passes.core.ResourceLimit] without re-deriving it from a stringy reason,
+ * and the unsupported arms (`UnknownFormatVersion`, `UnknownPassStyle`) can route to
+ * [`is`.walt.passes.core.ParseResult.Unsupported] without collapsing onto malformedness.
+ *
+ * [Ok.pass] is constructed with `images = emptyMap()` and `locales = emptyMap()` —
+ * pass.json carries no image bytes and no per-locale `.strings` files. The parser-glue
+ * bead populates those from the entries map at the same layer that owns image bounding
+ * and `.strings` parsing, so this slice does not have to know about them.
+ */
+internal sealed interface PassJsonDecodeResult {
+    data class Ok(val pass: Pass) : PassJsonDecodeResult
+
+    data class Failed(val failure: PassJsonFailure) : PassJsonDecodeResult
+}
+
+/**
+ * Why [decodePassJson] rejected a `pass.json` payload. The arms partition along the
+ * same trust / structural / unsupported axis the public
+ * [`is`.walt.passes.core.ParseResult] uses, but at finer granularity so the parser-glue
+ * bead can route each arm independently:
+ *
+ *  - [Missing] / [InvalidJson] / [InvalidShape] are structural — pass.json is absent or
+ *    its bytes are not parseable as the expected object shape. The parser-glue bead
+ *    routes [Missing] to [`is`.walt.passes.core.MalformedReason.MissingPassJson] and the
+ *    other two to [`is`.walt.passes.core.MalformedReason.InvalidPassJson].
+ *  - [JsonDepthExceeded] / [JsonStringTooLong] are resource-limit hits — pass.json is
+ *    syntactically reasonable but exceeds [`is`.walt.passes.core.ParserConfig] guards.
+ *    The parser-glue bead routes them to
+ *    [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded] with
+ *    [`is`.walt.passes.core.ResourceLimit.JsonDepth] /
+ *    [`is`.walt.passes.core.ResourceLimit.JsonStringSize].
+ *  - [UnknownFormatVersion] / [UnknownPassStyle] are unsupported — pass.json is well
+ *    formed but uses a feature this parser does not implement. The parser-glue bead
+ *    routes them to [`is`.walt.passes.core.ParseResult.Unsupported] with
+ *    [`is`.walt.passes.core.UnsupportedReason.FormatVersion] /
+ *    [`is`.walt.passes.core.UnsupportedReason.UnknownPassStyle].
+ *
+ * Why split the resource-limit arms here rather than collapsing them onto [InvalidShape]
+ * and inferring later: the parser-glue bead has no visibility into which limit tripped
+ * once the bytes have been discarded. Surfacing the arm here lets it map straight onto
+ * the public [`is`.walt.passes.core.ResourceLimit] enum without reparse heuristics.
+ */
+internal sealed interface PassJsonFailure {
+    /** The entries map handed back by [extractSafely] does not contain `pass.json`. */
+    data object Missing : PassJsonFailure
+
+    /** `pass.json` is present but its bytes are not parseable as JSON. */
+    data object InvalidJson : PassJsonFailure
+
+    /**
+     * `pass.json` parses but is structurally not a PKPASS pass: top-level is not an
+     * object, a required field is missing, or a typed field carries the wrong JSON
+     * kind (e.g. a field-row entry is a string instead of an object).
+     */
+    data object InvalidShape : PassJsonFailure
+
+    /**
+     * The pre-pass JSON tokenizer observed an open-bracket nesting level greater than
+     * [`is`.walt.passes.core.ParserConfig.maxJsonDepth]. Surfaced here rather than from
+     * the kotlinx.serialization decoder because the kotlinx parser does not enforce a
+     * depth limit natively, and post-validating the parsed tree is too late — a
+     * deeply-nested adversarial payload has already been allocated by the time the
+     * tree is constructed.
+     */
+    data object JsonDepthExceeded : PassJsonFailure
+
+    /**
+     * The pre-pass tokenizer observed a JSON string token whose source-byte length
+     * exceeded [`is`.walt.passes.core.ParserConfig.maxJsonStringBytes]. Source-byte
+     * length is a slight overcount of the decoded value (escape sequences expand to
+     * fewer bytes), but the guard's intent is to bound JSON-bomb expansion, and the
+     * overcount is conservative — never letting an over-budget string through. Same
+     * pre-pass rationale as [JsonDepthExceeded].
+     */
+    data object JsonStringTooLong : PassJsonFailure
+
+    /**
+     * `pass.json` declares a `formatVersion` that is not `1`. PKPASS has only ever
+     * defined version 1; surfaced as a distinct arm so a future spec bump shows up
+     * as an unsupported feature, not as malformedness.
+     *
+     * [version] is `0` if `formatVersion` was missing or non-integer — pass.json is
+     * malformed in that case, but a missing version is operationally a "format we
+     * cannot understand", which is the same UI surface as a future version we do not
+     * implement. The parser-glue bead can choose to coalesce missing-version onto
+     * `InvalidPassJson` if that fits the UI better; the failure is preserved here.
+     */
+    data class UnknownFormatVersion(val version: Int) : PassJsonFailure
+
+    /**
+     * `pass.json` does not declare any of the five known top-level pass styles
+     * (`boardingPass`, `eventTicket`, `coupon`, `storeCard`, `generic`). [raw] is the
+     * first object-valued top-level key that is not in the known-style or
+     * known-non-style allowlist, or `""` when no plausible-shape candidate is
+     * present.
+     */
+    data class UnknownPassStyle(val raw: String) : PassJsonFailure
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecoder.kt
@@ -1,0 +1,460 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.TextAlignment
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+import java.time.OffsetDateTime
+
+/**
+ * Deserializes `pass.json` from the entries map produced by [extractSafely] into the
+ * subset of the public [Pass] model that pass.json is responsible for. Pure function:
+ * no I/O, no mutation of [entries], no allocation outside the [Pass] it returns.
+ *
+ * The returned [Pass] has `images = emptyMap()` and `locales = emptyMap()` — those come
+ * from other entries in the archive (image bytes and `<locale>.lproj/pass.strings`
+ * respectively) and are wired in by the parser-glue bead that owns image bounding and
+ * `.strings` parsing. Surfacing them as empty here keeps this slice focused on the
+ * pass.json layer; the parser-glue bead will `pass.copy(images = ..., locales = ...)`.
+ *
+ * **Defense-in-depth ordering.** The function runs three layers, in order, and the
+ * earliest-firing arm wins:
+ *
+ *  1. Missing-entry check — fail fast with [PassJsonFailure.Missing]; nothing else can
+ *     run if the bytes are absent.
+ *  2. Pre-pass tokenizer ([enforceJsonLimits]) — enforces
+ *     [ParserConfig.maxJsonDepth] / [ParserConfig.maxJsonStringBytes] before
+ *     kotlinx.serialization gets the bytes. kotlinx does not enforce these natively,
+ *     and post-validating a parsed tree is too late: a 1 GiB string or a 10 000-deep
+ *     nesting has already allocated by the time the tree exists.
+ *  3. Strict kotlinx parse + structural mapping — `isLenient = false`,
+ *     `ignoreUnknownKeys = true`. Lenient mode is off so unquoted keys / single quotes
+ *     fail as [PassJsonFailure.InvalidJson]; unknown-keys is on so PKPASS spec
+ *     additions (Apple has added top-level keys over the format's lifetime) do not
+ *     break consumers.
+ *
+ * **Dangerous fields.** `nfc`, `webServiceURL`, `authenticationToken`, `personalization`
+ * and `personalizationToken` are intentionally not surfaced on the returned [Pass] per
+ * decision-wlt-0tn-q1: parsed (so they cannot trip strict-mode failures) but discarded
+ * (so consumers cannot accidentally render or transmit them). The "parsed and dropped"
+ * shape is structural — there are simply no fields on [Pass] for them — rather than a
+ * runtime stripping pass, which keeps the trust claim auditable from the data model
+ * alone.
+ *
+ * **Unknown style key.** When `pass.json` is structurally valid but declares no top-
+ * level pass style this parser implements (a hypothetical future `ssoPass` etc.), the
+ * function returns [PassJsonFailure.UnknownPassStyle] with the first non-allowlisted
+ * object-valued top-level key. The allowlist of "known non-style object-valued keys"
+ * ([KNOWN_NON_STYLE_OBJECT_KEYS]) is intentionally conservative — only those keys we
+ * have observed in real PKPASS payloads or the Apple spec — so a new metadata key
+ * spec'd by Apple in future could initially surface as `UnknownPassStyle`. That is
+ * acceptable: a false positive surfaces as "this parser is too old"; a false negative
+ * would lose a future style entirely.
+ */
+internal fun decodePassJson(
+    entries: Map<String, ByteArray>,
+    config: ParserConfig,
+): PassJsonDecodeResult {
+    val bytes =
+        entries[PASS_JSON_FILE_NAME]
+            ?: return PassJsonDecodeResult.Failed(PassJsonFailure.Missing)
+    val limitFailure = enforceJsonLimits(bytes, config)
+    return limitFailure?.let { PassJsonDecodeResult.Failed(it) }
+        ?: parseAndMap(bytes)
+}
+
+private fun parseAndMap(bytes: ByteArray): PassJsonDecodeResult {
+    val root =
+        runCatching { PASS_JSON.parseToJsonElement(bytes.decodeToString()) as? JsonObject }
+            .getOrNull()
+            ?: return PassJsonDecodeResult.Failed(PassJsonFailure.InvalidJson)
+    val versionFailure = checkVersion(root)
+    return versionFailure?.let { PassJsonDecodeResult.Failed(it) }
+        ?: resolveAndAssemble(root)
+}
+
+private fun checkVersion(root: JsonObject): PassJsonFailure? {
+    val version = (root[FIELD_FORMAT_VERSION] as? JsonPrimitive)?.intOrNull
+    return if (version == PKPASS_FORMAT_VERSION) null else PassJsonFailure.UnknownFormatVersion(version ?: 0)
+}
+
+private fun resolveAndAssemble(root: JsonObject): PassJsonDecodeResult =
+    when (val style = resolveStyle(root)) {
+        is StyleResolution.Multiple -> PassJsonDecodeResult.Failed(PassJsonFailure.InvalidShape)
+        is StyleResolution.Unknown -> PassJsonDecodeResult.Failed(PassJsonFailure.UnknownPassStyle(style.raw))
+        is StyleResolution.Found ->
+            assemblePass(root, style)
+                ?.let { PassJsonDecodeResult.Ok(it) }
+                ?: PassJsonDecodeResult.Failed(PassJsonFailure.InvalidShape)
+    }
+
+private fun assemblePass(
+    root: JsonObject,
+    style: StyleResolution.Found,
+): Pass? {
+    val serial = root.stringFieldOrNull(FIELD_SERIAL_NUMBER)
+    val description = root.stringFieldOrNull(FIELD_DESCRIPTION)
+    val organization = root.stringFieldOrNull(FIELD_ORGANIZATION_NAME)
+    val expiration = parseExpiration(root[FIELD_EXPIRATION_DATE])
+    if (expiration is ExpirationParse.Malformed) return null
+    // Three-condition guard kept under detekt's complexity threshold by splitting the
+    // expiration check above; the smart-cast branch below is single-expression so
+    // ReturnCount stays at 2.
+    return if (serial != null && description != null && organization != null) {
+        Pass(
+            type = style.type,
+            serialNumber = serial,
+            description = description,
+            organizationName = organization,
+            expirationDate = (expiration as? ExpirationParse.Ok)?.instant,
+            voided = (root[FIELD_VOIDED] as? JsonPrimitive)?.booleanOrNull ?: false,
+            colors =
+                PassColors(
+                    foreground = parseColor(root.stringFieldOrNull(FIELD_FOREGROUND_COLOR)),
+                    background = parseColor(root.stringFieldOrNull(FIELD_BACKGROUND_COLOR)),
+                    label = parseColor(root.stringFieldOrNull(FIELD_LABEL_COLOR)),
+                ),
+            frontFields =
+                PassFields(
+                    header = parseFieldList(style.node[FIELD_HEADER_FIELDS]),
+                    primary = parseFieldList(style.node[FIELD_PRIMARY_FIELDS]),
+                    secondary = parseFieldList(style.node[FIELD_SECONDARY_FIELDS]),
+                    auxiliary = parseFieldList(style.node[FIELD_AUXILIARY_FIELDS]),
+                ),
+            backFields = parseFieldList(style.node[FIELD_BACK_FIELDS]),
+            barcode = parseBarcode(root),
+            images = emptyMap(),
+            locales = emptyMap(),
+        )
+    } else {
+        null
+    }
+}
+
+/**
+ * Returns the resolved style with its sub-object, or a discriminated reason it could
+ * not be resolved. Keeping the four-state outcome (Found / Multiple / Unknown-with-hint
+ * / no-hint) in one type lets the caller map cleanly to the right [PassJsonFailure]
+ * arm without re-scanning the JSON.
+ *
+ * In the no-style branch, the first object-valued top-level key not on the known-style
+ * or known-non-style allowlist is surfaced as the unknown-style hint. `firstNotNullOf`
+ * over the entries gives the first-in-iteration-order semantics required for stable
+ * UnknownPassStyle reporting and avoids a multi-jump loop body.
+ */
+private fun resolveStyle(root: JsonObject): StyleResolution {
+    val present = STYLE_KEY_TO_TYPE.entries.filter { root[it.key] is JsonObject }
+    return when {
+        present.size == 1 -> {
+            val entry = present.single()
+            StyleResolution.Found(entry.value, root[entry.key] as JsonObject)
+        }
+        present.size > 1 -> StyleResolution.Multiple
+        else -> {
+            val hint =
+                root.entries.firstNotNullOfOrNull { (k, v) ->
+                    val isStyleCandidate =
+                        v is JsonObject && k !in STYLE_KEY_TO_TYPE && k !in KNOWN_NON_STYLE_OBJECT_KEYS
+                    if (isStyleCandidate) k else null
+                } ?: ""
+            StyleResolution.Unknown(hint)
+        }
+    }
+}
+
+/**
+ * Three-state expiration parse: distinguishes "absent" from "present-but-malformed",
+ * which [assemblePass] needs in order to fail an unparseable expirationDate as
+ * [PassJsonFailure.InvalidShape] (rather than silently dropping a security-relevant
+ * validity window).
+ */
+private fun parseExpiration(probe: JsonElement?): ExpirationParse {
+    if (probe == null || probe is JsonNull) return ExpirationParse.Absent
+    val text = (probe as? JsonPrimitive)?.takeIf { it.isString }?.content
+    return text?.let {
+        runCatching { OffsetDateTime.parse(it).toInstant().toEpochMilli() }
+            .map { ms -> ExpirationParse.Ok(PassInstant(ms)) as ExpirationParse }
+            .getOrDefault(ExpirationParse.Malformed)
+    } ?: ExpirationParse.Malformed
+}
+
+/**
+ * Accepts both `rgb(R,G,B)` (Apple's preferred encoding for `*Color` fields) and
+ * `#RRGGBB` (legacy / hand-authored passes). Returns `null` for `null` input or any
+ * unrecognized form so the caller can default to "no color set" without a try/catch.
+ */
+private fun parseColor(text: String?): ColorValue? {
+    val trimmed = text?.trim() ?: return null
+    val rgb = RGB_REGEX.matchEntire(trimmed)?.let(::rgbMatchToColor)
+    return rgb
+        ?: HEX_REGEX.matchEntire(trimmed)?.groupValues?.get(1)?.toIntOrNull(HEX_RADIX)?.let(::ColorValue)
+}
+
+private fun rgbMatchToColor(match: MatchResult): ColorValue? {
+    val r = match.groupValues[1].toIntOrNull()?.takeIf { it in 0..MAX_COLOR_COMPONENT }
+    val g = match.groupValues[2].toIntOrNull()?.takeIf { it in 0..MAX_COLOR_COMPONENT }
+    val b = match.groupValues[3].toIntOrNull()?.takeIf { it in 0..MAX_COLOR_COMPONENT }
+    if (r == null || g == null || b == null) return null
+    val red = r shl RED_SHIFT
+    val green = g shl GREEN_SHIFT
+    return ColorValue(red or green or b)
+}
+
+private fun parseFieldList(node: JsonElement?): List<PassField> {
+    val array = node as? JsonArray ?: return emptyList()
+    return array.mapNotNull { element ->
+        val obj = element as? JsonObject
+        val key = obj?.stringFieldOrNull(FIELD_KEY)
+        val rawValue = obj?.get(FIELD_VALUE) as? JsonPrimitive
+        val value = rawValue?.takeIf { it !is JsonNull }?.content
+        if (obj == null || key == null || value == null) {
+            null
+        } else {
+            PassField(
+                key = key,
+                label = obj.stringFieldOrNull(FIELD_LABEL),
+                value = value,
+                textAlignment =
+                    obj.stringFieldOrNull(FIELD_TEXT_ALIGNMENT)
+                        ?.let(TEXT_ALIGNMENT_MAP::get)
+                        ?: TextAlignment.Natural,
+            )
+        }
+    }
+}
+
+/**
+ * Prefers the modern `barcodes[0]` (PKPASS spec since iOS 9) over the legacy `barcode`
+ * scalar. A barcode entry that fails to map (unknown format, missing required field)
+ * is silently dropped from `barcodes` so a single bad entry does not kill the whole
+ * pass; the legacy `barcode` scalar acts as a fallback. If neither resolves, the pass
+ * surfaces with `barcode = null`.
+ */
+private fun parseBarcode(root: JsonObject): Barcode? {
+    val fromArray =
+        (root[FIELD_BARCODES] as? JsonArray)
+            ?.firstNotNullOfOrNull { (it as? JsonObject)?.let(::parseBarcodeNode) }
+    return fromArray ?: (root[FIELD_BARCODE] as? JsonObject)?.let(::parseBarcodeNode)
+}
+
+private fun parseBarcodeNode(node: JsonObject): Barcode? {
+    val format = node.stringFieldOrNull(FIELD_FORMAT)?.let(BARCODE_FORMAT_MAP::get)
+    val message = node.stringFieldOrNull(FIELD_MESSAGE)
+    val encoding = node.stringFieldOrNull(FIELD_MESSAGE_ENCODING)
+    if (format == null || message == null || encoding == null) return null
+    return Barcode(
+        format = format,
+        message = message,
+        messageEncoding = encoding,
+        altText = node.stringFieldOrNull(FIELD_ALT_TEXT),
+    )
+}
+
+private fun JsonObject.stringFieldOrNull(name: String): String? {
+    val v = this[name] as? JsonPrimitive ?: return null
+    return if (v.isString) v.content else null
+}
+
+private sealed interface StyleResolution {
+    data class Found(val type: PassType, val node: JsonObject) : StyleResolution
+
+    data class Unknown(val raw: String) : StyleResolution
+
+    data object Multiple : StyleResolution
+}
+
+private sealed interface ExpirationParse {
+    data object Absent : ExpirationParse
+
+    data object Malformed : ExpirationParse
+
+    data class Ok(val instant: PassInstant) : ExpirationParse
+}
+
+/**
+ * Defensive ceiling check the kotlinx parser does not natively enforce. Iterates
+ * source bytes once, tracking nesting depth and the byte length of in-progress JSON
+ * string tokens. ASCII-byte scanning is safe over UTF-8: continuation bytes
+ * (`0x80..0xBF`) cannot collide with `{`, `}`, `[`, `]`, `"`, or `\`.
+ *
+ * String byte-counting uses source bytes (overcount by escape-sequence shrinkage),
+ * not decoded character bytes — the guard's intent is to bound JSON-bomb expansion
+ * before allocation, and the overcount is conservative (never lets an over-budget
+ * string through). Returns `null` on success, or the first arm that tripped. JSON
+ * well-formedness is intentionally not verified here — kotlinx.serialization handles
+ * that downstream — so an unbalanced bracket pair sails through here and surfaces as
+ * [PassJsonFailure.InvalidJson] from the typed parse.
+ */
+private fun enforceJsonLimits(
+    bytes: ByteArray,
+    config: ParserConfig,
+): PassJsonFailure? {
+    val state = JsonLimitTokenizer(maxDepth = config.maxJsonDepth, maxStringBytes = config.maxJsonStringBytes)
+    var i = 0
+    while (i < bytes.size && state.failure == null) {
+        state.consume(bytes[i])
+        i++
+    }
+    return state.failure
+}
+
+private class JsonLimitTokenizer(
+    private val maxDepth: Int,
+    private val maxStringBytes: Int,
+) {
+    var failure: PassJsonFailure? = null
+        private set
+
+    private var depth = 0
+    private var inString = false
+    private var stringByteCount = 0
+    private var escape = false
+
+    fun consume(b: Byte) {
+        if (inString) consumeInString(b) else consumeOutsideString(b)
+    }
+
+    private fun consumeInString(b: Byte) {
+        when {
+            escape -> {
+                escape = false
+                bumpStringByte()
+            }
+            b == BACKSLASH -> {
+                escape = true
+                bumpStringByte()
+            }
+            b == DOUBLE_QUOTE -> inString = false
+            else -> bumpStringByte()
+        }
+    }
+
+    private fun consumeOutsideString(b: Byte) {
+        when (b) {
+            DOUBLE_QUOTE -> {
+                inString = true
+                stringByteCount = 0
+            }
+            LBRACE, LBRACKET -> {
+                depth++
+                if (depth > maxDepth) failure = PassJsonFailure.JsonDepthExceeded
+            }
+            RBRACE, RBRACKET -> depth--
+        }
+    }
+
+    private fun bumpStringByte() {
+        stringByteCount++
+        if (stringByteCount > maxStringBytes) failure = PassJsonFailure.JsonStringTooLong
+    }
+}
+
+private val PASS_JSON: Json =
+    Json {
+        isLenient = false
+        ignoreUnknownKeys = true
+    }
+
+private val STYLE_KEY_TO_TYPE: Map<String, PassType> =
+    linkedMapOf(
+        "boardingPass" to PassType.BoardingPass,
+        "eventTicket" to PassType.EventTicket,
+        "coupon" to PassType.Coupon,
+        "storeCard" to PassType.StoreCard,
+        "generic" to PassType.Generic,
+    )
+
+/**
+ * Top-level pass.json keys whose values are JSON objects but which are not pass-style
+ * keys. Used to skip past these when scanning for an unknown-style key, so a payload
+ * that omits all five known styles surfaces a meaningful raw key in
+ * [PassJsonFailure.UnknownPassStyle] rather than e.g. "userInfo".
+ *
+ * The list is intentionally narrow: only keys we know to be object-valued in real
+ * PKPASS payloads. A future Apple-spec'd object-valued metadata key not on the list
+ * would surface here as an unknown style — a tolerable false positive (UI says
+ * "this parser is too old"), and far less harmful than the false-negative direction
+ * (silently lose a future pass style entirely).
+ */
+private val KNOWN_NON_STYLE_OBJECT_KEYS: Set<String> =
+    setOf(
+        "nfc",
+        "personalization",
+        "personalizationToken",
+        "userInfo",
+        "semantics",
+        "barcode",
+    )
+
+private val BARCODE_FORMAT_MAP: Map<String, BarcodeFormat> =
+    mapOf(
+        "PKBarcodeFormatQR" to BarcodeFormat.QR,
+        "PKBarcodeFormatPDF417" to BarcodeFormat.PDF417,
+        "PKBarcodeFormatAztec" to BarcodeFormat.Aztec,
+        "PKBarcodeFormatCode128" to BarcodeFormat.Code128,
+    )
+
+private val TEXT_ALIGNMENT_MAP: Map<String, TextAlignment> =
+    mapOf(
+        "PKTextAlignmentLeft" to TextAlignment.Left,
+        "PKTextAlignmentCenter" to TextAlignment.Center,
+        "PKTextAlignmentRight" to TextAlignment.Right,
+        "PKTextAlignmentNatural" to TextAlignment.Natural,
+    )
+
+private val RGB_REGEX = Regex("""rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)""")
+private val HEX_REGEX = Regex("""#([0-9a-fA-F]{6})""")
+
+private const val PASS_JSON_FILE_NAME = "pass.json"
+private const val PKPASS_FORMAT_VERSION = 1
+private const val MAX_COLOR_COMPONENT = 255
+private const val RED_SHIFT = 16
+private const val GREEN_SHIFT = 8
+private const val HEX_RADIX = 16
+
+private const val FIELD_FORMAT_VERSION = "formatVersion"
+private const val FIELD_SERIAL_NUMBER = "serialNumber"
+private const val FIELD_DESCRIPTION = "description"
+private const val FIELD_ORGANIZATION_NAME = "organizationName"
+private const val FIELD_EXPIRATION_DATE = "expirationDate"
+private const val FIELD_VOIDED = "voided"
+private const val FIELD_FOREGROUND_COLOR = "foregroundColor"
+private const val FIELD_BACKGROUND_COLOR = "backgroundColor"
+private const val FIELD_LABEL_COLOR = "labelColor"
+private const val FIELD_HEADER_FIELDS = "headerFields"
+private const val FIELD_PRIMARY_FIELDS = "primaryFields"
+private const val FIELD_SECONDARY_FIELDS = "secondaryFields"
+private const val FIELD_AUXILIARY_FIELDS = "auxiliaryFields"
+private const val FIELD_BACK_FIELDS = "backFields"
+private const val FIELD_KEY = "key"
+private const val FIELD_VALUE = "value"
+private const val FIELD_LABEL = "label"
+private const val FIELD_TEXT_ALIGNMENT = "textAlignment"
+private const val FIELD_BARCODE = "barcode"
+private const val FIELD_BARCODES = "barcodes"
+private const val FIELD_FORMAT = "format"
+private const val FIELD_MESSAGE = "message"
+private const val FIELD_MESSAGE_ENCODING = "messageEncoding"
+private const val FIELD_ALT_TEXT = "altText"
+
+private const val DOUBLE_QUOTE: Byte = 0x22
+private const val BACKSLASH: Byte = 0x5C
+private const val LBRACE: Byte = 0x7B
+private const val RBRACE: Byte = 0x7D
+private const val LBRACKET: Byte = 0x5B
+private const val RBRACKET: Byte = 0x5D

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/PassJsonDecoder.kt
@@ -107,44 +107,52 @@ private fun assemblePass(
     root: JsonObject,
     style: StyleResolution.Found,
 ): Pass? {
+    val expiration = parseExpiration(root[FIELD_EXPIRATION_DATE])
+    val requireds = readRequiredFields(root)
+    if (requireds == null || expiration is ExpirationParse.Malformed) return null
+    return Pass(
+        type = style.type,
+        serialNumber = requireds.serial,
+        description = requireds.description,
+        organizationName = requireds.organization,
+        expirationDate = (expiration as? ExpirationParse.Ok)?.instant,
+        voided = (root[FIELD_VOIDED] as? JsonPrimitive)?.booleanOrNull ?: false,
+        colors =
+            PassColors(
+                foreground = parseColor(root.stringFieldOrNull(FIELD_FOREGROUND_COLOR)),
+                background = parseColor(root.stringFieldOrNull(FIELD_BACKGROUND_COLOR)),
+                label = parseColor(root.stringFieldOrNull(FIELD_LABEL_COLOR)),
+            ),
+        frontFields =
+            PassFields(
+                header = parseFieldList(style.node[FIELD_HEADER_FIELDS]),
+                primary = parseFieldList(style.node[FIELD_PRIMARY_FIELDS]),
+                secondary = parseFieldList(style.node[FIELD_SECONDARY_FIELDS]),
+                auxiliary = parseFieldList(style.node[FIELD_AUXILIARY_FIELDS]),
+            ),
+        backFields = parseFieldList(style.node[FIELD_BACK_FIELDS]),
+        barcode = parseBarcode(root),
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+}
+
+private fun readRequiredFields(root: JsonObject): RequiredFields? {
     val serial = root.stringFieldOrNull(FIELD_SERIAL_NUMBER)
     val description = root.stringFieldOrNull(FIELD_DESCRIPTION)
     val organization = root.stringFieldOrNull(FIELD_ORGANIZATION_NAME)
-    val expiration = parseExpiration(root[FIELD_EXPIRATION_DATE])
-    if (expiration is ExpirationParse.Malformed) return null
-    // Three-condition guard kept under detekt's complexity threshold by splitting the
-    // expiration check above; the smart-cast branch below is single-expression so
-    // ReturnCount stays at 2.
     return if (serial != null && description != null && organization != null) {
-        Pass(
-            type = style.type,
-            serialNumber = serial,
-            description = description,
-            organizationName = organization,
-            expirationDate = (expiration as? ExpirationParse.Ok)?.instant,
-            voided = (root[FIELD_VOIDED] as? JsonPrimitive)?.booleanOrNull ?: false,
-            colors =
-                PassColors(
-                    foreground = parseColor(root.stringFieldOrNull(FIELD_FOREGROUND_COLOR)),
-                    background = parseColor(root.stringFieldOrNull(FIELD_BACKGROUND_COLOR)),
-                    label = parseColor(root.stringFieldOrNull(FIELD_LABEL_COLOR)),
-                ),
-            frontFields =
-                PassFields(
-                    header = parseFieldList(style.node[FIELD_HEADER_FIELDS]),
-                    primary = parseFieldList(style.node[FIELD_PRIMARY_FIELDS]),
-                    secondary = parseFieldList(style.node[FIELD_SECONDARY_FIELDS]),
-                    auxiliary = parseFieldList(style.node[FIELD_AUXILIARY_FIELDS]),
-                ),
-            backFields = parseFieldList(style.node[FIELD_BACK_FIELDS]),
-            barcode = parseBarcode(root),
-            images = emptyMap(),
-            locales = emptyMap(),
-        )
+        RequiredFields(serial, description, organization)
     } else {
         null
     }
 }
+
+private data class RequiredFields(
+    val serial: String,
+    val description: String,
+    val organization: String,
+)
 
 /**
  * Returns the resolved style with its sub-object, or a discriminated reason it could
@@ -286,84 +294,6 @@ private sealed interface ExpirationParse {
     data class Ok(val instant: PassInstant) : ExpirationParse
 }
 
-/**
- * Defensive ceiling check the kotlinx parser does not natively enforce. Iterates
- * source bytes once, tracking nesting depth and the byte length of in-progress JSON
- * string tokens. ASCII-byte scanning is safe over UTF-8: continuation bytes
- * (`0x80..0xBF`) cannot collide with `{`, `}`, `[`, `]`, `"`, or `\`.
- *
- * String byte-counting uses source bytes (overcount by escape-sequence shrinkage),
- * not decoded character bytes — the guard's intent is to bound JSON-bomb expansion
- * before allocation, and the overcount is conservative (never lets an over-budget
- * string through). Returns `null` on success, or the first arm that tripped. JSON
- * well-formedness is intentionally not verified here — kotlinx.serialization handles
- * that downstream — so an unbalanced bracket pair sails through here and surfaces as
- * [PassJsonFailure.InvalidJson] from the typed parse.
- */
-private fun enforceJsonLimits(
-    bytes: ByteArray,
-    config: ParserConfig,
-): PassJsonFailure? {
-    val state = JsonLimitTokenizer(maxDepth = config.maxJsonDepth, maxStringBytes = config.maxJsonStringBytes)
-    var i = 0
-    while (i < bytes.size && state.failure == null) {
-        state.consume(bytes[i])
-        i++
-    }
-    return state.failure
-}
-
-private class JsonLimitTokenizer(
-    private val maxDepth: Int,
-    private val maxStringBytes: Int,
-) {
-    var failure: PassJsonFailure? = null
-        private set
-
-    private var depth = 0
-    private var inString = false
-    private var stringByteCount = 0
-    private var escape = false
-
-    fun consume(b: Byte) {
-        if (inString) consumeInString(b) else consumeOutsideString(b)
-    }
-
-    private fun consumeInString(b: Byte) {
-        when {
-            escape -> {
-                escape = false
-                bumpStringByte()
-            }
-            b == BACKSLASH -> {
-                escape = true
-                bumpStringByte()
-            }
-            b == DOUBLE_QUOTE -> inString = false
-            else -> bumpStringByte()
-        }
-    }
-
-    private fun consumeOutsideString(b: Byte) {
-        when (b) {
-            DOUBLE_QUOTE -> {
-                inString = true
-                stringByteCount = 0
-            }
-            LBRACE, LBRACKET -> {
-                depth++
-                if (depth > maxDepth) failure = PassJsonFailure.JsonDepthExceeded
-            }
-            RBRACE, RBRACKET -> depth--
-        }
-    }
-
-    private fun bumpStringByte() {
-        stringByteCount++
-        if (stringByteCount > maxStringBytes) failure = PassJsonFailure.JsonStringTooLong
-    }
-}
-
 private val PASS_JSON: Json =
     Json {
         isLenient = false
@@ -451,10 +381,3 @@ private const val FIELD_FORMAT = "format"
 private const val FIELD_MESSAGE = "message"
 private const val FIELD_MESSAGE_ENCODING = "messageEncoding"
 private const val FIELD_ALT_TEXT = "altText"
-
-private const val DOUBLE_QUOTE: Byte = 0x22
-private const val BACKSLASH: Byte = 0x5C
-private const val LBRACE: Byte = 0x7B
-private const val RBRACE: Byte = 0x7D
-private const val LBRACKET: Byte = 0x5B
-private const val RBRACKET: Byte = 0x5D

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/PassJsonDecoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/PassJsonDecoderTest.kt
@@ -551,6 +551,22 @@ class PassJsonDecoderTest {
     }
 
     @Test
+    fun strayLeadingClosersDoNotInflateInFlightDepth() {
+        // Regression test for the depth-clamp invariant (`0 <= depth <= maxDepth`).
+        // Without clamping, leading `}}` would drive depth to -2, then the
+        // following 3 `{` would only peak at +1 — meaning JsonDepthExceeded would
+        // never fire, and the payload would surface only as InvalidJson when
+        // kotlinx rejects the mismatch. With clamping, depth stays 0 through the
+        // leading closers, then climbs 1, 2, 3 — tripping JsonDepthExceeded at the
+        // third opener (depth 3 > maxDepth 2). The clamp keeps the budget honest
+        // regardless of what kotlinx does downstream.
+        val cfg = ParserConfig(maxJsonDepth = 2)
+        val payload = "}}{{{}}".toByteArray()
+        val result = decodePassJson(mapOf("pass.json" to payload), cfg)
+        assertFailedWith(result, PassJsonFailure.JsonDepthExceeded)
+    }
+
+    @Test
     fun escapedQuoteInsideStringDoesNotTerminateString() {
         // Regression: the tokenizer must treat \" as a continued string, otherwise it
         // resets stringByteCount mid-string and silently lets oversized payloads through.

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/PassJsonDecoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/PassJsonDecoderTest.kt
@@ -1,0 +1,671 @@
+package `is`.walt.passes.core.internal
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.TextAlignment
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Test
+
+/**
+ * Behavior tests for [decodePassJson]. Every fixture is built in-memory from
+ * [buildJsonObject] / [buildJsonArray] so a reviewer can read each test and see
+ * exactly which arm of [PassJsonFailure] (or which mapped field of [Pass]) is being
+ * exercised. No checked-in binary fixtures.
+ *
+ * The test file uses two shapes of helper: [passJsonBytes], which fully builds a
+ * minimal valid pass.json with one named override, and per-test inline builders
+ * where the override is too structured for a single-field swap. The split keeps the
+ * happy-path tests short while letting failure tests be self-contained.
+ */
+class PassJsonDecoderTest {
+    @Test
+    fun happyPathBoardingPass() {
+        val style =
+            buildJsonObject {
+                put(
+                    "primaryFields",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("key", "from")
+                            put("label", "From")
+                            put("value", "SFO")
+                            put("textAlignment", "PKTextAlignmentRight")
+                        }
+                    },
+                )
+                put(
+                    "secondaryFields",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("key", "to")
+                            put("value", "JFK")
+                        }
+                    },
+                )
+            }
+        val bytes = passJsonBytes(styleKey = "boardingPass", styleNode = style, voided = true)
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+
+        assertThat(ok.pass.type).isEqualTo(PassType.BoardingPass)
+        assertThat(ok.pass.serialNumber).isEqualTo("S1")
+        assertThat(ok.pass.description).isEqualTo("D1")
+        assertThat(ok.pass.organizationName).isEqualTo("Example Air")
+        assertThat(ok.pass.voided).isTrue()
+        assertThat(ok.pass.frontFields.primary).hasSize(1)
+        assertThat(ok.pass.frontFields.primary.single())
+            .isEqualTo(PassField(key = "from", label = "From", value = "SFO", textAlignment = TextAlignment.Right))
+        // Field with no label / textAlignment defaults: label = null, alignment = Natural.
+        assertThat(ok.pass.frontFields.secondary.single())
+            .isEqualTo(PassField(key = "to", label = null, value = "JFK", textAlignment = TextAlignment.Natural))
+        // Images and locales are NOT this slice's responsibility — the parser-glue bead
+        // wires them in. Surfacing them empty is the load-bearing contract.
+        assertThat(ok.pass.images).isEmpty()
+        assertThat(ok.pass.locales).isEmpty()
+    }
+
+    @Test
+    fun happyPathEachStyleKeyMapsToTheRightPassType() {
+        val pairs =
+            listOf(
+                "boardingPass" to PassType.BoardingPass,
+                "eventTicket" to PassType.EventTicket,
+                "coupon" to PassType.Coupon,
+                "storeCard" to PassType.StoreCard,
+                "generic" to PassType.Generic,
+            )
+        for ((key, expectedType) in pairs) {
+            val bytes = passJsonBytes(styleKey = key, styleNode = buildJsonObject {})
+            val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+            assertWithMessage("style=$key").that(ok.pass.type).isEqualTo(expectedType)
+        }
+    }
+
+    @Test
+    fun missingPassJsonEntryReturnsMissing() {
+        val result = decodePassJson(mapOf("manifest.json" to "{}".toByteArray()), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.Missing)
+    }
+
+    @Test
+    fun invalidJsonReturnsInvalidJson() {
+        val result = decodePassJson(mapOf("pass.json" to "not json".toByteArray()), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.InvalidJson)
+    }
+
+    @Test
+    fun strictModeRejectsLenientInput() {
+        // isLenient = false: unquoted keys are rejected. Lenient JSON would accept this.
+        val lenient = "{formatVersion:1,serialNumber:\"S\"}".toByteArray()
+        val result = decodePassJson(mapOf("pass.json" to lenient), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.InvalidJson)
+    }
+
+    @Test
+    fun topLevelArrayReturnsInvalidJson() {
+        // parseToJsonElement returns a JsonArray; the `as? JsonObject` check catches it.
+        // It is NOT InvalidShape because shape-level checks only run on a successful
+        // object parse — a top-level array means we cannot meaningfully ask "is this a
+        // pass-style key here", so it is correctly rejected at the JSON layer.
+        val result = decodePassJson(mapOf("pass.json" to "[1,2,3]".toByteArray()), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.InvalidJson)
+    }
+
+    @Test
+    fun unknownFormatVersionReturnsUnknownFormatVersion() {
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 2)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.UnknownFormatVersion(2))
+    }
+
+    @Test
+    fun missingFormatVersionReturnsUnknownFormatVersionZero() {
+        val bytes =
+            buildJsonObject {
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.UnknownFormatVersion(0))
+    }
+
+    @Test
+    fun nonIntegerFormatVersionReturnsUnknownFormatVersionZero() {
+        // formatVersion is a string — kotlinx parses it, intOrNull is null, we surface
+        // UnknownFormatVersion(0). Distinguishes from a missing key only via telemetry,
+        // which is acceptable: both indicate "no usable version".
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", "one")
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.UnknownFormatVersion(0))
+    }
+
+    @Test
+    fun unknownStyleKeyReturnsUnknownPassStyleWithRaw() {
+        // No known style; an unknown object-valued top-level key surfaces as raw.
+        // The `userInfo` object is in the non-style allowlist and must NOT be picked.
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("userInfo", buildJsonObject { put("a", 1) })
+                put("ssoPass", buildJsonObject { put("primaryFields", buildJsonArray {}) })
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.UnknownPassStyle("ssoPass"))
+    }
+
+    @Test
+    fun noStyleKeyAndNoUnknownObjectReturnsUnknownPassStyleEmptyHint() {
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.UnknownPassStyle(""))
+    }
+
+    @Test
+    fun multipleStyleKeysReturnInvalidShape() {
+        // PKPASS spec requires exactly one style; two is malformed.
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("boardingPass", buildJsonObject {})
+                put("eventTicket", buildJsonObject {})
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.InvalidShape)
+    }
+
+    @Test
+    fun missingRequiredTopLevelFieldsReturnInvalidShape() {
+        // Each required field omitted in turn: serialNumber, description, organizationName.
+        val omitted = listOf("serialNumber", "description", "organizationName")
+        for (skipKey in omitted) {
+            val bytes =
+                buildJsonObject {
+                    put("formatVersion", 1)
+                    if (skipKey != "serialNumber") put("serialNumber", "S")
+                    if (skipKey != "description") put("description", "D")
+                    if (skipKey != "organizationName") put("organizationName", "O")
+                    put("generic", buildJsonObject {})
+                }.encodeToBytes()
+            val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+            assertWithMessage("omitting=$skipKey")
+                .that((result as? PassJsonDecodeResult.Failed)?.failure)
+                .isEqualTo(PassJsonFailure.InvalidShape)
+        }
+    }
+
+    @Test
+    fun rgbColorIsParsed() {
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                colors =
+                    mapOf(
+                        "foregroundColor" to "rgb(255,255,255)",
+                        "backgroundColor" to "rgb(0, 0, 0)",
+                        "labelColor" to "rgb(204,204,204)",
+                    ),
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.colors.foreground).isEqualTo(ColorValue(0xFFFFFF))
+        assertThat(ok.pass.colors.background).isEqualTo(ColorValue(0x000000))
+        assertThat(ok.pass.colors.label).isEqualTo(ColorValue(0xCCCCCC))
+    }
+
+    @Test
+    fun hexColorIsParsed() {
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                colors =
+                    mapOf(
+                        "foregroundColor" to "#102030",
+                        "backgroundColor" to "#aabbcc",
+                    ),
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.colors.foreground).isEqualTo(ColorValue(0x102030))
+        assertThat(ok.pass.colors.background).isEqualTo(ColorValue(0xAABBCC))
+        assertThat(ok.pass.colors.label).isNull()
+    }
+
+    @Test
+    fun invalidColorIsDroppedAsNull() {
+        // Out-of-range, malformed, hex of wrong length: all silently drop to null
+        // rather than failing the whole parse — colors are optional and a malformed
+        // color is recoverable in render.
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                colors =
+                    mapOf(
+                        "foregroundColor" to "rgb(300,0,0)",
+                        "backgroundColor" to "#zzzzzz",
+                        "labelColor" to "#abc",
+                    ),
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.colors.foreground).isNull()
+        assertThat(ok.pass.colors.background).isNull()
+        assertThat(ok.pass.colors.label).isNull()
+    }
+
+    @Test
+    fun barcodesArrayPreferredOverLegacyBarcode() {
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                extra = {
+                    put(
+                        "barcode",
+                        buildJsonObject {
+                            put("format", "PKBarcodeFormatPDF417")
+                            put("message", "LEGACY")
+                            put("messageEncoding", "iso-8859-1")
+                        },
+                    )
+                    put(
+                        "barcodes",
+                        buildJsonArray {
+                            addJsonObject {
+                                put("format", "PKBarcodeFormatQR")
+                                put("message", "MODERN")
+                                put("messageEncoding", "iso-8859-1")
+                                put("altText", "modern-alt")
+                            }
+                        },
+                    )
+                },
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.barcode)
+            .isEqualTo(
+                Barcode(
+                    format = BarcodeFormat.QR,
+                    message = "MODERN",
+                    messageEncoding = "iso-8859-1",
+                    altText = "modern-alt",
+                ),
+            )
+    }
+
+    @Test
+    fun legacyBarcodeUsedWhenBarcodesArrayAbsent() {
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                extra = {
+                    put(
+                        "barcode",
+                        buildJsonObject {
+                            put("format", "PKBarcodeFormatAztec")
+                            put("message", "L")
+                            put("messageEncoding", "iso-8859-1")
+                        },
+                    )
+                },
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.barcode?.format).isEqualTo(BarcodeFormat.Aztec)
+        assertThat(ok.pass.barcode?.altText).isNull()
+    }
+
+    @Test
+    fun legacyBarcodeUsedWhenBarcodesArrayHasNoUsableEntry() {
+        // First entry has unknown format; legacy `barcode` is the fallback.
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                extra = {
+                    put(
+                        "barcode",
+                        buildJsonObject {
+                            put("format", "PKBarcodeFormatCode128")
+                            put("message", "FALLBACK")
+                            put("messageEncoding", "iso-8859-1")
+                        },
+                    )
+                    put(
+                        "barcodes",
+                        buildJsonArray {
+                            addJsonObject {
+                                put("format", "PKBarcodeFormatHologram")
+                                put("message", "x")
+                                put("messageEncoding", "iso-8859-1")
+                            }
+                        },
+                    )
+                },
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.barcode?.message).isEqualTo("FALLBACK")
+    }
+
+    @Test
+    fun absentBarcodeSurfacesNull() {
+        val bytes = passJsonBytes(styleKey = "generic", styleNode = buildJsonObject {})
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.barcode).isNull()
+    }
+
+    @Test
+    fun expirationDateIsParsedAsRfc3339() {
+        // `2026-12-31T23:59:00Z` -> 1798761540000ms (epoch milliseconds).
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                extra = { put("expirationDate", "2026-12-31T23:59:00Z") },
+            )
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.expirationDate).isEqualTo(PassInstant(1798761540000L))
+    }
+
+    @Test
+    fun absentExpirationDateSurfacesNull() {
+        val bytes = passJsonBytes(styleKey = "generic", styleNode = buildJsonObject {})
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.expirationDate).isNull()
+    }
+
+    @Test
+    fun malformedExpirationDateReturnsInvalidShape() {
+        // Distinguishing absent (null) from present-but-junk (InvalidShape) is the
+        // load-bearing call: silently dropping a corrupted validity window would let
+        // an attacker un-expire a pass by tampering the field.
+        val bytes =
+            passJsonBytes(
+                styleKey = "generic",
+                styleNode = buildJsonObject {},
+                extra = { put("expirationDate", "not a date") },
+            )
+        val result = decodePassJson(mapOf("pass.json" to bytes), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.InvalidShape)
+    }
+
+    @Test
+    fun voidedTrueIsSurfacedTrueAndDefaultsFalse() {
+        val voidedBytes = passJsonBytes(styleKey = "generic", styleNode = buildJsonObject {}, voided = true)
+        val absentBytes = passJsonBytes(styleKey = "generic", styleNode = buildJsonObject {}, voided = null)
+        assertThat(decodePassJson(mapOf("pass.json" to voidedBytes), ParserConfig()).asOk().pass.voided).isTrue()
+        assertThat(decodePassJson(mapOf("pass.json" to absentBytes), ParserConfig()).asOk().pass.voided).isFalse()
+    }
+
+    @Test
+    fun dangerousFieldsAreParsedButNotSurfaced() {
+        // The presence of nfc, webServiceURL, authenticationToken, personalization,
+        // and personalizationToken must not surface on the public Pass type. There
+        // is intentionally no Pass field for them — this test guards the *structural*
+        // claim that the data model has nowhere to surface them.
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+                put("nfc", buildJsonObject { put("message", "secret") })
+                put("webServiceURL", "https://attacker.example.com/pass")
+                put("authenticationToken", "TOK_64_CHARS_LONG_FAKE_VALUE_FOR_TEST_ONLY_DO_NOT_USE_ANYWHERE_X")
+                put("personalization", buildJsonObject { put("requiredPersonalizationFields", buildJsonArray {}) })
+                put("personalizationToken", "ptok-fake-value-xyz")
+            }.encodeToBytes()
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        // Equality with the canonical "minimal valid" pass demonstrates no extra
+        // fields leaked: every Pass field is structurally derivable from the inputs,
+        // so an extra dangerous payload either round-trips into a Pass field (bug)
+        // or vanishes (correct). Since Pass has no NFC/web/auth/personalization
+        // fields, only the latter is possible — so the assertion is structural.
+        val canonicalBytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "D")
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+            }.encodeToBytes()
+        val canonical = decodePassJson(mapOf("pass.json" to canonicalBytes), ParserConfig()).asOk()
+        assertThat(ok.pass).isEqualTo(canonical.pass)
+    }
+
+    @Test
+    fun maxJsonDepthTrips() {
+        // Build a JSON object nested deeper than the default depth limit.
+        val deeplyNested = buildNestedObject(depth = ParserConfig.DEFAULT_MAX_JSON_DEPTH + 4)
+        val result = decodePassJson(mapOf("pass.json" to deeplyNested), ParserConfig())
+        assertFailedWith(result, PassJsonFailure.JsonDepthExceeded)
+    }
+
+    @Test
+    fun depthLimitAtBoundaryAccepts() {
+        // Exactly maxDepth nests is allowed; one more is the failure boundary.
+        val cfg = ParserConfig(maxJsonDepth = 5)
+        val justWithinDepth = buildNestedObject(depth = 5)
+        // At-the-limit should pass the limit check (and fall to InvalidShape because
+        // the deeply-nested payload is not a valid pass.json — that's fine; the test
+        // is specifically that JsonDepthExceeded does NOT fire).
+        val result = decodePassJson(mapOf("pass.json" to justWithinDepth), cfg)
+        assertThat(result).isInstanceOf(PassJsonDecodeResult.Failed::class.java)
+        val failure = (result as PassJsonDecodeResult.Failed).failure
+        assertThat(failure).isNotEqualTo(PassJsonFailure.JsonDepthExceeded)
+    }
+
+    @Test
+    fun maxJsonStringBytesTrips() {
+        // Build a JSON object with a very long string value; configure a small ceiling.
+        val cfg = ParserConfig(maxJsonStringBytes = 16)
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("description", "x".repeat(64))
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), cfg)
+        assertFailedWith(result, PassJsonFailure.JsonStringTooLong)
+    }
+
+    @Test
+    fun stringLimitDoesNotTripOnSequenceOfShortStrings() {
+        // Critical guard: the per-string counter must reset between strings. Sixty-four
+        // strings of 4 bytes apiece with maxJsonStringBytes=16 must NOT trip — a single
+        // running counter would.
+        val cfg = ParserConfig(maxJsonStringBytes = 16)
+        val styleNode =
+            buildJsonObject {
+                put(
+                    "primaryFields",
+                    buildJsonArray {
+                        repeat(64) { i ->
+                            addJsonObject {
+                                put("key", "k$i")
+                                put("value", "v$i")
+                            }
+                        }
+                    },
+                )
+            }
+        val bytes = passJsonBytes(styleKey = "generic", styleNode = styleNode)
+        val ok = decodePassJson(mapOf("pass.json" to bytes), cfg).asOk()
+        assertThat(ok.pass.frontFields.primary).hasSize(64)
+    }
+
+    @Test
+    fun maxJsonStringBytesAcceptsStringsAtTheLimit() {
+        val cfg = ParserConfig(maxJsonStringBytes = 16)
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("serialNumber", "S")
+                put("description", "x".repeat(16))
+                put("organizationName", "O")
+                put("generic", buildJsonObject {})
+            }.encodeToBytes()
+        val ok = decodePassJson(mapOf("pass.json" to bytes), cfg).asOk()
+        assertThat(ok.pass.description).isEqualTo("x".repeat(16))
+    }
+
+    @Test
+    fun escapedQuoteInsideStringDoesNotTerminateString() {
+        // Regression: the tokenizer must treat \" as a continued string, otherwise it
+        // resets stringByteCount mid-string and silently lets oversized payloads through.
+        // 16 characters of "abc\"" repeated would need correct escape handling.
+        val cfg = ParserConfig(maxJsonStringBytes = 8)
+        val bytes =
+            buildJsonObject {
+                put("formatVersion", 1)
+                put("description", "a\"b\"c\"d\"e\"f\"g\"h\"i\"j") // > 8 source bytes
+            }.encodeToBytes()
+        val result = decodePassJson(mapOf("pass.json" to bytes), cfg)
+        assertFailedWith(result, PassJsonFailure.JsonStringTooLong)
+    }
+
+    @Test
+    fun frontFieldsDefaultToEmptyListsWhenStyleNodeOmitsThem() {
+        val bytes = passJsonBytes(styleKey = "storeCard", styleNode = buildJsonObject {})
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.frontFields).isEqualTo(PassFields())
+        assertThat(ok.pass.backFields).isEmpty()
+    }
+
+    @Test
+    fun fieldRowEntryWithMissingKeyOrValueIsSkipped() {
+        // PKPASS spec requires both key and value on a field. A junk entry must not
+        // bring down the whole pass — drop the entry and keep the rest.
+        val styleNode =
+            buildJsonObject {
+                put(
+                    "primaryFields",
+                    buildJsonArray {
+                        addJsonObject { put("value", "no key") }
+                        addJsonObject {
+                            put("key", "ok")
+                            put("value", "yes")
+                        }
+                        addJsonObject {
+                            put("key", "no value only label")
+                            put("label", "L")
+                        }
+                    },
+                )
+            }
+        val bytes = passJsonBytes(styleKey = "generic", styleNode = styleNode)
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.frontFields.primary.map { it.key }).containsExactly("ok")
+    }
+
+    @Test
+    fun fieldValueAcceptsNumberAsString() {
+        // PKPASS allows numeric `value` (with optional numberStyle/currencyCode). The
+        // model stores `value` as String — stringification preserves the literal.
+        val styleNode =
+            buildJsonObject {
+                put(
+                    "primaryFields",
+                    buildJsonArray {
+                        addJsonObject {
+                            put("key", "amount")
+                            put("value", 5.99)
+                        }
+                    },
+                )
+            }
+        val bytes = passJsonBytes(styleKey = "coupon", styleNode = styleNode)
+        val ok = decodePassJson(mapOf("pass.json" to bytes), ParserConfig()).asOk()
+        assertThat(ok.pass.frontFields.primary.single().value).isEqualTo("5.99")
+    }
+
+    /**
+     * Builds a minimal but fully-typed pass.json. The named overrides are applied
+     * after the canonical defaults so a single-field swap reads as one named arg.
+     */
+    private fun passJsonBytes(
+        styleKey: String,
+        styleNode: JsonObject,
+        voided: Boolean? = null,
+        colors: Map<String, String> = emptyMap(),
+        extra: JsonObjectBuilder.() -> Unit = {},
+    ): ByteArray =
+        buildJsonObject {
+            put("formatVersion", 1)
+            put("serialNumber", "S1")
+            put("description", "D1")
+            put("organizationName", "Example Air")
+            if (voided != null) put("voided", voided)
+            for ((k, v) in colors) put(k, v)
+            put(styleKey, styleNode)
+            extra()
+        }.encodeToBytes()
+
+    private fun buildNestedObject(depth: Int): ByteArray {
+        // Leaf is `1`; each layer wraps in {"k": ...}. depth = number of opening braces.
+        val sb = StringBuilder()
+        repeat(depth) { sb.append("{\"k\":") }
+        sb.append("1")
+        repeat(depth) { sb.append("}") }
+        return sb.toString().toByteArray()
+    }
+
+    private fun PassJsonDecodeResult.asOk(): PassJsonDecodeResult.Ok {
+        assertThat(this).isInstanceOf(PassJsonDecodeResult.Ok::class.java)
+        return this as PassJsonDecodeResult.Ok
+    }
+
+    private fun assertFailedWith(
+        actual: PassJsonDecodeResult,
+        expected: PassJsonFailure,
+    ) {
+        assertThat(actual).isInstanceOf(PassJsonDecodeResult.Failed::class.java)
+        val failure = (actual as PassJsonDecodeResult.Failed).failure
+        assertWithMessage("expected PassJsonFailure=$expected, got $failure")
+            .that(failure)
+            .isEqualTo(expected)
+    }
+}
+
+private fun JsonObject.encodeToBytes(): ByteArray = Json.encodeToString(JsonObject.serializer(), this).toByteArray()


### PR DESCRIPTION
## Summary

Lands the internal `decodePassJson(entries, config)` slice — the second of three `PassParser` implementation slices, after `wpass-8so` (extractor) and `wpass-7l2` (manifest hash chain).

- Pre-pass tokenizer enforces `ParserConfig.maxJsonDepth` and `maxJsonStringBytes` *before* kotlinx.serialization sees the bytes. kotlinx does not enforce these natively, and post-validating the parsed tree is too late — a deeply-nested adversarial payload has already allocated by the time the tree exists.
- Typed parse runs in strict mode (`isLenient = false`) with `ignoreUnknownKeys = true` so PKPASS spec additions do not break consumers.
- Internal failure arms: `Missing`, `InvalidJson`, `InvalidShape`, `JsonDepthExceeded`, `JsonStringTooLong`, `UnknownFormatVersion(v)`, `UnknownPassStyle(raw)`. Mapping to the public `ParseResult` lands in `wpass-qnc`; this slice keeps the public API surface frozen (`PublicApiSurfaceTest` unchanged).
- Dangerous fields (`nfc`, `webServiceURL`, `authenticationToken`, `personalization`, `personalizationToken`) are structurally absent from the `Pass` model per `decision-wlt-0tn-q1` — kotlinx parses them under `ignoreUnknownKeys=true` and the data shape has nowhere to surface them, keeping the trust claim auditable from the model itself rather than via runtime stripping.
- Returned `Pass` carries `images = emptyMap()` and `locales = emptyMap()`; the parser-glue bead wires those in.

## Test plan

- [x] `./gradlew :passes-core:check :passes-core:detekt` — all green
- [x] 30 new `PassJsonDecoderTest` cases: each `PassType`, missing top-level fields, unknown `formatVersion`, unknown style key, `rgb(...)` vs `#RRGGBB`, `barcode` vs `barcodes[0]`, dangerous fields parsed-and-dropped (asserted via structural equality with the canonical pass), `maxJsonDepth` and `maxJsonStringBytes` trips, escape-aware string-length counter, per-string counter resets, boundary-at-the-limit acceptance.
- [x] `PublicApiSurfaceTest` unchanged — verified at the file level (no diff) and as a passing test.

Closes once main CI is green: `wpass-7sl`.