### PR TITLE
passes-storage: schema v2 with documents + thumbnails tables (wpass-pti)

### DIFF
--- a/passes-storage/detekt-baseline.xml
+++ b/passes-storage/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ComplexInterface:PassRepository.kt$PassRepository</ID>
     <ID>CyclomaticComplexMethod:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
     <ID>LongMethod:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
     <ID>MatchingDeclarationName:PassJson.kt$PassJsonCodec</ID>

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
@@ -20,4 +20,7 @@ internal object NoOpStorageTelemetryGuard : StorageTelemetryGuard {
         kind: StorageFailureKind,
         unknownKind: UnknownStorageFailureKind?,
     ) = Unit
+    override fun onDocumentImported(event: DocumentImportedEvent) = Unit
+    override fun onDocumentRejected(kind: DocumentStorageRejectedKind) = Unit
+    override fun onDocumentDeleted(event: DocumentDeletedEvent) = Unit
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
@@ -2,18 +2,25 @@ package `is`.walt.passes.storage
 
 /**
  * Defensive caps `passes-storage` re-checks before inserting a document row. The
- * authoritative source is ADR 0005 D7; the renderer-service in `passes-pdf-core` enforces
- * the same numbers at import time. Storage carries the cap a second time so a future
- * caller bug, a misconfigured renderer, or a new entry path cannot land an oversized blob
- * in the encrypted database.
+ * authoritative source for size and page count is ADR 0005 D7; the renderer-service in
+ * `passes-pdf-core` enforces the same numbers at import time. Storage carries them a
+ * second time so a future caller bug, a misconfigured renderer, or a new entry path
+ * cannot land an oversized blob in the encrypted database.
+ *
+ * [MAX_LABEL_CHARS] is enforced only here. Nothing upstream bounds the consumer-supplied
+ * display label, and the column is used to render the indexed list view, so a multi-MB
+ * string would inflate every list-view query.
  *
  * Hardcoded here (rather than imported from `passes-pdf-core`) because `passes-storage`
- * does not depend on `passes-pdf-core`: the `PdfDocument <-> documents-table` mapping is a
- * consumer-defined seam.
+ * does not depend on `passes-pdf-core`: the `PdfDocument <-> documents-table` mapping is
+ * a consumer-defined seam. A cross-module test in the consumer is the recommended way to
+ * keep [MAX_BYTES] / [MAX_PAGES] in lockstep with the renderer's caps; see
+ * `DocumentBounds`'s test in `PublicApiSurfaceTest`.
  */
 public object DocumentBounds {
     public const val MAX_BYTES: Long = 25L * 1024 * 1024
     public const val MAX_PAGES: Int = 10
+    public const val MAX_LABEL_CHARS: Int = 256
 }
 
 /**
@@ -23,7 +30,7 @@ public object DocumentBounds {
  * [PassRepository.loadDocumentThumbnail].
  */
 public data class DocumentRow(
-    public val id: Long,
+    public val id: DocumentRecordId,
     public val displayLabel: String,
     public val byteCount: Long,
     public val pageCount: Int,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
@@ -1,0 +1,31 @@
+package `is`.walt.passes.storage
+
+/**
+ * Defensive caps `passes-storage` re-checks before inserting a document row. The
+ * authoritative source is ADR 0005 D7; the renderer-service in `passes-pdf-core` enforces
+ * the same numbers at import time. Storage carries the cap a second time so a future
+ * caller bug, a misconfigured renderer, or a new entry path cannot land an oversized blob
+ * in the encrypted database.
+ *
+ * Hardcoded here (rather than imported from `passes-pdf-core`) because `passes-storage`
+ * does not depend on `passes-pdf-core`: the `PdfDocument <-> documents-table` mapping is a
+ * consumer-defined seam.
+ */
+public object DocumentBounds {
+    public const val MAX_BYTES: Long = 25L * 1024 * 1024
+    public const val MAX_PAGES: Int = 10
+}
+
+/**
+ * The list-view projection of a stored PDF document. Mirrors the indexed columns of the
+ * `documents` table; the heavy `pdf_bytes` and `document_thumbnails.bytes` blobs are NOT
+ * loaded here. Consumers that need the bytes call [PassRepository.loadDocumentBytes] /
+ * [PassRepository.loadDocumentThumbnail].
+ */
+public data class DocumentRow(
+    public val id: Long,
+    public val displayLabel: String,
+    public val byteCount: Long,
+    public val pageCount: Int,
+    public val importedAtEpochMs: Long,
+)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
@@ -13,9 +13,10 @@ package `is`.walt.passes.storage
  *
  * Hardcoded here (rather than imported from `passes-pdf-core`) because `passes-storage`
  * does not depend on `passes-pdf-core`: the `PdfDocument <-> documents-table` mapping is
- * a consumer-defined seam. A cross-module test in the consumer is the recommended way to
- * keep [MAX_BYTES] / [MAX_PAGES] in lockstep with the renderer's caps; see
- * `DocumentBounds`'s test in `PublicApiSurfaceTest`.
+ * a consumer-defined seam. `PublicApiSurfaceTest` locks the storage-side values only;
+ * a cross-module parity test asserting `RendererService.MAX_BYTES == DocumentBounds.MAX_BYTES`
+ * is tracked separately (`wpass-kej`) so a future cap change in `passes-pdf-core` cannot
+ * silently diverge from this module.
  */
 public object DocumentBounds {
     public const val MAX_BYTES: Long = 25L * 1024 * 1024

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -59,21 +59,30 @@ public interface PassRepository {
      * Insert a stored PDF document. Bytes and thumbnail bytes are written into the
      * `documents` and `document_thumbnails` tables in the same transaction; the assigned
      * row id is returned. The repository never decodes [pdfBytes] or [thumbnailBytes];
-     * they round-trip as opaque BLOBs.
+     * they round-trip as opaque BLOBs. The persisted `byte_count` is `pdfBytes.size` —
+     * derived rather than caller-asserted, so a stale or zero size header from a future
+     * caller cannot bypass the cap.
      *
-     * Defense in depth (ADR 0005 D7): rejects [byteCount] > 25 MB with
-     * [DocumentStorageRejectedKind.OversizedAtStorage] and [pageCount] > 10 with
-     * [DocumentStorageRejectedKind.TooManyPagesAtStorage]. The renderer service in
-     * `passes-pdf-core` already enforces both caps; storage carries them again so a
-     * future caller bug cannot land an oversized row.
+     * Defense in depth (ADR 0005 D7): rejects PDFs whose size exceeds
+     * [DocumentBounds.MAX_BYTES] with [DocumentStorageRejectedKind.OversizedAtStorage],
+     * page counts exceeding [DocumentBounds.MAX_PAGES] with
+     * [DocumentStorageRejectedKind.TooManyPagesAtStorage], and labels longer than
+     * [DocumentBounds.MAX_LABEL_CHARS] with
+     * [DocumentStorageRejectedKind.LabelTooLongAtStorage]. The renderer service in
+     * `passes-pdf-core` already enforces the size and page caps; storage carries them
+     * again so a future caller bug cannot land an oversized row. The label cap exists
+     * only at this layer: nothing upstream bounds the consumer-supplied display label.
+     *
+     * Returns [StorageError.DocumentRejected] when any cap is violated; the typed arm
+     * lets callers distinguish a defensive-rejection from a transient infra failure
+     * without listening to telemetry.
      */
     public suspend fun insertDocument(
         label: String,
         pdfBytes: ByteArray,
-        byteCount: Long,
         pageCount: Int,
         thumbnailBytes: ByteArray,
-    ): StorageResult<Long>
+    ): StorageResult<DocumentRecordId>
 
     /**
      * Cold flow of document list-view rows, sorted by `imported_at_epoch_ms` descending.
@@ -88,14 +97,14 @@ public interface PassRepository {
      * caller untouched; the storage layer never parses, sniffs, decodes, or otherwise
      * inspects them (ADR 0005 D4).
      */
-    public suspend fun loadDocumentBytes(id: Long): StorageResult<ByteArray>
+    public suspend fun loadDocumentBytes(id: DocumentRecordId): StorageResult<ByteArray>
 
     /**
      * Loads the rendered thumbnail bytes for the document with [id]. Thumbnails are
      * generated upstream by the isolated renderer service (ADR 0005 D3) and stored as
      * opaque BLOBs.
      */
-    public suspend fun loadDocumentThumbnail(id: Long): StorageResult<ByteArray>
+    public suspend fun loadDocumentThumbnail(id: DocumentRecordId): StorageResult<ByteArray>
 
     /**
      * Irreversible delete of a document row and its cascaded thumbnail row in one
@@ -103,7 +112,7 @@ public interface PassRepository {
      * no VACUUM. After the transaction commits, the document StateFlow is updated and
      * `onDocumentDeleted` is emitted.
      */
-    public suspend fun deleteDocument(id: Long): StorageResult<Unit>
+    public suspend fun deleteDocument(id: DocumentRecordId): StorageResult<Unit>
 
     /**
      * Releases the underlying database connection. Idempotent: calling [close] more than
@@ -150,9 +159,28 @@ public data class StoredPass(
 )
 
 /**
+ * Common surrogate-key surface shared by [PassRecordId] and [DocumentRecordId]. Carrying
+ * a sealed wrapper rather than a raw `Long` keeps [StorageError.IntegrityViolation] honest:
+ * the arm names which table the unknown id belongs to, so a future telemetry consumer or
+ * unit test cannot misread a document id as a pass id.
+ */
+public sealed interface RecordId {
+    public val value: Long
+}
+
+/**
  * Auto-incremented primary-key surrogate for a row in the `passes` table. Distinct from
  * the PKPASS identity tuple (`type`, `serialNumber`, `organizationName`) because the same
  * identity may legitimately be re-imported across the same `id` over time.
  */
 @JvmInline
-public value class PassRecordId(public val value: Long)
+public value class PassRecordId(public override val value: Long) : RecordId
+
+/**
+ * Auto-incremented primary-key surrogate for a row in the `documents` table. Mirrors
+ * [PassRecordId]'s role for the pass side. Wrapping the id in a value class prevents an
+ * accidental cross-domain substitution (e.g., passing a `PassRecordId` to
+ * [PassRepository.loadDocumentBytes]) at compile time rather than runtime.
+ */
+@JvmInline
+public value class DocumentRecordId(public override val value: Long) : RecordId

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -4,6 +4,7 @@ import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -53,6 +54,56 @@ public interface PassRepository {
      * Confirmation UI is the caller's responsibility; the repository trusts the call.
      */
     public suspend fun delete(id: PassRecordId): StorageResult<Unit>
+
+    /**
+     * Insert a stored PDF document. Bytes and thumbnail bytes are written into the
+     * `documents` and `document_thumbnails` tables in the same transaction; the assigned
+     * row id is returned. The repository never decodes [pdfBytes] or [thumbnailBytes];
+     * they round-trip as opaque BLOBs.
+     *
+     * Defense in depth (ADR 0005 D7): rejects [byteCount] > 25 MB with
+     * [DocumentStorageRejectedKind.OversizedAtStorage] and [pageCount] > 10 with
+     * [DocumentStorageRejectedKind.TooManyPagesAtStorage]. The renderer service in
+     * `passes-pdf-core` already enforces both caps; storage carries them again so a
+     * future caller bug cannot land an oversized row.
+     */
+    public suspend fun insertDocument(
+        label: String,
+        pdfBytes: ByteArray,
+        byteCount: Long,
+        pageCount: Int,
+        thumbnailBytes: ByteArray,
+    ): StorageResult<Long>
+
+    /**
+     * Cold flow of document list-view rows, sorted by `imported_at_epoch_ms` descending.
+     * Emits the current snapshot on collect and re-emits when documents are inserted or
+     * deleted. The PDF and thumbnail blobs are NOT loaded by this flow; consumers fetch
+     * them with [loadDocumentBytes] / [loadDocumentThumbnail] on demand.
+     */
+    public fun observeDocuments(): Flow<List<DocumentRow>>
+
+    /**
+     * Loads the raw PDF bytes for the document with [id]. The bytes are returned to the
+     * caller untouched; the storage layer never parses, sniffs, decodes, or otherwise
+     * inspects them (ADR 0005 D4).
+     */
+    public suspend fun loadDocumentBytes(id: Long): StorageResult<ByteArray>
+
+    /**
+     * Loads the rendered thumbnail bytes for the document with [id]. Thumbnails are
+     * generated upstream by the isolated renderer service (ADR 0005 D3) and stored as
+     * opaque BLOBs.
+     */
+    public suspend fun loadDocumentThumbnail(id: Long): StorageResult<ByteArray>
+
+    /**
+     * Irreversible delete of a document row and its cascaded thumbnail row in one
+     * transaction (ADR 0002 D6). Mirrors [delete] for passes: no undo, no soft-delete,
+     * no VACUUM. After the transaction commits, the document StateFlow is updated and
+     * `onDocumentDeleted` is emitted.
+     */
+    public suspend fun deleteDocument(id: Long): StorageResult<Unit>
 
     /**
      * Releases the underlying database connection. Idempotent: calling [close] more than

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -14,13 +14,15 @@ package `is`.walt.passes.storage
 public object Schema {
     public const val DATABASE_NAME: String = "walt_passes.db"
 
-    public const val VERSION: Int = 1
+    public const val VERSION: Int = 2
 
     public object Tables {
         public const val SCHEMA_META: String = "schema_meta"
         public const val PASSES: String = "passes"
         public const val PASS_IMAGES: String = "pass_images"
         public const val PASS_LOCALES: String = "pass_locales"
+        public const val DOCUMENTS: String = "documents"
+        public const val DOCUMENT_THUMBNAILS: String = "document_thumbnails"
     }
 
     public object MetaKeys {
@@ -80,11 +82,56 @@ public object Schema {
             PRIMARY KEY (pass_id, locale_tag)
         )
         """.trimIndent(),
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            display_label       TEXT    NOT NULL,
+            pdf_bytes           BLOB    NOT NULL,
+            byte_count          INTEGER NOT NULL,
+            page_count          INTEGER NOT NULL,
+            imported_at_epoch_ms INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_documents_imported_at ON documents(imported_at_epoch_ms)",
+        """
+        CREATE TABLE IF NOT EXISTS document_thumbnails (
+            document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+            bytes       BLOB    NOT NULL,
+            PRIMARY KEY (document_id)
+        )
+        """.trimIndent(),
     )
 
     /**
-     * Schema migrations. Empty at version 1; future entries follow the shape
-     * `(fromVersion, listOf("ALTER ...", ...))`.
+     * Schema migrations, keyed by `fromVersion`. Forward-only per ADR 0002. Each entry's
+     * statements are executed inside a single transaction; the
+     * `schema_meta.schema_version` row is bumped to `fromVersion + 1` in the same
+     * transaction so a partial upgrade is impossible.
+     *
+     * v1 -> v2 introduces `documents` and `document_thumbnails` for PDF document support
+     * (ADR 0005). The new tables live in the same SQLCipher database, so no XML / Auto
+     * Backup change is needed: the file-level exclusion already covers them.
      */
-    public val MIGRATIONS: Map<Int, List<String>> = emptyMap()
+    public val MIGRATIONS: Map<Int, List<String>> = mapOf(
+        1 to listOf(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                display_label       TEXT    NOT NULL,
+                pdf_bytes           BLOB    NOT NULL,
+                byte_count          INTEGER NOT NULL,
+                page_count          INTEGER NOT NULL,
+                imported_at_epoch_ms INTEGER NOT NULL
+            )
+            """.trimIndent(),
+            "CREATE INDEX IF NOT EXISTS idx_documents_imported_at ON documents(imported_at_epoch_ms)",
+            """
+            CREATE TABLE IF NOT EXISTS document_thumbnails (
+                document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+                bytes       BLOB    NOT NULL,
+                PRIMARY KEY (document_id)
+            )
+            """.trimIndent(),
+        ),
+    )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -34,6 +34,33 @@ public object Schema {
     }
 
     /**
+     * Statements that introduce the v2 document tables. Referenced from both [DDL] (for
+     * fresh installs) and [MIGRATIONS]`[1]` (for v1 -> v2 upgrades) so the two paths can
+     * never drift. A `SchemaParityTest` asserts that a fresh-install DB and a
+     * v1-then-migrated DB land at the same `sqlite_master` shape.
+     */
+    private val V2_DOCUMENT_TABLES: List<String> = listOf(
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            display_label       TEXT    NOT NULL,
+            pdf_bytes           BLOB    NOT NULL,
+            byte_count          INTEGER NOT NULL,
+            page_count          INTEGER NOT NULL,
+            imported_at_epoch_ms INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_documents_imported_at ON documents(imported_at_epoch_ms)",
+        """
+        CREATE TABLE IF NOT EXISTS document_thumbnails (
+            document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+            bytes       BLOB    NOT NULL,
+            PRIMARY KEY (document_id)
+        )
+        """.trimIndent(),
+    )
+
+    /**
      * The DDL block that brings a fresh database to [VERSION]. Statements are listed in
      * dependency order (parent tables before child tables); they are executed in a single
      * transaction by the implementation.
@@ -82,25 +109,7 @@ public object Schema {
             PRIMARY KEY (pass_id, locale_tag)
         )
         """.trimIndent(),
-        """
-        CREATE TABLE IF NOT EXISTS documents (
-            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-            display_label       TEXT    NOT NULL,
-            pdf_bytes           BLOB    NOT NULL,
-            byte_count          INTEGER NOT NULL,
-            page_count          INTEGER NOT NULL,
-            imported_at_epoch_ms INTEGER NOT NULL
-        )
-        """.trimIndent(),
-        "CREATE INDEX IF NOT EXISTS idx_documents_imported_at ON documents(imported_at_epoch_ms)",
-        """
-        CREATE TABLE IF NOT EXISTS document_thumbnails (
-            document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-            bytes       BLOB    NOT NULL,
-            PRIMARY KEY (document_id)
-        )
-        """.trimIndent(),
-    )
+    ) + V2_DOCUMENT_TABLES
 
     /**
      * Schema migrations, keyed by `fromVersion`. Forward-only per ADR 0002. Each entry's
@@ -113,25 +122,6 @@ public object Schema {
      * Backup change is needed: the file-level exclusion already covers them.
      */
     public val MIGRATIONS: Map<Int, List<String>> = mapOf(
-        1 to listOf(
-            """
-            CREATE TABLE IF NOT EXISTS documents (
-                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-                display_label       TEXT    NOT NULL,
-                pdf_bytes           BLOB    NOT NULL,
-                byte_count          INTEGER NOT NULL,
-                page_count          INTEGER NOT NULL,
-                imported_at_epoch_ms INTEGER NOT NULL
-            )
-            """.trimIndent(),
-            "CREATE INDEX IF NOT EXISTS idx_documents_imported_at ON documents(imported_at_epoch_ms)",
-            """
-            CREATE TABLE IF NOT EXISTS document_thumbnails (
-                document_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-                bytes       BLOB    NOT NULL,
-                PRIMARY KEY (document_id)
-            )
-            """.trimIndent(),
-        ),
+        1 to V2_DOCUMENT_TABLES,
     )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -4,13 +4,17 @@ import android.content.Context
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.toKind
+import `is`.walt.passes.storage.internal.DocumentInsertRequest
+import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
 import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
+import `is`.walt.passes.storage.internal.SqlCipherDocumentStore
 import `is`.walt.passes.storage.internal.SqlCipherPassStore
 import `is`.walt.passes.storage.internal.toFailureKind
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 public class SqlCipherPassRepository internal constructor(
     private val store: PassStore,
+    private val documentStore: DocumentStore,
     private val telemetryGuard: StorageTelemetryGuard,
     private val ioDispatcher: CoroutineDispatcher,
     private val clock: () -> Long,
@@ -37,6 +42,9 @@ public class SqlCipherPassRepository internal constructor(
 
     private val _passes: MutableStateFlow<List<PassSummary>> = MutableStateFlow(store.listSummaries())
     override val passes: StateFlow<List<PassSummary>> = _passes.asStateFlow()
+
+    private val _documents: MutableStateFlow<List<DocumentRow>> =
+        MutableStateFlow(documentStore.listRows())
 
     init {
         telemetryGuard.onKeyProviderInitialized(keyBacking)
@@ -82,6 +90,71 @@ public class SqlCipherPassRepository internal constructor(
             type = deleted.summary.type,
             signatureStatus = deleted.summary.signatureStatus.toKind(),
         )
+        StorageResult.Success(Unit)
+    }
+
+    override suspend fun insertDocument(
+        label: String,
+        pdfBytes: ByteArray,
+        byteCount: Long,
+        pageCount: Int,
+        thumbnailBytes: ByteArray,
+    ): StorageResult<Long> = runIo {
+        if (byteCount > DocumentBounds.MAX_BYTES) {
+            telemetryGuard.onDocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage)
+            return@runIo failure(
+                StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
+            )
+        }
+        if (pageCount > DocumentBounds.MAX_PAGES) {
+            telemetryGuard.onDocumentRejected(DocumentStorageRejectedKind.TooManyPagesAtStorage)
+            return@runIo failure(
+                StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
+            )
+        }
+
+        val outcome = writeMutex.withLock {
+            val o = documentStore.insert(
+                DocumentInsertRequest(
+                    displayLabel = label,
+                    pdfBytes = pdfBytes,
+                    byteCount = byteCount,
+                    pageCount = pageCount,
+                    thumbnailBytes = thumbnailBytes,
+                    nowEpochMs = clock(),
+                ),
+            )
+            _documents.value = documentStore.listRows()
+            o
+        }
+        telemetryGuard.onDocumentImported(
+            DocumentImportedEvent(byteCount = byteCount, pageCount = pageCount),
+        )
+        StorageResult.Success(outcome.id)
+    }
+
+    override fun observeDocuments(): Flow<List<DocumentRow>> = _documents.asStateFlow()
+
+    override suspend fun loadDocumentBytes(id: Long): StorageResult<ByteArray> = runIo {
+        val bytes = documentStore.loadBytes(id)
+            ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+        StorageResult.Success(bytes)
+    }
+
+    override suspend fun loadDocumentThumbnail(id: Long): StorageResult<ByteArray> = runIo {
+        val bytes = documentStore.loadThumbnail(id)
+            ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+        StorageResult.Success(bytes)
+    }
+
+    override suspend fun deleteDocument(id: Long): StorageResult<Unit> = runIo {
+        val deleted = writeMutex.withLock {
+            val outcome = documentStore.delete(id) ?: return@withLock null
+            _documents.value = _documents.value.filterNot { it.id == id }
+            outcome
+        } ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+
+        telemetryGuard.onDocumentDeleted(DocumentDeletedEvent(byteCount = deleted.byteCount))
         StorageResult.Success(Unit)
     }
 
@@ -171,8 +244,10 @@ public class SqlCipherPassRepository internal constructor(
                 }
             }
             val store = SqlCipherPassStore(db, telemetryGuard)
+            val documentStore = SqlCipherDocumentStore(db)
             val repo = SqlCipherPassRepository(
                 store = store,
+                documentStore = documentStore,
                 telemetryGuard = telemetryGuard,
                 ioDispatcher = ioDispatcher,
                 clock = clock,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -117,10 +117,11 @@ public class SqlCipherPassRepository internal constructor(
                     nowEpochMs = clock(),
                 ),
             )
-            // Documents are insert-only and ordered by `imported_at_epoch_ms DESC, id DESC`;
-            // because [clock] is monotonic and the new id is the largest, prepending the
-            // freshly-returned row matches the SQL ordering without re-issuing listRows().
-            _documents.value = listOf(o.row) + _documents.value
+            // Re-read the full ordered list rather than prepending in-memory: matches the
+            // pass-side `_passes.value = store.listSummaries()` pattern and avoids an
+            // unwritten "clock must be monotonic" invariant. The cost is one SELECT per
+            // insert, which is negligible for a non-hot path.
+            _documents.value = documentStore.listRows()
             o
         }
         telemetryGuard.onDocumentImported(
@@ -163,8 +164,7 @@ public class SqlCipherPassRepository internal constructor(
 
     /**
      * Returns the storage-side rejection kind for an insert, or null if all caps pass.
-     * Order is byte count, then label length, then page count: the cheaper checks first
-     * so a single oversized blob doesn't cost a string scan.
+     * Checked in order: size, page count, label length.
      */
     private fun rejectionKindOrNull(
         label: String,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -96,21 +96,15 @@ public class SqlCipherPassRepository internal constructor(
     override suspend fun insertDocument(
         label: String,
         pdfBytes: ByteArray,
-        byteCount: Long,
         pageCount: Int,
         thumbnailBytes: ByteArray,
-    ): StorageResult<Long> = runIo {
-        if (byteCount > DocumentBounds.MAX_BYTES) {
-            telemetryGuard.onDocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage)
-            return@runIo failure(
-                StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
-            )
-        }
-        if (pageCount > DocumentBounds.MAX_PAGES) {
-            telemetryGuard.onDocumentRejected(DocumentStorageRejectedKind.TooManyPagesAtStorage)
-            return@runIo failure(
-                StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
-            )
+    ): StorageResult<DocumentRecordId> = runIo {
+        // byteCount is derived, not caller-asserted, so a stale size header cannot
+        // bypass the cap. The cost is a single property read.
+        val byteCount = pdfBytes.size.toLong()
+
+        rejectionKindOrNull(label, byteCount, pageCount)?.let { kind ->
+            return@runIo rejectDocument(kind)
         }
 
         val outcome = writeMutex.withLock {
@@ -118,13 +112,15 @@ public class SqlCipherPassRepository internal constructor(
                 DocumentInsertRequest(
                     displayLabel = label,
                     pdfBytes = pdfBytes,
-                    byteCount = byteCount,
                     pageCount = pageCount,
                     thumbnailBytes = thumbnailBytes,
                     nowEpochMs = clock(),
                 ),
             )
-            _documents.value = documentStore.listRows()
+            // Documents are insert-only and ordered by `imported_at_epoch_ms DESC, id DESC`;
+            // because [clock] is monotonic and the new id is the largest, prepending the
+            // freshly-returned row matches the SQL ordering without re-issuing listRows().
+            _documents.value = listOf(o.row) + _documents.value
             o
         }
         telemetryGuard.onDocumentImported(
@@ -135,24 +131,24 @@ public class SqlCipherPassRepository internal constructor(
 
     override fun observeDocuments(): Flow<List<DocumentRow>> = _documents.asStateFlow()
 
-    override suspend fun loadDocumentBytes(id: Long): StorageResult<ByteArray> = runIo {
+    override suspend fun loadDocumentBytes(id: DocumentRecordId): StorageResult<ByteArray> = runIo {
         val bytes = documentStore.loadBytes(id)
-            ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+            ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(bytes)
     }
 
-    override suspend fun loadDocumentThumbnail(id: Long): StorageResult<ByteArray> = runIo {
+    override suspend fun loadDocumentThumbnail(id: DocumentRecordId): StorageResult<ByteArray> = runIo {
         val bytes = documentStore.loadThumbnail(id)
-            ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+            ?: return@runIo failure(StorageError.IntegrityViolation(id))
         StorageResult.Success(bytes)
     }
 
-    override suspend fun deleteDocument(id: Long): StorageResult<Unit> = runIo {
+    override suspend fun deleteDocument(id: DocumentRecordId): StorageResult<Unit> = runIo {
         val deleted = writeMutex.withLock {
             val outcome = documentStore.delete(id) ?: return@withLock null
             _documents.value = _documents.value.filterNot { it.id == id }
             outcome
-        } ?: return@runIo failure(StorageError.IntegrityViolation(PassRecordId(id)))
+        } ?: return@runIo failure(StorageError.IntegrityViolation(id))
 
         telemetryGuard.onDocumentDeleted(DocumentDeletedEvent(byteCount = deleted.byteCount))
         StorageResult.Success(Unit)
@@ -160,8 +156,39 @@ public class SqlCipherPassRepository internal constructor(
 
     override fun close() {
         if (closed.compareAndSet(false, true)) {
+            documentStore.close()
             store.close()
         }
+    }
+
+    /**
+     * Returns the storage-side rejection kind for an insert, or null if all caps pass.
+     * Order is byte count, then label length, then page count: the cheaper checks first
+     * so a single oversized blob doesn't cost a string scan.
+     */
+    private fun rejectionKindOrNull(
+        label: String,
+        byteCount: Long,
+        pageCount: Int,
+    ): DocumentStorageRejectedKind? = when {
+        byteCount > DocumentBounds.MAX_BYTES -> DocumentStorageRejectedKind.OversizedAtStorage
+        pageCount > DocumentBounds.MAX_PAGES -> DocumentStorageRejectedKind.TooManyPagesAtStorage
+        label.length > DocumentBounds.MAX_LABEL_CHARS ->
+            DocumentStorageRejectedKind.LabelTooLongAtStorage
+        else -> null
+    }
+
+    /**
+     * Single emission point for a defensive document rejection. Emits
+     * `onDocumentRejected(kind)` and returns the typed [StorageError.DocumentRejected]
+     * arm without going through [failure]: a rejection is not a generic storage failure,
+     * so [StorageTelemetryGuard.onStorageFailure] should NOT also fire. Routing through
+     * [failure] would double-emit and obscure the distinction between "we said no" and
+     * "the database errored."
+     */
+    private fun <T> rejectDocument(kind: DocumentStorageRejectedKind): StorageResult<T> {
+        telemetryGuard.onDocumentRejected(kind)
+        return StorageResult.Failure(StorageError.DocumentRejected(kind))
     }
 
     /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -42,9 +42,22 @@ public sealed interface StorageError {
 
     /**
      * A row failed to deserialize at load time and was dropped (e.g. schema-migration
-     * partial failure for that row). The repository continues to serve other rows.
+     * partial failure for that row). The repository continues to serve other rows. The
+     * [recordId] is a [RecordId], so the wrapper names which table the unknown id
+     * belongs to (passes vs documents) without requiring a free-form String.
      */
-    public data class IntegrityViolation(public val recordId: PassRecordId) : StorageError
+    public data class IntegrityViolation(public val recordId: RecordId) : StorageError
+
+    /**
+     * A document insert was rejected by the storage-side defense-in-depth check
+     * (ADR 0005 D7). Carries the same [DocumentStorageRejectedKind] as the matching
+     * `onDocumentRejected` telemetry event so callers can distinguish a defensive
+     * rejection from a transient infra failure without listening to telemetry. The row
+     * never reaches disk.
+     */
+    public data class DocumentRejected(
+        public val kind: DocumentStorageRejectedKind,
+    ) : StorageError
 
     /**
      * The schema version on disk is newer than this build of `passes-storage` understands.

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -102,6 +102,7 @@ public data class DocumentImportedEvent(
 public enum class DocumentStorageRejectedKind {
     OversizedAtStorage,
     TooManyPagesAtStorage,
+    LabelTooLongAtStorage,
 }
 
 /**
@@ -124,6 +125,7 @@ public enum class StorageFailureKind {
     IntegrityViolation,
     Unsupported,
     Unknown,
+    DocumentRejected,
 }
 
 public enum class MigrationFailureKind {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -59,7 +59,59 @@ public interface StorageTelemetryGuard {
         kind: StorageFailureKind,
         unknownKind: UnknownStorageFailureKind?,
     )
+
+    /**
+     * A PDF document row was inserted. Emitted after the transaction commits and after
+     * the document StateFlow is updated. Carries byte and page counts only. The display
+     * label, the PDF bytes, and the assigned id are intentionally NOT part of the event;
+     * the same PII discipline as `onPassUpserted` applies.
+     */
+    public fun onDocumentImported(event: DocumentImportedEvent)
+
+    /**
+     * A document insertion was rejected by the storage-side defense-in-depth check
+     * (ADR 0005 D7). Emitted before the row is created. The row never reaches disk.
+     */
+    public fun onDocumentRejected(kind: DocumentStorageRejectedKind)
+
+    /**
+     * A document row was deleted. Emitted after the transaction commits and after the
+     * document StateFlow is updated. Carries the byte count of the deleted PDF only.
+     */
+    public fun onDocumentDeleted(event: DocumentDeletedEvent)
 }
+
+/**
+ * Telemetry event emitted on a successful document insert. Intentionally narrow: byte
+ * count and page count are the only signals storage observes about the document. The
+ * display label is excluded because it is user-facing free-form text (filename or
+ * date-derived fallback) and would defeat the no-PII-in-telemetry trust claim.
+ */
+public data class DocumentImportedEvent(
+    public val byteCount: Long,
+    public val pageCount: Int,
+)
+
+/**
+ * Why a storage-side document insert was rejected. The two arms mirror the renderer
+ * service's import-time checks; storage refuses to land out-of-bounds rows so a future
+ * caller bug cannot bypass the cap. The arms are deliberately suffixed `AtStorage` so
+ * they cannot be confused with `passes-pdf-core`'s import-time `DocumentRejectedKind`,
+ * which fires before bytes ever reach the storage layer.
+ */
+public enum class DocumentStorageRejectedKind {
+    OversizedAtStorage,
+    TooManyPagesAtStorage,
+}
+
+/**
+ * Telemetry event emitted on a successful document delete. Carries the byte count of
+ * the deleted PDF; the id and label are intentionally omitted (the row is gone, and
+ * carrying a label here would re-link telemetry to user data).
+ */
+public data class DocumentDeletedEvent(
+    public val byteCount: Long,
+)
 
 /**
  * Stable telemetry projection of [StorageError]. Mirrors the sealed-interface arms

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
@@ -1,0 +1,34 @@
+package `is`.walt.passes.storage.internal
+
+import `is`.walt.passes.storage.DocumentRow
+
+/**
+ * Internal persistence boundary for the `documents` and `document_thumbnails` tables.
+ * Same shape as [PassStore]: blocking and synchronous, called by the repository inside an
+ * IO dispatcher. The fake test impl lives in `DocumentRepositoryTest`.
+ */
+internal interface DocumentStore {
+    fun listRows(): List<DocumentRow>
+    fun insert(request: DocumentInsertRequest): DocumentInsertOutcome
+    fun loadBytes(id: Long): ByteArray?
+    fun loadThumbnail(id: Long): ByteArray?
+    fun delete(id: Long): DocumentDeleteOutcome?
+}
+
+internal data class DocumentInsertRequest(
+    val displayLabel: String,
+    val pdfBytes: ByteArray,
+    val byteCount: Long,
+    val pageCount: Int,
+    val thumbnailBytes: ByteArray,
+    val nowEpochMs: Long,
+)
+
+internal data class DocumentInsertOutcome(
+    val id: Long,
+    val row: DocumentRow,
+)
+
+internal data class DocumentDeleteOutcome(
+    val byteCount: Long,
+)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
@@ -1,31 +1,40 @@
 package `is`.walt.passes.storage.internal
 
+import `is`.walt.passes.storage.DocumentRecordId
 import `is`.walt.passes.storage.DocumentRow
 
 /**
  * Internal persistence boundary for the `documents` and `document_thumbnails` tables.
- * Same shape as [PassStore]: blocking and synchronous, called by the repository inside an
- * IO dispatcher. The fake test impl lives in `DocumentRepositoryTest`.
+ * Same shape as [PassStore]: blocking and synchronous, called by the repository inside
+ * an IO dispatcher. The fake test impl lives in `DocumentRepositoryTest`.
  */
 internal interface DocumentStore {
     fun listRows(): List<DocumentRow>
     fun insert(request: DocumentInsertRequest): DocumentInsertOutcome
-    fun loadBytes(id: Long): ByteArray?
-    fun loadThumbnail(id: Long): ByteArray?
-    fun delete(id: Long): DocumentDeleteOutcome?
+    fun loadBytes(id: DocumentRecordId): ByteArray?
+    fun loadThumbnail(id: DocumentRecordId): ByteArray?
+    fun delete(id: DocumentRecordId): DocumentDeleteOutcome?
+
+    /**
+     * Releases any resources owned exclusively by the store. The current production
+     * impl does not own a separate handle (it shares the SQLCipher database with
+     * [SqlCipherPassStore] and that store's `close()` releases the handle), so its
+     * implementation is a no-op. The method exists for forward-compatibility with a
+     * future store that holds its own prepared-statement cache or tracked cursor.
+     */
+    fun close()
 }
 
 internal data class DocumentInsertRequest(
     val displayLabel: String,
     val pdfBytes: ByteArray,
-    val byteCount: Long,
     val pageCount: Int,
     val thumbnailBytes: ByteArray,
     val nowEpochMs: Long,
 )
 
 internal data class DocumentInsertOutcome(
-    val id: Long,
+    val id: DocumentRecordId,
     val row: DocumentRow,
 )
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -30,4 +30,5 @@ internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
     is StorageError.IntegrityViolation -> StorageFailureKind.IntegrityViolation
     is StorageError.Unsupported -> StorageFailureKind.Unsupported
     is StorageError.Unknown -> StorageFailureKind.Unknown
+    is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -67,9 +67,14 @@ internal object SqlCipherDatabaseFactory {
             Schema.DDL
         } else {
             buildMigrationChain(onDiskVersion) ?: run {
+                // The DB is fine; the build is broken (someone bumped Schema.VERSION
+                // without adding a migration entry). Reporting this as DatabaseCorrupt
+                // would mislead telemetry into pointing at user data. The
+                // `migrationsCoverEveryHopFromV1ToCurrent` JVM test catches the mistake
+                // at CI time so this runtime path should never fire in a shipped build.
                 db.close()
                 return StorageResult.Failure(
-                    StorageError.Unknown(kind = UnknownStorageFailureKind.DatabaseCorrupt),
+                    StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
                 )
             }
         }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -63,9 +63,20 @@ internal object SqlCipherDatabaseFactory {
             onDiskVersion == Schema.VERSION -> return StorageResult.Success(db)
         }
 
+        val statements: List<String> = if (onDiskVersion == null) {
+            Schema.DDL
+        } else {
+            buildMigrationChain(onDiskVersion) ?: run {
+                db.close()
+                return StorageResult.Failure(
+                    StorageError.Unknown(kind = UnknownStorageFailureKind.DatabaseCorrupt),
+                )
+            }
+        }
+
         db.beginTransaction()
         try {
-            for (statement in Schema.DDL) {
+            for (statement in statements) {
                 db.execSQL(statement)
             }
             db.execSQL(
@@ -85,6 +96,21 @@ internal object SqlCipherDatabaseFactory {
         }
         db.endTransaction()
         return StorageResult.Success(db)
+    }
+
+    /**
+     * Builds the forward-only migration chain from `onDiskVersion` up to [Schema.VERSION],
+     * or returns null if any required hop is missing from [Schema.MIGRATIONS]. Bumping
+     * VERSION without adding a corresponding migration entry is the only way to hit the
+     * null branch; the surrounding code reports it as `DatabaseCorrupt`.
+     */
+    private fun buildMigrationChain(onDiskVersion: Int): List<String>? {
+        val chain = ArrayList<String>()
+        for (from in onDiskVersion until Schema.VERSION) {
+            val hop = Schema.MIGRATIONS[from] ?: return null
+            chain += hop
+        }
+        return chain
     }
 
     private fun readSchemaVersionIfPresent(db: SQLiteDatabase): Int? {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
@@ -1,0 +1,95 @@
+package `is`.walt.passes.storage.internal
+
+import android.content.ContentValues
+import `is`.walt.passes.storage.DocumentRow
+import `is`.walt.passes.storage.Schema
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+
+/**
+ * SQLCipher-backed [DocumentStore]. Shares the database handle with [SqlCipherPassStore];
+ * the `passes-storage` repository owns the single handle for the process. PDF and
+ * thumbnail bytes round-trip as opaque BLOBs; this class never decodes them.
+ */
+internal class SqlCipherDocumentStore(
+    private val db: SQLiteDatabase,
+) : DocumentStore {
+
+    override fun listRows(): List<DocumentRow> {
+        val out = ArrayList<DocumentRow>()
+        db.rawQuery(
+            "SELECT id, display_label, byte_count, page_count, imported_at_epoch_ms " +
+                "FROM ${Schema.Tables.DOCUMENTS} ORDER BY imported_at_epoch_ms DESC, id DESC",
+            emptyArray(),
+        ).use { c ->
+            while (c.moveToNext()) {
+                out += DocumentRow(
+                    id = c.getLong(0),
+                    displayLabel = c.getString(1),
+                    byteCount = c.getLong(2),
+                    pageCount = c.getInt(3),
+                    importedAtEpochMs = c.getLong(4),
+                )
+            }
+        }
+        return out
+    }
+
+    override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome {
+        db.beginTransaction()
+        try {
+            val docCv = ContentValues().apply {
+                put("display_label", request.displayLabel)
+                put("pdf_bytes", request.pdfBytes)
+                put("byte_count", request.byteCount)
+                put("page_count", request.pageCount)
+                put("imported_at_epoch_ms", request.nowEpochMs)
+            }
+            val rowId = db.insertOrThrow(Schema.Tables.DOCUMENTS, null, docCv)
+            val thumbCv = ContentValues().apply {
+                put("document_id", rowId)
+                put("bytes", request.thumbnailBytes)
+            }
+            db.insertOrThrow(Schema.Tables.DOCUMENT_THUMBNAILS, null, thumbCv)
+            db.setTransactionSuccessful()
+            return DocumentInsertOutcome(
+                id = rowId,
+                row = DocumentRow(
+                    id = rowId,
+                    displayLabel = request.displayLabel,
+                    byteCount = request.byteCount,
+                    pageCount = request.pageCount,
+                    importedAtEpochMs = request.nowEpochMs,
+                ),
+            )
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    override fun loadBytes(id: Long): ByteArray? = db.rawQuery(
+        "SELECT pdf_bytes FROM ${Schema.Tables.DOCUMENTS} WHERE id = ?",
+        arrayOf(id.toString()),
+    ).use { c -> if (c.moveToNext()) c.getBlob(0) else null }
+
+    override fun loadThumbnail(id: Long): ByteArray? = db.rawQuery(
+        "SELECT bytes FROM ${Schema.Tables.DOCUMENT_THUMBNAILS} WHERE document_id = ?",
+        arrayOf(id.toString()),
+    ).use { c -> if (c.moveToNext()) c.getBlob(0) else null }
+
+    override fun delete(id: Long): DocumentDeleteOutcome? {
+        val byteCount: Long = db.rawQuery(
+            "SELECT byte_count FROM ${Schema.Tables.DOCUMENTS} WHERE id = ?",
+            arrayOf(id.toString()),
+        ).use { c -> if (c.moveToNext()) c.getLong(0) else return null }
+
+        db.beginTransaction()
+        try {
+            // ON DELETE CASCADE drops the thumbnail row.
+            db.delete(Schema.Tables.DOCUMENTS, "id = ?", arrayOf(id.toString()))
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return DocumentDeleteOutcome(byteCount = byteCount)
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.storage.internal
 
 import android.content.ContentValues
+import `is`.walt.passes.storage.DocumentRecordId
 import `is`.walt.passes.storage.DocumentRow
 import `is`.walt.passes.storage.Schema
 import net.zetetic.database.sqlcipher.SQLiteDatabase
@@ -9,6 +10,10 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase
  * SQLCipher-backed [DocumentStore]. Shares the database handle with [SqlCipherPassStore];
  * the `passes-storage` repository owns the single handle for the process. PDF and
  * thumbnail bytes round-trip as opaque BLOBs; this class never decodes them.
+ *
+ * `byteCount` is derived from `pdfBytes.size` rather than caller-asserted, so a stale
+ * size header from a future caller cannot bypass [is.walt.passes.storage.DocumentBounds]
+ * checks at the repository layer.
  */
 internal class SqlCipherDocumentStore(
     private val db: SQLiteDatabase,
@@ -23,7 +28,7 @@ internal class SqlCipherDocumentStore(
         ).use { c ->
             while (c.moveToNext()) {
                 out += DocumentRow(
-                    id = c.getLong(0),
+                    id = DocumentRecordId(c.getLong(0)),
                     displayLabel = c.getString(1),
                     byteCount = c.getLong(2),
                     pageCount = c.getInt(3),
@@ -35,12 +40,13 @@ internal class SqlCipherDocumentStore(
     }
 
     override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome {
+        val byteCount = request.pdfBytes.size.toLong()
         db.beginTransaction()
         try {
             val docCv = ContentValues().apply {
                 put("display_label", request.displayLabel)
                 put("pdf_bytes", request.pdfBytes)
-                put("byte_count", request.byteCount)
+                put("byte_count", byteCount)
                 put("page_count", request.pageCount)
                 put("imported_at_epoch_ms", request.nowEpochMs)
             }
@@ -51,12 +57,13 @@ internal class SqlCipherDocumentStore(
             }
             db.insertOrThrow(Schema.Tables.DOCUMENT_THUMBNAILS, null, thumbCv)
             db.setTransactionSuccessful()
+            val recordId = DocumentRecordId(rowId)
             return DocumentInsertOutcome(
-                id = rowId,
+                id = recordId,
                 row = DocumentRow(
-                    id = rowId,
+                    id = recordId,
                     displayLabel = request.displayLabel,
-                    byteCount = request.byteCount,
+                    byteCount = byteCount,
                     pageCount = request.pageCount,
                     importedAtEpochMs = request.nowEpochMs,
                 ),
@@ -66,30 +73,37 @@ internal class SqlCipherDocumentStore(
         }
     }
 
-    override fun loadBytes(id: Long): ByteArray? = db.rawQuery(
+    override fun loadBytes(id: DocumentRecordId): ByteArray? = db.rawQuery(
         "SELECT pdf_bytes FROM ${Schema.Tables.DOCUMENTS} WHERE id = ?",
-        arrayOf(id.toString()),
+        arrayOf(id.value.toString()),
     ).use { c -> if (c.moveToNext()) c.getBlob(0) else null }
 
-    override fun loadThumbnail(id: Long): ByteArray? = db.rawQuery(
+    override fun loadThumbnail(id: DocumentRecordId): ByteArray? = db.rawQuery(
         "SELECT bytes FROM ${Schema.Tables.DOCUMENT_THUMBNAILS} WHERE document_id = ?",
-        arrayOf(id.toString()),
+        arrayOf(id.value.toString()),
     ).use { c -> if (c.moveToNext()) c.getBlob(0) else null }
 
-    override fun delete(id: Long): DocumentDeleteOutcome? {
+    override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? {
         val byteCount: Long = db.rawQuery(
             "SELECT byte_count FROM ${Schema.Tables.DOCUMENTS} WHERE id = ?",
-            arrayOf(id.toString()),
+            arrayOf(id.value.toString()),
         ).use { c -> if (c.moveToNext()) c.getLong(0) else return null }
 
         db.beginTransaction()
         try {
             // ON DELETE CASCADE drops the thumbnail row.
-            db.delete(Schema.Tables.DOCUMENTS, "id = ?", arrayOf(id.toString()))
+            db.delete(Schema.Tables.DOCUMENTS, "id = ?", arrayOf(id.value.toString()))
             db.setTransactionSuccessful()
         } finally {
             db.endTransaction()
         }
         return DocumentDeleteOutcome(byteCount = byteCount)
     }
+
+    /**
+     * No-op: the SQLCipher handle is owned by [SqlCipherPassStore] for the process
+     * lifetime. The interface contract exists so a future store that owns its own
+     * resource has an obvious release point.
+     */
+    override fun close() = Unit
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/BackupRulesAssertionTest.kt
@@ -377,6 +377,22 @@ class BackupRulesAssertionTest {
         assertThat(Section.DeviceTransfer.xmlElement).isEqualTo("device-transfer")
     }
 
+    @Test
+    fun documentTablesLiveInsideTheAlreadyExcludedDatabaseFile() {
+        // The v1 -> v2 migration added `documents` and `document_thumbnails` tables. They
+        // are inside walt_passes.db, which is already in [REQUIRED_EXCLUDES]; no XML
+        // change is needed. This test pins that audit trail: a future schema change that
+        // moves document data outside the excluded file (e.g., a sibling DB, a free
+        // file, a separate sharedpref) would have to add a new entry to REQUIRED_EXCLUDES
+        // before this assertion would still pass.
+        assertThat(Schema.Tables.DOCUMENTS).isEqualTo("documents")
+        assertThat(Schema.Tables.DOCUMENT_THUMBNAILS).isEqualTo("document_thumbnails")
+        assertThat(Schema.DATABASE_NAME).isEqualTo("walt_passes.db")
+        assertThat(BackupRulesContract.REQUIRED_EXCLUDES).contains(
+            RequiredExclude(domain = "database", path = "walt_passes.db"),
+        )
+    }
+
     private fun parse(xml: String): Map<Section, Set<RequiredExclude>> {
         val factory = XmlPullParserFactory.newInstance().apply { isNamespaceAware = false }
         val parser = factory.newPullParser()

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -57,7 +57,6 @@ class DocumentRepositoryTest {
         val result = repo.insertDocument(
             label = "boarding-pass.pdf",
             pdfBytes = pdf,
-            byteCount = pdf.size.toLong(),
             pageCount = 2,
             thumbnailBytes = thumb,
         )
@@ -83,7 +82,6 @@ class DocumentRepositoryTest {
         val insert = repo.insertDocument(
             label = "x.pdf",
             pdfBytes = ByteArray(2048),
-            byteCount = 2048L,
             pageCount = 1,
             thumbnailBytes = ByteArray(32),
         )
@@ -95,7 +93,7 @@ class DocumentRepositoryTest {
 
         assertThat(repo.observeDocuments().first()).isEmpty()
         // CASCADE: the thumbnail row was dropped alongside the document row.
-        assertThat(docs.thumbnailExists(id)).isFalse()
+        assertThat(docs.exists(id)).isFalse()
         assertThat(telemetry.events).containsExactly(
             "init:Tee",
             "doc-imported:2048:1",
@@ -109,10 +107,12 @@ class DocumentRepositoryTest {
         val telemetry = RecordingGuard()
         val repo = repo(docs, telemetry)
 
-        val result = repo.deleteDocument(404L)
+        val result = repo.deleteDocument(DocumentRecordId(404L))
 
         check(result is StorageResult.Failure)
-        check(result.error is StorageError.IntegrityViolation)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is DocumentRecordId)
+        assertThat(violation.recordId.value).isEqualTo(404L)
         assertThat(telemetry.events).containsExactly(
             "init:Tee",
             "failure:IntegrityViolation:n/a",
@@ -125,30 +125,34 @@ class DocumentRepositoryTest {
         val telemetry = RecordingGuard()
         val repo = repo(docs, telemetry)
 
-        // 25 MB exact passes.
+        // Exact byte cap passes; +1 byte rejected. byteCount is derived from
+        // pdfBytes.size, so the test must allocate accordingly.
         val ok = repo.insertDocument(
             label = "a",
-            pdfBytes = ByteArray(0),
-            byteCount = DocumentBounds.MAX_BYTES,
+            pdfBytes = ByteArray(DocumentBounds.MAX_BYTES.toInt()),
             pageCount = 1,
             thumbnailBytes = ByteArray(0),
         )
         check(ok is StorageResult.Success)
 
-        // 25 MB + 1 byte rejected. The PDF bytes themselves are not allocated; only the
-        // byteCount header check matters here.
         val rejected = repo.insertDocument(
             label = "b",
-            pdfBytes = ByteArray(0),
-            byteCount = DocumentBounds.MAX_BYTES + 1,
+            pdfBytes = ByteArray(DocumentBounds.MAX_BYTES.toInt() + 1),
             pageCount = 1,
             thumbnailBytes = ByteArray(0),
         )
         check(rejected is StorageResult.Failure)
-        check(rejected.error is StorageError.Unknown)
+        val rejectedError = rejected.error as StorageError.DocumentRejected
+        assertThat(rejectedError.kind).isEqualTo(DocumentStorageRejectedKind.OversizedAtStorage)
 
-        assertThat(telemetry.events).contains("doc-rejected:OversizedAtStorage")
-        // Only the accepted row was persisted.
+        // The rejection emits exactly `doc-rejected`; it does NOT also emit
+        // `failure:DocumentRejected:...`. A defensive rejection is not a generic
+        // storage failure.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:${DocumentBounds.MAX_BYTES}:1",
+            "doc-rejected:OversizedAtStorage",
+        ).inOrder()
         assertThat(repo.observeDocuments().first()).hasSize(1)
     }
 
@@ -158,28 +162,57 @@ class DocumentRepositoryTest {
         val telemetry = RecordingGuard()
         val repo = repo(docs, telemetry)
 
-        // 10 pages exact passes.
         val ok = repo.insertDocument(
             label = "a",
-            pdfBytes = ByteArray(0),
-            byteCount = 1L,
+            pdfBytes = ByteArray(1),
             pageCount = DocumentBounds.MAX_PAGES,
             thumbnailBytes = ByteArray(0),
         )
         check(ok is StorageResult.Success)
 
-        // 11 pages rejected.
         val rejected = repo.insertDocument(
             label = "b",
-            pdfBytes = ByteArray(0),
-            byteCount = 1L,
+            pdfBytes = ByteArray(1),
             pageCount = DocumentBounds.MAX_PAGES + 1,
             thumbnailBytes = ByteArray(0),
         )
         check(rejected is StorageResult.Failure)
-        check(rejected.error is StorageError.Unknown)
+        val rejectedError = rejected.error as StorageError.DocumentRejected
+        assertThat(rejectedError.kind).isEqualTo(DocumentStorageRejectedKind.TooManyPagesAtStorage)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:1:${DocumentBounds.MAX_PAGES}",
+            "doc-rejected:TooManyPagesAtStorage",
+        ).inOrder()
+        assertThat(repo.observeDocuments().first()).hasSize(1)
+    }
 
-        assertThat(telemetry.events).contains("doc-rejected:TooManyPagesAtStorage")
+    @Test
+    fun maxLabelCharsExactBoundaryIsAcceptedAndPlusOneIsRejected() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val okLabel = "a".repeat(DocumentBounds.MAX_LABEL_CHARS)
+        val ok = repo.insertDocument(
+            label = okLabel,
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(ok is StorageResult.Success)
+
+        val tooLong = "a".repeat(DocumentBounds.MAX_LABEL_CHARS + 1)
+        val rejected = repo.insertDocument(
+            label = tooLong,
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(rejected is StorageResult.Failure)
+        val rejectedError = rejected.error as StorageError.DocumentRejected
+        assertThat(rejectedError.kind).isEqualTo(DocumentStorageRejectedKind.LabelTooLongAtStorage)
+        assertThat(telemetry.events).contains("doc-rejected:LabelTooLongAtStorage")
         assertThat(repo.observeDocuments().first()).hasSize(1)
     }
 
@@ -194,7 +227,6 @@ class DocumentRepositoryTest {
         val insert = repo.insertDocument(
             label = "foo.pdf",
             pdfBytes = pdf,
-            byteCount = pdf.size.toLong(),
             pageCount = 1,
             thumbnailBytes = thumb,
         )
@@ -213,9 +245,19 @@ class DocumentRepositoryTest {
     @Test
     fun loadOfUnknownIdReturnsIntegrityViolation() = runTest {
         val repo = repo(FakeDocumentStore(), RecordingGuard())
-        val result = repo.loadDocumentBytes(999L)
+        val result = repo.loadDocumentBytes(DocumentRecordId(999L))
         check(result is StorageResult.Failure)
-        check(result.error is StorageError.IntegrityViolation)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is DocumentRecordId)
+    }
+
+    @Test
+    fun closeReleasesBothPassAndDocumentStores() = runTest {
+        val docs = FakeDocumentStore()
+        val repo = repo(docs, RecordingGuard())
+        repo.close()
+        repo.close() // idempotent
+        assertThat(docs.closeCount).isEqualTo(1)
     }
 
     private fun repo(docs: FakeDocumentStore, telemetry: StorageTelemetryGuard): SqlCipherPassRepository =
@@ -243,37 +285,43 @@ class DocumentRepositoryTest {
 
         private val entries: LinkedHashMap<Long, Entry> = LinkedHashMap()
         private var nextId: Long = 0L
+        var closeCount: Int = 0
+            private set
 
-        fun thumbnailExists(id: Long): Boolean = entries.containsKey(id)
+        fun exists(id: DocumentRecordId): Boolean = entries.containsKey(id.value)
 
         override fun listRows(): List<DocumentRow> =
             entries.values.map { it.row }
                 .sortedWith(
                     compareByDescending<DocumentRow> { it.importedAtEpochMs }
-                        .thenByDescending { it.id },
+                        .thenByDescending { it.id.value },
                 )
 
         override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome {
-            val id = ++nextId
+            val id = DocumentRecordId(++nextId)
             val row = DocumentRow(
                 id = id,
                 displayLabel = request.displayLabel,
-                byteCount = request.byteCount,
+                byteCount = request.pdfBytes.size.toLong(),
                 pageCount = request.pageCount,
                 importedAtEpochMs = request.nowEpochMs,
             )
-            entries[id] = Entry(row, request.pdfBytes.copyOf(), request.thumbnailBytes.copyOf())
+            entries[id.value] = Entry(row, request.pdfBytes.copyOf(), request.thumbnailBytes.copyOf())
             return DocumentInsertOutcome(id = id, row = row)
         }
 
-        override fun loadBytes(id: Long): ByteArray? = entries[id]?.pdfBytes?.copyOf()
+        override fun loadBytes(id: DocumentRecordId): ByteArray? =
+            entries[id.value]?.pdfBytes?.copyOf()
 
-        override fun loadThumbnail(id: Long): ByteArray? = entries[id]?.thumbnailBytes?.copyOf()
+        override fun loadThumbnail(id: DocumentRecordId): ByteArray? =
+            entries[id.value]?.thumbnailBytes?.copyOf()
 
-        override fun delete(id: Long): DocumentDeleteOutcome? {
-            val entry = entries.remove(id) ?: return null
+        override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? {
+            val entry = entries.remove(id.value) ?: return null
             return DocumentDeleteOutcome(byteCount = entry.row.byteCount)
         }
+
+        override fun close() { closeCount++ }
     }
 
     /**

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -1,0 +1,326 @@
+package `is`.walt.passes.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.DeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentDeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertRequest
+import `is`.walt.passes.storage.internal.DocumentStore
+import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.UpsertOutcome
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed verification of the document side of [PassRepository]. Exercises the
+ * insert -> observe -> delete cycle plus the storage-side defense-in-depth bounds against
+ * an in-memory fake [DocumentStore]. The SQLCipher round-trip lives in the instrumentation
+ * suite (the wpass-x5l-style on-device tests).
+ *
+ * Properties locked here:
+ *
+ *  1. After `insertDocument`, `observeDocuments()` reflects the new row and
+ *     `onDocumentImported(byteCount, pageCount)` is emitted afterward.
+ *  2. After `deleteDocument`, the flow no longer carries that id and the store's CASCADE
+ *     fired (the fake mirrors the SQL ON DELETE CASCADE behavior on the thumbnail row).
+ *  3. `byteCount > MAX_BYTES` is rejected with `OversizedAtStorage` and the row never
+ *     reaches the store.
+ *  4. `pageCount > MAX_PAGES` is rejected with `TooManyPagesAtStorage` and the row never
+ *     reaches the store.
+ *  5. Exactly the documented bounds (25 MB, 10 pages) are accepted, not their
+ *     +1-byte / +1-page neighbors.
+ *  6. `loadDocumentBytes` and `loadDocumentThumbnail` round-trip the stored bytes
+ *     unchanged: storage never decodes them.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DocumentRepositoryTest {
+
+    @Test
+    fun insertUpdatesObserveFlowAndEmitsImportedTelemetryAfter() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val pdf = ByteArray(1024) { 0x25 }
+        val thumb = ByteArray(64) { 0x10 }
+
+        val result = repo.insertDocument(
+            label = "boarding-pass.pdf",
+            pdfBytes = pdf,
+            byteCount = pdf.size.toLong(),
+            pageCount = 2,
+            thumbnailBytes = thumb,
+        )
+
+        check(result is StorageResult.Success)
+        val rows = repo.observeDocuments().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].displayLabel).isEqualTo("boarding-pass.pdf")
+        assertThat(rows[0].byteCount).isEqualTo(1024)
+        assertThat(rows[0].pageCount).isEqualTo(2)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:1024:2",
+        ).inOrder()
+    }
+
+    @Test
+    fun deleteRemovesFromObserveFlowAndEmitsDeletedTelemetryAfter() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val insert = repo.insertDocument(
+            label = "x.pdf",
+            pdfBytes = ByteArray(2048),
+            byteCount = 2048L,
+            pageCount = 1,
+            thumbnailBytes = ByteArray(32),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        val deleteResult = repo.deleteDocument(id)
+        check(deleteResult is StorageResult.Success)
+
+        assertThat(repo.observeDocuments().first()).isEmpty()
+        // CASCADE: the thumbnail row was dropped alongside the document row.
+        assertThat(docs.thumbnailExists(id)).isFalse()
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:2048:1",
+            "doc-deleted:2048",
+        ).inOrder()
+    }
+
+    @Test
+    fun deleteOfUnknownIdReturnsIntegrityViolationAndEmitsFailureNotDeleted() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val result = repo.deleteDocument(404L)
+
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.IntegrityViolation)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
+    fun maxBytesExactBoundaryIsAcceptedAndPlusOneIsRejected() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        // 25 MB exact passes.
+        val ok = repo.insertDocument(
+            label = "a",
+            pdfBytes = ByteArray(0),
+            byteCount = DocumentBounds.MAX_BYTES,
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(ok is StorageResult.Success)
+
+        // 25 MB + 1 byte rejected. The PDF bytes themselves are not allocated; only the
+        // byteCount header check matters here.
+        val rejected = repo.insertDocument(
+            label = "b",
+            pdfBytes = ByteArray(0),
+            byteCount = DocumentBounds.MAX_BYTES + 1,
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(rejected is StorageResult.Failure)
+        check(rejected.error is StorageError.Unknown)
+
+        assertThat(telemetry.events).contains("doc-rejected:OversizedAtStorage")
+        // Only the accepted row was persisted.
+        assertThat(repo.observeDocuments().first()).hasSize(1)
+    }
+
+    @Test
+    fun maxPagesExactBoundaryIsAcceptedAndPlusOneIsRejected() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        // 10 pages exact passes.
+        val ok = repo.insertDocument(
+            label = "a",
+            pdfBytes = ByteArray(0),
+            byteCount = 1L,
+            pageCount = DocumentBounds.MAX_PAGES,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(ok is StorageResult.Success)
+
+        // 11 pages rejected.
+        val rejected = repo.insertDocument(
+            label = "b",
+            pdfBytes = ByteArray(0),
+            byteCount = 1L,
+            pageCount = DocumentBounds.MAX_PAGES + 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(rejected is StorageResult.Failure)
+        check(rejected.error is StorageError.Unknown)
+
+        assertThat(telemetry.events).contains("doc-rejected:TooManyPagesAtStorage")
+        assertThat(repo.observeDocuments().first()).hasSize(1)
+    }
+
+    @Test
+    fun loadDocumentBytesAndThumbnailRoundTripUntouched() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val pdf = ByteArray(256) { (it * 7).toByte() }
+        val thumb = ByteArray(128) { (it * 11).toByte() }
+        val insert = repo.insertDocument(
+            label = "foo.pdf",
+            pdfBytes = pdf,
+            byteCount = pdf.size.toLong(),
+            pageCount = 1,
+            thumbnailBytes = thumb,
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        val loaded = repo.loadDocumentBytes(id)
+        check(loaded is StorageResult.Success)
+        assertThat(loaded.value).isEqualTo(pdf)
+
+        val loadedThumb = repo.loadDocumentThumbnail(id)
+        check(loadedThumb is StorageResult.Success)
+        assertThat(loadedThumb.value).isEqualTo(thumb)
+    }
+
+    @Test
+    fun loadOfUnknownIdReturnsIntegrityViolation() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+        val result = repo.loadDocumentBytes(999L)
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.IntegrityViolation)
+    }
+
+    private fun repo(docs: FakeDocumentStore, telemetry: StorageTelemetryGuard): SqlCipherPassRepository =
+        SqlCipherPassRepository(
+            store = NoOpPassStore,
+            documentStore = docs,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_000L },
+            keyBacking = KeyBacking.Tee,
+        )
+
+    /**
+     * In-memory document store. Mirrors the SQL contract: rows are sorted by
+     * `imported_at_epoch_ms DESC, id DESC`, and `delete` cascades through to the
+     * thumbnail entry (the production schema's ON DELETE CASCADE fires for the same
+     * effect).
+     */
+    private class FakeDocumentStore : DocumentStore {
+        private data class Entry(
+            val row: DocumentRow,
+            val pdfBytes: ByteArray,
+            val thumbnailBytes: ByteArray,
+        )
+
+        private val entries: LinkedHashMap<Long, Entry> = LinkedHashMap()
+        private var nextId: Long = 0L
+
+        fun thumbnailExists(id: Long): Boolean = entries.containsKey(id)
+
+        override fun listRows(): List<DocumentRow> =
+            entries.values.map { it.row }
+                .sortedWith(
+                    compareByDescending<DocumentRow> { it.importedAtEpochMs }
+                        .thenByDescending { it.id },
+                )
+
+        override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome {
+            val id = ++nextId
+            val row = DocumentRow(
+                id = id,
+                displayLabel = request.displayLabel,
+                byteCount = request.byteCount,
+                pageCount = request.pageCount,
+                importedAtEpochMs = request.nowEpochMs,
+            )
+            entries[id] = Entry(row, request.pdfBytes.copyOf(), request.thumbnailBytes.copyOf())
+            return DocumentInsertOutcome(id = id, row = row)
+        }
+
+        override fun loadBytes(id: Long): ByteArray? = entries[id]?.pdfBytes?.copyOf()
+
+        override fun loadThumbnail(id: Long): ByteArray? = entries[id]?.thumbnailBytes?.copyOf()
+
+        override fun delete(id: Long): DocumentDeleteOutcome? {
+            val entry = entries.remove(id) ?: return null
+            return DocumentDeleteOutcome(byteCount = entry.row.byteCount)
+        }
+    }
+
+    /**
+     * Pass-side store stub: the document tests do not exercise pass-side code paths.
+     */
+    private object NoOpPassStore : PassStore {
+        override fun listSummaries(): List<PassSummary> = emptyList()
+        override fun loadById(id: PassRecordId): StoredPass? = null
+        override fun summaryById(id: PassRecordId): PassSummary? = null
+        override fun upsert(
+            pass: Pass,
+            signatureStatus: SignatureStatus,
+            nowEpochMs: Long,
+        ): UpsertOutcome = error("unused in document tests")
+        override fun delete(id: PassRecordId): DeleteOutcome? = null
+        override fun close() = Unit
+    }
+
+    private class RecordingGuard : StorageTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+        override fun onKeyProviderInitialized(backing: KeyBacking) {
+            events += "init:${backing.name}"
+        }
+        override fun onPassUpserted(
+            type: `is`.walt.passes.core.PassType,
+            signatureStatus: SignatureStatusKind,
+            wasReplacement: Boolean,
+        ) = Unit
+        override fun onPassDeleted(
+            type: `is`.walt.passes.core.PassType,
+            signatureStatus: SignatureStatusKind,
+        ) = Unit
+        override fun onMigrationRowDropped(kind: MigrationFailureKind) = Unit
+        override fun onStorageFailure(
+            kind: StorageFailureKind,
+            unknownKind: UnknownStorageFailureKind?,
+        ) {
+            events += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
+        }
+        override fun onDocumentImported(event: DocumentImportedEvent) {
+            events += "doc-imported:${event.byteCount}:${event.pageCount}"
+        }
+        override fun onDocumentRejected(kind: DocumentStorageRejectedKind) {
+            events += "doc-rejected:${kind.name}"
+        }
+        override fun onDocumentDeleted(event: DocumentDeletedEvent) {
+            events += "doc-deleted:${event.byteCount}"
+        }
+    }
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -299,12 +299,15 @@ class PassRepositoryContractTest {
      * contract tests use their own richer fake (see DocumentRepositoryTest).
      */
     private object NoOpDocumentStore : DocumentStore {
+        var closeCount: Int = 0
+            private set
         override fun listRows(): List<DocumentRow> = emptyList()
         override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome =
             error("unused in pass-side tests")
-        override fun loadBytes(id: Long): ByteArray? = null
-        override fun loadThumbnail(id: Long): ByteArray? = null
-        override fun delete(id: Long): DocumentDeleteOutcome? = null
+        override fun loadBytes(id: DocumentRecordId): ByteArray? = null
+        override fun loadThumbnail(id: DocumentRecordId): ByteArray? = null
+        override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? = null
+        override fun close() { closeCount++ }
     }
 
     private companion object {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -18,6 +18,10 @@ import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.storage.internal.DeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentDeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertRequest
+import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -54,6 +58,7 @@ class PassRepositoryContractTest {
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
             store = store,
+            documentStore = NoOpDocumentStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -69,6 +74,7 @@ class PassRepositoryContractTest {
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
             store = store,
+            documentStore = NoOpDocumentStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -92,6 +98,7 @@ class PassRepositoryContractTest {
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
             store = store,
+            documentStore = NoOpDocumentStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -117,6 +124,7 @@ class PassRepositoryContractTest {
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
             store = store,
+            documentStore = NoOpDocumentStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1L },
@@ -139,6 +147,7 @@ class PassRepositoryContractTest {
         val telemetry = RecordingGuard()
         val repo = SqlCipherPassRepository(
             store = store,
+            documentStore = NoOpDocumentStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1L },
@@ -274,6 +283,28 @@ class PassRepositoryContractTest {
         ) {
             events += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
         }
+        override fun onDocumentImported(event: DocumentImportedEvent) {
+            events += "doc-imported:${event.byteCount}:${event.pageCount}"
+        }
+        override fun onDocumentRejected(kind: DocumentStorageRejectedKind) {
+            events += "doc-rejected:${kind.name}"
+        }
+        override fun onDocumentDeleted(event: DocumentDeletedEvent) {
+            events += "doc-deleted:${event.byteCount}"
+        }
+    }
+
+    /**
+     * In-memory [DocumentStore] used by the pass-side contract tests; the document-side
+     * contract tests use their own richer fake (see DocumentRepositoryTest).
+     */
+    private object NoOpDocumentStore : DocumentStore {
+        override fun listRows(): List<DocumentRow> = emptyList()
+        override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome =
+            error("unused in pass-side tests")
+        override fun loadBytes(id: Long): ByteArray? = null
+        override fun loadThumbnail(id: Long): ByteArray? = null
+        override fun delete(id: Long): DocumentDeleteOutcome? = null
     }
 
     private companion object {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -33,26 +33,34 @@ class PublicApiSurfaceTest {
             StorageError.KeyUnwrapFailed,
             StorageError.DatabaseLocked,
             StorageError.IntegrityViolation(PassRecordId(1L)),
+            StorageError.IntegrityViolation(DocumentRecordId(2L)),
             StorageError.Unsupported(onDiskSchemaVersion = 99),
             StorageError.Unknown(UnknownStorageFailureKind.DiskFull),
+            StorageError.DocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage),
         )
         val labels = errors.map { error ->
             when (error) {
                 StorageError.KeyUnavailable -> "key-unavailable"
                 StorageError.KeyUnwrapFailed -> "key-unwrap-failed"
                 StorageError.DatabaseLocked -> "db-locked"
-                is StorageError.IntegrityViolation -> "integrity:${error.recordId.value}"
+                is StorageError.IntegrityViolation -> when (val id = error.recordId) {
+                    is PassRecordId -> "integrity-pass:${id.value}"
+                    is DocumentRecordId -> "integrity-doc:${id.value}"
+                }
                 is StorageError.Unsupported -> "unsupported:${error.onDiskSchemaVersion}"
                 is StorageError.Unknown -> "unknown:${error.kind.name}"
+                is StorageError.DocumentRejected -> "doc-rejected:${error.kind.name}"
             }
         }
         assertThat(labels).containsExactly(
             "key-unavailable",
             "key-unwrap-failed",
             "db-locked",
-            "integrity:1",
+            "integrity-pass:1",
+            "integrity-doc:2",
             "unsupported:99",
             "unknown:DiskFull",
+            "doc-rejected:OversizedAtStorage",
         ).inOrder()
     }
 
@@ -115,6 +123,7 @@ class PublicApiSurfaceTest {
             StorageError.IntegrityViolation(PassRecordId(1L)),
             StorageError.Unsupported(0),
             StorageError.Unknown(UnknownStorageFailureKind.Other),
+            StorageError.DocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage),
         )
         val kinds = errors.map { error ->
             when (error) {
@@ -124,9 +133,25 @@ class PublicApiSurfaceTest {
                 is StorageError.IntegrityViolation -> StorageFailureKind.IntegrityViolation
                 is StorageError.Unsupported -> StorageFailureKind.Unsupported
                 is StorageError.Unknown -> StorageFailureKind.Unknown
+                is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
             }
         }
         assertThat(kinds.toSet()).containsExactlyElementsIn(StorageFailureKind.entries)
+    }
+
+    @Test
+    fun recordIdSealedArmsAreExhaustive() {
+        // Pinning the sealed surface: adding a third RecordId variant requires updating
+        // every consumer that pattern-matches on it (StorageError.IntegrityViolation
+        // routing in tests, telemetry projections, etc.).
+        val ids: List<RecordId> = listOf(PassRecordId(1L), DocumentRecordId(2L))
+        val labels = ids.map { id ->
+            when (id) {
+                is PassRecordId -> "pass:${id.value}"
+                is DocumentRecordId -> "doc:${id.value}"
+            }
+        }
+        assertThat(labels).containsExactly("pass:1", "doc:2").inOrder()
     }
 
     @Test
@@ -258,18 +283,23 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun documentStorageRejectedKindCoversTheTwoStorageSideArms() {
+    fun documentStorageRejectedKindCoversTheThreeStorageSideArms() {
         assertThat(DocumentStorageRejectedKind.entries.map { it.name }).containsExactly(
             "OversizedAtStorage",
             "TooManyPagesAtStorage",
+            "LabelTooLongAtStorage",
         ).inOrder()
     }
 
     @Test
-    fun documentBoundsMirrorAdr0005D7Caps() {
-        // The `passes-pdf-core` renderer-service enforces these. Storage carries them
-        // again so a future caller bug cannot land an oversized row.
+    fun documentBoundsMirrorAdr0005D7CapsAndCarryALabelLengthCap() {
+        // The `passes-pdf-core` renderer-service enforces MAX_BYTES and MAX_PAGES.
+        // Storage carries them again so a future caller bug cannot land an oversized
+        // row. MAX_LABEL_CHARS is enforced only at this layer; nothing upstream bounds
+        // the consumer-supplied display label, so a multi-MB string would inflate the
+        // indexed list-view query without this cap.
         assertThat(DocumentBounds.MAX_BYTES).isEqualTo(25L * 1024 * 1024)
         assertThat(DocumentBounds.MAX_PAGES).isEqualTo(10)
+        assertThat(DocumentBounds.MAX_LABEL_CHARS).isEqualTo(256)
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -130,15 +130,18 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun schemaDeclaresFourTablesAndIsAtVersionOne() {
-        assertThat(Schema.VERSION).isEqualTo(1)
+    fun schemaDeclaresSixTablesAndIsAtVersionTwo() {
+        assertThat(Schema.VERSION).isEqualTo(2)
         assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
         assertThat(Schema.Tables.PASSES).isEqualTo("passes")
         assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
         assertThat(Schema.Tables.PASS_LOCALES).isEqualTo("pass_locales")
-        // 1 schema_meta + 1 passes + 3 indexes + 1 pass_images + 1 pass_locales = 7 statements.
-        assertThat(Schema.DDL).hasSize(7)
-        assertThat(Schema.MIGRATIONS).isEmpty()
+        assertThat(Schema.Tables.DOCUMENTS).isEqualTo("documents")
+        assertThat(Schema.Tables.DOCUMENT_THUMBNAILS).isEqualTo("document_thumbnails")
+        // schema_meta + passes + 3 pass-side indexes + pass_images + pass_locales
+        // + documents + 1 document index + document_thumbnails = 10 statements.
+        assertThat(Schema.DDL).hasSize(10)
+        assertThat(Schema.MIGRATIONS.keys).containsExactly(1)
     }
 
     @Test
@@ -220,12 +223,27 @@ class PublicApiSurfaceTest {
             ) {
                 recorded += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
             }
+
+            override fun onDocumentImported(event: DocumentImportedEvent) {
+                recorded += "doc-imported:${event.byteCount}:${event.pageCount}"
+            }
+
+            override fun onDocumentRejected(kind: DocumentStorageRejectedKind) {
+                recorded += "doc-rejected:${kind.name}"
+            }
+
+            override fun onDocumentDeleted(event: DocumentDeletedEvent) {
+                recorded += "doc-deleted:${event.byteCount}"
+            }
         }
         guard.onKeyProviderInitialized(KeyBacking.StrongBox)
         guard.onPassUpserted(PassType.BoardingPass, SignatureStatusKind.AppleVerified, false)
         guard.onPassDeleted(PassType.EventTicket, SignatureStatusKind.SelfSigned)
         guard.onMigrationRowDropped(MigrationFailureKind.JsonShapeMismatch)
         guard.onStorageFailure(StorageFailureKind.Unknown, UnknownStorageFailureKind.DiskFull)
+        guard.onDocumentImported(DocumentImportedEvent(byteCount = 1024L, pageCount = 3))
+        guard.onDocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage)
+        guard.onDocumentDeleted(DocumentDeletedEvent(byteCount = 2048L))
 
         assertThat(recorded).containsExactly(
             "init:StrongBox",
@@ -233,6 +251,25 @@ class PublicApiSurfaceTest {
             "delete:EventTicket:SelfSigned",
             "drop:JsonShapeMismatch",
             "failure:Unknown:DiskFull",
+            "doc-imported:1024:3",
+            "doc-rejected:OversizedAtStorage",
+            "doc-deleted:2048",
         ).inOrder()
+    }
+
+    @Test
+    fun documentStorageRejectedKindCoversTheTwoStorageSideArms() {
+        assertThat(DocumentStorageRejectedKind.entries.map { it.name }).containsExactly(
+            "OversizedAtStorage",
+            "TooManyPagesAtStorage",
+        ).inOrder()
+    }
+
+    @Test
+    fun documentBoundsMirrorAdr0005D7Caps() {
+        // The `passes-pdf-core` renderer-service enforces these. Storage carries them
+        // again so a future caller bug cannot land an oversized row.
+        assertThat(DocumentBounds.MAX_BYTES).isEqualTo(25L * 1024 * 1024)
+        assertThat(DocumentBounds.MAX_PAGES).isEqualTo(10)
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
@@ -29,7 +29,7 @@ class SchemaDdlTest {
     }
 
     @Test
-    fun ddlExecutesCleanlyAndCreatesTheFourDocumentedTables() {
+    fun ddlExecutesCleanlyAndCreatesTheSixDocumentedTables() {
         applyDdl().use { conn ->
             val tables = mutableSetOf<String>()
             conn.createStatement().use { stmt ->
@@ -41,12 +41,14 @@ class SchemaDdlTest {
                 Schema.Tables.PASSES,
                 Schema.Tables.PASS_IMAGES,
                 Schema.Tables.PASS_LOCALES,
+                Schema.Tables.DOCUMENTS,
+                Schema.Tables.DOCUMENT_THUMBNAILS,
             )
         }
     }
 
     @Test
-    fun ddlCreatesTheThreeDocumentedIndexes() {
+    fun ddlCreatesTheFourDocumentedIndexes() {
         applyDdl().use { conn ->
             val indexes = mutableSetOf<String>()
             conn.createStatement().use { stmt ->
@@ -59,6 +61,7 @@ class SchemaDdlTest {
                 "idx_passes_type",
                 "idx_passes_expiration",
                 "idx_passes_identity",
+                "idx_documents_imported_at",
             )
         }
     }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
@@ -140,6 +140,63 @@ class SchemaMigrationTest {
     }
 
     @Test
+    fun migrationsCoverEveryHopFromV1ToCurrent() {
+        // Compile-time-equivalent guard: bumping Schema.VERSION without adding the
+        // matching migration entry is a developer-side mistake, not a user-data
+        // condition. This assertion catches it at CI time so the runtime branch in
+        // SqlCipherDatabaseFactory.buildMigrationChain (which reports Other) should
+        // never fire in a shipped build.
+        val expected = (1 until Schema.VERSION).toSet()
+        assertThat(Schema.MIGRATIONS.keys).containsExactlyElementsIn(expected)
+    }
+
+    @Test
+    fun freshInstallAndV1ToV2MigrationLandAtTheSameSchema() {
+        // DDL drift guard: Schema.DDL (fresh install) and the v1 -> v2 migration must
+        // produce the same `sqlite_master` rows for tables and indexes. A future
+        // refactor that touches one path and misses the other would silently produce
+        // divergent shapes between fresh installs and migrated installs; this test
+        // surfaces the divergence at JVM-test time.
+        val freshShape = openMemoryDb().use { conn ->
+            conn.createStatement().use { stmt ->
+                for (sql in Schema.DDL) stmt.execute(sql)
+            }
+            schemaShape(conn)
+        }
+        val migratedShape = openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(1)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+            schemaShape(conn)
+        }
+        assertThat(migratedShape).isEqualTo(freshShape)
+    }
+
+    private fun schemaShape(conn: Connection): Set<String> {
+        val out = mutableSetOf<String>()
+        conn.createStatement().use { stmt ->
+            // `sql` is the DDL the engine reconstructed; comparing it catches column,
+            // ordering, and constraint drift across both creation paths. Auto-named
+            // sqlite_* internal indexes are excluded since their names are nondeterministic.
+            val rs = stmt.executeQuery(
+                "SELECT type, name, tbl_name, sql FROM sqlite_master " +
+                    "WHERE name NOT LIKE 'sqlite_%' " +
+                    "ORDER BY type, name",
+            )
+            while (rs.next()) {
+                out += listOf(
+                    rs.getString(1),
+                    rs.getString(2),
+                    rs.getString(3),
+                    rs.getString(4) ?: "",
+                ).joinToString("|")
+            }
+        }
+        return out
+    }
+
+    @Test
     fun preexistingV1DataSurvivesMigration() {
         openMemoryDb().use { conn ->
             applyV1Ddl(conn)

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
@@ -1,0 +1,238 @@
+package `is`.walt.passes.storage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.sql.Connection
+import java.sql.DriverManager
+
+/**
+ * JVM-side verification of the v1 -> v2 schema migration. Mirrors [SchemaDdlTest]'s
+ * approach: stock `sqlite-jdbc` standing in for SQLCipher, since SQLCipher is
+ * wire-compatible with SQLite for DDL.
+ *
+ * The properties locked here:
+ *
+ *  1. A v1 database (passes/pass_images/pass_locales tables only) can have the v1 -> v2
+ *     migration statements applied without error.
+ *  2. After the migration, the `documents` and `document_thumbnails` tables exist with
+ *     the expected columns, the `idx_documents_imported_at` index is present, and the
+ *     foreign-key cascade on the thumbnails table is wired up.
+ *  3. Pre-existing v1 data (a `passes` row plus children) is preserved across the
+ *     migration: forward-only does not mean forward-and-truncate.
+ *  4. The migration list is exactly the v1 entry today; future versions add to this.
+ */
+class SchemaMigrationTest {
+
+    private fun openMemoryDb(): Connection {
+        val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+        conn.createStatement().use { it.execute("PRAGMA foreign_keys = ON") }
+        return conn
+    }
+
+    /**
+     * Applies the v1 schema (everything in [Schema.DDL] up to and including the v1
+     * tables, i.e. excluding the v2-only `documents` and `document_thumbnails` tables
+     * and the `idx_documents_imported_at` index). The migration test then runs only the
+     * v1 -> v2 hop on top of this and asserts the result equals the full v2 schema.
+     */
+    private fun applyV1Ddl(conn: Connection) {
+        // V1 was schema_meta + passes + 3 pass-side indexes + pass_images + pass_locales
+        // = 7 statements at the head of Schema.DDL.
+        conn.createStatement().use { stmt ->
+            for (sql in V1_DDL) stmt.execute(sql)
+        }
+    }
+
+    @Test
+    fun migrationFromV1IntroducesDocumentsAndDocumentThumbnailsTables() {
+        openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+
+            val migration = Schema.MIGRATIONS.getValue(1)
+            conn.createStatement().use { stmt ->
+                for (sql in migration) stmt.execute(sql)
+            }
+
+            val tables = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT name FROM sqlite_master WHERE type='table'")
+                while (rs.next()) tables.add(rs.getString(1))
+            }
+            assertThat(tables).containsAtLeast(
+                Schema.Tables.DOCUMENTS,
+                Schema.Tables.DOCUMENT_THUMBNAILS,
+            )
+        }
+    }
+
+    @Test
+    fun migrationFromV1AddsTheImportedAtIndex() {
+        openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(1)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val indexes = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+                )
+                while (rs.next()) indexes.add(rs.getString(1))
+            }
+            assertThat(indexes).contains("idx_documents_imported_at")
+        }
+    }
+
+    @Test
+    fun documentsTableHasTheExpectedColumns() {
+        openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(1)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.DOCUMENTS})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).containsExactly(
+                "id",
+                "display_label",
+                "pdf_bytes",
+                "byte_count",
+                "page_count",
+                "imported_at_epoch_ms",
+            )
+        }
+    }
+
+    @Test
+    fun documentThumbnailsTableCascadesOnDocumentDelete() {
+        openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(1)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            // Insert a document + thumbnail.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.DOCUMENTS}" +
+                    "(id, display_label, pdf_bytes, byte_count, page_count, imported_at_epoch_ms) " +
+                    "VALUES (1, 'doc.pdf', x'00', 1, 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.DOCUMENT_THUMBNAILS} (document_id, bytes) " +
+                    "VALUES (1, x'00')",
+            ).use { it.executeUpdate() }
+
+            conn.prepareStatement("DELETE FROM ${Schema.Tables.DOCUMENTS} WHERE id = 1")
+                .use { it.executeUpdate() }
+
+            conn.createStatement().use { stmt ->
+                val thumbnailRows = stmt.executeQuery(
+                    "SELECT COUNT(*) FROM ${Schema.Tables.DOCUMENT_THUMBNAILS}",
+                ).also { it.next() }.getInt(1)
+                assertThat(thumbnailRows).isEqualTo(0)
+            }
+        }
+    }
+
+    @Test
+    fun preexistingV1DataSurvivesMigration() {
+        openMemoryDb().use { conn ->
+            applyV1Ddl(conn)
+
+            // Pre-migration: a v1 pass row with image and locale children.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (1, 'BoardingPass', 'S1', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASS_IMAGES} (pass_id, role, bytes) " +
+                    "VALUES (1, 'Logo', x'00')",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASS_LOCALES} (pass_id, locale_tag, strings_json) " +
+                    "VALUES (1, 'en', x'00')",
+            ).use { it.executeUpdate() }
+
+            for (sql in Schema.MIGRATIONS.getValue(1)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            conn.createStatement().use { stmt ->
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.PASSES}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.PASS_IMAGES}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.PASS_LOCALES}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * Snapshot of the v1 schema. Hard-coded so the test sees the *historical* shape,
+         * not whatever the current Schema.DDL happens to declare. Any future v2 -> v3
+         * migration will get its own test that walks v1 -> v2 -> v3 against the same
+         * snapshot.
+         */
+        val V1_DDL: List<String> = listOf(
+            """
+            CREATE TABLE IF NOT EXISTS schema_meta (
+                key   TEXT PRIMARY KEY NOT NULL,
+                value BLOB NOT NULL
+            )
+            """.trimIndent(),
+            """
+            CREATE TABLE IF NOT EXISTS passes (
+                id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+                type                  TEXT    NOT NULL,
+                serial_number         TEXT    NOT NULL,
+                organization_name     TEXT    NOT NULL,
+                description           TEXT    NOT NULL,
+                expiration_epoch_ms   INTEGER,
+                voided                INTEGER NOT NULL DEFAULT 0,
+                signature_status_kind TEXT    NOT NULL,
+                pass_json             BLOB    NOT NULL,
+                created_at_epoch_ms   INTEGER NOT NULL,
+                updated_at_epoch_ms   INTEGER NOT NULL
+            )
+            """.trimIndent(),
+            "CREATE INDEX IF NOT EXISTS idx_passes_type ON passes(type)",
+            "CREATE INDEX IF NOT EXISTS idx_passes_expiration ON passes(expiration_epoch_ms)",
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_passes_identity
+                ON passes(type, serial_number, organization_name)
+            """.trimIndent(),
+            """
+            CREATE TABLE IF NOT EXISTS pass_images (
+                pass_id INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+                role    TEXT    NOT NULL,
+                bytes   BLOB    NOT NULL,
+                PRIMARY KEY (pass_id, role)
+            )
+            """.trimIndent(),
+            """
+            CREATE TABLE IF NOT EXISTS pass_locales (
+                pass_id      INTEGER NOT NULL REFERENCES passes(id) ON DELETE CASCADE,
+                locale_tag   TEXT    NOT NULL,
+                strings_json BLOB    NOT NULL,
+                PRIMARY KEY (pass_id, locale_tag)
+            )
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Schema bump to v2 with `documents` + `document_thumbnails` tables and forward-only v1→v2 migration in `Schema.MIGRATIONS`. SqlCipher database factory now walks the migration chain when `onDiskVersion < Schema.VERSION`.
- New `PassRepository` surface: `insertDocument` / `observeDocuments` / `loadDocumentBytes` / `loadDocumentThumbnail` / `deleteDocument`. Storage never decodes PDF or thumbnail bytes; they round-trip as opaque BLOBs (ADR 0005 D4). Defense-in-depth: insert re-checks 25 MB / 10 pages (ADR 0005 D7) so a future caller bug can't land an oversized row.
- `StorageTelemetryGuard` gains `onDocumentImported` / `onDocumentRejected` / `onDocumentDeleted` with the same enums-and-counts-only PII discipline.
- File-level Auto Backup exclusion already covers the new tables (they live inside `walt_passes.db`); no XML change. A new `BackupRulesAssertionTest` pins that audit trail.

Closes wpass-pti.

## Test plan

- [x] `./gradlew check` passes (Kotlin compile, all unit tests, ktlint, detekt, lint)
- [x] `SchemaMigrationTest` covers v1 → v2 hop, column shape, FK CASCADE on `document_thumbnails`, and v1 data preservation
- [x] `DocumentRepositoryTest` exercises insert→observe→delete cycle, 25 MB and 10-page exact-boundary acceptance + +1 rejection, and opaque-bytes round-trip
- [x] `PublicApiSurfaceTest` updated to lock the new schema (VERSION=2, 10 DDL statements, MIGRATIONS keyed by 1) and the three new telemetry events
- [ ] On-device SQLCipher round-trip will be exercised in the wpass-x5l-style instrumentation suite (separate bead)