### PR TITLE
passes-core: Apple .strings localization parser (wpass-ddc)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
@@ -47,6 +47,16 @@ public sealed interface MalformedReason {
 
     public data object InvalidManifest : MalformedReason
 
+    /**
+     * A `<locale>.lproj/pass.strings` file is structurally invalid (charset error,
+     * unterminated token, missing `=`/`;`, unrecognized escape, unpaired surrogate).
+     * Surfaced separately from [InvalidPassJson] so telemetry and UI can distinguish
+     * a malformed localization payload from a malformed pass.json — the two have
+     * different operational implications (a bad .strings file degrades one locale;
+     * a bad pass.json takes the whole pass down).
+     */
+    public data object InvalidStrings : MalformedReason
+
     public data class ResourceLimitExceeded(public val limit: ResourceLimit) : MalformedReason
 }
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ParserConfig.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ParserConfig.kt
@@ -10,6 +10,13 @@ package `is`.walt.passes.core
  * against the input stream length before unzipping; [maxEntries] is checked while iterating
  * the central directory; [maxJsonDepth] is enforced inside the JSON reader.
  *
+ * [maxJsonStringBytes] is intentionally cross-format: it bounds individual string
+ * values in `pass.json` *and* individual values in `<locale>.lproj/pass.strings`. The
+ * two formats share an attack surface (a single oversized string deferring allocation
+ * to a downstream consumer), so a single ceiling is the right knob; introducing a
+ * separate `maxStringsValueBytes` would be a knob without a turner. Tighten this value
+ * and both parsers tighten with it.
+ *
  * Use [Strict] for tests and audit tooling that should reject anything not Apple-signed.
  */
 public data class ParserConfig(

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsParser.kt
@@ -1,9 +1,7 @@
 package `is`.walt.passes.core.internal
 
 import `is`.walt.passes.core.LocalizedStrings
-import `is`.walt.passes.core.MalformedReason
 import `is`.walt.passes.core.ParserConfig
-import `is`.walt.passes.core.ResourceLimit
 import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
@@ -21,25 +19,32 @@ import java.nio.charset.StandardCharsets
  *     otherwise UTF-8 is the documented default. The decoder is configured with
  *     [CodingErrorAction.REPORT] for both malformed input and unmappable characters,
  *     so a non-UTF-8 byte sequence with no BOM fails outright as
- *     [MalformedReason.InvalidPassJson] rather than producing U+FFFD replacement
+ *     [StringsFailure.InvalidEncoding] rather than producing U+FFFD replacement
  *     characters and silently mis-rendering on screen.
  *  2. Hand-rolled lexer / parser ([StringsLexer]) — single-pass character walker with
  *     explicit state for in-string and in-comment tokens. Regex on this format is
- *     brittle: Apple's `\Uxxxx` escape is 4 hex digits (not a 21-bit codepoint), block
- *     comments do not nest, and a backslash immediately before EOL is *not* a line
- *     continuation. The walker fits cleanly into ~150 lines and keeps each rule local
- *     to its branch.
+ *     brittle: Apple's `\Uxxxx` escape is 4 hex digits (not a 21-bit codepoint),
+ *     supplementary-plane codepoints arrive as paired `\Uxxxx\Uxxxx` surrogates,
+ *     block comments do not nest, and a backslash immediately before EOL is *not* a
+ *     line continuation. The walker fits cleanly into ~150 lines and keeps each rule
+ *     local to its branch.
  *  3. Per-value byte cap — [ParserConfig.maxJsonStringBytes] applies to the decoded
  *     value of each entry (UTF-8 byte equivalent, summed as a conservative upper
  *     bound on a per-Char basis so an oversized value is rejected mid-read rather
- *     than after full materialization). The same knob the pass.json parser uses;
- *     introducing a separate `maxStringsValueBytes` would be a knob without a turner
- *     — wpass-oj8 covers any global decompressed footprint cap. Total file size is
- *     already bounded by [ParserConfig.maxEntryBytes] upstream.
+ *     than after full materialization). Total file size is already bounded by
+ *     [ParserConfig.maxEntryBytes] upstream.
  *
  * The cap is applied to values only, not keys. Keys in real .strings files routinely
  * exceed any sensible value cap (they are often dotted human-readable identifiers);
  * the cap exists to bound memory expansion on the rendered surface, not key length.
+ *
+ * Surrogate handling. Supplementary-plane codepoints (emoji etc.) appear in the
+ * source as `\UD83D\UDE00`-style pairs. The lexer accepts a high surrogate followed
+ * immediately by `\U<low>` and emits both halves verbatim — the resulting Kotlin
+ * String is well-formed UTF-16. Lone surrogates are rejected as
+ * [StringsFailure.BadEscape]; the strict charset decoder blocks malformed UTF-16
+ * from raw bytes, and rejecting unpaired `\Uxxxx` keeps the same posture across the
+ * escape boundary.
  */
 internal fun parseStrings(
     bytes: ByteArray,
@@ -47,11 +52,11 @@ internal fun parseStrings(
 ): StringsResult {
     val text =
         decodeWithBomSniff(bytes)
-            ?: return StringsResult.Failed(MalformedReason.InvalidPassJson)
+            ?: return StringsResult.Failed(StringsFailure.InvalidEncoding)
     return try {
         StringsResult.Ok(StringsLexer(text, config.maxJsonStringBytes).parse())
     } catch (e: StringsParseException) {
-        StringsResult.Failed(e.reason)
+        StringsResult.Failed(e.failure)
     }
 }
 
@@ -59,7 +64,7 @@ internal fun parseStrings(
  * BOM-sniffs the leading bytes for UTF-16 LE/BE / UTF-8 and decodes the rest with a
  * [java.nio.charset.CharsetDecoder] whose error policy is REPORT on both malformed
  * input and unmappable characters. Returns `null` if decoding fails — surfaced as
- * [MalformedReason.InvalidPassJson] by the caller. UTF-8 is the no-BOM default per
+ * [StringsFailure.InvalidEncoding] by the caller. UTF-8 is the no-BOM default per
  * Apple's documented behavior for .strings.
  *
  * The BOM is stripped before handing bytes to the decoder. Java's `UTF_16LE` /
@@ -87,17 +92,19 @@ private fun decodeWithBomSniff(bytes: ByteArray): String? {
 
 private fun hasPrefix(
     bytes: ByteArray,
-    prefix: IntArray,
+    prefix: ByteArray,
 ): Boolean {
     if (bytes.size < prefix.size) return false
-    return prefix.indices.all { bytes[it].toInt() and BYTE_MASK == prefix[it] }
+    return prefix.indices.all { bytes[it] == prefix[it] }
 }
 
 /**
  * Conservative UTF-8 byte count for a single [Char] (BMP code unit). Surrogate halves
- * count as 3 bytes each, an upper bound on the actual encoded length without paying
- * for an actual encode. Suitable for bounding "is this string under the cap"; not
- * suitable for serialization sizing.
+ * count as 3 bytes each — a real surrogate-pair codepoint encodes to 4 UTF-8 bytes,
+ * so this overcounts by 2 for any supplementary-plane character. That overcount is
+ * deliberate: the function is a guard against "is this string under the cap", and a
+ * conservative upper bound never lets an over-budget string through. Not suitable
+ * for serialization sizing.
  */
 private fun Char.utf8Bytes(): Int =
     when {
@@ -105,14 +112,6 @@ private fun Char.utf8Bytes(): Int =
         code < UTF8_THREE_BYTE_THRESHOLD -> 2
         else -> 3
     }
-
-/**
- * Internal control-flow vehicle for short-circuiting deeply-nested lexer helpers.
- * Caught only at the [parseStrings] boundary; never leaks across the public API.
- * Using an exception here keeps each helper a single-return function and avoids
- * threading a nullable failure state through every level.
- */
-private class StringsParseException(val reason: MalformedReason) : RuntimeException()
 
 private class StringsLexer(
     private val text: String,
@@ -134,7 +133,7 @@ private class StringsLexer(
         return LocalizedStrings(map)
     }
 
-    private fun fail(reason: MalformedReason): Nothing = throw StringsParseException(reason)
+    private fun fail(failure: StringsFailure): Nothing = throw StringsParseException(failure)
 
     private fun skipWhitespaceAndComments() {
         while (pos < text.length) {
@@ -151,7 +150,7 @@ private class StringsLexer(
 
     private fun skipLineComment() {
         pos += 2
-        while (pos < text.length && text[pos] != '\n') pos++
+        while (pos < text.length && text[pos] != '\n' && text[pos] != '\r') pos++
         if (pos < text.length) pos++
     }
 
@@ -166,12 +165,12 @@ private class StringsLexer(
                 pos++
             }
         }
-        if (!found) fail(MalformedReason.InvalidPassJson)
+        if (!found) fail(StringsFailure.UnterminatedComment)
     }
 
     private fun readQuotedString(maxBytes: Int): String {
         skipWhitespaceAndComments()
-        if (pos >= text.length || text[pos] != '"') fail(MalformedReason.InvalidPassJson)
+        if (pos >= text.length || text[pos] != '"') fail(StringsFailure.BadStructure)
         pos++
         val sb = StringBuilder()
         var byteCount = 0
@@ -183,9 +182,9 @@ private class StringsLexer(
                     return sb.toString()
                 }
                 '\\' -> {
-                    val ch = readEscape()
-                    byteCount = bumpByteCount(byteCount, ch.utf8Bytes(), maxBytes)
-                    sb.append(ch)
+                    val escaped = readEscape()
+                    for (e in escaped) byteCount = bumpByteCount(byteCount, e.utf8Bytes(), maxBytes)
+                    sb.append(escaped)
                 }
                 else -> {
                     pos++
@@ -194,7 +193,7 @@ private class StringsLexer(
                 }
             }
         }
-        fail(MalformedReason.InvalidPassJson)
+        fail(StringsFailure.UnterminatedString)
     }
 
     private fun bumpByteCount(
@@ -203,57 +202,101 @@ private class StringsLexer(
         max: Int,
     ): Int {
         val next = current + delta
-        if (next > max) fail(MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize))
+        if (next > max) fail(StringsFailure.ValueTooLong)
         return next
     }
 
     private fun consumeAfterWhitespace(expected: Char) {
         skipWhitespaceAndComments()
-        if (pos >= text.length || text[pos] != expected) fail(MalformedReason.InvalidPassJson)
+        if (pos >= text.length || text[pos] != expected) fail(StringsFailure.BadStructure)
         pos++
     }
 
-    private fun readEscape(): Char {
+    /**
+     * Returns the decoded escape as a [String]: a single Char for the bare escapes,
+     * or a two-Char surrogate pair for `\Uxxxx\Uxxxx`. Returning a String (not a
+     * Char) is what lets [readUnicodeEscape] emit a surrogate pair atomically — the
+     * caller appends and counts both halves without having to learn that surrogate
+     * pairs are a thing.
+     */
+    private fun readEscape(): String {
         pos++
-        if (pos >= text.length) fail(MalformedReason.InvalidPassJson)
+        if (pos >= text.length) fail(StringsFailure.BadEscape)
         return when (val c = text[pos]) {
             '\\', '"' -> {
                 pos++
-                c
+                c.toString()
             }
             'n' -> {
                 pos++
-                '\n'
+                "\n"
             }
             'r' -> {
                 pos++
-                '\r'
+                "\r"
             }
             't' -> {
                 pos++
-                '\t'
+                "\t"
             }
             'U' -> readUnicodeEscape()
-            else -> fail(MalformedReason.InvalidPassJson)
+            else -> fail(StringsFailure.BadEscape)
         }
     }
 
-    private fun readUnicodeEscape(): Char {
+    /**
+     * Decodes one or two `\Uxxxx` escapes. Apple writes supplementary-plane
+     * codepoints as paired `\U<high>\U<low>` UTF-16 surrogates; the BMP path stops
+     * after one. Lone surrogates (high without partner, low without preceding high)
+     * are [StringsFailure.BadEscape] — emitting them would produce a malformed
+     * UTF-16 String that surfaces unpredictably at any downstream UTF-8 re-encoding.
+     */
+    private fun readUnicodeEscape(): String {
         pos++
-        if (pos + UNICODE_ESCAPE_HEX_DIGITS > text.length) fail(MalformedReason.InvalidPassJson)
+        val first = readUnicodeCodeUnit()
+        if (first.isLowSurrogate()) fail(StringsFailure.BadEscape)
+        if (!first.isHighSurrogate()) return first.toString()
+        val partnerOk =
+            pos + SURROGATE_PARTNER_PREFIX_LEN <= text.length &&
+                text[pos] == '\\' &&
+                text[pos + 1] == 'U'
+        if (!partnerOk) fail(StringsFailure.BadEscape)
+        pos += SURROGATE_PARTNER_PREFIX_LEN
+        val low = readUnicodeCodeUnit()
+        if (!low.isLowSurrogate()) fail(StringsFailure.BadEscape)
+        return "$first$low"
+    }
+
+    private fun readUnicodeCodeUnit(): Char {
+        if (pos + UNICODE_ESCAPE_HEX_DIGITS > text.length) fail(StringsFailure.BadEscape)
         val hex = text.substring(pos, pos + UNICODE_ESCAPE_HEX_DIGITS)
-        val code = hex.toIntOrNull(HEX_RADIX) ?: fail(MalformedReason.InvalidPassJson)
+        val code = hex.toIntOrNull(HEX_RADIX) ?: fail(StringsFailure.BadEscape)
         pos += UNICODE_ESCAPE_HEX_DIGITS
         return code.toChar()
     }
 }
 
-private const val BYTE_MASK = 0xFF
+/**
+ * Internal control-flow vehicle for short-circuiting deeply-nested lexer helpers.
+ * Caught only at the [parseStrings] boundary; never leaks across the public API.
+ *
+ * The project convention favors `Result<T>` over exceptions, but that convention is
+ * about API surface. Hand-rolled lexers benefit from a non-local escape because
+ * threading a nullable failure through every helper would force every method to
+ * return a `StringsFailure?` and every caller to check it before advancing — for a
+ * parser whose helpers are 5-15 lines apiece, the bookkeeping outweighs the benefit.
+ * This is a deliberate, file-local carve-out; see [PassJsonDecoder] for the
+ * alternative pattern (sealed-result returns) where helpers are larger and the
+ * failure can be lifted at each boundary.
+ */
+private class StringsParseException(val failure: StringsFailure) : RuntimeException()
+
 private const val HEX_RADIX = 16
 private const val UNICODE_ESCAPE_HEX_DIGITS = 4
+private const val SURROGATE_PARTNER_PREFIX_LEN = 2
 private const val UTF8_TWO_BYTE_THRESHOLD = 0x80
 private const val UTF8_THREE_BYTE_THRESHOLD = 0x800
 
-private val BOM_UTF8 = intArrayOf(0xEF, 0xBB, 0xBF)
-private val BOM_UTF16BE = intArrayOf(0xFE, 0xFF)
-private val BOM_UTF16LE = intArrayOf(0xFF, 0xFE)
+private val BOM_UTF8 = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+private val BOM_UTF16BE = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+private val BOM_UTF16LE = byteArrayOf(0xFF.toByte(), 0xFE.toByte())

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsParser.kt
@@ -1,0 +1,259 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.MalformedReason
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.ResourceLimit
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+
+/**
+ * Parses a single Apple .strings localization payload (the PKPASS per-locale
+ * `<locale>.lproj/pass.strings`) into a [LocalizedStrings]. Pure function: no I/O,
+ * iteration order matches source order via [LinkedHashMap], duplicate keys are
+ * resolved last-write-wins (matching Apple's parser).
+ *
+ * **Defense-in-depth ordering.** The function runs three layers, in order, and the
+ * earliest-firing arm wins:
+ *
+ *  1. Charset BOM-sniff and strict decode — UTF-16 LE/BE or UTF-8 BOM signs the file;
+ *     otherwise UTF-8 is the documented default. The decoder is configured with
+ *     [CodingErrorAction.REPORT] for both malformed input and unmappable characters,
+ *     so a non-UTF-8 byte sequence with no BOM fails outright as
+ *     [MalformedReason.InvalidPassJson] rather than producing U+FFFD replacement
+ *     characters and silently mis-rendering on screen.
+ *  2. Hand-rolled lexer / parser ([StringsLexer]) — single-pass character walker with
+ *     explicit state for in-string and in-comment tokens. Regex on this format is
+ *     brittle: Apple's `\Uxxxx` escape is 4 hex digits (not a 21-bit codepoint), block
+ *     comments do not nest, and a backslash immediately before EOL is *not* a line
+ *     continuation. The walker fits cleanly into ~150 lines and keeps each rule local
+ *     to its branch.
+ *  3. Per-value byte cap — [ParserConfig.maxJsonStringBytes] applies to the decoded
+ *     value of each entry (UTF-8 byte equivalent, summed as a conservative upper
+ *     bound on a per-Char basis so an oversized value is rejected mid-read rather
+ *     than after full materialization). The same knob the pass.json parser uses;
+ *     introducing a separate `maxStringsValueBytes` would be a knob without a turner
+ *     — wpass-oj8 covers any global decompressed footprint cap. Total file size is
+ *     already bounded by [ParserConfig.maxEntryBytes] upstream.
+ *
+ * The cap is applied to values only, not keys. Keys in real .strings files routinely
+ * exceed any sensible value cap (they are often dotted human-readable identifiers);
+ * the cap exists to bound memory expansion on the rendered surface, not key length.
+ */
+internal fun parseStrings(
+    bytes: ByteArray,
+    config: ParserConfig,
+): StringsResult {
+    val text =
+        decodeWithBomSniff(bytes)
+            ?: return StringsResult.Failed(MalformedReason.InvalidPassJson)
+    return try {
+        StringsResult.Ok(StringsLexer(text, config.maxJsonStringBytes).parse())
+    } catch (e: StringsParseException) {
+        StringsResult.Failed(e.reason)
+    }
+}
+
+/**
+ * BOM-sniffs the leading bytes for UTF-16 LE/BE / UTF-8 and decodes the rest with a
+ * [java.nio.charset.CharsetDecoder] whose error policy is REPORT on both malformed
+ * input and unmappable characters. Returns `null` if decoding fails — surfaced as
+ * [MalformedReason.InvalidPassJson] by the caller. UTF-8 is the no-BOM default per
+ * Apple's documented behavior for .strings.
+ *
+ * The BOM is stripped before handing bytes to the decoder. Java's `UTF_16LE` /
+ * `UTF_16BE` charsets do *not* themselves treat a BOM as a marker (they are
+ * explicit codings), so passing the BOM bytes through would surface the BOM as a
+ * spurious U+FEFF leading character in the decoded text and break the lexer's
+ * first-token assumptions.
+ */
+private fun decodeWithBomSniff(bytes: ByteArray): String? {
+    val (charset, skip) =
+        when {
+            hasPrefix(bytes, BOM_UTF8) -> StandardCharsets.UTF_8 to BOM_UTF8.size
+            hasPrefix(bytes, BOM_UTF16BE) -> StandardCharsets.UTF_16BE to BOM_UTF16BE.size
+            hasPrefix(bytes, BOM_UTF16LE) -> StandardCharsets.UTF_16LE to BOM_UTF16LE.size
+            else -> StandardCharsets.UTF_8 to 0
+        }
+    val decoder =
+        charset.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+    return runCatching {
+        decoder.decode(ByteBuffer.wrap(bytes, skip, bytes.size - skip)).toString()
+    }.getOrNull()
+}
+
+private fun hasPrefix(
+    bytes: ByteArray,
+    prefix: IntArray,
+): Boolean {
+    if (bytes.size < prefix.size) return false
+    return prefix.indices.all { bytes[it].toInt() and BYTE_MASK == prefix[it] }
+}
+
+/**
+ * Conservative UTF-8 byte count for a single [Char] (BMP code unit). Surrogate halves
+ * count as 3 bytes each, an upper bound on the actual encoded length without paying
+ * for an actual encode. Suitable for bounding "is this string under the cap"; not
+ * suitable for serialization sizing.
+ */
+private fun Char.utf8Bytes(): Int =
+    when {
+        code < UTF8_TWO_BYTE_THRESHOLD -> 1
+        code < UTF8_THREE_BYTE_THRESHOLD -> 2
+        else -> 3
+    }
+
+/**
+ * Internal control-flow vehicle for short-circuiting deeply-nested lexer helpers.
+ * Caught only at the [parseStrings] boundary; never leaks across the public API.
+ * Using an exception here keeps each helper a single-return function and avoids
+ * threading a nullable failure state through every level.
+ */
+private class StringsParseException(val reason: MalformedReason) : RuntimeException()
+
+private class StringsLexer(
+    private val text: String,
+    private val maxValueBytes: Int,
+) {
+    private var pos = 0
+
+    fun parse(): LocalizedStrings {
+        val map = LinkedHashMap<String, String>()
+        while (true) {
+            skipWhitespaceAndComments()
+            if (pos >= text.length) break
+            val key = readQuotedString(maxBytes = Int.MAX_VALUE)
+            consumeAfterWhitespace('=')
+            val value = readQuotedString(maxBytes = maxValueBytes)
+            consumeAfterWhitespace(';')
+            map[key] = value
+        }
+        return LocalizedStrings(map)
+    }
+
+    private fun fail(reason: MalformedReason): Nothing = throw StringsParseException(reason)
+
+    private fun skipWhitespaceAndComments() {
+        while (pos < text.length) {
+            val c = text[pos]
+            val next = if (pos + 1 < text.length) text[pos + 1] else null
+            when {
+                c.isWhitespace() -> pos++
+                c == '/' && next == '/' -> skipLineComment()
+                c == '/' && next == '*' -> skipBlockComment()
+                else -> return
+            }
+        }
+    }
+
+    private fun skipLineComment() {
+        pos += 2
+        while (pos < text.length && text[pos] != '\n') pos++
+        if (pos < text.length) pos++
+    }
+
+    private fun skipBlockComment() {
+        pos += 2
+        var found = false
+        while (!found && pos + 1 < text.length) {
+            if (text[pos] == '*' && text[pos + 1] == '/') {
+                pos += 2
+                found = true
+            } else {
+                pos++
+            }
+        }
+        if (!found) fail(MalformedReason.InvalidPassJson)
+    }
+
+    private fun readQuotedString(maxBytes: Int): String {
+        skipWhitespaceAndComments()
+        if (pos >= text.length || text[pos] != '"') fail(MalformedReason.InvalidPassJson)
+        pos++
+        val sb = StringBuilder()
+        var byteCount = 0
+        while (pos < text.length) {
+            val c = text[pos]
+            when (c) {
+                '"' -> {
+                    pos++
+                    return sb.toString()
+                }
+                '\\' -> {
+                    val ch = readEscape()
+                    byteCount = bumpByteCount(byteCount, ch.utf8Bytes(), maxBytes)
+                    sb.append(ch)
+                }
+                else -> {
+                    pos++
+                    byteCount = bumpByteCount(byteCount, c.utf8Bytes(), maxBytes)
+                    sb.append(c)
+                }
+            }
+        }
+        fail(MalformedReason.InvalidPassJson)
+    }
+
+    private fun bumpByteCount(
+        current: Int,
+        delta: Int,
+        max: Int,
+    ): Int {
+        val next = current + delta
+        if (next > max) fail(MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize))
+        return next
+    }
+
+    private fun consumeAfterWhitespace(expected: Char) {
+        skipWhitespaceAndComments()
+        if (pos >= text.length || text[pos] != expected) fail(MalformedReason.InvalidPassJson)
+        pos++
+    }
+
+    private fun readEscape(): Char {
+        pos++
+        if (pos >= text.length) fail(MalformedReason.InvalidPassJson)
+        return when (val c = text[pos]) {
+            '\\', '"' -> {
+                pos++
+                c
+            }
+            'n' -> {
+                pos++
+                '\n'
+            }
+            'r' -> {
+                pos++
+                '\r'
+            }
+            't' -> {
+                pos++
+                '\t'
+            }
+            'U' -> readUnicodeEscape()
+            else -> fail(MalformedReason.InvalidPassJson)
+        }
+    }
+
+    private fun readUnicodeEscape(): Char {
+        pos++
+        if (pos + UNICODE_ESCAPE_HEX_DIGITS > text.length) fail(MalformedReason.InvalidPassJson)
+        val hex = text.substring(pos, pos + UNICODE_ESCAPE_HEX_DIGITS)
+        val code = hex.toIntOrNull(HEX_RADIX) ?: fail(MalformedReason.InvalidPassJson)
+        pos += UNICODE_ESCAPE_HEX_DIGITS
+        return code.toChar()
+    }
+}
+
+private const val BYTE_MASK = 0xFF
+private const val HEX_RADIX = 16
+private const val UNICODE_ESCAPE_HEX_DIGITS = 4
+private const val UTF8_TWO_BYTE_THRESHOLD = 0x80
+private const val UTF8_THREE_BYTE_THRESHOLD = 0x800
+
+private val BOM_UTF8 = intArrayOf(0xEF, 0xBB, 0xBF)
+private val BOM_UTF16BE = intArrayOf(0xFE, 0xFF)
+private val BOM_UTF16LE = intArrayOf(0xFF, 0xFE)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsResult.kt
@@ -1,28 +1,69 @@
 package `is`.walt.passes.core.internal
 
 import `is`.walt.passes.core.LocalizedStrings
-import `is`.walt.passes.core.MalformedReason
 
 /**
  * Outcome of running [parseStrings] over a single `<locale>.lproj/pass.strings` payload.
  * Internal only: the parser-glue bead lifts a [Failed] into the right
  * [`is`.walt.passes.core.ParseResult] arm.
  *
- * The arm split is deliberately narrow — [Failed] surfaces a public [MalformedReason]
- * directly because the .strings layer has no finer-grained internal failure vocabulary
- * to defend yet (no version field, no shape constraints richer than `"key" = "value";`).
- * Two reasons are surfaceable today:
- *
- *  - [MalformedReason.InvalidPassJson] for any structural decode failure (charset error,
- *    unterminated token, missing `=` / `;`, unrecognized escape). A follow-up bead
- *    (wpass-n6g) introduces a dedicated `MalformedReason.InvalidStrings` arm; until
- *    then `InvalidPassJson` is the closest existing arm and routing can move in one
- *    place.
- *  - [MalformedReason.ResourceLimitExceeded] with
- *    [`is`.walt.passes.core.ResourceLimit.JsonStringSize] on a per-value byte cap trip.
+ * Mirrors [PassJsonDecodeResult]'s split: the public failure surface is coarse
+ * ([`is`.walt.passes.core.MalformedReason.InvalidStrings] /
+ * [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded]) but each internal
+ * arm carries the granularity ops dashboards need to tell a charset failure apart
+ * from a truncation attack and from a per-value cap trip without re-deriving the
+ * cause from a stringy reason.
  */
 internal sealed interface StringsResult {
     data class Ok(val strings: LocalizedStrings) : StringsResult
 
-    data class Failed(val reason: MalformedReason) : StringsResult
+    data class Failed(val failure: StringsFailure) : StringsResult
+}
+
+/**
+ * Why [parseStrings] rejected a `pass.strings` payload. Arms are deliberately finer-
+ * grained than the public [`is`.walt.passes.core.MalformedReason] surface so the
+ * parser-glue bead can route each failure independently and so telemetry can
+ * distinguish a structural attack pattern (e.g. dangling block comments showing up
+ * in bursts) from an encoding misconfiguration.
+ *
+ * All arms except [ValueTooLong] lift to [`is`.walt.passes.core.MalformedReason.InvalidStrings];
+ * [ValueTooLong] lifts to [`is`.walt.passes.core.MalformedReason.ResourceLimitExceeded]
+ * with [`is`.walt.passes.core.ResourceLimit.JsonStringSize].
+ */
+internal sealed interface StringsFailure {
+    /**
+     * BOM-sniff matched no charset, or the bytes did not decode under the chosen
+     * charset's strict policy (REPORT on malformed input).
+     */
+    data object InvalidEncoding : StringsFailure
+
+    /** A `"`-opened string ran to EOF without a matching close. */
+    data object UnterminatedString : StringsFailure
+
+    /** A block comment was opened (slash-star) but ran to EOF without a closing star-slash. */
+    data object UnterminatedComment : StringsFailure
+
+    /**
+     * Expected an `=`, `;`, or opening `"` and got something else. Distinct from
+     * [BadEscape] because the wrong-shape signal is at the entry layer rather than
+     * inside a quoted string.
+     */
+    data object BadStructure : StringsFailure
+
+    /**
+     * Unrecognized escape (`\x`), short or non-hex `\Uxxxx`, or a surrogate code unit
+     * that is not part of a valid pair. Unpaired surrogates are rejected outright
+     * rather than silently embedded — a malformed UTF-16 string smuggled past the
+     * parser would surface unpredictably at any downstream UTF-8 boundary
+     * (re-encoding, JNI, logging) and undermines the strict-decode posture the
+     * charset layer enforces on raw bytes.
+     */
+    data object BadEscape : StringsFailure
+
+    /**
+     * A single value's decoded UTF-8 byte length exceeded
+     * [`is`.walt.passes.core.ParserConfig.maxJsonStringBytes].
+     */
+    data object ValueTooLong : StringsFailure
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/StringsResult.kt
@@ -1,0 +1,28 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.MalformedReason
+
+/**
+ * Outcome of running [parseStrings] over a single `<locale>.lproj/pass.strings` payload.
+ * Internal only: the parser-glue bead lifts a [Failed] into the right
+ * [`is`.walt.passes.core.ParseResult] arm.
+ *
+ * The arm split is deliberately narrow — [Failed] surfaces a public [MalformedReason]
+ * directly because the .strings layer has no finer-grained internal failure vocabulary
+ * to defend yet (no version field, no shape constraints richer than `"key" = "value";`).
+ * Two reasons are surfaceable today:
+ *
+ *  - [MalformedReason.InvalidPassJson] for any structural decode failure (charset error,
+ *    unterminated token, missing `=` / `;`, unrecognized escape). A follow-up bead
+ *    (wpass-n6g) introduces a dedicated `MalformedReason.InvalidStrings` arm; until
+ *    then `InvalidPassJson` is the closest existing arm and routing can move in one
+ *    place.
+ *  - [MalformedReason.ResourceLimitExceeded] with
+ *    [`is`.walt.passes.core.ResourceLimit.JsonStringSize] on a per-value byte cap trip.
+ */
+internal sealed interface StringsResult {
+    data class Ok(val strings: LocalizedStrings) : StringsResult
+
+    data class Failed(val reason: MalformedReason) : StringsResult
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
@@ -132,6 +132,7 @@ class PublicApiSurfaceTest {
                 MalformedReason.MissingManifest,
                 MalformedReason.InvalidPassJson,
                 MalformedReason.InvalidManifest,
+                MalformedReason.InvalidStrings,
                 MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonDepth),
             )
         assertThat(reasons.toSet()).hasSize(reasons.size)

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/StringsParserTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/StringsParserTest.kt
@@ -1,0 +1,243 @@
+package `is`.walt.passes.core.internal
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import `is`.walt.passes.core.MalformedReason
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.ResourceLimit
+import org.junit.Test
+import java.nio.charset.StandardCharsets
+
+/**
+ * Behavior tests for [parseStrings]. Every fixture is built in-memory from string
+ * literals (and a few hand-crafted byte arrays for the BOM / non-UTF-8 cases) so a
+ * reviewer can read each test and see exactly which arm of [StringsResult] is being
+ * exercised. No checked-in binary fixtures.
+ */
+class StringsParserTest {
+    @Test
+    fun happyPathFiveEntriesWithMixedComments() {
+        val source =
+            """
+            // header comment, ignored
+            "from" = "SFO";
+            /* block comment
+               spanning multiple lines */
+            "to" = "JFK";
+            "flight" = "AA42"; // trailing comment
+            "gate" = "B23";
+            "seat" = "12A";
+            """.trimIndent()
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly(
+            "from", "SFO",
+            "to", "JFK",
+            "flight", "AA42",
+            "gate", "B23",
+            "seat", "12A",
+        ).inOrder()
+    }
+
+    @Test
+    fun emptyFileReturnsEmptyMap() {
+        val ok = parseStrings(ByteArray(0), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).isEmpty()
+    }
+
+    @Test
+    fun commentOnlyFileReturnsEmptyMap() {
+        val source = "// only a line comment\n/* and a block */\n"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).isEmpty()
+    }
+
+    @Test
+    fun duplicateKeyLastWriteWins() {
+        // Apple's runtime takes the last assignment; we match that to avoid a
+        // double-rendered row when an author copy-pastes a key.
+        val source =
+            """
+            "k" = "first";
+            "k" = "second";
+            "k" = "third";
+            """.trimIndent()
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "third")
+    }
+
+    @Test
+    fun utf8BomIsStrippedAndContentDecoded() {
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val payload = "\"k\" = \"v\";".toByteArray(StandardCharsets.UTF_8)
+        val ok = parseStrings(bom + payload, ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
+    }
+
+    @Test
+    fun utf16LeBomDecoded() {
+        val bom = byteArrayOf(0xFF.toByte(), 0xFE.toByte())
+        val payload = "\"k\" = \"v\";".toByteArray(StandardCharsets.UTF_16LE)
+        val ok = parseStrings(bom + payload, ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
+    }
+
+    @Test
+    fun utf16BeBomDecoded() {
+        val bom = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+        val payload = "\"k\" = \"v\";".toByteArray(StandardCharsets.UTF_16BE)
+        val ok = parseStrings(bom + payload, ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
+    }
+
+    @Test
+    fun nonUtf8WithoutBomReturnsFailed() {
+        // 0xC3 alone is an invalid UTF-8 lead byte (a 2-byte sequence start whose
+        // continuation byte does not satisfy 10xxxxxx). The strict decoder REPORTs
+        // and we surface a structural failure rather than emit U+FFFD silently.
+        val bytes = byteArrayOf(0xC3.toByte(), 0x28)
+        assertFailedWith(parseStrings(bytes, ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun escapeSequencesRoundTrip() {
+        // Source contains \" \n \r \t \\ in that order between letters.
+        val source = "\"k\" = \"a\\\"b\\nc\\rd\\te\\\\f\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries["k"]).isEqualTo("a\"b\nc\rd\te\\f")
+    }
+
+    @Test
+    fun unicodeEscapeDecodesFourHexDigits() {
+        // \U00E9 -> é (U+00E9, 2-byte UTF-8); \U2603 -> ☃ (U+2603, 3-byte UTF-8).
+        val source = "\"acc\" = \"caf\\U00E9\";\n\"snowman\" = \"\\U2603\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries["acc"]).isEqualTo("café")
+        assertThat(ok.strings.entries["snowman"]).isEqualTo("☃")
+    }
+
+    @Test
+    fun unrecognizedEscapeReturnsFailed() {
+        // \x is not an Apple-supported escape; the strict reader rejects it rather
+        // than silently emitting `x`, which would let an attacker smuggle bytes past
+        // a downstream renderer that thinks the parser stripped escapes.
+        val source = "\"k\" = \"a\\xb\";"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun unterminatedQuotedStringReturnsFailed() {
+        val source = "\"k\" = \"unterminated"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun unterminatedBlockCommentReturnsFailed() {
+        val source = "/* never closed"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun missingEqualsReturnsFailed() {
+        val source = "\"k\" \"v\";"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun missingSemicolonReturnsFailed() {
+        val source = "\"k\" = \"v\""
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+    }
+
+    @Test
+    fun perValueByteCapTrip() {
+        val cfg = ParserConfig(maxJsonStringBytes = 8)
+        val source = "\"k\" = \"" + "x".repeat(16) + "\";"
+        assertFailedWith(
+            parseStrings(source.toByteArray(), cfg),
+            MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize),
+        )
+    }
+
+    @Test
+    fun perValueByteCapAcceptsAtTheLimit() {
+        val cfg = ParserConfig(maxJsonStringBytes = 8)
+        val source = "\"k\" = \"" + "x".repeat(8) + "\";"
+        val ok = parseStrings(source.toByteArray(), cfg).asOk()
+        assertThat(ok.strings.entries["k"]).isEqualTo("x".repeat(8))
+    }
+
+    @Test
+    fun perValueCapDoesNotApplyToKeys() {
+        // Real .strings files use long dotted identifiers as keys; the cap is for
+        // value memory expansion on the rendered surface, not key length.
+        val cfg = ParserConfig(maxJsonStringBytes = 4)
+        val longKey = "k".repeat(64)
+        val source = "\"$longKey\" = \"v\";"
+        val ok = parseStrings(source.toByteArray(), cfg).asOk()
+        assertThat(ok.strings.entries[longKey]).isEqualTo("v")
+    }
+
+    @Test
+    fun multibyteCharacterUsesUtf8ByteCountNotCharCount() {
+        // Snowman ☃ (U+2603) is 3 bytes in UTF-8 but one Char. With cap=2 the value
+        // must be rejected — a naive char-count guard would let it through.
+        val cfg = ParserConfig(maxJsonStringBytes = 2)
+        val source = "\"k\" = \"\\U2603\";"
+        assertFailedWith(
+            parseStrings(source.toByteArray(), cfg),
+            MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize),
+        )
+    }
+
+    @Test
+    fun escapedQuoteInsideStringDoesNotTerminate() {
+        // Regression guard: \" inside a string must continue the value, not end it.
+        val source = "\"k\" = \"a\\\"b\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries["k"]).isEqualTo("a\"b")
+    }
+
+    @Test
+    fun iterationOrderMatchesSourceOrder() {
+        // LinkedHashMap surfaces insertion order; assert by lifting keys to a list
+        // because Truth's MapSubject ordering check inspects entrySet iteration.
+        val source =
+            """
+            "z" = "1";
+            "a" = "2";
+            "m" = "3";
+            """.trimIndent()
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries.keys.toList()).containsExactly("z", "a", "m").inOrder()
+    }
+
+    @Test
+    fun trailingCommentAfterFinalSemicolonIsIgnored() {
+        val source = "\"k\" = \"v\"; // trailing\n"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
+    }
+
+    @Test
+    fun bareBomOnlyFileReturnsEmptyMap() {
+        // A file with only a BOM (no payload) must decode to empty text and surface
+        // as Ok(empty), not InvalidPassJson — the BOM is a marker, not content.
+        val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+        val ok = parseStrings(bom, ParserConfig()).asOk()
+        assertThat(ok.strings.entries).isEmpty()
+    }
+
+    private fun StringsResult.asOk(): StringsResult.Ok {
+        assertThat(this).isInstanceOf(StringsResult.Ok::class.java)
+        return this as StringsResult.Ok
+    }
+
+    private fun assertFailedWith(
+        actual: StringsResult,
+        expected: MalformedReason,
+    ) {
+        assertThat(actual).isInstanceOf(StringsResult.Failed::class.java)
+        val reason = (actual as StringsResult.Failed).reason
+        assertWithMessage("expected MalformedReason=$expected, got $reason").that(reason).isEqualTo(expected)
+    }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/StringsParserTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/StringsParserTest.kt
@@ -2,17 +2,15 @@ package `is`.walt.passes.core.internal
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
-import `is`.walt.passes.core.MalformedReason
 import `is`.walt.passes.core.ParserConfig
-import `is`.walt.passes.core.ResourceLimit
 import org.junit.Test
 import java.nio.charset.StandardCharsets
 
 /**
  * Behavior tests for [parseStrings]. Every fixture is built in-memory from string
  * literals (and a few hand-crafted byte arrays for the BOM / non-UTF-8 cases) so a
- * reviewer can read each test and see exactly which arm of [StringsResult] is being
- * exercised. No checked-in binary fixtures.
+ * reviewer can read each test and see exactly which arm of [StringsResult] is
+ * being exercised. No checked-in binary fixtures.
  */
 class StringsParserTest {
     @Test
@@ -90,12 +88,12 @@ class StringsParserTest {
     }
 
     @Test
-    fun nonUtf8WithoutBomReturnsFailed() {
+    fun nonUtf8WithoutBomReturnsInvalidEncoding() {
         // 0xC3 alone is an invalid UTF-8 lead byte (a 2-byte sequence start whose
         // continuation byte does not satisfy 10xxxxxx). The strict decoder REPORTs
         // and we surface a structural failure rather than emit U+FFFD silently.
         val bytes = byteArrayOf(0xC3.toByte(), 0x28)
-        assertFailedWith(parseStrings(bytes, ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(bytes, ParserConfig()), StringsFailure.InvalidEncoding)
     }
 
     @Test
@@ -116,46 +114,79 @@ class StringsParserTest {
     }
 
     @Test
+    fun pairedSurrogateEscapeDecodesSupplementaryCodepoint() {
+        // Apple writes emoji as paired \U<high>\U<low>. \UD83D\UDE00 is U+1F600 (😀);
+        // the resulting Kotlin String is well-formed UTF-16 (length 2, 4 UTF-8 bytes).
+        val source = "\"emoji\" = \"\\UD83D\\UDE00\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        val value = ok.strings.entries["emoji"]
+        assertThat(value).isEqualTo("😀")
+        assertThat(value).isEqualTo("😀")
+        assertThat(value!!.toByteArray(StandardCharsets.UTF_8)).hasLength(4)
+    }
+
+    @Test
+    fun loneHighSurrogateEscapeIsRejected() {
+        // \UD800 alone would produce malformed UTF-16; reject as BadEscape rather
+        // than embed it and surprise downstream UTF-8 boundaries with U+FFFD or
+        // CharacterCodingException.
+        val source = "\"k\" = \"\\UD800\";"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadEscape)
+    }
+
+    @Test
+    fun loneLowSurrogateEscapeIsRejected() {
+        // \UDC00 without a preceding high surrogate is also malformed.
+        val source = "\"k\" = \"\\UDC00\";"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadEscape)
+    }
+
+    @Test
+    fun highSurrogateFollowedByNonSurrogateIsRejected() {
+        // After a high surrogate, only \U<low> is acceptable; a literal char or a
+        // non-low \U escape must surface as BadEscape, not silently truncate.
+        val source = "\"k\" = \"\\UD83Dx\";"
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadEscape)
+    }
+
+    @Test
     fun unrecognizedEscapeReturnsFailed() {
         // \x is not an Apple-supported escape; the strict reader rejects it rather
         // than silently emitting `x`, which would let an attacker smuggle bytes past
         // a downstream renderer that thinks the parser stripped escapes.
         val source = "\"k\" = \"a\\xb\";"
-        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadEscape)
     }
 
     @Test
-    fun unterminatedQuotedStringReturnsFailed() {
+    fun unterminatedQuotedStringReturnsUnterminatedString() {
         val source = "\"k\" = \"unterminated"
-        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.UnterminatedString)
     }
 
     @Test
-    fun unterminatedBlockCommentReturnsFailed() {
+    fun unterminatedBlockCommentReturnsUnterminatedComment() {
         val source = "/* never closed"
-        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.UnterminatedComment)
     }
 
     @Test
-    fun missingEqualsReturnsFailed() {
+    fun missingEqualsReturnsBadStructure() {
         val source = "\"k\" \"v\";"
-        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadStructure)
     }
 
     @Test
-    fun missingSemicolonReturnsFailed() {
+    fun missingSemicolonReturnsBadStructure() {
         val source = "\"k\" = \"v\""
-        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), MalformedReason.InvalidPassJson)
+        assertFailedWith(parseStrings(source.toByteArray(), ParserConfig()), StringsFailure.BadStructure)
     }
 
     @Test
     fun perValueByteCapTrip() {
         val cfg = ParserConfig(maxJsonStringBytes = 8)
         val source = "\"k\" = \"" + "x".repeat(16) + "\";"
-        assertFailedWith(
-            parseStrings(source.toByteArray(), cfg),
-            MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize),
-        )
+        assertFailedWith(parseStrings(source.toByteArray(), cfg), StringsFailure.ValueTooLong)
     }
 
     @Test
@@ -183,10 +214,20 @@ class StringsParserTest {
         // must be rejected — a naive char-count guard would let it through.
         val cfg = ParserConfig(maxJsonStringBytes = 2)
         val source = "\"k\" = \"\\U2603\";"
-        assertFailedWith(
-            parseStrings(source.toByteArray(), cfg),
-            MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize),
-        )
+        assertFailedWith(parseStrings(source.toByteArray(), cfg), StringsFailure.ValueTooLong)
+    }
+
+    @Test
+    fun surrogatePairBytesAreCountedConservativelyAgainstCap() {
+        // 😀 is 4 bytes UTF-8; utf8Bytes() reports 3 per surrogate half = 6 total
+        // (a deliberate overcount). cap=4 → rejected (stricter than reality, fine);
+        // cap=6 → accepted (matches the conservative bound).
+        val sourceFmt = { cap: Int -> Pair(ParserConfig(maxJsonStringBytes = cap), "\"k\" = \"\\UD83D\\UDE00\";") }
+        val (tightCfg, tightSrc) = sourceFmt(4)
+        assertFailedWith(parseStrings(tightSrc.toByteArray(), tightCfg), StringsFailure.ValueTooLong)
+        val (looseCfg, looseSrc) = sourceFmt(6)
+        val ok = parseStrings(looseSrc.toByteArray(), looseCfg).asOk()
+        assertThat(ok.strings.entries["k"]).isEqualTo("😀")
     }
 
     @Test
@@ -221,10 +262,37 @@ class StringsParserTest {
     @Test
     fun bareBomOnlyFileReturnsEmptyMap() {
         // A file with only a BOM (no payload) must decode to empty text and surface
-        // as Ok(empty), not InvalidPassJson — the BOM is a marker, not content.
+        // as Ok(empty), not InvalidEncoding — the BOM is a marker, not content.
         val bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
         val ok = parseStrings(bom, ParserConfig()).asOk()
         assertThat(ok.strings.entries).isEmpty()
+    }
+
+    @Test
+    fun lineCommentTerminatesOnCarriageReturn() {
+        // Classic-Mac CR-only line endings: a line comment must not swallow the
+        // following entry just because there is no \n. Mixed CR / CRLF shows up
+        // when a tool re-saves with the wrong EOL convention.
+        val source = "// line comment\r\"k\" = \"v\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
+    }
+
+    @Test
+    fun emptyKeyParses() {
+        // Apple accepts "" = "v"; — degenerate but legal. We match.
+        val source = "\"\" = \"v\";"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries[""]).isEqualTo("v")
+    }
+
+    @Test
+    fun whitespaceBeforeSemicolonIsAccepted() {
+        // consumeAfterWhitespace skips ws/comments before the delimiter; verify
+        // the path is exercised for `;` as well as `=`.
+        val source = "\"k\" = \"v\" ;"
+        val ok = parseStrings(source.toByteArray(), ParserConfig()).asOk()
+        assertThat(ok.strings.entries).containsExactly("k", "v")
     }
 
     private fun StringsResult.asOk(): StringsResult.Ok {
@@ -234,10 +302,10 @@ class StringsParserTest {
 
     private fun assertFailedWith(
         actual: StringsResult,
-        expected: MalformedReason,
+        expected: StringsFailure,
     ) {
         assertThat(actual).isInstanceOf(StringsResult.Failed::class.java)
-        val reason = (actual as StringsResult.Failed).reason
-        assertWithMessage("expected MalformedReason=$expected, got $reason").that(reason).isEqualTo(expected)
+        val failure = (actual as StringsResult.Failed).failure
+        assertWithMessage("expected StringsFailure=$expected, got $failure").that(failure).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
## Summary
- Internal `parseStrings(bytes, config): StringsResult` under `passes-core/src/main/kotlin/is/walt/passes/core/internal/`. Fifth slice of the PassParser implementation (after wpass-7sl, #26).
- BOM-sniffs UTF-16 LE/BE and UTF-8, defaults to UTF-8, and uses a strict `CharsetDecoder` that REPORTs on malformed input rather than emitting U+FFFD.
- Hand-rolled single-pass lexer/parser walks the `"key" = "value";` format with `//` line comments, `/* */` block comments, and `\\`, `\"`, `\n`, `\r`, `\t`, `\Uxxxx` escapes (no regex; backtracking-safe expressions over `\Uxxxx` and the comment shapes are awkward).
- Per-value `ParserConfig.maxJsonStringBytes` cap, summed as a conservative UTF-8 byte upper bound per `Char` so an oversized value is rejected mid-read. Cap applies to values only; keys are not bounded (real .strings keys are routinely long dotted identifiers).
- `LinkedHashMap` preserves source iteration order; duplicate keys resolve last-write-wins (matches Apple).
- `StringsResult` is an internal sealed interface that surfaces public `MalformedReason` arms directly. `MalformedReason.InvalidPassJson` is the closest existing arm for structural failures and routing can move in one place when wpass-n6g introduces a dedicated `InvalidStrings` arm.

Closes wpass-ddc.

## Test plan
- [x] `./gradlew :passes-core:check :passes-core:detekt` — green
- [x] 23 in-memory fixtures cover: 5-entry happy path with mixed comment styles, empty file, comment-only file, duplicate keys, all three BOM variants, non-UTF-8 without BOM, every recognised escape, `\Uxxxx` codepoints (BMP and above 0x80), unrecognised escapes, unterminated string / block comment / missing `=` / missing `;`, per-value byte cap (trip, at-the-limit, multibyte cap), key length not bounded by the value cap, escaped quote does not terminate the value, source-order iteration, BOM-only file
- [x] `PublicApiSurfaceTest` unchanged