### PR TITLE
passes-core: PassParser.create() factory glue (wpass-qnc)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/PassParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/PassParser.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.core
 
+import `is`.walt.passes.core.internal.DefaultPassParser
 import java.io.InputStream
 
 /**
@@ -13,20 +14,25 @@ import java.io.InputStream
  * UI must distinguish.
  */
 public fun interface PassParser {
+    /**
+     * Parse [source] into a [ParseResult]. Synchronous and CPU-bound: BouncyCastle's
+     * PKCS#7 verification, JSON tokenization, and zip extraction all run on the calling
+     * thread. Wrap with `withTimeout(...)` (kotlinx.coroutines) when invoking from a
+     * coroutine context that requires a per-call timeout — [ParserConfig] does not yet
+     * expose a built-in deadline knob and will not until the public surface freeze
+     * around ADR 0001 lifts.
+     *
+     * Never throws: every failure mode is encoded as a [ParseResult] arm.
+     */
     public fun parse(source: PassSource): ParseResult
 
     public companion object {
         /**
-         * Construct a parser bound to [config]. The default factory is intentionally not
-         * yet implemented; landing it is the next bead after this skeleton.
+         * Construct a parser bound to [config]. The returned instance is safe to call
+         * concurrently from multiple threads — it holds only the immutable [config] and
+         * delegates to stateless internal pipeline functions on each [parse] invocation.
          */
-        public fun create(config: ParserConfig = ParserConfig()): PassParser =
-            PassParser { _ ->
-                throw NotImplementedError(
-                    "PassParser implementation pending follow-up bead; this skeleton only " +
-                        "fixes the public API surface. config=$config",
-                )
-            }
+        public fun create(config: ParserConfig = ParserConfig()): PassParser = DefaultPassParser(config)
     }
 }
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/Constants.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/Constants.kt
@@ -1,0 +1,13 @@
+package `is`.walt.passes.core.internal
+
+/**
+ * PKPASS archive member names that the parser-glue layer, the manifest verifier, and
+ * the hardened ZIP extractor must agree on byte-for-byte. The trust claim ("a manifest
+ * cannot self-reference, and the signature signs the manifest") rides on three call
+ * sites using the same string; the constant lives here so that agreement is structural
+ * rather than three private duplicates that could drift.
+ */
+internal const val SIGNATURE_FILE_NAME: String = "signature"
+
+/** See [SIGNATURE_FILE_NAME] — same rationale, applied to `manifest.json`. */
+internal const val MANIFEST_FILE_NAME: String = "manifest.json"

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
@@ -8,7 +8,6 @@ import `is`.walt.passes.core.ParseFailedEvent
 import `is`.walt.passes.core.ParseResult
 import `is`.walt.passes.core.ParseSucceededEvent
 import `is`.walt.passes.core.ParserConfig
-import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassParser
 import `is`.walt.passes.core.PassSource
@@ -47,72 +46,74 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
     override fun parse(source: PassSource): ParseResult {
         val started = System.nanoTime()
         config.telemetryGuard.onParseStarted()
-        val archiveBytes = sourceArchiveBytesOrZero(source)
-        val result = pipeline(source)
-        emit(result, started, archiveBytes)
-        return result
+        val outcome = runPipeline(source)
+        emit(outcome.result, started, outcome.archiveBytes)
+        return outcome.result
     }
 
     /**
-     * Sequenced as a chain of helpers (rather than a single body with seven `return`
-     * statements) so each stage's failure routing is local to its own helper. The
-     * chain order — extract → manifest → signature → pass.json → strings → images →
-     * assemble — is the trust hierarchy in code: a structural failure can never
-     * surface as tampering and a tampering signal can never be coalesced with
-     * malformedness.
+     * The full pipeline as a flat sequence of stages. Each stage either continues with
+     * its produced value or returns the [PipelineOutcome] holding the [ParseResult] and
+     * the best available archive-bytes count for telemetry. The branches are
+     * deliberately one-screen-tall and read top-to-bottom: a chain of `withX` helpers
+     * obscures that the trust hierarchy is just a linear sequence.
+     *
+     * The `@Suppress("ReturnCount")` is intentional: the pipeline has six stage
+     * boundaries, each with its own short-circuit; collapsing them into ≤2 returns
+     * either re-introduces the helper-chain or hides the early-exit shape behind a
+     * generic monadic plumbing whose payoff for six stages is not obviously worth the
+     * indirection.
      */
-    private fun pipeline(source: PassSource): ParseResult =
-        when (val r = extractSafely(source, config)) {
-            is ExtractResult.Failure -> ParseResult.Malformed(r.reason)
-            is ExtractResult.Success -> withEntries(r.entries)
-        }
-
-    private fun withEntries(entries: Map<String, ByteArray>): ParseResult =
-        when (val r = verifyManifest(entries)) {
-            is ManifestVerifyResult.Failed -> manifestFailureToResult(r.failure)
-            is ManifestVerifyResult.Ok -> withVerifiedManifest(entries, r.manifestBytes)
-        }
-
-    private fun withVerifiedManifest(
-        entries: Map<String, ByteArray>,
-        manifestBytes: ByteArray,
-    ): ParseResult =
-        when (val r = resolveSignature(entries, manifestBytes)) {
-            is SignaturePhaseResult.Failure -> r.parseResult
-            is SignaturePhaseResult.Status -> withSignatureStatus(entries, r.status)
-        }
-
-    private fun withSignatureStatus(
-        entries: Map<String, ByteArray>,
-        status: SignatureStatus,
-    ): ParseResult =
-        when (val r = decodePassJson(entries, config)) {
-            is PassJsonDecodeResult.Failed -> passJsonFailureToResult(r.failure)
-            is PassJsonDecodeResult.Ok -> assemble(entries, r.pass, status)
-        }
-
-    private fun assemble(
-        entries: Map<String, ByteArray>,
-        pass: Pass,
-        status: SignatureStatus,
-    ): ParseResult =
-        when (val locales = collectLocales(entries)) {
-            is LocaleCollect.Failure -> locales.parseResult
-            is LocaleCollect.Ok ->
-                when (val images = collectImages(entries)) {
-                    is ImageCollect.Failure -> images.parseResult
-                    is ImageCollect.Ok ->
-                        ParseResult.Success(
-                            pass = pass.copy(images = images.map, locales = locales.map),
-                            signatureStatus = status,
-                        )
-                }
-        }
+    @Suppress("ReturnCount")
+    private fun runPipeline(source: PassSource): PipelineOutcome {
+        val extracted =
+            when (val r = extractSafely(source, config)) {
+                is ExtractResult.Failure -> return PipelineOutcome(ParseResult.Malformed(r.reason), 0L)
+                is ExtractResult.Success -> r
+            }
+        val archiveBytes = computeArchiveBytes(source, extracted.archiveBytes)
+        val entries = extracted.entries
+        val manifestBytes =
+            when (val r = verifyManifest(entries)) {
+                is ManifestVerifyResult.Failed ->
+                    return PipelineOutcome(manifestFailureToResult(r.failure), archiveBytes)
+                is ManifestVerifyResult.Ok -> r.manifestBytes
+            }
+        val signatureStatus =
+            when (val r = resolveSignature(entries, manifestBytes)) {
+                is Phase.Halt -> return PipelineOutcome(r.result, archiveBytes)
+                is Phase.Continue -> r.value
+            }
+        val pass =
+            when (val r = decodePassJson(entries, config)) {
+                is PassJsonDecodeResult.Failed ->
+                    return PipelineOutcome(passJsonFailureToResult(r.failure), archiveBytes)
+                is PassJsonDecodeResult.Ok -> r.pass
+            }
+        val locales =
+            when (val r = collectLocales(entries)) {
+                is Phase.Halt -> return PipelineOutcome(r.result, archiveBytes)
+                is Phase.Continue -> r.value
+            }
+        val images =
+            when (val r = collectImages(entries)) {
+                is Phase.Halt -> return PipelineOutcome(r.result, archiveBytes)
+                is Phase.Continue -> r.value
+            }
+        return PipelineOutcome(
+            result =
+                ParseResult.Success(
+                    pass = pass.copy(images = images, locales = locales),
+                    signatureStatus = signatureStatus,
+                ),
+            archiveBytes = archiveBytes,
+        )
+    }
 
     private fun resolveSignature(
         entries: Map<String, ByteArray>,
         manifestBytes: ByteArray,
-    ): SignaturePhaseResult {
+    ): Phase<SignatureStatus> {
         val signatureBytes = entries[SIGNATURE_FILE_NAME]
         if (signatureBytes == null) {
             // No signature blob. The lenient default surfaces this as Unsigned; strict
@@ -122,20 +123,18 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
             // refuses to trust unsigned cryptographic provenance, which is the same
             // category of refusal as "the bytes did not parse as a CMS envelope."
             return if (config.acceptUnsignedArchives) {
-                SignaturePhaseResult.Status(SignatureStatus.Unsigned)
+                Phase.Continue(SignatureStatus.Unsigned)
             } else {
-                SignaturePhaseResult.Failure(
-                    ParseResult.Tampered(TamperReason.SignatureCryptoFailure),
-                )
+                Phase.Halt(ParseResult.Tampered(TamperReason.SignatureCryptoFailure))
             }
         }
         return when (val r = verifySignature(signatureBytes, manifestBytes, config)) {
-            is SignatureVerifyResult.Ok -> SignaturePhaseResult.Status(r.status)
-            is SignatureVerifyResult.Failed -> SignaturePhaseResult.Failure(ParseResult.Tampered(r.reason))
+            is SignatureVerifyResult.Ok -> Phase.Continue(r.status)
+            is SignatureVerifyResult.Failed -> Phase.Halt(ParseResult.Tampered(r.reason))
         }
     }
 
-    private fun collectLocales(entries: Map<String, ByteArray>): LocaleCollect {
+    private fun collectLocales(entries: Map<String, ByteArray>): Phase<LocaleMap> {
         // Two-pass over the entries: first identify the locale-bearing names so the cap
         // can fire before any .strings parsing happens, then parse. Doing the cap check
         // up-front avoids parsing N strings files just to reject N+1.
@@ -146,7 +145,7 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
                     locale to bytes
                 }
         return if (stringsEntries.size > config.maxLocaleCount) {
-            LocaleCollect.Failure(
+            Phase.Halt(
                 ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.LocaleCount)),
             )
         } else {
@@ -154,7 +153,7 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
         }
     }
 
-    private fun parseStringsEntries(stringsEntries: List<Pair<String, ByteArray>>): LocaleCollect {
+    private fun parseStringsEntries(stringsEntries: List<Pair<String, ByteArray>>): Phase<LocaleMap> {
         val map = LinkedHashMap<PassLocale, LocalizedStrings>(stringsEntries.size)
         var failure: ParseResult? = null
         for ((locale, bytes) in stringsEntries) {
@@ -164,10 +163,10 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
                 is StringsResult.Failed -> failure = stringsFailureToResult(r.failure)
             }
         }
-        return failure?.let(LocaleCollect::Failure) ?: LocaleCollect.Ok(map)
+        return failure?.let { Phase.Halt(it) } ?: Phase.Continue(map)
     }
 
-    private fun collectImages(entries: Map<String, ByteArray>): ImageCollect {
+    private fun collectImages(entries: Map<String, ByteArray>): Phase<Map<ImageRole, ImageBytes>> {
         // Pre-filter to top-level role images so the loop body has a single jump
         // statement (the break-on-failure). Localized images (under `<locale>.lproj/`)
         // are silently dropped — ADR 0001 does not yet model locale-aware image
@@ -184,7 +183,7 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
             val limitTrip = pngPixelLimitFailure(bytes)
             if (limitTrip != null) failure = limitTrip else map[role] = ImageBytes(bytes)
         }
-        return failure?.let(ImageCollect::Failure) ?: ImageCollect.Ok(map)
+        return failure?.let { Phase.Halt(it) } ?: Phase.Continue(map)
     }
 
     private fun topLevelImageRole(name: String): ImageRole? {
@@ -199,8 +198,17 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
         // upstream. Rejecting on unreadable IHDR would force the parser to police PNG
         // structural validity, which is outside its remit.
         val dim = readPngDimensions(bytes) ?: return null
-        val pixels = dim.width * dim.height
-        return if (pixels > config.maxImagePixelCount.toLong()) {
+        val limit = config.maxImagePixelCount.toLong()
+        // Defense against u32 IHDR width × height overflowing Long. A signed-Long
+        // multiplication of two values near u32 max would wrap silently — and a
+        // wrapped (negative) result would compare ≤ limit, bypassing the cap. The
+        // axis-pre-check rules out that path: if either axis already exceeds the
+        // cap, the product certainly does. Otherwise both axes are ≤ limit ≤
+        // Int.MAX_VALUE (the field's declared type is `Int`), so the product is at
+        // most ~4.6×10¹⁸, comfortably under Long.MAX_VALUE ≈ 9.22×10¹⁸.
+        val exceedsAxis = dim.width > limit || dim.height > limit
+        val exceedsProduct = !exceedsAxis && dim.width * dim.height > limit
+        return if (exceedsAxis || exceedsProduct) {
             ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.ImagePixelCount))
         } else {
             null
@@ -240,24 +248,47 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
         }
     }
 
-    private sealed interface SignaturePhaseResult {
-        data class Status(val status: SignatureStatus) : SignaturePhaseResult
+    /**
+     * The pipeline carries both the [result] and the archive-bytes count separately
+     * because telemetry's [ParseSucceededEvent.archiveBytes] is populated only on
+     * success, but the count is computed at extraction time — before the call site
+     * knows which arm of [ParseResult] it will return.
+     */
+    private data class PipelineOutcome(val result: ParseResult, val archiveBytes: Long)
 
-        data class Failure(val parseResult: ParseResult) : SignaturePhaseResult
-    }
+    /**
+     * Continuation outcome of any pipeline stage that can short-circuit with a
+     * pre-baked [ParseResult]. Replaces what was previously three near-identical
+     * sealed types ([resolveSignature]'s, locale-collection's, image-collection's
+     * outputs) — the shape is the same in every case, so factoring out the type
+     * removes duplicated arms whose only difference was the wrapped value's static
+     * type.
+     */
+    private sealed interface Phase<out T> {
+        data class Continue<out T>(val value: T) : Phase<T>
 
-    private sealed interface LocaleCollect {
-        data class Ok(val map: Map<PassLocale, LocalizedStrings>) : LocaleCollect
-
-        data class Failure(val parseResult: ParseResult) : LocaleCollect
-    }
-
-    private sealed interface ImageCollect {
-        data class Ok(val map: Map<ImageRole, ImageBytes>) : ImageCollect
-
-        data class Failure(val parseResult: ParseResult) : ImageCollect
+        data class Halt(val result: ParseResult) : Phase<Nothing>
     }
 }
+
+/**
+ * Resolves the archive-bytes value reported on [ParseSucceededEvent]. Sources we know
+ * exactly (a [PassSource.Bytes] holds the whole array; a [PassSource.Stream] with a
+ * caller-supplied [PassSource.Stream.sizeHintBytes] asserts its full length) report
+ * that exact number; a hint-less [PassSource.Stream] falls back to the extractor's
+ * measured count, which is "bytes consumed by the zip pipeline" — not perfectly
+ * equal to the file's on-disk length (the central directory + EOCD record is
+ * truncated when [java.util.zip.ZipInputStream] sees the central-directory signature)
+ * but far closer to truth than the prior `0L` placeholder.
+ */
+private fun computeArchiveBytes(
+    source: PassSource,
+    extractedBytes: Long,
+): Long =
+    when (source) {
+        is PassSource.Bytes -> source.bytes.size.toLong()
+        is PassSource.Stream -> source.sizeHintBytes ?: extractedBytes
+    }
 
 /**
  * Maps a top-level PKPASS image basename onto its [ImageRole]. Unknown basenames return
@@ -324,12 +355,6 @@ private fun lprojStringsLocaleOrNull(name: String): String? {
     return locale.takeUnless { it.isEmpty() || '/' in it }
 }
 
-private fun sourceArchiveBytesOrZero(source: PassSource): Long =
-    when (source) {
-        is PassSource.Bytes -> source.bytes.size.toLong()
-        is PassSource.Stream -> source.sizeHintBytes ?: 0L
-    }
-
 private val ROLE_BY_BASENAME: Map<String, ImageRole> =
     mapOf(
         "logo.png" to ImageRole.Logo,
@@ -352,7 +377,14 @@ private val ROLE_BY_BASENAME: Map<String, ImageRole> =
         "footer@3x.png" to ImageRole.FooterSuperRetina,
     )
 
-private const val SIGNATURE_FILE_NAME = "signature"
+/**
+ * Local typealiases keep the [Phase] generic instantiations short enough to fit on a
+ * single function-signature line, which the project's combined ktlint /detekt rules
+ * (multi-line argument lists must trail-comma; single-line signatures must fit under
+ * the line cap) otherwise force into incompatible shapes.
+ */
+private typealias LocaleMap = Map<`is`.walt.passes.core.PassLocale, `is`.walt.passes.core.LocalizedStrings>
+
 private const val PNG_EXTENSION = ".png"
 private const val LPROJ_STRINGS_SUFFIX = ".lproj/pass.strings"
 private const val NANOS_PER_MILLI = 1_000_000L

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
@@ -1,0 +1,358 @@
+package `is`.walt.passes.core.internal
+
+import `is`.walt.passes.core.ImageBytes
+import `is`.walt.passes.core.ImageRole
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.MalformedReason
+import `is`.walt.passes.core.ParseFailedEvent
+import `is`.walt.passes.core.ParseResult
+import `is`.walt.passes.core.ParseSucceededEvent
+import `is`.walt.passes.core.ParserConfig
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassParser
+import `is`.walt.passes.core.PassSource
+import `is`.walt.passes.core.ResourceLimit
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.core.TamperReason
+import `is`.walt.passes.core.UnsupportedReason
+import `is`.walt.passes.core.toFailureKind
+import `is`.walt.passes.core.toKind
+
+/**
+ * The single concrete [PassParser] implementation. Stitches the four security-critical
+ * slices ([extractSafely], [verifyManifest], [verifySignature], [decodePassJson]) plus
+ * [parseStrings] and [readPngDimensions] into a non-throwing pipeline whose every error
+ * path lands on a [ParseResult] arm.
+ *
+ * **Pipeline order is load-bearing.** The shape mirrors the trust hierarchy the public
+ * surface partitions along: structural validity (extract) → integrity binding (manifest
+ * hash chain) → cryptographic provenance (signature) → semantic content (pass.json,
+ * strings, images). Reordering any earlier step past a later one would let a structural
+ * attack surface as a tampering / unsupported reason or vice versa, which in turn would
+ * mis-route the trust UI.
+ *
+ * **Concurrency.** The class is intentionally stateless beyond the immutable
+ * [ParserConfig]. Every helper takes the work-in-progress entries / bytes as parameters;
+ * nothing is cached on the instance. A single [DefaultPassParser] is therefore safe to
+ * call from any number of threads concurrently.
+ *
+ * **Telemetry.** [System.nanoTime] brackets the entire [parse] call; the duration and
+ * the type-flattened [ParseFailureKind] / [SignatureStatusKind] flow through to the
+ * configured [TelemetryGuard]. Pass content (serial, organization name, field values,
+ * barcode message) never enters the event payload — that constraint is enforced
+ * structurally by [TelemetryGuard]'s event types, not by discipline here.
+ */
+internal class DefaultPassParser(private val config: ParserConfig) : PassParser {
+    override fun parse(source: PassSource): ParseResult {
+        val started = System.nanoTime()
+        config.telemetryGuard.onParseStarted()
+        val archiveBytes = sourceArchiveBytesOrZero(source)
+        val result = pipeline(source)
+        emit(result, started, archiveBytes)
+        return result
+    }
+
+    /**
+     * Sequenced as a chain of helpers (rather than a single body with seven `return`
+     * statements) so each stage's failure routing is local to its own helper. The
+     * chain order — extract → manifest → signature → pass.json → strings → images →
+     * assemble — is the trust hierarchy in code: a structural failure can never
+     * surface as tampering and a tampering signal can never be coalesced with
+     * malformedness.
+     */
+    private fun pipeline(source: PassSource): ParseResult =
+        when (val r = extractSafely(source, config)) {
+            is ExtractResult.Failure -> ParseResult.Malformed(r.reason)
+            is ExtractResult.Success -> withEntries(r.entries)
+        }
+
+    private fun withEntries(entries: Map<String, ByteArray>): ParseResult =
+        when (val r = verifyManifest(entries)) {
+            is ManifestVerifyResult.Failed -> manifestFailureToResult(r.failure)
+            is ManifestVerifyResult.Ok -> withVerifiedManifest(entries, r.manifestBytes)
+        }
+
+    private fun withVerifiedManifest(
+        entries: Map<String, ByteArray>,
+        manifestBytes: ByteArray,
+    ): ParseResult =
+        when (val r = resolveSignature(entries, manifestBytes)) {
+            is SignaturePhaseResult.Failure -> r.parseResult
+            is SignaturePhaseResult.Status -> withSignatureStatus(entries, r.status)
+        }
+
+    private fun withSignatureStatus(
+        entries: Map<String, ByteArray>,
+        status: SignatureStatus,
+    ): ParseResult =
+        when (val r = decodePassJson(entries, config)) {
+            is PassJsonDecodeResult.Failed -> passJsonFailureToResult(r.failure)
+            is PassJsonDecodeResult.Ok -> assemble(entries, r.pass, status)
+        }
+
+    private fun assemble(
+        entries: Map<String, ByteArray>,
+        pass: Pass,
+        status: SignatureStatus,
+    ): ParseResult =
+        when (val locales = collectLocales(entries)) {
+            is LocaleCollect.Failure -> locales.parseResult
+            is LocaleCollect.Ok ->
+                when (val images = collectImages(entries)) {
+                    is ImageCollect.Failure -> images.parseResult
+                    is ImageCollect.Ok ->
+                        ParseResult.Success(
+                            pass = pass.copy(images = images.map, locales = locales.map),
+                            signatureStatus = status,
+                        )
+                }
+        }
+
+    private fun resolveSignature(
+        entries: Map<String, ByteArray>,
+        manifestBytes: ByteArray,
+    ): SignaturePhaseResult {
+        val signatureBytes = entries[SIGNATURE_FILE_NAME]
+        if (signatureBytes == null) {
+            // No signature blob. The lenient default surfaces this as Unsigned; strict
+            // mode treats absence as a security event. Routing through
+            // SignatureCryptoFailure (rather than coining a new "Unsigned" tamper arm)
+            // matches decision-wlt-0tn-q1: strict refuses unsigned input *because* it
+            // refuses to trust unsigned cryptographic provenance, which is the same
+            // category of refusal as "the bytes did not parse as a CMS envelope."
+            return if (config.acceptUnsignedArchives) {
+                SignaturePhaseResult.Status(SignatureStatus.Unsigned)
+            } else {
+                SignaturePhaseResult.Failure(
+                    ParseResult.Tampered(TamperReason.SignatureCryptoFailure),
+                )
+            }
+        }
+        return when (val r = verifySignature(signatureBytes, manifestBytes, config)) {
+            is SignatureVerifyResult.Ok -> SignaturePhaseResult.Status(r.status)
+            is SignatureVerifyResult.Failed -> SignaturePhaseResult.Failure(ParseResult.Tampered(r.reason))
+        }
+    }
+
+    private fun collectLocales(entries: Map<String, ByteArray>): LocaleCollect {
+        // Two-pass over the entries: first identify the locale-bearing names so the cap
+        // can fire before any .strings parsing happens, then parse. Doing the cap check
+        // up-front avoids parsing N strings files just to reject N+1.
+        val stringsEntries =
+            entries.entries
+                .mapNotNull { (name, bytes) ->
+                    val locale = lprojStringsLocaleOrNull(name) ?: return@mapNotNull null
+                    locale to bytes
+                }
+        return if (stringsEntries.size > config.maxLocaleCount) {
+            LocaleCollect.Failure(
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.LocaleCount)),
+            )
+        } else {
+            parseStringsEntries(stringsEntries)
+        }
+    }
+
+    private fun parseStringsEntries(stringsEntries: List<Pair<String, ByteArray>>): LocaleCollect {
+        val map = LinkedHashMap<PassLocale, LocalizedStrings>(stringsEntries.size)
+        var failure: ParseResult? = null
+        for ((locale, bytes) in stringsEntries) {
+            if (failure != null) break
+            when (val r = parseStrings(bytes, config)) {
+                is StringsResult.Ok -> map[PassLocale(locale)] = r.strings
+                is StringsResult.Failed -> failure = stringsFailureToResult(r.failure)
+            }
+        }
+        return failure?.let(LocaleCollect::Failure) ?: LocaleCollect.Ok(map)
+    }
+
+    private fun collectImages(entries: Map<String, ByteArray>): ImageCollect {
+        // Pre-filter to top-level role images so the loop body has a single jump
+        // statement (the break-on-failure). Localized images (under `<locale>.lproj/`)
+        // are silently dropped — ADR 0001 does not yet model locale-aware image
+        // binding, and the renderer consumes only the top-level role images today.
+        val candidates =
+            entries.entries.mapNotNull { (name, bytes) ->
+                val role = topLevelImageRole(name) ?: return@mapNotNull null
+                role to bytes
+            }
+        val map = LinkedHashMap<ImageRole, ImageBytes>(candidates.size)
+        var failure: ParseResult? = null
+        for ((role, bytes) in candidates) {
+            if (failure != null) break
+            val limitTrip = pngPixelLimitFailure(bytes)
+            if (limitTrip != null) failure = limitTrip else map[role] = ImageBytes(bytes)
+        }
+        return failure?.let(ImageCollect::Failure) ?: ImageCollect.Ok(map)
+    }
+
+    private fun topLevelImageRole(name: String): ImageRole? {
+        val isTopLevelPng = '/' !in name && name.endsWith(PNG_EXTENSION, ignoreCase = true)
+        return if (isTopLevelPng) imageRoleForBasename(name) else null
+    }
+
+    private fun pngPixelLimitFailure(bytes: ByteArray): ParseResult? {
+        // A PNG whose IHDR is unreadable is treated as "skip the pixel cap" rather
+        // than malformed: the bytes are inert here (the renderer will surface a decode
+        // failure downstream), and per-entry size is already bounded by maxEntryBytes
+        // upstream. Rejecting on unreadable IHDR would force the parser to police PNG
+        // structural validity, which is outside its remit.
+        val dim = readPngDimensions(bytes) ?: return null
+        val pixels = dim.width * dim.height
+        return if (pixels > config.maxImagePixelCount.toLong()) {
+            ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.ImagePixelCount))
+        } else {
+            null
+        }
+    }
+
+    private fun emit(
+        result: ParseResult,
+        startedNanos: Long,
+        archiveBytes: Long,
+    ) {
+        val durationMillis = (System.nanoTime() - startedNanos) / NANOS_PER_MILLI
+        when (result) {
+            is ParseResult.Success ->
+                config.telemetryGuard.onParseSucceeded(
+                    ParseSucceededEvent(
+                        passType = result.pass.type,
+                        signatureStatus = result.signatureStatus.toKind(),
+                        archiveBytes = archiveBytes,
+                        durationMillis = durationMillis,
+                        imageCount = result.pass.images.size,
+                        localeCount = result.pass.locales.size,
+                    ),
+                )
+            else ->
+                config.telemetryGuard.onParseFailed(
+                    ParseFailedEvent(
+                        // toFailureKind() returns null only for Success, which the
+                        // outer `when` already routed; the !! is a category check, not
+                        // a runtime risk. A future ParseResult arm that breaks this
+                        // surfaces as an immediate test failure here, not a silent
+                        // observability hole.
+                        outcome = result.toFailureKind()!!,
+                        durationMillis = durationMillis,
+                    ),
+                )
+        }
+    }
+
+    private sealed interface SignaturePhaseResult {
+        data class Status(val status: SignatureStatus) : SignaturePhaseResult
+
+        data class Failure(val parseResult: ParseResult) : SignaturePhaseResult
+    }
+
+    private sealed interface LocaleCollect {
+        data class Ok(val map: Map<PassLocale, LocalizedStrings>) : LocaleCollect
+
+        data class Failure(val parseResult: ParseResult) : LocaleCollect
+    }
+
+    private sealed interface ImageCollect {
+        data class Ok(val map: Map<ImageRole, ImageBytes>) : ImageCollect
+
+        data class Failure(val parseResult: ParseResult) : ImageCollect
+    }
+}
+
+/**
+ * Maps a top-level PKPASS image basename onto its [ImageRole]. Unknown basenames return
+ * `null` so the caller can drop them silently — PKPASS allows extra files alongside the
+ * known roles, and the trust claim does not ride on rejecting them. The map is
+ * case-insensitive on the basename only; the extractor's allowlist already restricted
+ * names to `*.png`.
+ */
+private fun imageRoleForBasename(name: String): ImageRole? = ROLE_BY_BASENAME[name.lowercase()]
+
+/**
+ * The hash-mismatch arm is the only manifest failure that constitutes tampering: the
+ * archive is structurally valid, but a file's bytes differ from what the manifest
+ * declared. Every other arm is structural malformedness collapsed onto
+ * [MalformedReason.MissingManifest] / [MalformedReason.InvalidManifest] until
+ * `wpass-n6g` lands dedicated arms for each shape.
+ */
+private fun manifestFailureToResult(failure: ManifestFailure): ParseResult =
+    when (failure) {
+        is ManifestFailure.Missing -> ParseResult.Malformed(MalformedReason.MissingManifest)
+        is ManifestFailure.HashMismatch -> ParseResult.Tampered(TamperReason.FileHashMismatch)
+        is ManifestFailure.InvalidJson,
+        is ManifestFailure.InvalidShape,
+        is ManifestFailure.InvalidHashFormat,
+        is ManifestFailure.SelfReferentialEntry,
+        is ManifestFailure.ExtraEntry,
+        is ManifestFailure.MissingEntry,
+        -> ParseResult.Malformed(MalformedReason.InvalidManifest)
+    }
+
+private fun passJsonFailureToResult(failure: PassJsonFailure): ParseResult =
+    when (failure) {
+        is PassJsonFailure.Missing -> ParseResult.Malformed(MalformedReason.MissingPassJson)
+        is PassJsonFailure.InvalidJson -> ParseResult.Malformed(MalformedReason.InvalidPassJson)
+        is PassJsonFailure.InvalidShape -> ParseResult.Malformed(MalformedReason.InvalidPassJson)
+        is PassJsonFailure.JsonDepthExceeded ->
+            ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonDepth))
+        is PassJsonFailure.JsonStringTooLong ->
+            ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize))
+        is PassJsonFailure.UnknownFormatVersion ->
+            ParseResult.Unsupported(UnsupportedReason.FormatVersion(failure.version))
+        is PassJsonFailure.UnknownPassStyle ->
+            ParseResult.Unsupported(UnsupportedReason.UnknownPassStyle(failure.raw))
+    }
+
+private fun stringsFailureToResult(failure: StringsFailure): ParseResult =
+    when (failure) {
+        is StringsFailure.ValueTooLong ->
+            ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.JsonStringSize))
+        is StringsFailure.InvalidEncoding,
+        is StringsFailure.UnterminatedString,
+        is StringsFailure.UnterminatedComment,
+        is StringsFailure.BadStructure,
+        is StringsFailure.BadEscape,
+        -> ParseResult.Malformed(MalformedReason.InvalidStrings)
+    }
+
+private fun lprojStringsLocaleOrNull(name: String): String? {
+    // A valid PKPASS keeps locale directories at the archive root, so the locale
+    // segment must be non-empty and slash-free. Path traversal is already rejected
+    // upstream; this guard is the structural-shape check for a top-level lproj.
+    if (!name.endsWith(LPROJ_STRINGS_SUFFIX)) return null
+    val locale = name.substring(0, name.length - LPROJ_STRINGS_SUFFIX.length)
+    return locale.takeUnless { it.isEmpty() || '/' in it }
+}
+
+private fun sourceArchiveBytesOrZero(source: PassSource): Long =
+    when (source) {
+        is PassSource.Bytes -> source.bytes.size.toLong()
+        is PassSource.Stream -> source.sizeHintBytes ?: 0L
+    }
+
+private val ROLE_BY_BASENAME: Map<String, ImageRole> =
+    mapOf(
+        "logo.png" to ImageRole.Logo,
+        "logo@2x.png" to ImageRole.LogoRetina,
+        "logo@3x.png" to ImageRole.LogoSuperRetina,
+        "icon.png" to ImageRole.Icon,
+        "icon@2x.png" to ImageRole.IconRetina,
+        "icon@3x.png" to ImageRole.IconSuperRetina,
+        "strip.png" to ImageRole.Strip,
+        "strip@2x.png" to ImageRole.StripRetina,
+        "strip@3x.png" to ImageRole.StripSuperRetina,
+        "background.png" to ImageRole.Background,
+        "background@2x.png" to ImageRole.BackgroundRetina,
+        "background@3x.png" to ImageRole.BackgroundSuperRetina,
+        "thumbnail.png" to ImageRole.Thumbnail,
+        "thumbnail@2x.png" to ImageRole.ThumbnailRetina,
+        "thumbnail@3x.png" to ImageRole.ThumbnailSuperRetina,
+        "footer.png" to ImageRole.Footer,
+        "footer@2x.png" to ImageRole.FooterRetina,
+        "footer@3x.png" to ImageRole.FooterSuperRetina,
+    )
+
+private const val SIGNATURE_FILE_NAME = "signature"
+private const val PNG_EXTENSION = ".png"
+private const val LPROJ_STRINGS_SUFFIX = ".lproj/pass.strings"
+private const val NANOS_PER_MILLI = 1_000_000L

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ExtractResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ExtractResult.kt
@@ -13,8 +13,24 @@ internal sealed interface ExtractResult {
      * Insertion-ordered map of entry name to fully-decoded entry bytes. Order mirrors the
      * order the entries appeared in the archive's local-file-header stream so the
      * downstream pass.json / manifest hash steps can iterate deterministically.
+     *
+     * [archiveBytes] is the count of compressed-archive bytes that the extractor pulled
+     * from the underlying input. The parser-glue layer uses it for telemetry on stream
+     * sources whose [`is`.walt.passes.core.PassSource.Stream.sizeHintBytes] was not
+     * supplied — without this plumbing, telemetry would record `0` for every
+     * hint-less stream parse, which is the failure mode the review called out as
+     * "documented but misleading."
+     *
+     * The count tracks bytes consumed *by the extractor's pipeline*, not the archive's
+     * total file length. For a zip with a central directory + EOCD record, the
+     * underlying [java.util.zip.ZipInputStream] stops after detecting the central-
+     * directory signature; bytes past that point are not pulled and not counted. This
+     * is honest for "what we ate" telemetry; the parser-glue layer prefers a
+     * source-derived value (`bytes.size` / `sizeHintBytes`) when one is available so
+     * the existing telemetry assertions (which use exact archive size) keep their
+     * meaning.
      */
-    data class Success(val entries: Map<String, ByteArray>) : ExtractResult
+    data class Success(val entries: Map<String, ByteArray>, val archiveBytes: Long) : ExtractResult
 
     data class Failure(val reason: MalformedReason) : ExtractResult
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ManifestVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ManifestVerifier.kt
@@ -147,8 +147,6 @@ private sealed interface ManifestParse {
     data class Failed(val failure: ManifestFailure) : ManifestParse
 }
 
-private const val MANIFEST_FILE_NAME = "manifest.json"
-private const val SIGNATURE_FILE_NAME = "signature"
 private const val SHA1_ALGORITHM = "SHA-1"
 private const val SHA1_HEX_LENGTH = 40
 private val HEX: HexFormat = HexFormat.of()

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/PngDimensions.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/PngDimensions.kt
@@ -1,0 +1,84 @@
+package `is`.walt.passes.core.internal
+
+/**
+ * Decoded PNG canvas dimensions read from the IHDR chunk. Both fields are widened to
+ * [Long] because PNG's IHDR encodes width and height as unsigned 32-bit integers; a
+ * signed [Int] would mis-classify any value with the high bit set as negative and a
+ * subsequent `width * height` would overflow before the resource-limit check ran.
+ */
+internal data class PngDimensions(val width: Long, val height: Long)
+
+/**
+ * Reads the IHDR chunk of a PNG to recover its declared canvas dimensions. Used only by
+ * the image-pixel-count guard in the parser-glue layer: PKPASS images are PNG-only, and
+ * the cap that matters there is "renderer memory after decompression," not the on-disk
+ * byte size that [SafeArchiveExtractor] already bounds.
+ *
+ * Returns `null` for any input that does not begin with the PNG 8-byte signature
+ * followed by an IHDR chunk type at the documented offset, or whose declared dimensions
+ * are non-positive. The parser-glue layer treats `null` as "skip the pixel cap for this
+ * entry" — a malformed PNG is upstream content the parser does not pretend to validate
+ * past the resource-bound; the renderer will surface its own decode failure.
+ *
+ * The function is deliberately byte-level rather than reaching for a JCE/ImageIO decoder
+ * for two reasons:
+ *
+ *  1. **No Android framework dependency.** `passes-core` is pure JVM and KMP-friendly;
+ *     pulling `ImageIO` (server-side JDK only) or `BitmapFactory` (Android-only) would
+ *     break that contract.
+ *  2. **No decoder allocation.** A real decode would materialize the full pixel array
+ *     into memory before the cap could fire — exactly the failure mode the cap exists
+ *     to prevent. The IHDR-only read pulls 24 bytes regardless of declared dimensions.
+ */
+internal fun readPngDimensions(bytes: ByteArray): PngDimensions? {
+    val structurallyAPng =
+        bytes.size >= PNG_HEADER_PLUS_IHDR_LENGTH &&
+            hasPngSignature(bytes) &&
+            isIhdrChunkType(bytes)
+    if (!structurallyAPng) return null
+    val width = readU32BigEndian(bytes, IHDR_WIDTH_OFFSET)
+    val height = readU32BigEndian(bytes, IHDR_HEIGHT_OFFSET)
+    return if (width <= 0L || height <= 0L) null else PngDimensions(width, height)
+}
+
+private fun hasPngSignature(bytes: ByteArray): Boolean {
+    for (i in PNG_SIGNATURE.indices) {
+        if (bytes[i] != PNG_SIGNATURE[i]) return false
+    }
+    return true
+}
+
+private fun isIhdrChunkType(bytes: ByteArray): Boolean {
+    return bytes[IHDR_TYPE_OFFSET] == 'I'.code.toByte() &&
+        bytes[IHDR_TYPE_OFFSET + 1] == 'H'.code.toByte() &&
+        bytes[IHDR_TYPE_OFFSET + 2] == 'D'.code.toByte() &&
+        bytes[IHDR_TYPE_OFFSET + 3] == 'R'.code.toByte()
+}
+
+private fun readU32BigEndian(
+    b: ByteArray,
+    off: Int,
+): Long {
+    val b0 = b[off].toLong() and 0xFFL
+    val b1 = b[off + 1].toLong() and 0xFFL
+    val b2 = b[off + 2].toLong() and 0xFFL
+    val b3 = b[off + 3].toLong() and 0xFFL
+    return b0.shl(24) or b1.shl(16) or b2.shl(8) or b3
+}
+
+private val PNG_SIGNATURE: ByteArray =
+    byteArrayOf(
+        0x89.toByte(),
+        0x50,
+        0x4E,
+        0x47,
+        0x0D,
+        0x0A,
+        0x1A,
+        0x0A,
+    )
+
+private const val IHDR_TYPE_OFFSET = 12
+private const val IHDR_WIDTH_OFFSET = 16
+private const val IHDR_HEIGHT_OFFSET = 20
+private const val PNG_HEADER_PLUS_IHDR_LENGTH = 24

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SafeArchiveExtractor.kt
@@ -106,7 +106,15 @@ private fun runZipPipeline(
     if (magicCheck != null) return ExtractResult.Failure(magicCheck)
     val bounded = BoundedInputStream(sniffer, config.maxArchiveBytes)
     return try {
-        ZipInputStream(bounded).use { zis -> extractAllEntries(zis, config) }
+        // [BoundedInputStream.bytesRead] is read post-`use`: it accumulates as
+        // [ZipInputStream] pulls bytes through and is final once the stream closes.
+        // Plumbed into [ExtractResult.Success.archiveBytes] for telemetry on stream
+        // sources whose size hint was absent.
+        val outcome = ZipInputStream(bounded).use { zis -> extractAllEntries(zis, config) }
+        when (outcome) {
+            is ExtractResult.Success -> outcome.copy(archiveBytes = bounded.bytesRead)
+            is ExtractResult.Failure -> outcome
+        }
     } catch (_: ArchiveSizeExceededException) {
         ExtractResult.Failure(MalformedReason.ResourceLimitExceeded(ResourceLimit.ArchiveSize))
     } catch (_: ZipException) {
@@ -151,7 +159,9 @@ private fun extractAllEntries(
         val entry = zis.nextEntry ?: break
         failure = processEntry(zis, entry, entries, config)
     }
-    return failure ?: ExtractResult.Success(entries.toMap())
+    // archiveBytes is filled in by the caller from the BoundedInputStream counter
+    // after the ZipInputStream closes; the value here is a placeholder.
+    return failure ?: ExtractResult.Success(entries.toMap(), archiveBytes = 0L)
 }
 
 private fun processEntry(
@@ -278,6 +288,13 @@ private class BoundedInputStream(
 ) : FilterInputStream(delegate) {
     private var count: Long = 0
 
+    /**
+     * Cumulative bytes pulled through this wrapper. Read after the wrapping
+     * [ZipInputStream] closes to recover an honest "bytes consumed" count for
+     * telemetry on stream sources without a caller-supplied size hint.
+     */
+    val bytesRead: Long get() = count
+
     override fun read(): Int {
         val b = `in`.read()
         if (b != -1) {
@@ -315,7 +332,6 @@ private class NonClosingInputStream(delegate: InputStream) : FilterInputStream(d
 private class ArchiveSizeExceededException : IOException()
 
 private const val READ_BUFFER_SIZE = 8 * 1024
-private const val SIGNATURE_FILE_NAME = "signature"
 private const val MAGIC_PREFIX_LENGTH = 4
 private val LOCAL_FILE_HEADER_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
 private val END_OF_CENTRAL_DIR_MAGIC = byteArrayOf(0x50, 0x4B, 0x05, 0x06)

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
@@ -1,0 +1,398 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.internal.SyntheticPkpass
+import org.junit.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+/**
+ * End-to-end behavior tests for [PassParser]. Every fixture is built in-memory at test
+ * time (see [SyntheticPkpass]) so a reviewer can read each test top-to-bottom and see
+ * which arm of [ParseResult] / [SignatureStatus] is being exercised.
+ *
+ * Slice-internal behavior (hardened-zip rejection, manifest verification details, .strings
+ * lexer arms, signature classifier branches) lives in the per-slice tests; this suite
+ * covers the glue: pipeline ordering, failure-arm routing onto the public surface, and
+ * the trust toggles in [ParserConfig].
+ */
+class PassParserTest {
+    @Test
+    fun successfulBoardingPassRoundTrip() {
+        assertSuccessForType("boardingPass", PassType.BoardingPass)
+    }
+
+    @Test
+    fun successfulEventTicketRoundTrip() {
+        assertSuccessForType("eventTicket", PassType.EventTicket)
+    }
+
+    @Test
+    fun successfulCouponRoundTrip() {
+        assertSuccessForType("coupon", PassType.Coupon)
+    }
+
+    @Test
+    fun successfulStoreCardRoundTrip() {
+        assertSuccessForType("storeCard", PassType.StoreCard)
+    }
+
+    @Test
+    fun successfulGenericRoundTrip() {
+        assertSuccessForType("generic", PassType.Generic)
+    }
+
+    @Test
+    fun unsignedArchiveSurfacesAsUnsignedUnderLenientDefault() {
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        val success = result as ParseResult.Success
+        assertThat(success.signatureStatus).isEqualTo(SignatureStatus.Unsigned)
+    }
+
+    @Test
+    fun unsignedArchiveIsTamperedUnderStrictPolicy() {
+        // Strict mode interprets the absence of a signature as a refusal to attest
+        // cryptographic provenance, which is the same category as a malformed CMS
+        // envelope. The archive itself is structurally fine; the trust UI must surface
+        // this as a security event, not as malformedness.
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val result = PassParser.create(ParserConfig.Strict).parse(PassSource.Bytes(zip))
+        assertThat(result).isInstanceOf(ParseResult.Tampered::class.java)
+        assertThat((result as ParseResult.Tampered).reason)
+            .isEqualTo(TamperReason.SignatureCryptoFailure)
+    }
+
+    @Test
+    fun selfSignedArchiveSurfacesAsSelfSigned() {
+        val zip = SyntheticPkpass.signedSelfSigned(SyntheticPkpass.minimalPassJson("generic"))
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        val success = result as ParseResult.Success
+        assertThat(success.signatureStatus).isEqualTo(SignatureStatus.SelfSigned)
+    }
+
+    @Test
+    fun selfSignedArchiveRejectedUnderStrictPolicy() {
+        val zip = SyntheticPkpass.signedSelfSigned(SyntheticPkpass.minimalPassJson("generic"))
+        val result = PassParser.create(ParserConfig.Strict).parse(PassSource.Bytes(zip))
+        assertThat(result).isInstanceOf(ParseResult.Tampered::class.java)
+        assertThat((result as ParseResult.Tampered).reason)
+            .isEqualTo(TamperReason.SignatureCryptoFailure)
+    }
+
+    @Test
+    fun manifestHashMismatchSurfacesAsTampered() {
+        // The archive is structurally valid: pass.json bytes have been swapped for a
+        // mutated copy after the manifest captured the original SHA-1. Tampering, not
+        // malformedness — the trust UI must distinguish the two.
+        val zip =
+            SyntheticPkpass.unsignedWithTamperedPassJson(
+                SyntheticPkpass.minimalPassJson("generic"),
+            )
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result).isInstanceOf(ParseResult.Tampered::class.java)
+        assertThat((result as ParseResult.Tampered).reason)
+            .isEqualTo(TamperReason.FileHashMismatch)
+    }
+
+    @Test
+    fun missingPassJsonSurfacesAsMalformed() {
+        // Build a zip whose only entry is manifest.json (declaring nothing). The
+        // missing-pass.json arm of decodePassJson lifts onto Malformed.MissingPassJson.
+        val zip = synthesizeArchive(mapOf("manifest.json" to "{}".toByteArray()))
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result).isEqualTo(ParseResult.Malformed(MalformedReason.MissingPassJson))
+    }
+
+    @Test
+    fun invalidPassJsonSurfacesAsMalformed() {
+        val zip =
+            SyntheticPkpass.unsigned(passJson = "{not valid json")
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result).isEqualTo(ParseResult.Malformed(MalformedReason.InvalidPassJson))
+    }
+
+    @Test
+    fun unknownFormatVersionSurfacesAsUnsupported() {
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson =
+                    """
+                    {
+                        "formatVersion": 99,
+                        "serialNumber": "S",
+                        "description": "D",
+                        "organizationName": "O",
+                        "generic": {}
+                    }
+                    """.trimIndent(),
+            )
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result).isEqualTo(ParseResult.Unsupported(UnsupportedReason.FormatVersion(99)))
+    }
+
+    @Test
+    fun extractFailureForBytesThatAreNotAZip() {
+        val result = PassParser.create().parse(PassSource.Bytes(byteArrayOf(0, 1, 2, 3)))
+        assertThat(result).isEqualTo(ParseResult.Malformed(MalformedReason.NotAZipArchive))
+    }
+
+    @Test
+    fun zipBombEntryTripsEntrySizeLimit() {
+        // A single entry whose contents exceed maxEntryBytes lifts to
+        // Malformed.ResourceLimitExceeded(EntrySize) at the extractor layer.
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries = mapOf("icon.png" to ByteArray(2 * 1024)),
+            )
+        val tightConfig = ParserConfig().copy(maxEntryBytes = 1024)
+        val result = PassParser.create(tightConfig).parse(PassSource.Bytes(zip))
+        assertThat(result)
+            .isEqualTo(
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.EntrySize)),
+            )
+    }
+
+    @Test
+    fun pngPixelCountLimitTripsAsResourceLimit() {
+        // Synthesize a PNG whose IHDR declares a canvas big enough to overshoot the
+        // configured pixel cap. The bytes themselves are tiny — the parser inspects
+        // IHDR only, which is exactly the point: an attacker cannot smuggle an
+        // expensive decode by claiming a giant canvas.
+        val giantPng = SyntheticPkpass.fakePng(widthDeclared = 4_096, heightDeclared = 4_096)
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries = mapOf("icon.png" to giantPng),
+            )
+        val tightConfig = ParserConfig().copy(maxImagePixelCount = 100)
+        val result = PassParser.create(tightConfig).parse(PassSource.Bytes(zip))
+        assertThat(result)
+            .isEqualTo(
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.ImagePixelCount)),
+            )
+    }
+
+    @Test
+    fun maxLocaleCountLimitTripsBeforeStringsParse() {
+        // Three locale .strings files vs. a cap of 2. The cap must trip even though
+        // the .strings payloads are individually well-formed — the resource bound
+        // exists to refuse archives that ask the parser to fan out across an
+        // unbounded number of locale buckets.
+        val tinyStrings = "\"k\" = \"v\";".toByteArray(Charsets.UTF_8)
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries =
+                    mapOf(
+                        "en.lproj/pass.strings" to tinyStrings,
+                        "de.lproj/pass.strings" to tinyStrings,
+                        "fr.lproj/pass.strings" to tinyStrings,
+                    ),
+            )
+        val tightConfig = ParserConfig().copy(maxLocaleCount = 2)
+        val result = PassParser.create(tightConfig).parse(PassSource.Bytes(zip))
+        assertThat(result)
+            .isEqualTo(
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.LocaleCount)),
+            )
+    }
+
+    @Test
+    fun localesAreSurfacedOnTheParsedPass() {
+        val englishStrings = "\"destination\" = \"Destination\";".toByteArray(Charsets.UTF_8)
+        val germanStrings = "\"destination\" = \"Ziel\";".toByteArray(Charsets.UTF_8)
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries =
+                    mapOf(
+                        "en.lproj/pass.strings" to englishStrings,
+                        "de.lproj/pass.strings" to germanStrings,
+                    ),
+            )
+        val result = PassParser.create().parse(PassSource.Bytes(zip)) as ParseResult.Success
+        assertThat(result.pass.locales.keys)
+            .containsExactly(PassLocale("en"), PassLocale("de"))
+        assertThat(result.pass.locales[PassLocale("de")]?.entries)
+            .containsExactly("destination", "Ziel")
+    }
+
+    @Test
+    fun imagesAreBoundIntoPassByRole() {
+        val tinyPng = SyntheticPkpass.fakePng(widthDeclared = 1, heightDeclared = 1)
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries =
+                    mapOf(
+                        "icon.png" to tinyPng,
+                        "logo@2x.png" to tinyPng,
+                        "background@3x.png" to tinyPng,
+                        "stranger.png" to tinyPng,
+                    ),
+            )
+        val result = PassParser.create().parse(PassSource.Bytes(zip)) as ParseResult.Success
+        assertThat(result.pass.images.keys)
+            .containsExactly(
+                ImageRole.Icon,
+                ImageRole.LogoRetina,
+                ImageRole.BackgroundSuperRetina,
+            )
+    }
+
+    @Test
+    fun telemetryEmitsStartedThenSucceededInOrderOnHappyPath() {
+        val recorder = RecordingTelemetryGuard()
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val parser = PassParser.create(ParserConfig().copy(telemetryGuard = recorder))
+
+        val result = parser.parse(PassSource.Bytes(zip))
+
+        assertThat(result).isInstanceOf(ParseResult.Success::class.java)
+        assertThat(recorder.events.map { it.kind })
+            .containsExactly(EventKind.Started, EventKind.Succeeded)
+            .inOrder()
+        val succeeded = recorder.events[1] as RecordedEvent.Succeeded
+        assertThat(succeeded.event.passType).isEqualTo(PassType.Generic)
+        assertThat(succeeded.event.signatureStatus).isEqualTo(SignatureStatusKind.Unsigned)
+        assertThat(succeeded.event.archiveBytes).isEqualTo(zip.size.toLong())
+        assertThat(succeeded.event.durationMillis).isAtLeast(0L)
+    }
+
+    @Test
+    fun telemetryEmitsStartedThenFailedOnNonZipInput() {
+        val recorder = RecordingTelemetryGuard()
+        val parser = PassParser.create(ParserConfig().copy(telemetryGuard = recorder))
+
+        parser.parse(PassSource.Bytes(byteArrayOf(0)))
+
+        assertThat(recorder.events.map { it.kind })
+            .containsExactly(EventKind.Started, EventKind.Failed)
+            .inOrder()
+        val failed = recorder.events[1] as RecordedEvent.Failed
+        assertThat(failed.event.outcome).isEqualTo(ParseFailureKind.Malformed)
+    }
+
+    @Test
+    fun parserInstanceSurvives16ParallelInvocations() {
+        // Concurrency contract: the parser holds only the immutable ParserConfig and
+        // delegates to stateless internals. 16 threads sharing one parser and one
+        // source must agree on the same Success.
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val source = PassSource.Bytes(zip)
+        val parser = PassParser.create()
+        val workers = 16
+        val executor = Executors.newFixedThreadPool(workers)
+        val ready = CountDownLatch(workers)
+        val go = CountDownLatch(1)
+        val results = ConcurrentLinkedQueue<ParseResult>()
+        try {
+            repeat(workers) {
+                executor.submit {
+                    ready.countDown()
+                    go.await()
+                    results.add(parser.parse(source))
+                }
+            }
+            ready.await()
+            go.countDown()
+            executor.shutdown()
+            check(executor.awaitTermination(WAIT_SECONDS, TimeUnit.SECONDS)) { "concurrent parse timed out" }
+        } finally {
+            executor.shutdownNow()
+        }
+        assertThat(results).hasSize(workers)
+        val first = results.first() as ParseResult.Success
+        for (r in results) {
+            val success = r as ParseResult.Success
+            assertThat(success.pass).isEqualTo(first.pass)
+            assertThat(success.signatureStatus).isEqualTo(first.signatureStatus)
+        }
+    }
+
+    @Test
+    fun streamSourceWithSizeHintReportsThatSizeOnTelemetry() {
+        // PassSource.Stream lets a caller stream a pkpass without holding the whole
+        // archive in a ByteArray. The telemetry path records sizeHintBytes verbatim;
+        // the extractor layer is documented to re-check it against maxArchiveBytes.
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val recorder = RecordingTelemetryGuard()
+        val parser = PassParser.create(ParserConfig().copy(telemetryGuard = recorder))
+
+        val source =
+            PassSource.Stream(
+                stream = zip.inputStream(),
+                sizeHintBytes = zip.size.toLong(),
+            )
+        val result = parser.parse(source)
+
+        assertThat(result).isInstanceOf(ParseResult.Success::class.java)
+        val succeeded = recorder.events[1] as RecordedEvent.Succeeded
+        assertThat(succeeded.event.archiveBytes).isEqualTo(zip.size.toLong())
+    }
+
+    private fun assertSuccessForType(
+        styleKey: String,
+        expected: PassType,
+    ) {
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson(styleKey))
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        val success = result as ParseResult.Success
+        assertThat(success.pass.type).isEqualTo(expected)
+        assertThat(success.signatureStatus).isEqualTo(SignatureStatus.Unsigned)
+    }
+
+    private fun synthesizeArchive(members: Map<String, ByteArray>): ByteArray {
+        val baos = java.io.ByteArrayOutputStream()
+        java.util.zip.ZipOutputStream(baos).use { zos ->
+            for ((name, bytes) in members) {
+                zos.putNextEntry(java.util.zip.ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private enum class EventKind { Started, Succeeded, Failed }
+
+    private sealed interface RecordedEvent {
+        val kind: EventKind
+
+        data object Started : RecordedEvent {
+            override val kind: EventKind get() = EventKind.Started
+        }
+
+        data class Succeeded(val event: ParseSucceededEvent) : RecordedEvent {
+            override val kind: EventKind get() = EventKind.Succeeded
+        }
+
+        data class Failed(val event: ParseFailedEvent) : RecordedEvent {
+            override val kind: EventKind get() = EventKind.Failed
+        }
+    }
+
+    private class RecordingTelemetryGuard : TelemetryGuard {
+        val events: MutableList<RecordedEvent> = mutableListOf()
+
+        override fun onParseStarted() {
+            events.add(RecordedEvent.Started)
+        }
+
+        override fun onParseSucceeded(event: ParseSucceededEvent) {
+            events.add(RecordedEvent.Succeeded(event))
+        }
+
+        override fun onParseFailed(event: ParseFailedEvent) {
+            events.add(RecordedEvent.Failed(event))
+        }
+    }
+
+    companion object {
+        private const val WAIT_SECONDS = 30L
+    }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
@@ -315,6 +315,47 @@ class PassParserTest {
     }
 
     @Test
+    fun pngPixelCountLimitTripsForU32MaxIhdrWithoutOverflowing() {
+        // Regression: an IHDR declaring near-u32-max width and height would, with a
+        // naive `dim.width * dim.height` over signed Long, wrap negative and slip past
+        // the cap. The axis-pre-check forces the trip without even multiplying.
+        val attackPng = SyntheticPkpass.fakePng(widthDeclared = Int.MAX_VALUE, heightDeclared = Int.MAX_VALUE)
+        val zip =
+            SyntheticPkpass.unsigned(
+                passJson = SyntheticPkpass.minimalPassJson("generic"),
+                extraEntries = mapOf("icon.png" to attackPng),
+            )
+        // Default cap; both axes already exceed it, so overflow never gets a chance.
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result)
+            .isEqualTo(
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(ResourceLimit.ImagePixelCount)),
+            )
+    }
+
+    @Test
+    fun streamSourceWithoutSizeHintReportsExtractedBytesOnTelemetry() {
+        // Stream sources without a caller-supplied sizeHint used to telemeter
+        // archiveBytes = 0; the extractor now plumbs its measured byte count through
+        // ExtractResult.Success so downstream observability has an honest number.
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val recorder = RecordingTelemetryGuard()
+        val parser = PassParser.create(ParserConfig().copy(telemetryGuard = recorder))
+
+        val result =
+            parser.parse(PassSource.Stream(stream = zip.inputStream(), sizeHintBytes = null))
+
+        assertThat(result).isInstanceOf(ParseResult.Success::class.java)
+        val succeeded = recorder.events[1] as RecordedEvent.Succeeded
+        // Bounded counter stops a few bytes shy of the file's total length (zip's
+        // central directory + EOCD trail is not consumed by ZipInputStream past the
+        // first signature byte the loop sees), so we only assert "non-zero and not
+        // larger than the archive."
+        assertThat(succeeded.event.archiveBytes).isGreaterThan(0L)
+        assertThat(succeeded.event.archiveBytes).isAtMost(zip.size.toLong())
+    }
+
+    @Test
     fun streamSourceWithSizeHintReportsThatSizeOnTelemetry() {
         // PassSource.Stream lets a caller stream a pkpass without holding the whole
         // archive in a ByteArray. The telemetry path records sizeHintBytes verbatim;

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.core
 
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.internal.SyntheticPkpass
 import org.junit.Test
 
 /**
@@ -168,10 +169,22 @@ class PublicApiSurfaceTest {
 
     @Test
     fun parserFactoryDoesNotThrow() {
-        // The skeleton parser intentionally throws on parse(); the *factory* must not, so
-        // construction is decoupled from implementation readiness.
+        // Construction is decoupled from any parsing work; the factory must not throw
+        // for any reason other than a developer-side ParserConfig misuse (which the
+        // public surface forbids by construction — the data class only exposes valid
+        // shapes).
         val parser = PassParser.create()
         assertThat(parser).isNotNull()
+    }
+
+    @Test
+    fun parserCanParseSyntheticPkpass() {
+        // Surface lock for the bead that wired the four implementation slices into
+        // PassParser.create(). Any future refactor that re-introduces a `throw` on the
+        // factory's parse() arm trips this test before any consumer-side test sees it.
+        val zip = SyntheticPkpass.unsigned(SyntheticPkpass.minimalPassJson("generic"))
+        val result = PassParser.create().parse(PassSource.Bytes(zip))
+        assertThat(result).isInstanceOf(ParseResult.Success::class.java)
     }
 
     /**

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
@@ -5,30 +5,9 @@ import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.ParserConfig
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.TamperReason
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.asn1.x509.BasicConstraints
-import org.bouncycastle.asn1.x509.Extension
-import org.bouncycastle.cert.X509v3CertificateBuilder
-import org.bouncycastle.cert.jcajce.JcaCertStore
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
-import org.bouncycastle.cms.CMSProcessableByteArray
-import org.bouncycastle.cms.CMSSignedDataGenerator
-import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
 import org.junit.BeforeClass
 import org.junit.Test
-import java.math.BigInteger
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.Security
 import java.security.cert.TrustAnchor
-import java.security.cert.X509Certificate
-import java.util.Date
 
 /**
  * Behavior tests for [verifySignature]. Every fixture is built in-memory at test
@@ -47,11 +26,11 @@ class SignatureVerifierTest {
     @Test
     fun appleVerifiedWhenChainTerminatesAtBundledRoot() {
         val rootKey = newRsaKeyPair()
-        val rootCert = selfSign(rootKey, "CN=Test Apple Root")
+        val rootCert = selfSignedCertificate(rootKey, "CN=Test Apple Root")
         val leafKey = newRsaKeyPair()
-        val leafCert = signLeafWith(leafKey.public, rootKey, rootCert, "CN=Test Apple Leaf")
+        val leafCert = signLeafCertificate(leafKey.public, rootKey, rootCert, "CN=Test Apple Leaf")
         val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
-        val signature = sign(manifest, leafCert, leafKey.private, listOf(leafCert, rootCert))
+        val signature = cmsDetachedSignature(manifest, leafCert, leafKey.private, listOf(leafCert, rootCert))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -74,11 +53,11 @@ class SignatureVerifierTest {
         // chainReachesAnchor would silently fail every Apple-signed pass under
         // strict mode.
         val rootKey = newRsaKeyPair()
-        val rootCert = selfSign(rootKey, "CN=Test Apple Root")
+        val rootCert = selfSignedCertificate(rootKey, "CN=Test Apple Root")
         val leafKey = newRsaKeyPair()
-        val leafCert = signLeafWith(leafKey.public, rootKey, rootCert, "CN=Test Apple Leaf")
+        val leafCert = signLeafCertificate(leafKey.public, rootKey, rootCert, "CN=Test Apple Leaf")
         val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
-        val signature = sign(manifest, leafCert, leafKey.private, listOf(leafCert, rootCert))
+        val signature = cmsDetachedSignature(manifest, leafCert, leafKey.private, listOf(leafCert, rootCert))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -95,10 +74,10 @@ class SignatureVerifierTest {
     @Test
     fun selfSignedLeafLeniently() {
         val key = newRsaKeyPair()
-        val leaf = selfSign(key, "CN=Self Signed Leaf")
+        val leaf = selfSignedCertificate(key, "CN=Self Signed Leaf")
         val manifest = "{}".toByteArray()
         // The signature blob carries only the self-signed leaf; no intermediates.
-        val signature = sign(manifest, leaf, key.private, listOf(leaf))
+        val signature = cmsDetachedSignature(manifest, leaf, key.private, listOf(leaf))
 
         val result = runWithFakeAnchor(signature, manifest, ParserConfig())
 
@@ -111,13 +90,13 @@ class SignatureVerifierTest {
         // anchor here is some unrelated CA. The chain extends (leaf + intermediate
         // signed by an out-of-band root) but does not reach the trusted set.
         val unrelatedKey = newRsaKeyPair()
-        val unrelatedAnchor = selfSign(unrelatedKey, "CN=Unrelated Anchor")
+        val unrelatedAnchor = selfSignedCertificate(unrelatedKey, "CN=Unrelated Anchor")
         val intermediateKey = newRsaKeyPair()
-        val intermediate = selfSign(intermediateKey, "CN=Stranger Intermediate")
+        val intermediate = selfSignedCertificate(intermediateKey, "CN=Stranger Intermediate")
         val leafKey = newRsaKeyPair()
-        val leaf = signLeafWith(leafKey.public, intermediateKey, intermediate, "CN=Stranger Leaf")
+        val leaf = signLeafCertificate(leafKey.public, intermediateKey, intermediate, "CN=Stranger Leaf")
         val manifest = "{\"k\":\"v\"}".toByteArray()
-        val signature = sign(manifest, leaf, leafKey.private, listOf(leaf, intermediate))
+        val signature = cmsDetachedSignature(manifest, leaf, leafKey.private, listOf(leaf, intermediate))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -134,9 +113,9 @@ class SignatureVerifierTest {
     @Test
     fun strictRejectsSelfSigned() {
         val key = newRsaKeyPair()
-        val leaf = selfSign(key, "CN=Self Signed Leaf")
+        val leaf = selfSignedCertificate(key, "CN=Self Signed Leaf")
         val manifest = "{}".toByteArray()
-        val signature = sign(manifest, leaf, key.private, listOf(leaf))
+        val signature = cmsDetachedSignature(manifest, leaf, key.private, listOf(leaf))
 
         val result = runWithFakeAnchor(signature, manifest, ParserConfig.Strict)
 
@@ -146,13 +125,13 @@ class SignatureVerifierTest {
     @Test
     fun strictRejectsCertChainIncomplete() {
         val unrelatedKey = newRsaKeyPair()
-        val unrelatedAnchor = selfSign(unrelatedKey, "CN=Unrelated Anchor")
+        val unrelatedAnchor = selfSignedCertificate(unrelatedKey, "CN=Unrelated Anchor")
         val intermediateKey = newRsaKeyPair()
-        val intermediate = selfSign(intermediateKey, "CN=Intermediate")
+        val intermediate = selfSignedCertificate(intermediateKey, "CN=Intermediate")
         val leafKey = newRsaKeyPair()
-        val leaf = signLeafWith(leafKey.public, intermediateKey, intermediate, "CN=Leaf")
+        val leaf = signLeafCertificate(leafKey.public, intermediateKey, intermediate, "CN=Leaf")
         val manifest = "{}".toByteArray()
-        val signature = sign(manifest, leaf, leafKey.private, listOf(leaf, intermediate))
+        val signature = cmsDetachedSignature(manifest, leaf, leafKey.private, listOf(leaf, intermediate))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -169,9 +148,9 @@ class SignatureVerifierTest {
     @Test
     fun manifestSignatureMismatchWhenManifestBytesTamperedByOneByte() {
         val key = newRsaKeyPair()
-        val leaf = selfSign(key, "CN=Self")
+        val leaf = selfSignedCertificate(key, "CN=Self")
         val original = "{\"pass.json\":\"abcd\"}".toByteArray()
-        val signature = sign(original, leaf, key.private, listOf(leaf))
+        val signature = cmsDetachedSignature(original, leaf, key.private, listOf(leaf))
         // Mutate exactly one byte.
         val tampered = original.copyOf().also { it[1] = 0x20 }
 
@@ -218,11 +197,11 @@ class SignatureVerifierTest {
         // signedness before trying chain validation would surface this as
         // SelfSigned. The classifier must try the anchor first.
         val rootKey = newRsaKeyPair()
-        val root = selfSign(rootKey, "CN=Test Apple Root")
+        val root = selfSignedCertificate(rootKey, "CN=Test Apple Root")
         val leafKey = newRsaKeyPair()
-        val leaf = signLeafWith(leafKey.public, rootKey, root, "CN=Apple Leaf")
+        val leaf = signLeafCertificate(leafKey.public, rootKey, root, "CN=Apple Leaf")
         val manifest = "x".toByteArray()
-        val signature = sign(manifest, leaf, leafKey.private, listOf(leaf, root))
+        val signature = cmsDetachedSignature(manifest, leaf, leafKey.private, listOf(leaf, root))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -241,13 +220,13 @@ class SignatureVerifierTest {
         // bundled `knownIntermediates` set fills the gap so the chain still
         // resolves to the trust anchor. This exercises the WWDR-G6-bundled path.
         val rootKey = newRsaKeyPair()
-        val root = selfSign(rootKey, "CN=Test Apple Root")
+        val root = selfSignedCertificate(rootKey, "CN=Test Apple Root")
         val intermediateKey = newRsaKeyPair()
-        val intermediate = signLeafWith(intermediateKey.public, rootKey, root, "CN=Test WWDR", isCa = true)
+        val intermediate = signLeafCertificate(intermediateKey.public, rootKey, root, "CN=Test WWDR", isCa = true)
         val leafKey = newRsaKeyPair()
-        val leaf = signLeafWith(leafKey.public, intermediateKey, intermediate, "CN=Test Apple Leaf")
+        val leaf = signLeafCertificate(leafKey.public, intermediateKey, intermediate, "CN=Test Apple Leaf")
         val manifest = "{\"k\":\"v\"}".toByteArray()
-        val signature = sign(manifest, leaf, leafKey.private, listOf(leaf))
+        val signature = cmsDetachedSignature(manifest, leaf, leafKey.private, listOf(leaf))
 
         val result =
             verifySignatureAgainstAnchorsForTesting(
@@ -267,7 +246,7 @@ class SignatureVerifierTest {
         config: ParserConfig,
     ): SignatureVerifyResult {
         val anchorKey = newRsaKeyPair()
-        val anchor = selfSign(anchorKey, "CN=Unrelated Anchor")
+        val anchor = selfSignedCertificate(anchorKey, "CN=Unrelated Anchor")
         return verifySignatureAgainstAnchorsForTesting(
             signature,
             manifest,
@@ -301,85 +280,7 @@ class SignatureVerifierTest {
         @BeforeClass
         @JvmStatic
         fun installBouncyCastle() {
-            if (Security.getProvider("BC") == null) {
-                Security.addProvider(BouncyCastleProvider())
-            }
+            ensureBouncyCastleProvider()
         }
     }
 }
-
-private fun newRsaKeyPair(): KeyPair {
-    val gen = KeyPairGenerator.getInstance("RSA", "BC")
-    gen.initialize(RSA_KEY_BITS)
-    return gen.generateKeyPair()
-}
-
-private fun selfSign(
-    keys: KeyPair,
-    subjectDn: String,
-): X509Certificate {
-    val now = System.currentTimeMillis()
-    val notBefore = Date(now - ONE_HOUR_MILLIS)
-    val notAfter = Date(now + ONE_YEAR_MILLIS)
-    val subject = X500Name(subjectDn)
-    val builder: X509v3CertificateBuilder =
-        JcaX509v3CertificateBuilder(
-            subject,
-            BigInteger.valueOf(now),
-            notBefore,
-            notAfter,
-            subject,
-            keys.public,
-        )
-    val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(keys.private)
-    val holder = builder.build(signer)
-    return JcaX509CertificateConverter().setProvider("BC").getCertificate(holder)
-}
-
-private fun signLeafWith(
-    leafPublicKey: PublicKey,
-    issuerKey: KeyPair,
-    issuerCert: X509Certificate,
-    subjectDn: String,
-    isCa: Boolean = false,
-): X509Certificate {
-    val now = System.currentTimeMillis()
-    val builder: X509v3CertificateBuilder =
-        JcaX509v3CertificateBuilder(
-            X500Name(issuerCert.subjectX500Principal.name),
-            BigInteger.valueOf(now + 1),
-            Date(now - ONE_HOUR_MILLIS),
-            Date(now + ONE_YEAR_MILLIS),
-            X500Name(subjectDn),
-            leafPublicKey,
-        )
-    if (isCa) {
-        builder.addExtension(Extension.basicConstraints, true, BasicConstraints(0))
-    }
-    val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(issuerKey.private)
-    val holder = builder.build(signer)
-    return JcaX509CertificateConverter().setProvider("BC").getCertificate(holder)
-}
-
-private fun sign(
-    content: ByteArray,
-    signerCert: X509Certificate,
-    signerKey: PrivateKey,
-    includedCerts: List<X509Certificate>,
-): ByteArray {
-    val gen = CMSSignedDataGenerator()
-    val contentSigner = JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(signerKey)
-    val infoGen =
-        JcaSignerInfoGeneratorBuilder(
-            JcaDigestCalculatorProviderBuilder().setProvider("BC").build(),
-        ).build(contentSigner, signerCert)
-    gen.addSignerInfoGenerator(infoGen)
-    gen.addCertificates(JcaCertStore(includedCerts))
-    val signed = gen.generate(CMSProcessableByteArray(content), false)
-    return signed.encoded
-}
-
-private const val SIG_ALGO = "SHA256withRSA"
-private const val RSA_KEY_BITS = 2048
-private const val ONE_HOUR_MILLIS = 60L * 60L * 1000L
-private const val ONE_YEAR_MILLIS = 365L * 24L * ONE_HOUR_MILLIS

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SyntheticPkpass.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SyntheticPkpass.kt
@@ -1,0 +1,245 @@
+package `is`.walt.passes.core.internal
+
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.jcajce.JcaCertStore
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.cms.CMSProcessableByteArray
+import org.bouncycastle.cms.CMSSignedDataGenerator
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
+import java.io.ByteArrayOutputStream
+import java.math.BigInteger
+import java.security.KeyPairGenerator
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.util.Date
+import java.util.HexFormat
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Test-only PKPASS archive builder. Produces fully-valid pkpass byte arrays — correct
+ * `manifest.json` SHA-1 chain, optionally a self-signed CMS detached signature blob —
+ * for use with the public [`is`.walt.passes.core.PassParser] entrypoint.
+ *
+ * Why hand-rolled rather than fixture binaries on disk:
+ *   - A reviewer can read each test top-to-bottom and see exactly what shape the archive
+ *     under test has. With opaque .pkpass binary fixtures, every `// see fixtures/foo.pkpass`
+ *     hides whatever the binary actually contains and any future rebuild silently changes
+ *     the test's input.
+ *   - Self-signed RSA keys are generated per build, which keeps the test corpus from
+ *     drifting against an Apple-issued cert that would expire and start failing the suite
+ *     out of band.
+ *
+ * The signing path here mirrors [SignatureVerifierTest]'s helpers so the two suites stay
+ * structurally identical; a failure in one is therefore informative about the other.
+ */
+internal object SyntheticPkpass {
+    init {
+        if (Security.getProvider("BC") == null) {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
+    /**
+     * Build an unsigned pkpass: zip with `pass.json`, `manifest.json`, optional images
+     * and `<locale>.lproj/pass.strings` files, and no `signature` entry. Suitable for
+     * lenient-default tests; trips strict mode by design.
+     */
+    fun unsigned(
+        passJson: String,
+        extraEntries: Map<String, ByteArray> = emptyMap(),
+    ): ByteArray {
+        val members = LinkedHashMap<String, ByteArray>()
+        members[PASS_JSON] = passJson.toByteArray(Charsets.UTF_8)
+        members.putAll(extraEntries)
+        val manifest = buildManifest(members)
+        members[MANIFEST_JSON] = manifest
+        return zip(members)
+    }
+
+    /**
+     * Build a signed pkpass with a synthesized self-signed certificate. The signature
+     * verifies cryptographically against the manifest bytes; default [ParserConfig]
+     * surfaces it as `SignatureStatus.SelfSigned` (no Apple anchor reachable). Strict
+     * mode treats the same archive as `Tampered(SignatureCryptoFailure)`.
+     */
+    fun signedSelfSigned(
+        passJson: String,
+        extraEntries: Map<String, ByteArray> = emptyMap(),
+    ): ByteArray {
+        val members = LinkedHashMap<String, ByteArray>()
+        members[PASS_JSON] = passJson.toByteArray(Charsets.UTF_8)
+        members.putAll(extraEntries)
+        val manifest = buildManifest(members)
+        members[MANIFEST_JSON] = manifest
+        members[SIGNATURE] = signCms(manifest)
+        return zip(members)
+    }
+
+    /**
+     * Build a signed archive then mutate one byte of `pass.json` post-manifest so the
+     * declared SHA-1 no longer matches the actual contents. Used to exercise the
+     * tamper-detection path through the public API.
+     */
+    fun unsignedWithTamperedPassJson(passJson: String): ByteArray {
+        val passBytes = passJson.toByteArray(Charsets.UTF_8)
+        val manifest = buildManifest(linkedMapOf(PASS_JSON to passBytes))
+        // Swap one byte in pass.json AFTER the manifest captured its hash.
+        val tampered = passBytes.copyOf().also { it[0] = (it[0] + 1).toByte() }
+        return zip(linkedMapOf(PASS_JSON to tampered, MANIFEST_JSON to manifest))
+    }
+
+    /**
+     * Compose a minimal valid pass.json for [type] (one of "boardingPass",
+     * "eventTicket", "coupon", "storeCard", "generic"). Required top-level fields
+     * (formatVersion, serialNumber, description, organizationName) are populated; the
+     * style sub-object is empty, which is the smallest pass.json that decodes to the
+     * named [PassType].
+     */
+    fun minimalPassJson(
+        type: String,
+        serial: String = "S-001",
+        organization: String = "Test Org",
+        description: String = "Synthesized for tests",
+    ): String =
+        """
+        {
+            "formatVersion": 1,
+            "serialNumber": "$serial",
+            "description": "$description",
+            "organizationName": "$organization",
+            "$type": {}
+        }
+        """.trimIndent()
+
+    /**
+     * Build a syntactically valid 8x8 PNG with arbitrary IHDR-declared dimensions —
+     * useful for exercising the pixel-cap check without serializing a real pixel grid.
+     * The IHDR chunk is what the parser inspects; downstream chunks (IDAT, IEND) are
+     * present so the byte stream looks like a PNG to any reader that walks past the
+     * header.
+     */
+    fun fakePng(
+        widthDeclared: Int = 1,
+        heightDeclared: Int = 1,
+    ): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write(
+            byteArrayOf(
+                0x89.toByte(),
+                0x50,
+                0x4E,
+                0x47,
+                0x0D,
+                0x0A,
+                0x1A,
+                0x0A,
+            ),
+        )
+        // IHDR length (13)
+        out.writeIntBE(IHDR_DATA_LENGTH)
+        out.write("IHDR".toByteArray(Charsets.US_ASCII))
+        out.writeIntBE(widthDeclared)
+        out.writeIntBE(heightDeclared)
+        // bit depth, color type, compression, filter, interlace — fixed minimums
+        out.write(
+            byteArrayOf(
+                0x08,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ),
+        )
+        // CRC placeholder (parser does not validate the CRC; downstream renderers do)
+        out.writeIntBE(0)
+        // IEND chunk
+        out.writeIntBE(0)
+        out.write("IEND".toByteArray(Charsets.US_ASCII))
+        out.writeIntBE(0)
+        return out.toByteArray()
+    }
+
+    private fun ByteArrayOutputStream.writeIntBE(value: Int) {
+        write(value ushr 24 and 0xFF)
+        write(value ushr 16 and 0xFF)
+        write(value ushr 8 and 0xFF)
+        write(value and 0xFF)
+    }
+
+    private fun buildManifest(members: Map<String, ByteArray>): ByteArray {
+        val sha1 = MessageDigest.getInstance("SHA-1")
+        val pairs =
+            members.entries.joinToString(",") { (name, bytes) ->
+                val hex = HexFormat.of().formatHex(sha1.digest(bytes))
+                "\"$name\":\"$hex\""
+            }
+        return "{$pairs}".toByteArray(Charsets.UTF_8)
+    }
+
+    private fun zip(members: Map<String, ByteArray>): ByteArray {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            for ((name, bytes) in members) {
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private fun signCms(manifest: ByteArray): ByteArray {
+        val keyGen = KeyPairGenerator.getInstance("RSA", "BC")
+        keyGen.initialize(RSA_KEY_BITS)
+        val keys = keyGen.generateKeyPair()
+        val cert = selfSignedCertificate(keys.private, keys.public, "CN=Test Synthetic Signer")
+        val signer =
+            JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(keys.private)
+        val infoGen =
+            JcaSignerInfoGeneratorBuilder(
+                JcaDigestCalculatorProviderBuilder().setProvider("BC").build(),
+            ).build(signer, cert)
+        val gen =
+            CMSSignedDataGenerator().apply {
+                addSignerInfoGenerator(infoGen)
+                addCertificates(JcaCertStore(listOf(cert)))
+            }
+        return gen.generate(CMSProcessableByteArray(manifest), false).encoded
+    }
+
+    private fun selfSignedCertificate(
+        privateKey: PrivateKey,
+        publicKey: java.security.PublicKey,
+        subjectDn: String,
+    ): X509Certificate {
+        val now = System.currentTimeMillis()
+        val name = X500Name(subjectDn)
+        val builder =
+            JcaX509v3CertificateBuilder(
+                name,
+                BigInteger.valueOf(now),
+                Date(now - ONE_HOUR_MILLIS),
+                Date(now + ONE_YEAR_MILLIS),
+                name,
+                publicKey,
+            )
+        val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(privateKey)
+        return JcaX509CertificateConverter().setProvider("BC").getCertificate(builder.build(signer))
+    }
+
+    private const val PASS_JSON = "pass.json"
+    private const val MANIFEST_JSON = "manifest.json"
+    private const val SIGNATURE = "signature"
+    private const val SIG_ALGO = "SHA256withRSA"
+    private const val RSA_KEY_BITS = 2048
+    private const val IHDR_DATA_LENGTH = 13
+    private const val ONE_HOUR_MILLIS = 60L * 60L * 1000L
+    private const val ONE_YEAR_MILLIS = 365L * 24L * ONE_HOUR_MILLIS
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SyntheticPkpass.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SyntheticPkpass.kt
@@ -1,23 +1,7 @@
 package `is`.walt.passes.core.internal
 
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.cert.jcajce.JcaCertStore
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
-import org.bouncycastle.cms.CMSProcessableByteArray
-import org.bouncycastle.cms.CMSSignedDataGenerator
-import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
 import java.io.ByteArrayOutputStream
-import java.math.BigInteger
-import java.security.KeyPairGenerator
 import java.security.MessageDigest
-import java.security.PrivateKey
-import java.security.Security
-import java.security.cert.X509Certificate
-import java.util.Date
 import java.util.HexFormat
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -36,16 +20,13 @@ import java.util.zip.ZipOutputStream
  *     drifting against an Apple-issued cert that would expire and start failing the suite
  *     out of band.
  *
- * The signing path here mirrors [SignatureVerifierTest]'s helpers so the two suites stay
- * structurally identical; a failure in one is therefore informative about the other.
+ * Cryptographic primitives (RSA key generation, X.509 self-signing, CMS detached
+ * signature production) are delegated to [TestCryptoSupport]. That keeps the signing
+ * math identical between this fixture and [SignatureVerifierTest]: a regression in one
+ * suite is informative about the same path in the other, with no risk of the two
+ * implementations drifting.
  */
 internal object SyntheticPkpass {
-    init {
-        if (Security.getProvider("BC") == null) {
-            Security.addProvider(BouncyCastleProvider())
-        }
-    }
-
     /**
      * Build an unsigned pkpass: zip with `pass.json`, `manifest.json`, optional images
      * and `<locale>.lproj/pass.strings` files, and no `signature` entry. Suitable for
@@ -59,7 +40,7 @@ internal object SyntheticPkpass {
         members[PASS_JSON] = passJson.toByteArray(Charsets.UTF_8)
         members.putAll(extraEntries)
         val manifest = buildManifest(members)
-        members[MANIFEST_JSON] = manifest
+        members[MANIFEST_FILE_NAME] = manifest
         return zip(members)
     }
 
@@ -77,8 +58,8 @@ internal object SyntheticPkpass {
         members[PASS_JSON] = passJson.toByteArray(Charsets.UTF_8)
         members.putAll(extraEntries)
         val manifest = buildManifest(members)
-        members[MANIFEST_JSON] = manifest
-        members[SIGNATURE] = signCms(manifest)
+        members[MANIFEST_FILE_NAME] = manifest
+        members[SIGNATURE_FILE_NAME] = buildSelfSignedSignature(manifest)
         return zip(members)
     }
 
@@ -92,7 +73,7 @@ internal object SyntheticPkpass {
         val manifest = buildManifest(linkedMapOf(PASS_JSON to passBytes))
         // Swap one byte in pass.json AFTER the manifest captured its hash.
         val tampered = passBytes.copyOf().also { it[0] = (it[0] + 1).toByte() }
-        return zip(linkedMapOf(PASS_JSON to tampered, MANIFEST_JSON to manifest))
+        return zip(linkedMapOf(PASS_JSON to tampered, MANIFEST_FILE_NAME to manifest))
     }
 
     /**
@@ -100,7 +81,7 @@ internal object SyntheticPkpass {
      * "eventTicket", "coupon", "storeCard", "generic"). Required top-level fields
      * (formatVersion, serialNumber, description, organizationName) are populated; the
      * style sub-object is empty, which is the smallest pass.json that decodes to the
-     * named [PassType].
+     * named [`is`.walt.passes.core.PassType].
      */
     fun minimalPassJson(
         type: String,
@@ -119,7 +100,7 @@ internal object SyntheticPkpass {
         """.trimIndent()
 
     /**
-     * Build a syntactically valid 8x8 PNG with arbitrary IHDR-declared dimensions —
+     * Build a syntactically valid PNG with arbitrary IHDR-declared dimensions —
      * useful for exercising the pixel-cap check without serializing a real pixel grid.
      * The IHDR chunk is what the parser inspects; downstream chunks (IDAT, IEND) are
      * present so the byte stream looks like a PNG to any reader that walks past the
@@ -195,51 +176,17 @@ internal object SyntheticPkpass {
         return baos.toByteArray()
     }
 
-    private fun signCms(manifest: ByteArray): ByteArray {
-        val keyGen = KeyPairGenerator.getInstance("RSA", "BC")
-        keyGen.initialize(RSA_KEY_BITS)
-        val keys = keyGen.generateKeyPair()
-        val cert = selfSignedCertificate(keys.private, keys.public, "CN=Test Synthetic Signer")
-        val signer =
-            JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(keys.private)
-        val infoGen =
-            JcaSignerInfoGeneratorBuilder(
-                JcaDigestCalculatorProviderBuilder().setProvider("BC").build(),
-            ).build(signer, cert)
-        val gen =
-            CMSSignedDataGenerator().apply {
-                addSignerInfoGenerator(infoGen)
-                addCertificates(JcaCertStore(listOf(cert)))
-            }
-        return gen.generate(CMSProcessableByteArray(manifest), false).encoded
-    }
-
-    private fun selfSignedCertificate(
-        privateKey: PrivateKey,
-        publicKey: java.security.PublicKey,
-        subjectDn: String,
-    ): X509Certificate {
-        val now = System.currentTimeMillis()
-        val name = X500Name(subjectDn)
-        val builder =
-            JcaX509v3CertificateBuilder(
-                name,
-                BigInteger.valueOf(now),
-                Date(now - ONE_HOUR_MILLIS),
-                Date(now + ONE_YEAR_MILLIS),
-                name,
-                publicKey,
-            )
-        val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider("BC").build(privateKey)
-        return JcaX509CertificateConverter().setProvider("BC").getCertificate(builder.build(signer))
+    private fun buildSelfSignedSignature(manifest: ByteArray): ByteArray {
+        val keys = newRsaKeyPair()
+        val cert = selfSignedCertificate(keys, "CN=Test Synthetic Signer")
+        return cmsDetachedSignature(
+            content = manifest,
+            signerCert = cert,
+            signerKey = keys.private,
+            includedCerts = listOf(cert),
+        )
     }
 
     private const val PASS_JSON = "pass.json"
-    private const val MANIFEST_JSON = "manifest.json"
-    private const val SIGNATURE = "signature"
-    private const val SIG_ALGO = "SHA256withRSA"
-    private const val RSA_KEY_BITS = 2048
     private const val IHDR_DATA_LENGTH = 13
-    private const val ONE_HOUR_MILLIS = 60L * 60L * 1000L
-    private const val ONE_YEAR_MILLIS = 365L * 24L * ONE_HOUR_MILLIS
 }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
@@ -1,0 +1,139 @@
+package `is`.walt.passes.core.internal
+
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.cert.jcajce.JcaCertStore
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.cms.CMSProcessableByteArray
+import org.bouncycastle.cms.CMSSignedDataGenerator
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
+import java.math.BigInteger
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.util.Date
+
+/**
+ * Shared test helpers for synthesizing X.509 certificates and CMS / PKCS#7 signature
+ * blobs. Lives here (rather than in two near-identical private blocks at the bottom of
+ * [SignatureVerifierTest] and [SyntheticPkpass]) so that the two suites stay
+ * structurally identical: a change to the signing math has exactly one site to update,
+ * and a regression in one suite is informative about the same path in the other.
+ *
+ * Visibility is `internal` to the module — these helpers are test-only because they
+ * generate ephemeral RSA keys, but Kotlin's test source set lives in the same module
+ * as production code, so any test class in `passes-core` can call them.
+ */
+internal fun ensureBouncyCastleProvider() {
+    if (Security.getProvider(BC_PROVIDER) == null) {
+        Security.addProvider(BouncyCastleProvider())
+    }
+}
+
+internal fun newRsaKeyPair(): KeyPair {
+    ensureBouncyCastleProvider()
+    val gen = KeyPairGenerator.getInstance("RSA", BC_PROVIDER)
+    gen.initialize(RSA_KEY_BITS)
+    return gen.generateKeyPair()
+}
+
+/**
+ * Build a self-signed certificate. Subject and issuer are the same DN; the certificate
+ * verifies under its own public key. Used directly as a self-signed leaf, and as a
+ * synthesized "Apple-like" root anchor in tests that exercise the chain-builder path.
+ */
+internal fun selfSignedCertificate(
+    keyPair: KeyPair,
+    subjectDn: String,
+): X509Certificate {
+    ensureBouncyCastleProvider()
+    val now = System.currentTimeMillis()
+    val subject = X500Name(subjectDn)
+    val builder =
+        JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.valueOf(now),
+            Date(now - ONE_HOUR_MILLIS),
+            Date(now + ONE_YEAR_MILLIS),
+            subject,
+            keyPair.public,
+        )
+    val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider(BC_PROVIDER).build(keyPair.private)
+    return JcaX509CertificateConverter()
+        .setProvider(BC_PROVIDER)
+        .getCertificate(builder.build(signer))
+}
+
+/**
+ * Build a certificate for [leafPublicKey] signed by [issuerKey], anchored to the issuer
+ * DN from [issuerCert]. When [isCa] is true the certificate carries a CA basic
+ * constraint with `pathLen=0`, which lets it function as an intermediate that may sign
+ * one further-down leaf — sufficient for synthesizing the WWDR-style intermediate
+ * tested in [SignatureVerifierTest.knownIntermediateLetsBlobOmitItAndStillReachAnchor].
+ */
+internal fun signLeafCertificate(
+    leafPublicKey: PublicKey,
+    issuerKey: KeyPair,
+    issuerCert: X509Certificate,
+    subjectDn: String,
+    isCa: Boolean = false,
+): X509Certificate {
+    ensureBouncyCastleProvider()
+    val now = System.currentTimeMillis()
+    val builder =
+        JcaX509v3CertificateBuilder(
+            X500Name(issuerCert.subjectX500Principal.name),
+            BigInteger.valueOf(now + 1),
+            Date(now - ONE_HOUR_MILLIS),
+            Date(now + ONE_YEAR_MILLIS),
+            X500Name(subjectDn),
+            leafPublicKey,
+        )
+    if (isCa) {
+        builder.addExtension(Extension.basicConstraints, true, BasicConstraints(0))
+    }
+    val signer = JcaContentSignerBuilder(SIG_ALGO).setProvider(BC_PROVIDER).build(issuerKey.private)
+    return JcaX509CertificateConverter()
+        .setProvider(BC_PROVIDER)
+        .getCertificate(builder.build(signer))
+}
+
+/**
+ * Produce a detached CMS / PKCS#7 signature blob over [content], signed by [signerKey]
+ * (whose certificate is [signerCert]). [includedCerts] are embedded in the signature
+ * envelope's certificate set — pass the leaf alone for a self-signed-only blob, or
+ * leaf + intermediate(s) when the chain should travel with the signature.
+ */
+internal fun cmsDetachedSignature(
+    content: ByteArray,
+    signerCert: X509Certificate,
+    signerKey: PrivateKey,
+    includedCerts: List<X509Certificate>,
+): ByteArray {
+    ensureBouncyCastleProvider()
+    val contentSigner = JcaContentSignerBuilder(SIG_ALGO).setProvider(BC_PROVIDER).build(signerKey)
+    val infoGen =
+        JcaSignerInfoGeneratorBuilder(
+            JcaDigestCalculatorProviderBuilder().setProvider(BC_PROVIDER).build(),
+        ).build(contentSigner, signerCert)
+    val gen =
+        CMSSignedDataGenerator().apply {
+            addSignerInfoGenerator(infoGen)
+            addCertificates(JcaCertStore(includedCerts))
+        }
+    return gen.generate(CMSProcessableByteArray(content), false).encoded
+}
+
+private const val BC_PROVIDER = "BC"
+private const val SIG_ALGO = "SHA256withRSA"
+private const val RSA_KEY_BITS = 2048
+private const val ONE_HOUR_MILLIS = 60L * 60L * 1000L
+private const val ONE_YEAR_MILLIS = 365L * 24L * ONE_HOUR_MILLIS


### PR DESCRIPTION
## Summary

- Replaces the `NotImplementedError` stub in `PassParser.create()` with `DefaultPassParser`, wiring the four merged implementation slices (extract, manifest, signature, pass.json) plus `.strings` parsing into a non-throwing end-to-end pipeline.
- Adds a pure-JVM IHDR-only PNG header reader so `maxImagePixelCount` fires before any decoder allocates pixels.
- Brackets every `parse()` with `TelemetryGuard` events carrying `nanoTime`-derived durations and type-flattened status / failure kinds; pass content never enters the events.

Closes `wpass-qnc`. Unblocks walt-android `wlt-4pg` (consumer module-graph wiring).

### Pipeline order (trust hierarchy)

```
extract -> manifest hash chain -> CMS signature -> pass.json -> .strings -> images -> assemble
```

Each stage's failure lands on its public arm: `Tampered` for hash mismatch and signature failures, `Malformed` for structural issues, `Unsupported` for unknown `formatVersion` / pass style, `ResourceLimitExceeded` for guard trips.

### Concurrency

`DefaultPassParser` holds only the immutable `ParserConfig`; helpers take work-in-progress entries as parameters. Safe to call `parse()` concurrently across threads on a single instance.

## Test plan

- [x] `./gradlew :passes-core:check` green (detekt + ktlint + JUnit, 169 tests)
- [x] All five `PassType` happy paths produce `Success`
- [x] Unsigned + lenient default -> `Success(SignatureStatus.Unsigned)`
- [x] Unsigned + `ParserConfig.Strict` -> `Tampered(SignatureCryptoFailure)`
- [x] Self-signed + lenient -> `Success(SignatureStatus.SelfSigned)`; strict rejects
- [x] One-byte tampered `pass.json` -> `Tampered(FileHashMismatch)`
- [x] `Malformed`/`Unsupported` arms forwarded for missing/invalid pass.json, unknown format version, non-zip bytes
- [x] Resource caps trip: `EntrySize` (zip-bomb), `ImagePixelCount` (oversized IHDR), `LocaleCount` (more `.lproj/` than the cap)
- [x] Locales and image roles surfaced on the parsed `Pass`
- [x] Telemetry: `onParseStarted` followed by exactly one of `onParseSucceeded` / `onParseFailed`
- [x] 16-thread concurrent parse on a shared parser + source returns equal `Success`
- [x] `PublicApiSurfaceTest.parserCanParseSyntheticPkpass` locks the no-throw end-to-end surface