### PR TITLE
docs: PDF threat model + ADR 0005 (wpass-0ri)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Pre-alpha. Architecture and design phase. No releases yet.
 | Back-field URLs go through a visible-confirmation flow before opening | `passes-ui` — `UrlConfirmationSheet` composable |
 | Pass deletion is irreversible; caches are wiped | `passes-storage` — deletion logic |
 | Expired passes show an "Expired" badge but are not auto-deleted | `passes-ui` + `passes-storage` |
+| PDF document import is contained in an isolated renderer process; bytes are never extracted, parsed for fields, or shared back out | [`docs/PDF_THREAT_MODEL.md`](docs/PDF_THREAT_MODEL.md); [`docs/adr/0005-pdf-document-support.md`](docs/adr/0005-pdf-document-support.md); `passes-pdf` (forthcoming) |
 
 (These point to *intended* locations; modules are not yet implemented.)
 
@@ -42,6 +43,7 @@ Pre-alpha. Architecture and design phase. No releases yet.
 - PKPASS file import via OS-level intent filter and in-app file picker.
 - Front + back fields displayed; barcode/QR rendering; full localization (all locales retained, re-render on locale change); expired badge; visible-URL confirmation for back-field actionables.
 - Encrypted local storage; irreversible deletion.
+- PDF document import (e.g., concert tickets distributed as PDF) as a sibling concept to PKPASS, in a separate "Documents" lane. Rendering happens in an isolated process; PDF bytes are never extracted, parsed for fields, or shared back out. See [`docs/PDF_THREAT_MODEL.md`](docs/PDF_THREAT_MODEL.md) and [`docs/adr/0005-pdf-document-support.md`](docs/adr/0005-pdf-document-support.md).
 
 **Out:**
 - NFC / transit passes (HCE conflict with payment).

--- a/docs/PDF_THREAT_MODEL.md
+++ b/docs/PDF_THREAT_MODEL.md
@@ -1,0 +1,308 @@
+# PDF document import: threat model
+
+The trust claim that this repository carries is "every security-and-privacy-critical
+behavior Walt makes about pass handling lives in code you can read." For PDF
+import, that decomposes into a per-threat enumeration plus three load-bearing
+controls. Each threat is listed below with: where it lives in the format, what
+control mitigates it, and (for accepted-risk items) the rationale for accepting
+the residual exposure.
+
+This document is the security-side companion to ADR 0005 ("PDF document
+support"). Where ADR 0005 records *what* the architecture is, this document
+records *why each piece of it has to exist*.
+
+## Three load-bearing controls
+
+The mitigations below all reduce to combinations of three structural controls.
+Each is named here so individual threats can reference them by short label
+rather than re-stating the rationale.
+
+**C1. System renderer only (`android.graphics.pdf.PdfRenderer`).** Walt does
+not bundle a PDF parser. PDFium ships in Android's MediaProvider Mainline
+module on Android 13+ and updates via Play System Updates, so PDFium CVE
+response is decoupled from Walt's release cadence. The API surface is narrow
+(`ParcelFileDescriptor` in, `Bitmap` out) and the API explicitly does not
+execute JavaScript, does not process `URI` / `Launch` / `SubmitForm` actions
+during page render, and does not perform network I/O. ADR 0005 D2.
+
+**C2. Isolated-process renderer service.** All PDF parsing and rasterization
+runs in a `Service` annotated `android:isolatedProcess="true"`. The service has
+no app-data access, no inherited network permission, no Keystore session, and
+OS-level crash containment. A use-after-free or out-of-bounds read inside
+PDFium brings down the service, not the wallet process. ADR 0005 D3.
+
+**C3. No-extraction discipline.** Walt performs exactly one operation on a
+PDF: `PdfRenderer.openPage(N).render(bitmap, ...)`. Walt does not extract
+text, metadata, form-field values, annotations, links, or attachments. The
+renderer service's binder API exposes exactly two methods, `probe(fd)` and
+`render(fd, page, w, h)`. ADR 0005 D4.
+
+## Format-level threats
+
+### 1. Embedded JavaScript (`/JavaScript`, `/JS` actions)
+
+**What.** PDF supports an embedded JavaScript runtime, with hooks for
+`/OpenAction`, document open, page open, form-field events, and bookmark
+navigation. Adobe Acrobat executes these. Reader-side JS has been a CVE source
+for two decades.
+
+**Mitigation.** C1: `PdfRenderer` does not implement the JavaScript runtime;
+script bytes are inert. C3: Walt never enumerates `/Names` or
+`/AcroForm/Fields`, so even the codepath that *discovers* JS-bearing nodes
+is never invoked. `wpass-6m9` empirically verifies non-execution against a
+PDF carrying a JS `/OpenAction`.
+
+**Status.** Mitigated.
+
+### 2. Action triggers (`/Launch`, `/SubmitForm`, `/URI`, `/GoToR`, `/RemoteGoTo`)
+
+**What.** Annotations and bookmarks can carry actions that fire intents
+(`/Launch`), navigate to remote PDFs (`/GoToR`), submit form data over the
+network (`/SubmitForm`), or open URLs (`/URI`). A hostile PDF that the
+renderer "follows" actions for can attempt local-app attack, phone-home, or
+URL-hijack flows.
+
+**Mitigation.** C1: `PdfRenderer.render()` does not interpret action
+dictionaries; rasterization ignores them. C3: Walt never extracts annotations
+or bookmarks, so the action dictionaries never reach Walt-controlled code.
+
+**Status.** Mitigated.
+
+### 3. AcroForm and XFA active content
+
+**What.** AcroForm fields can carry calculation scripts, validation scripts,
+and submit actions. XFA (XML Forms Architecture) is an embedded XML form
+runtime with its own scripting (FormCalc, JavaScript). XFA in particular has
+been a recurring CVE source.
+
+**Mitigation.** C1: `PdfRenderer` does not run XFA; `PdfRenderer` rasterizes
+AcroForm fields as static visuals without invoking calc/validate/submit
+hooks. C3: Walt never reads form-field values, so even widget-text leakage
+is not surfaced.
+
+**Status.** Mitigated.
+
+### 4. Embedded file attachments (`/EmbeddedFiles`)
+
+**What.** PDFs may carry arbitrary file payloads in the `/Names` →
+`/EmbeddedFiles` tree. Historic exploits use this for malware delivery via
+Adobe Reader's "save attachment" UI.
+
+**Mitigation.** C3: Walt never traverses `/Names` and never offers a "save
+attachment" affordance. The bytes sit unreferenced inside the PDF blob and
+never reach a code path that interprets them. C2 ensures that even a
+hypothetical bug in the renderer that *did* materialize an attachment would
+do so inside the isolated process with no DB or filesystem write capability.
+
+**Status.** Mitigated.
+
+### 5. PDF digital signatures (PAdES / CMS)
+
+**What.** PDFs can carry PKCS#7-CMS signatures (legacy and PAdES profiles).
+Signature semantics in the wild are inconsistent: whole-document vs.
+partial-document, certification vs. approval, MDP transforms with varying
+permission levels.
+
+**Mitigation.** Not verified. ADR 0005 D5. Every PDF imported into Walt
+carries `Provenance.UserProvided`, structurally distinct from PKPASS's
+`SignatureStatus.AppleVerified` / `SelfSigned` ladder. The
+`DocumentTrustCaption` ("User-provided document. Walt has not verified the
+source.") is non-suppressible, in the same visual register as the existing
+`SignatureStatus.SelfSigned` pill.
+
+**Rationale for not verifying.** A "Verified" UI signal that Walt cannot
+honestly back would dilute the PKPASS signature trust signal. There is no
+analogue to Apple's WWDR root for ticket issuance. Implementing PAdES
+correctly (across MDP transforms, certification chains, revocation) is its
+own project, and a half-correct implementation is worse than none.
+
+**Status.** Accepted, with structural UI mitigation (D5, D8 non-suppressible
+caption).
+
+### 6. Network fetches at render time
+
+**What.** PDFs can reference remote resources (color profiles, forms,
+external images, `/RemoteGoTo`). A reader that resolves these on render
+phones home, leaks IPs, and turns into a probe vector.
+
+**Mitigation.** C1: `PdfRenderer.render()` does not resolve external
+references. C2: the isolated-process service's manifest declares zero
+`uses-permission`; `INTERNET` is not inherited. Even if a future renderer
+update added a remote-resolution path, the OS would deny network access.
+
+**Status.** Mitigated, with defense-in-depth at the permission layer.
+
+### 7. Decoder-CVE-heavy subformats (JBIG2, JPEG2000, CCITT)
+
+**What.** Image subformats inside PDF have a long CVE history. JBIG2
+specifically has shipped at least two memory-corruption issues with public
+exploit chains in the past five years (FORCEDENTRY, etc.). JPEG2000 (JPX)
+and CCITT Fax have similar histories at lower volume.
+
+**Mitigation.** C2: a use-after-free or out-of-bounds write inside the
+PDFium image-codec path is contained to the isolated renderer process. The
+process has no DB, no Keystore session, no filesystem write outside its
+bitmap output, and no network. The blast radius of a successful exploit is
+"the user re-taps to view the document; the rendering service rebinds."
+
+C1: PDFium ships in MediaProvider Mainline on Android 13+, so codec fixes
+flow via Play System Updates without a Walt release.
+
+**Status.** Mitigated against persistence and lateral movement; CVE-window
+exposure in the renderer process itself is the residual risk and is
+quantified in `wpass-6m9`.
+
+### 8. Object-graph attacks (deep nesting, malformed xref, oversized streams)
+
+**What.** PDFs are graphs of indirect objects with `/Parent` references and
+xref tables. Hostile inputs include xref-table cycles, deeply recursive
+page-tree structures, billion-laughs-style stream expansion, and integer
+overflow in object-number fields.
+
+**Mitigation.** C2 contains decoder bugs to the isolated process. ADR 0005
+D7 caps page count at 10 (the renderer rejects a `pageCount > 10` PDF
+before any further traversal). The 5-second render watchdog kills the
+service on unbounded loops in stream decoding. The 25 MB import cap stops
+the worst-case input volume.
+
+**Status.** Mitigated, with hard caps as second line.
+
+### 9. Encrypted PDFs
+
+**What.** PDFs may be encrypted with a user password. The reader normally
+prompts for the password to decrypt and render.
+
+**Mitigation.** Refused at import. ADR 0005 D6. The renderer service
+detects the encryption flag at `probe()` and returns
+`Rejected(Encrypted)`; Walt does not surface a password prompt.
+
+**Rationale.** A password prompt invoked from PDF-encryption metadata is
+a UI vector controlled by an untrusted file. A user habituated to typing
+passwords into Walt is one prompt-spoof exploit away from a real
+credential leak (the spoofed prompt could phrase itself as a Walt /
+Google / device password request). The cost is that users with
+password-protected files must decrypt elsewhere first.
+
+**Status.** Accepted by refusal.
+
+### 10. Render bombs
+
+**What.** Hostile PDFs that declare enormous page sizes, request very
+large bitmap allocations, or carry deeply recursive page trees. Goal:
+OOM-crash the host or exhaust the device.
+
+**Mitigation.** ADR 0005 D7 hard caps:
+- 25 MB import-size ceiling
+- 10-page document ceiling
+- 4 MP per-page rasterized-bitmap ceiling
+- 5 s render-call watchdog with `Process.killProcess` on timeout
+
+The ceiling values are enforced both in the renderer service (first line)
+and at the storage-layer insert (defense in depth, so a future caller bug
+cannot land an oversized blob).
+
+**Status.** Mitigated.
+
+### 11. Cross-pass exfiltration via renderer compromise
+
+**What.** A renderer-process exploit that survives long enough to read
+memory or filesystem could, in theory, exfiltrate the SQLCipher key,
+decoded PKPASS bytes, or other user data co-resident in the wallet
+process.
+
+**Mitigation.** C2 places the renderer in a process that has none of the
+above in its address space or filesystem view. Isolated-process services
+on Android are forbidden from reading `/data/data/<app>/`, cannot bind the
+Keystore, and cannot bind network sockets. A successful PDFium exploit
+inside the isolated process can corrupt the rendered bitmap; it cannot
+read SQLCipher pages because they are not in that process's memory.
+
+**Status.** Mitigated structurally (the data is not reachable).
+
+### 12. Phishing-barcode at the gate
+
+**What.** A hostile "ticket" PDF whose visible barcode/QR resolves to a
+credential-phishing URL when scanned. The user scans it at the gate or
+elsewhere, trusts the scanner's intent, and lands on an attacker page.
+
+**Mitigation.** None applicable from Walt. The barcode is rasterized
+content the user is responsible for sourcing, and Walt makes no claim
+about the contents of an unverified document. The non-suppressible
+`DocumentTrustCaption` is the user-facing signal; the structural absence
+of a "Verified" pill prevents false-confidence escalation.
+
+**Status.** Accepted-risk for v1; the trust-caption discipline is the
+user-facing mitigation.
+
+### 13. Bidi/control-character spoofing in display label
+
+**What.** The PDF's filename (or fallback "PDF, added <date>" string) is
+user-controlled and rendered alongside the trust caption. A filename
+containing U+202E or other Cf/Cc characters could rearrange visible glyphs
+to spoof Walt UI text.
+
+**Mitigation.** `DocumentTrustCaption` and the Documents-lane tile wrap
+the display label in U+2068 / U+2069 (FSI / PDI) bidi isolates, mirroring
+the existing `B3UrlConfirmSheet` discipline (`passes-ui/TRUST_CLAIMS.md`
+section 2). `wpass-7wn`'s instrumentation tests verify the wrap.
+
+**Status.** Mitigated.
+
+## Inventory: PKPASS controls and PDF equivalents
+
+| PKPASS control                                  | PDF equivalent                                                                |
+|-------------------------------------------------|-------------------------------------------------------------------------------|
+| `ParserConfig.maxArchiveBytes` (10 MB)          | `PdfImportConfig.maxBytes` (25 MB); enforced at import and at storage         |
+| Manifest hash + PKCS#7 signature                | Not applicable; provenance is `UserProvided` (D5)                             |
+| `ImageRenderBounds` (1920 x 1920, 4 MP)         | Per-page rendered-bitmap cap of 4 MP                                          |
+| `SignatureStatus` four-band badge               | Single-band "User-provided document" caption, non-suppressible                |
+| `FieldLinkScanner` Cf/Cc rejection              | Not applicable (no link extraction)                                           |
+| `B3UrlConfirmSheet`                             | Not applicable (no URL surfaced)                                              |
+| `ExpiredOverlayState`                           | Not applicable (no expiration metadata; sort by import date)                  |
+| `TelemetryGuard` PII discipline                 | `DocumentTelemetryGuard` mirrors the discipline (enums / counts / durations)  |
+| `application/vnd.apple.pkpass` intent filter    | `application/pdf` intent filter, registered in walt-android                  |
+| Encrypted-at-rest (SQLCipher) + Auto Backup off | Same database, same XML rules apply automatically                             |
+| Irreversible delete with cache wipe             | Same `ON DELETE CASCADE` and unwind contract                                  |
+| (n/a)                                           | New: isolated-process renderer (C2)                                           |
+
+## Explicit non-features
+
+The list below is load-bearing: a future contributor proposing any of these
+items must amend ADR 0005, not just file a PR. The non-features below are not
+"deferred to v2"; they are deliberately absent because each one re-opens a
+threat row above.
+
+- **No PDF digital-signature verification.** Re-opens row 5.
+- **No text, form-field, or annotation extraction.** Re-opens rows 1, 2, 3.
+- **No URL surfaced from PDF.** Re-opens row 2.
+- **No PDF-metadata-driven labels.** Re-opens parsing surface for `/Title`,
+  `/Author`, XMP; re-introduces a parser-side string handling path that the
+  current design avoids entirely.
+- **No DB / Keystore / network / file-system access from inside the renderer
+  process.** Re-opens row 11.
+- **No "share" / "export" of PDF bytes out of Walt.** ADR 0005 D8: every
+  egress codepath is a potential exfiltration path if a future bug routes
+  content through it implicitly.
+
+## How each control is tested
+
+The implementation beads (`wpass-jsb`, `wpass-pti`, `wpass-5v9`, `wpass-7wn`)
+each carry tests pinning the controls used here. The mapping is recorded in
+ADR 0005 ("Tests pinning the controls above") and is not duplicated here.
+
+The renderer-validation bead `wpass-6m9` is the empirical complement to this
+document: where this document asserts "C1 does not execute JavaScript," that
+bead's deliverable is a recorded reproduction with a JS-laden test PDF on at
+least one Pixel device and one OEM device.
+
+## Out of scope for this document
+
+- The wallet's payment / HCE surface is unchanged by PDF import; documented
+  in the parent epic `wpass-i2r` and in the existing payment-side trust
+  documentation.
+- The Walt-side onboarding, Hilt wiring, and intent-filter manifest are
+  consumer-side concerns tracked in walt-android's beads database.
+- Performance tuning of the renderer service (binder-call latency, LRU cache
+  sizing) is implementation detail for `wpass-5v9` and `wpass-7wn`; the
+  numbers in ADR 0005's Consequences section are targets, not security
+  controls.

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -1,0 +1,138 @@
+# ADR 0005: PDF document support
+
+- Status: Accepted
+- Date: 2026-05-06
+- Tracks: parent epic `wpass-i2r`; threat-model bead `wpass-0ri`; renderer-validation bead `wpass-6m9`; child beads `wpass-jsb` (core model), `wpass-pti` (storage schema), `wpass-5v9` (renderer service), `wpass-7wn` (UI integration)
+- Decision context: 2026-05-06 brainstorming on add-flow coverage on Android; user-confirmed defaults on 2026-05-06 with two overrides (max pages = 10, no share-out).
+
+## Context
+
+Walt v1 imports PKPASS files exclusively. Many concerts, events, transit operators, and airlines distribute tickets only as PDFs, especially on Android where the "Add to Google Wallet" pathway is structurally unreachable to a third-party wallet (Google Wallet passes are server-hosted objects under an authenticated Google API, not a portable file format Walt can ingest). To close that user-visible gap without converting Walt into a Google Wallet client, PDF support is added as a sibling concept to PKPASS passes.
+
+PDFs are an order of magnitude worse than PKPASS as a parser-side attack surface. The format permits embedded JavaScript, `Launch`/`SubmitForm`/`URI`/`GoToR` actions, AcroForm and XFA active content, embedded file attachments, attached digital signatures, network fetches at render time, decoder-CVE-heavy subformats (JBIG2, JPEG2000, CCITT), object-graph attacks, encrypted documents, and render bombs.
+
+This ADR codifies the security posture, the renderer architecture, and the deliberate non-features that prevent a future contributor from re-introducing the surface that the v1 design strips out.
+
+## Decisions
+
+### D1. Sibling concept; PDFs are not Passes
+
+A new `PassDocument` data class lives alongside `Pass`. Documents have no `PassType`, no `SignatureStatus`, no structured fields, no expiration. They carry: opaque PDF bytes, a thumbnail bitmap, page count, original filename, import timestamp, and `Provenance.UserProvided` (single-arm, by design).
+
+A separate `documents` table is added to the existing `walt_passes.db` SQLCipher database (schema v1 to v2). Same database key, same backup-exclusion rules, same irreversible-delete contract.
+
+A separate "Documents" lane appears below the passes list in `passes-ui`. Users see passes and documents as related-but-distinct concepts.
+
+Rationale: the trust contract differs structurally. Mixing PDFs into the `Pass` model would put a "Verified" pill API path within reach of code that should never offer it. Sibling separation moves that risk from "policed at every call site forever" to "physically impossible."
+
+### D2. System renderer only: `android.graphics.pdf.PdfRenderer`
+
+Rendering uses the platform `android.graphics.pdf.PdfRenderer` API. No third-party PDF library is bundled.
+
+PDFium ships in the MediaProvider Mainline module on Android 13+ and updates via Play System Updates, decoupling PDFium CVE response from Walt release cadence. The API is structurally narrow: open `ParcelFileDescriptor`, render page N to `Bitmap`. No JavaScript execution path. No `URI` / `Launch` / `SubmitForm` action processing during page render. No network. The PDF cannot paint outside the bitmap Walt provides.
+
+Alternatives considered:
+
+- **PdfBox-Android (Apache PDFBox port)**. Rejected because (a) larger code surface in-process, (b) parses content Walt does not need (forms, annotations, signatures), opening codepaths the no-extraction rule wants closed, (c) Walt would own the CVE response.
+- **MuPDF**. Rejected on license grounds (AGPL/commercial), which conflicts with the open-source-for-trust positioning of this repository.
+
+### D3. Renderer runs in an isolated process
+
+A `Service` annotated `android:isolatedProcess="true"` hosts the renderer. The main wallet process binds the service, sends a `ParcelFileDescriptor` to the PDF bytes, receives a `Bitmap` over shared memory, and unbinds. The service has no app-data access, no inherited network permission, and OS-level crash containment.
+
+This is the load-bearing control. A PDFium use-after-free or out-of-bounds read in the main process would share an address space with the SQLCipher key, the Keystore session, and decoded bytes from other passes. The same exploit in an isolated process compromises an empty sandbox that returns to the OS on crash. Walt observes a `RemoteException`, surfaces "could not render," and the wallet process keeps running.
+
+`wpass-6m9` empirically verifies this isolation on at least one Pixel device and one OEM device before the service ships.
+
+### D4. No extraction
+
+The PDF is opaque from import to deletion. Walt does not extract text, metadata (`/Title`, `/Author`, XMP), form-field values, annotations, links, or attached files. The only operation Walt performs on a PDF is `PdfRenderer.openPage(N).render(bitmap, ...)`.
+
+Every extraction codepath is an attack surface (`Launch`/`URI`/`SubmitForm` actions hide in annotations and bookmarks; XFA forms are arbitrary XML execution; embedded files are arbitrary payloads). Refusing to invoke those codepaths collapses the attack surface to "what the rasterizer touches," which is what the system renderer is hardened against and what the isolated process contains.
+
+The renderer service's binder API exposes exactly two methods, `probe(fd)` and `render(fd, page, w, h)`. Adding any extraction method (`getText`, `getMetadata`, `getAnnotations`) is a security-policy change requiring an ADR amendment.
+
+### D5. PDF digital signatures are not verified
+
+Walt does not parse `/AcroForm/SigFlags`, does not validate PAdES/CMS signatures, does not surface a "signed" indicator.
+
+PDF signature semantics are inconsistent in the wild (whole-document vs. partial-document signatures, certification vs. approval signatures, MDP transforms). There is no equivalent to Apple's WWDR root for ticket issuance. A "verified" UI signal that Walt cannot honestly back would dilute the PKPASS signature trust signal. Accepting all PDFs as `Provenance.UserProvided` is the honest position.
+
+### D6. Encrypted PDFs are rejected at import
+
+Password-protected PDFs are detected at the encryption-probe step in the renderer service and refused. Walt does not surface a password prompt.
+
+A password prompt invoked from PDF-encryption metadata is a UI vector controlled by an untrusted file. A user habituated to typing passwords into Walt is one prompt-spoof exploit away from a real credential leak. The cost is that users with password-protected files must decrypt elsewhere first; this is a deliberate trade.
+
+### D7. Hard caps: 25 MB, 10 pages, 4 MP per rendered bitmap, 5 s render timeout
+
+Import-time validation rejects:
+
+| Reject reason          | Threshold                                                  |
+|------------------------|------------------------------------------------------------|
+| `OversizedAtImport`    | size > 25 MB                                               |
+| `NotAPdf`              | first 8 bytes not `%PDF-` with version in 1.0..2.0         |
+| `Encrypted`            | renderer reports the encrypted flag                        |
+| `TooManyPages`         | pageCount > 10                                             |
+| `RendererFailed`       | page-0 smoke render fails or exceeds 5 s timeout           |
+
+Per-page rendered bitmaps are bounded at 4 MP, mirroring `ImageRenderBounds.Default` for PKPASS images.
+
+The 10-page ceiling sits well above legitimate ticket density (1-3 pages typical) and well below page-tree-bomb territory. The 5 s timeout caps resource exhaustion via deeply pathological PDFs; on timeout, the service is killed via `Process.killProcess(Process.myPid())` and the binder surfaces `RemoteException`.
+
+The caps are defense-in-depth: storage layer re-checks `byteCount <= 25 MB` and `pageCount <= 10` on insert so a future caller bug cannot land an oversized blob.
+
+### D8. No share-out
+
+Documents in Walt have no "share" or "export" affordance. The bytes are one-way: file picker in, no UI path back to a sharing intent.
+
+Every egress codepath is a potential exfiltration path if a future bug routes content through it implicitly. The user can re-obtain the original PDF from the source they imported it from. The forward-only flow simplifies the trust audit: "PDF bytes leave this app" is structurally false.
+
+A `PublicApiSurfaceTest` enforces this by classpath-scanning `passes-ui` and `passes-pdf` for any construction of `Intent.ACTION_SEND` with a PDF MIME type.
+
+## Module changes
+
+A new `passes-pdf` Android Gradle module hosts the renderer service, the `PassDocument` model, and import-time validation. The module is self-contained for audit: a reviewer reads one module to see every byte of code that touches the PDF format.
+
+`passes-storage` schema migrates v1 to v2: new tables `documents` and `document_thumbnails`, new `StorageTelemetryGuard` events `onDocumentImported` / `onDocumentRejected(kind)` / `onDocumentDeleted` mirroring the existing pass-event PII discipline (no `String` parameters, no labels in events). Migration is forward-only per ADR 0002.
+
+`passes-ui` adds a `DocumentView` composable bound to the `passes-pdf` service over an internal `Binder`, plus the "Documents" list lane and a non-suppressible `DocumentTrustCaption` ("User-provided document. Walt has not verified the source.") in the same visual register as the existing "Self-signed" pill.
+
+`passes-core` is unchanged.
+
+walt-android (consumer-side, closed source) registers the `application/pdf` intent filter, widens the in-app file picker MIME filter to include PDF, and wires the `passes-pdf` and `passes-storage` modules through Hilt. Tracked separately as a cross-repo task in walt-android's beads database.
+
+## Telemetry discipline
+
+`DocumentTelemetryGuard` (in `passes-pdf`) and the new `StorageTelemetryGuard` events all accept exclusively enums, counts, and durations. No `String`, `CharSequence`, `ByteArray`, or `Map` parameters. This mirrors the load-bearing rule from the existing `passes-core/TelemetryGuard`: a future addition of a `String` parameter is a security-policy change requiring re-review.
+
+A reflection-based `DocumentTelemetryGuardSurfaceTest` enforces this structurally.
+
+## Consequences
+
+- PDFs imported into Walt are strongly contained but minimally featured: no search, no auto-expiration, no labels beyond filename, no sharing. This matches v1 product intent. Future work that wants any of those features re-opens the threat model and amends this ADR.
+- The isolated-process service adds approximately 200-400 ms of binder-call latency per first-render. Subsequent pages within a session are LRU-cached in main memory and avoid the round-trip.
+- The 10-page ceiling will reject some legitimate documents (multi-leg flight itineraries, event-ticket booklets with vouchers). Rejection telemetry will be monitored; raising the ceiling is a future ADR amendment, not a code-only change.
+- Users running Android versions older than 13 do not benefit from PDFium Mainline updates; PDFium fixes ship via full-OS updates only on those versions. The exposure window is documented in `wpass-6m9`. If the window is too wide, a feature-gate raising minSdk for PDF import (without raising it for the rest of Walt) is the fallback, recorded as an addendum to this ADR if invoked.
+
+## Tests pinning the controls above
+
+Each decision maps to at least one test:
+
+| Decision | Test                                                                                                  |
+|----------|-------------------------------------------------------------------------------------------------------|
+| D1       | `PublicApiSurfaceTest`: `PassDocument` is not assignable to `Pass` and shares no superclass.          |
+| D2       | classpath-scan test: `passes-pdf` declares no dependency on `pdfbox-android`, `mupdf`, or similar.    |
+| D3       | instrumented test: malformed PDF crashes the renderer service; main process survives; rebind succeeds.|
+| D4       | reflection test: renderer binder exposes exactly `probe` and `render`; no extraction methods.         |
+| D5       | reflection test: no public symbol named `verifySignature` / `signatureStatus` in `passes-pdf`.        |
+| D6       | unit test: encrypted PDF probe returns `Rejected(Encrypted)`.                                         |
+| D7       | unit tests at each cap boundary; watchdog test covers timeout-then-kill.                              |
+| D8       | classpath-scan test: no `Intent.ACTION_SEND` construction in `passes-ui` or `passes-pdf`.             |
+
+## Out of scope for this ADR
+
+- PDF metadata-driven labels, OCR, or barcode extraction. Re-considering any of these requires re-opening the threat model.
+- PDF digital signature display ("this PDF is signed by Foo Inc."). The format's signature semantics do not justify the chrome.
+- Sharing PDFs out of Walt. See D8.
+- Inter-document linking, search, or tagging. Documents are sorted by import date only.


### PR DESCRIPTION
## Summary

Codify the security posture for PDF document import before any implementation lands. This is the doc-only foundation that the four implementation beads (`wpass-jsb` core model, `wpass-pti` storage schema, `wpass-5v9` renderer service, `wpass-7wn` UI integration) reference by name in their tests.

- **ADR 0005 (Accepted)** records eight load-bearing decisions:
  - D1 sibling data model (PDFs are not Passes)
  - D2 system `android.graphics.pdf.PdfRenderer` only; no third-party PDF library
  - D3 renderer runs in an `android:isolatedProcess` Service
  - D4 no extraction (text, metadata, annotations, links, attachments)
  - D5 no PDF signature verification (`Provenance.UserProvided` only)
  - D6 reject encrypted PDFs at import (no password prompt)
  - D7 hard caps: 25 MB / 10 pages / 4 MP per-page bitmap / 5 s render watchdog
  - D8 no share-out (no `Intent.ACTION_SEND` egress)
- **`docs/PDF_THREAT_MODEL.md`** enumerates 13 threat rows and maps each to the specific control (C1 system renderer, C2 isolated process, C3 no extraction) or to an explicit accepted-risk paragraph: embedded JS, `Launch`/`URI`/`SubmitForm` actions, AcroForm/XFA, embedded files, digital signatures, network fetches, JBIG2/JPEG2000/CCITT decoder bugs, object-graph attacks, encrypted PDFs, render bombs, cross-pass exfiltration via renderer compromise, phishing barcode at the gate, bidi spoofing in display label.
- **README** scope and trust-claim audit map gain entries pointing at the new docs.

The two recommendation overrides from the planning conversation are baked in: max pages = 10 (not the originally proposed 64), no share-out (not the originally proposed explicit-button share).

## Test plan

- [x] Doc-only change; `paths-ignore` in `.github/workflows/ci.yml` skips build/test/lint and connected-tests on this PR.
- [x] `dependency-review` does not trigger because no manifest files changed.
- [ ] Reviewer can read `PDF_THREAT_MODEL.md` and ADR 0005 side-by-side and identify, for each enumerated threat, the specific control that mitigates it OR the explicit accepted-risk rationale.
- [ ] No threat is left without either a control reference or an accepted-risk paragraph.
- [ ] ADR 0005 references the threat-model doc and vice versa.

Parent epic: `wpass-i2r`. Closes `wpass-0ri`.