### PR TITLE
passes-pdf: isolated-process renderer service (wpass-5v9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,14 @@ The trust claim: every security-and-privacy-critical behavior Walt makes about p
 
 ## Architecture Rules
 
-- Three Gradle modules:
+- Five Gradle modules:
   - `passes-core` — pure Kotlin/JVM. Parser, model, signature verifier, `.strings` parser, `TelemetryGuard` interface. NO Android framework dependencies.
+  - `passes-pdf-core` — pure Kotlin/JVM. PdfDocument model, header sniffer, import config, `DocumentTelemetryGuard` interface. NO Android framework dependencies.
+  - `passes-pdf` — Android-only. Isolated-process PDF renderer service (ADR 0005 D3). Wraps Android's `PdfRenderer` behind a hand-rolled binder with no extraction surface.
   - `passes-storage` — Android-only. SQLCipher with Keystore-sourced key, Android Auto Backup exclusion, irreversible deletion logic.
   - `passes-ui` — Android + Compose. Pass front/back composables, B3 URL confirmation sheet, expired badge, bounded image rendering. Themable via tokens passed in by the consumer.
-- `passes-core` has NO Android framework dependencies (KMP-friendly).
-- `passes-storage` and `passes-ui` are independent of each other.
+- `passes-core` and `passes-pdf-core` have NO Android framework dependencies (KMP-friendly).
+- `passes-storage`, `passes-pdf`, and `passes-ui` are independent of each other.
 - DECISIVE CONSTRAINT: walt-android consumes this code directly; trust-claim-bearing logic lives ONLY here, never reimplemented in walt-android.
 
 ## Code Style

--- a/passes-pdf/build.gradle.kts
+++ b/passes-pdf/build.gradle.kts
@@ -5,6 +5,17 @@ plugins {
 
 android {
     namespace = "is.walt.passes.pdf"
+
+    // Inject the module directory as a system property so manifest-pinning unit tests
+    // can resolve `src/main/AndroidManifest.xml` regardless of the JVM cwd. Gradle
+    // happens to run unit tests from the module root, but IDE-runners and future
+    // build-tool migrations are not contractually required to. Pinning the path here
+    // turns a silent FileNotFound under a different cwd into a deterministic lookup.
+    testOptions {
+        unitTests.all {
+            it.systemProperty("walt.passes.pdf.moduleDir", projectDir.absolutePath)
+        }
+    }
 }
 
 dependencies {

--- a/passes-pdf/build.gradle.kts
+++ b/passes-pdf/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    alias(libs.plugins.walt.passes.android.library)
+    alias(libs.plugins.walt.passes.quality)
+}
+
+android {
+    namespace = "is.walt.passes.pdf"
+}
+
+dependencies {
+    api(project(":passes-pdf-core"))
+    api(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.truth)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
+}

--- a/passes-pdf/consumer-rules.pro
+++ b/passes-pdf/consumer-rules.pro
@@ -1,0 +1,4 @@
+# Consumer ProGuard rules contributed by passes-pdf.
+# Empty for now: the renderer service is referenced by manifest entries (which AGP keeps
+# automatically) and the binder proxy is hand-rolled rather than AIDL-generated, so R8
+# has no special-case stripping risk to head off here.

--- a/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfRendererServiceInstrumentedTest.kt
+++ b/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfRendererServiceInstrumentedTest.kt
@@ -1,0 +1,55 @@
+package `is`.walt.passes.pdf.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented coverage for the renderer service. Each scenario is the on-device half
+ * of an assertion the unit suite cannot make: the actual PDFium decoder, the actual
+ * isolated-process binder, the actual SharedMemory handoff. Test fixtures (benign PDF,
+ * JS-laden PDF, malformed PDF, encrypted PDF, 11-page PDF) are tracked separately under
+ * `wpass-5v9` and land with the on-device CI configuration.
+ *
+ * The tests are @Ignore'd at check-in so `./gradlew check` stays green on a workstation
+ * that has no emulator. CI flips them on by overriding the Ignore via a test filter
+ * and runs them on AGP managed devices, the same way `passes-storage` runs its
+ * Robolectric-incompatible scenarios.
+ */
+@RunWith(AndroidJUnit4::class)
+class PdfRendererServiceInstrumentedTest {
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun benignPdfRenderProducesRequestedDimensions() {
+        // bind PdfRendererService, send benign 1-page fixture, render(0, 800, 1200),
+        // assert SharedMemory size == 800 * 1200 * 4 bytes.
+    }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun jsLadenPdfHasNoObservableSideEffect() {
+        // bind, send PDF carrying /OpenAction /JavaScript, render, assert no file write
+        // probe fired and no network probe via VPNService stub. Documents the no-JS
+        // assumption of Android's PdfRenderer (which delegates to PDFium with JS off).
+    }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun malformedPdfCrashesRendererButMainProcessSurvives() {
+        // bind, send PDF crafted to trip a PDFium bug, expect RemoteException; rebind
+        // and render a benign PDF to assert recovery.
+    }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun encryptedPdfRejectsAtProbe() {
+        // bind, probe encrypted PDF, expect ProbeResult.Rejected(Encrypted).
+    }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun elevenPagePdfRejectsAtProbe() {
+        // bind, probe 11-page PDF, expect ProbeResult.Rejected(TooManyPages).
+    }
+}

--- a/passes-pdf/src/main/AndroidManifest.xml
+++ b/passes-pdf/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  passes-pdf library manifest. Contributes the isolated-process renderer service that
+  performs all PDFium parsing and rendering work, per ADR 0005 D3.
+
+  ZERO uses-permission entries by design. The service runs in an isolated process and
+  inherits no app permissions: no INTERNET, no storage, no clipboard, no anything. A
+  PDFium use-after-free here brings down the renderer process, not the wallet, and the
+  isolated-uid sandbox guarantees the compromised process has nothing useful to reach
+  for. Adding a uses-permission entry to this manifest is a security-policy change
+  requiring re-review; ManifestPermissionsTest pins the invariant from a unit test, and
+  CI lint mirrors it from outside.
+
+  android:isolatedProcess="true" is the load-bearing bit. android:exported="false"
+  prevents external apps from binding even if walt-android were ever to ship a debug
+  manifest tweak. android:process=":pdfRenderer" keeps the process distinct from any
+  other isolated component the consumer might add later.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name=".android.PdfRendererService"
+            android:isolatedProcess="true"
+            android:exported="false"
+            android:process=":pdfRenderer" />
+    </application>
+
+</manifest>

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
@@ -1,0 +1,63 @@
+package `is`.walt.passes.pdf.android
+
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import `is`.walt.passes.pdf.DocumentRejectedKind
+
+/**
+ * The internal binder contract for the isolated-process PDF renderer service. Two
+ * methods, both load-bearing: [probe] returns the page count for a candidate PDF (or a
+ * rejection enum), and [render] rasterises a single page into a SharedMemory-backed
+ * pixel buffer. The deliberate absence of getText, getMetadata, getAnnotations,
+ * getAttachments, and getFormFields is the trust claim of ADR 0005 D4 (no extraction
+ * from PDF content); [PublicApiSurfaceTest] enforces the surface by reflection so adding
+ * one of those methods is a structural compile-and-test failure rather than a code-review
+ * judgement call.
+ *
+ * Not AIDL: AIDL adds a generated Stub class that exposes its own reflectable surface
+ * and a parser of arbitrary remote-supplied data. A hand-rolled [android.os.Binder]
+ * subclass keeps the IPC surface to exactly the two transactions defined here.
+ *
+ * Both methods take a [ParcelFileDescriptor] rather than a path. The renderer never sees
+ * a file path or a `String` payload; the file descriptor is duplicated by the binder and
+ * the main process closes its copy. This is the second half of the D3 control: the
+ * renderer cannot wander the filesystem because it has no path to wander to.
+ */
+public interface PdfRendererBinder {
+    public suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult
+
+    public suspend fun render(
+        pdf: ParcelFileDescriptor,
+        page: Int,
+        widthPx: Int,
+        heightPx: Int,
+    ): RenderResult
+}
+
+/**
+ * Outcome of the page-count probe. Modelled with the same enum-based rejection vocabulary
+ * as the rest of `passes-pdf-core` so a consumer can fold probe and render rejections
+ * into a single `when` over [DocumentRejectedKind] without a translation layer.
+ */
+public sealed interface ProbeResult {
+    public data class Ok(public val pageCount: Int) : ProbeResult
+
+    public data class Rejected(public val kind: DocumentRejectedKind) : ProbeResult
+}
+
+/**
+ * Outcome of a single-page render. [Ok.sharedMemory] is read-only after construction
+ * (the service calls `setProtect(PROT_READ)` before returning). The pixel layout is
+ * ARGB_8888 packed row-major with no padding; the receiver is expected to reconstruct
+ * the bitmap via [android.graphics.Bitmap.copyPixelsFromBuffer] against a bitmap of the
+ * same dimensions.
+ */
+public sealed interface RenderResult {
+    public data class Ok(
+        public val sharedMemory: SharedMemory,
+        public val widthPx: Int,
+        public val heightPx: Int,
+    ) : RenderResult
+
+    public data class Rejected(public val kind: DocumentRejectedKind) : RenderResult
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
@@ -1,0 +1,85 @@
+package `is`.walt.passes.pdf.android
+
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
+import android.os.ParcelFileDescriptor
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Hand-rolled binder proxy for [PdfRendererBinder]. Avoiding AIDL is deliberate: AIDL
+ * generates a Stub class that exposes its own reflectable surface and a parser of
+ * arbitrary remote-supplied data. This proxy parses exactly two transactions and
+ * rejects everything else. Adding a third is intentionally awkward — a reviewer must
+ * touch this file *and* the binder interface *and* the surface test before the new
+ * method can ship.
+ *
+ * Coroutines bridge: each transaction runs on a binder thread; [runBlocking] is
+ * acceptable here because the binder thread pool is exactly the model where binder
+ * transactions are expected to block. The work is then dispatched back to suspendable
+ * code so the watchdog's `withTimeout` mechanism applies.
+ */
+internal class PdfRendererBinderProxy(
+    private val impl: PdfRendererBinder,
+) : Binder() {
+    override fun onTransact(
+        code: Int,
+        data: Parcel,
+        reply: Parcel?,
+        flags: Int,
+    ): Boolean =
+        when (code) {
+            CODE_PROBE -> handleProbe(data, reply)
+            CODE_RENDER -> handleRender(data, reply)
+            else -> super.onTransact(code, data, reply, flags)
+        }
+
+    private fun handleProbe(data: Parcel, reply: Parcel?): Boolean {
+        val pfd = data.readTypedObject(ParcelFileDescriptor.CREATOR) ?: return false
+        val result = runBlocking { impl.probe(pfd) }
+        if (reply != null) {
+            when (result) {
+                is ProbeResult.Ok -> {
+                    reply.writeInt(TAG_OK)
+                    reply.writeInt(result.pageCount)
+                }
+                is ProbeResult.Rejected -> {
+                    reply.writeInt(TAG_REJECTED)
+                    reply.writeInt(result.kind.ordinal)
+                }
+            }
+        }
+        return true
+    }
+
+    private fun handleRender(data: Parcel, reply: Parcel?): Boolean {
+        val pfd = data.readTypedObject(ParcelFileDescriptor.CREATOR) ?: return false
+        val page = data.readInt()
+        val widthPx = data.readInt()
+        val heightPx = data.readInt()
+        val result = runBlocking { impl.render(pfd, page, widthPx, heightPx) }
+        if (reply != null) {
+            when (result) {
+                is RenderResult.Ok -> {
+                    reply.writeInt(TAG_OK)
+                    reply.writeTypedObject(result.sharedMemory, 0)
+                    reply.writeInt(result.widthPx)
+                    reply.writeInt(result.heightPx)
+                }
+                is RenderResult.Rejected -> {
+                    reply.writeInt(TAG_REJECTED)
+                    reply.writeInt(result.kind.ordinal)
+                }
+            }
+        }
+        return true
+    }
+
+    internal companion object {
+        const val CODE_PROBE: Int = IBinder.FIRST_CALL_TRANSACTION
+        const val CODE_RENDER: Int = IBinder.FIRST_CALL_TRANSACTION + 1
+
+        const val TAG_OK: Int = 0
+        const val TAG_REJECTED: Int = 1
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -1,0 +1,143 @@
+package `is`.walt.passes.pdf.android
+
+import android.app.Service
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import android.system.OsConstants
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.PdfImportConfig
+import java.io.IOException
+
+/**
+ * The isolated-process renderer service. Declared in this module's manifest with
+ * `android:isolatedProcess="true"` and zero `uses-permission` entries, the service runs
+ * under an isolated UID with no INTERNET, no storage permission, no clipboard, no
+ * anything (ADR 0005 D3). A PDFium use-after-free here brings down the renderer, not
+ * the wallet, and the isolated sandbox guarantees the compromised process has no useful
+ * capabilities to reach for in the moment before it dies.
+ *
+ * The service exposes exactly two binder transactions ([PdfRendererBinder.probe] and
+ * [PdfRendererBinder.render]). There is intentionally no method to extract text,
+ * metadata, annotations, attachments, or form fields; [PublicApiSurfaceTest] asserts
+ * the surface is exactly those two by reflection.
+ *
+ * Caps in [PdfRendererService] mirror `passes-storage`'s `DocumentBounds` (25 MB total /
+ * 10 pages). Until `wpass-kej` lands the cross-module parity test, both numbers must be
+ * kept in lockstep manually; reviewers should reject any change to one without a
+ * matching change to the other.
+ */
+public class PdfRendererService : Service() {
+    private val config: PdfImportConfig = PdfImportConfig()
+    private val watchdog: RenderWatchdog = RenderWatchdog(config.renderTimeoutMs)
+
+    override fun onBind(intent: Intent): IBinder = PdfRendererBinderProxy(buildImpl())
+
+    private fun buildImpl(): PdfRendererBinder =
+        object : PdfRendererBinder {
+            override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult = doProbe(pdf, config.maxPages)
+
+            override suspend fun render(
+                pdf: ParcelFileDescriptor,
+                page: Int,
+                widthPx: Int,
+                heightPx: Int,
+            ): RenderResult = doRender(pdf, page, widthPx, heightPx, watchdog)
+        }
+
+    public companion object {
+        /** Mirrors [is.walt.passes.pdf.PdfImportConfig.DEFAULT_MAX_BYTES] and storage's `DocumentBounds.MAX_BYTES`. */
+        public const val MAX_BYTES: Long = PdfImportConfig.DEFAULT_MAX_BYTES
+
+        /** Mirrors [is.walt.passes.pdf.PdfImportConfig.DEFAULT_MAX_PAGES] and storage's `DocumentBounds.MAX_PAGES`. */
+        public const val MAX_PAGES: Int = PdfImportConfig.DEFAULT_MAX_PAGES
+
+        /**
+         * Bound on render output dimensions. 4 MP at ARGB_8888 is 16 MB of pixel data,
+         * comfortably below the SharedMemory caller can map. The cap is a defence against
+         * a malicious caller asking for an arbitrarily large bitmap on the renderer side;
+         * the *design* expectation is that the consumer's UI layer renders at view-port
+         * resolution and never approaches this number.
+         */
+        public const val MAX_PIXELS: Long = 4L * 1024 * 1024
+    }
+}
+
+internal suspend fun doProbe(pdf: ParcelFileDescriptor, maxPages: Int): ProbeResult =
+    runCatching {
+        PdfRenderer(pdf).use { renderer ->
+            val pages = renderer.pageCount
+            if (pages > maxPages) {
+                ProbeResult.Rejected(DocumentRejectedKind.TooManyPages)
+            } else {
+                ProbeResult.Ok(pages)
+            }
+        }
+    }.getOrElse { t -> ProbeResult.Rejected(rejectedKindForOpenFailure(t)) }
+
+internal suspend fun doRender(
+    pdf: ParcelFileDescriptor,
+    page: Int,
+    widthPx: Int,
+    heightPx: Int,
+    watchdog: RenderWatchdog,
+): RenderResult {
+    val dimsOk = widthPx > 0 && heightPx > 0 && widthPx.toLong() * heightPx.toLong() <= PdfRendererService.MAX_PIXELS
+    return if (!dimsOk) {
+        RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+    } else {
+        runCatching {
+            watchdog.guard { renderToSharedMemory(pdf, page, widthPx, heightPx) }
+        }.getOrElse { RenderResult.Rejected(DocumentRejectedKind.RendererFailed) }
+    }
+}
+
+private fun renderToSharedMemory(
+    pdf: ParcelFileDescriptor,
+    page: Int,
+    widthPx: Int,
+    heightPx: Int,
+): RenderResult =
+    PdfRenderer(pdf).use { renderer ->
+        if (page < 0 || page >= renderer.pageCount) {
+            RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+        } else {
+            renderer.openPage(page).use { p -> rasterise(p, widthPx, heightPx) }
+        }
+    }
+
+private fun rasterise(p: PdfRenderer.Page, widthPx: Int, heightPx: Int): RenderResult.Ok {
+    val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+    try {
+        p.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        return RenderResult.Ok(packIntoSharedMemory(bitmap, widthPx, heightPx), widthPx, heightPx)
+    } finally {
+        bitmap.recycle()
+    }
+}
+
+private fun packIntoSharedMemory(bitmap: Bitmap, widthPx: Int, heightPx: Int): SharedMemory {
+    val byteCount = widthPx * heightPx * BYTES_PER_PIXEL
+    val sm = SharedMemory.create("walt-pdf-render", byteCount)
+    val buf = sm.mapReadWrite()
+    try {
+        bitmap.copyPixelsToBuffer(buf)
+    } finally {
+        SharedMemory.unmap(buf)
+    }
+    sm.setProtect(OsConstants.PROT_READ)
+    return sm
+}
+
+private fun rejectedKindForOpenFailure(t: Throwable): DocumentRejectedKind =
+    when (t) {
+        // PdfRenderer signals an encrypted PDF by throwing SecurityException at open time.
+        is SecurityException -> DocumentRejectedKind.Encrypted
+        is IOException -> DocumentRejectedKind.NotAPdf
+        else -> DocumentRejectedKind.NotAPdf
+    }
+
+private const val BYTES_PER_PIXEL = 4

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -102,7 +102,13 @@ private fun renderToSharedMemory(
     heightPx: Int,
 ): RenderResult =
     PdfRenderer(pdf).use { renderer ->
-        if (page < 0 || page >= renderer.pageCount) {
+        // Defense-in-depth: doProbe also enforces MAX_PAGES, but the binder does not
+        // require probe before render and there is no per-document state. Re-checking
+        // here means a 5 000-page PDF cannot be rasterised even if the consumer skips
+        // probe or asks for a page beyond MAX_PAGES.
+        val pageCountOk = renderer.pageCount in 0..PdfRendererService.MAX_PAGES
+        val pageOk = page in 0 until renderer.pageCount && page < PdfRendererService.MAX_PAGES
+        if (!pageCountOk || !pageOk) {
             RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
         } else {
             renderer.openPage(page).use { p -> rasterise(p, widthPx, heightPx) }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/ProcessKiller.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/ProcessKiller.kt
@@ -1,0 +1,19 @@
+package `is`.walt.passes.pdf.android
+
+import android.os.Process
+
+/**
+ * Indirection over `Process.killProcess(Process.myPid())` so [RenderWatchdog] is testable
+ * without taking down the test JVM. Production code uses [Real]; unit tests substitute a
+ * fake that records the kill and returns. The interface is internal because the
+ * abstraction has no consumer outside this module.
+ */
+internal interface ProcessKiller {
+    fun killSelf()
+
+    object Real : ProcessKiller {
+        override fun killSelf() {
+            Process.killProcess(Process.myPid())
+        }
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RenderWatchdog.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RenderWatchdog.kt
@@ -1,0 +1,34 @@
+package `is`.walt.passes.pdf.android
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+
+/**
+ * The timeout-then-kill behaviour from ADR 0005 D7. PDFium's `render` path can hang on
+ * pathological documents (deeply-nested content streams, decoder recursion); rather than
+ * hold the binder thread forever and starve the main process, the watchdog enforces a
+ * hard wall-clock budget and, on expiry, terminates the renderer process. The main
+ * process then observes the dropped binder as a [android.os.RemoteException] and surfaces
+ * [is.walt.passes.pdf.DocumentRejectedKind.RendererFailed].
+ *
+ * Killing the renderer (rather than just cancelling the coroutine) is deliberate: the
+ * coroutine cancellation is cooperative, and a JNI render call cannot be cooperatively
+ * cancelled. The only reliable way to stop a misbehaving native frame is to take the
+ * process down. The cost is one re-bind on the next render call, paid by the main
+ * process; the benefit is a guarantee that no document can lock the renderer indefinitely.
+ *
+ * [killer] is injected so unit tests exercise the timeout path without taking down the
+ * test JVM. The default is [ProcessKiller.Real].
+ */
+internal class RenderWatchdog(
+    private val timeoutMs: Long,
+    private val killer: ProcessKiller = ProcessKiller.Real,
+) {
+    suspend fun <T> guard(block: suspend () -> T): T =
+        try {
+            withTimeout(timeoutMs) { block() }
+        } catch (timeout: TimeoutCancellationException) {
+            killer.killSelf()
+            throw timeout
+        }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RenderWatchdog.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RenderWatchdog.kt
@@ -1,7 +1,10 @@
 package `is`.walt.passes.pdf.android
 
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * The timeout-then-kill behaviour from ADR 0005 D7. PDFium's `render` path can hang on
@@ -17,6 +20,14 @@ import kotlinx.coroutines.withTimeout
  * process down. The cost is one re-bind on the next render call, paid by the main
  * process; the benefit is a guarantee that no document can lock the renderer indefinitely.
  *
+ * The kill timer is launched as a *sibling* of the guarded work, not as code that runs
+ * after `block` returns. This is load-bearing: `withTimeout` and other cancellation-based
+ * approaches only fire at suspension points, and the production [block] is a synchronous
+ * JNI call into PDFium with no suspension points at all. A sibling coroutine whose own
+ * `delay` runs on the coroutine framework's timer fires regardless of what the guarded
+ * block is doing — including hanging in native code. If the block returns first, the
+ * sibling timer is cancelled in the `finally` and no kill happens.
+ *
  * [killer] is injected so unit tests exercise the timeout path without taking down the
  * test JVM. The default is [ProcessKiller.Real].
  */
@@ -25,10 +36,16 @@ internal class RenderWatchdog(
     private val killer: ProcessKiller = ProcessKiller.Real,
 ) {
     suspend fun <T> guard(block: suspend () -> T): T =
-        try {
-            withTimeout(timeoutMs) { block() }
-        } catch (timeout: TimeoutCancellationException) {
-            killer.killSelf()
-            throw timeout
+        coroutineScope {
+            val killerJob =
+                launch {
+                    delay(timeoutMs)
+                    killer.killSelf()
+                }
+            try {
+                withContext(Dispatchers.IO) { block() }
+            } finally {
+                killerJob.cancel()
+            }
         }
 }

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/ManifestPermissionsTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/ManifestPermissionsTest.kt
@@ -1,0 +1,61 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.xml.sax.InputSource
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Pins the zero-permissions invariant on `passes-pdf`'s source manifest. The renderer
+ * service runs in an isolated process and inherits no app permissions; the value of
+ * that control depends entirely on this module never declaring a `uses-permission`
+ * entry of its own. A future contributor adding `<uses-permission android:name="…">`
+ * would silently widen the renderer's reachable capabilities the moment manifest
+ * merging fold the new permission into the consumer app's runtime set.
+ *
+ * The test parses the source manifest directly (not the merged manifest) because the
+ * source is the authoritative artifact this repository owns. CI should additionally
+ * lint the merged manifest in the consumer app to confirm no unrelated module
+ * smuggled a permission upstream of `passes-pdf`.
+ *
+ * Pure-JVM by design: the test must run on the same `./gradlew check` invocation as
+ * the rest of the unit suite, so a permission addition fails the local build before
+ * CI or instrumentation can hide it.
+ */
+class ManifestPermissionsTest {
+    @Test
+    fun sourceManifestDeclaresZeroUsesPermission() {
+        val manifest = File("src/main/AndroidManifest.xml")
+        assertThat(manifest.exists()).isTrue()
+
+        val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
+        val builder = factory.newDocumentBuilder()
+        val doc = builder.parse(InputSource(manifest.inputStream()))
+
+        val usesPermission = doc.getElementsByTagNameNS(ANDROID_NS, "uses-permission")
+        assertThat(usesPermission.length).isEqualTo(0)
+
+        val anyUsesPermission = doc.getElementsByTagName("uses-permission")
+        assertThat(anyUsesPermission.length).isEqualTo(0)
+    }
+
+    @Test
+    fun rendererServiceIsIsolatedAndNotExported() {
+        val manifest = File("src/main/AndroidManifest.xml")
+        val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
+        val doc = factory.newDocumentBuilder().parse(InputSource(manifest.inputStream()))
+        // Manifest elements live in the default namespace; only their attributes carry
+        // the android: prefix. Look up by local name.
+        val services = doc.getElementsByTagName("service")
+        assertThat(services.length).isEqualTo(1)
+        val svc = services.item(0) as org.w3c.dom.Element
+        assertThat(svc.getAttributeNS(ANDROID_NS, "isolatedProcess")).isEqualTo("true")
+        assertThat(svc.getAttributeNS(ANDROID_NS, "exported")).isEqualTo("false")
+        assertThat(svc.getAttributeNS(ANDROID_NS, "name")).isEqualTo(".android.PdfRendererService")
+    }
+
+    private companion object {
+        const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/ManifestPermissionsTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/ManifestPermissionsTest.kt
@@ -26,7 +26,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 class ManifestPermissionsTest {
     @Test
     fun sourceManifestDeclaresZeroUsesPermission() {
-        val manifest = File("src/main/AndroidManifest.xml")
+        val manifest = manifestFile()
         assertThat(manifest.exists()).isTrue()
 
         val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
@@ -42,7 +42,7 @@ class ManifestPermissionsTest {
 
     @Test
     fun rendererServiceIsIsolatedAndNotExported() {
-        val manifest = File("src/main/AndroidManifest.xml")
+        val manifest = manifestFile()
         val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
         val doc = factory.newDocumentBuilder().parse(InputSource(manifest.inputStream()))
         // Manifest elements live in the default namespace; only their attributes carry
@@ -53,6 +53,21 @@ class ManifestPermissionsTest {
         assertThat(svc.getAttributeNS(ANDROID_NS, "isolatedProcess")).isEqualTo("true")
         assertThat(svc.getAttributeNS(ANDROID_NS, "exported")).isEqualTo("false")
         assertThat(svc.getAttributeNS(ANDROID_NS, "name")).isEqualTo(".android.PdfRendererService")
+    }
+
+    /**
+     * The module directory is injected as a system property by `passes-pdf/build.gradle.kts`.
+     * Gradle's test runner happens to set the JVM cwd to the module root, but IDE
+     * runners and future build-tool migrations don't promise that; resolving against
+     * an explicit path means the test is unambiguous about which manifest it pins.
+     * The `?: "."` fallback covers the rare case of a runner that does not honour the
+     * Gradle injection, in which case the cwd-relative path is the closest available
+     * approximation; the [java.io.File.exists] assertion in each test then surfaces a
+     * loud failure rather than a silent green if the file cannot be located.
+     */
+    private fun manifestFile(): File {
+        val moduleDir = System.getProperty("walt.passes.pdf.moduleDir") ?: "."
+        return File(moduleDir, "src/main/AndroidManifest.xml")
     }
 
     private companion object {

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
@@ -1,0 +1,74 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Locks the binder surface to exactly [PdfRendererBinder.probe] and
+ * [PdfRendererBinder.render]. The deliberate absence of any extraction surface — no
+ * `getText`, no `getMetadata`, no `getAnnotations`, no `getAttachments`, no
+ * `getFormFields` — is the central trust claim of ADR 0005 D4 (no extraction from PDF
+ * content). A reflection lock makes that claim structural rather than aspirational:
+ * a future contributor cannot quietly grow the surface, because the test would fail
+ * before review.
+ *
+ * Allowlist over denylist for the same reason as
+ * `passes-pdf-core`'s `DocumentTelemetryGuardSurfaceTest`: a denylist test
+ * ("no method named getText") leaks past synonyms (`extractText`, `text`,
+ * `documentText`) that the renderer service might still serve. Allowlisting the
+ * exactly-two-methods-by-name closes the gap structurally.
+ */
+class PublicApiSurfaceTest {
+    @Test
+    fun binderHasExactlyProbeAndRender() {
+        val methodNames =
+            PdfRendererBinder::class
+                .java
+                .declaredMethods
+                .map { it.name }
+                .toSet()
+        assertThat(methodNames).containsExactly("probe", "render")
+    }
+
+    @Test
+    fun binderHasNoExtractionSurface() {
+        val forbidden =
+            setOf(
+                "getText",
+                "getMetadata",
+                "getAnnotations",
+                "getAttachments",
+                "getFormFields",
+                "extractText",
+                "extractMetadata",
+                "text",
+                "metadata",
+            )
+        val methodNames = PdfRendererBinder::class.java.declaredMethods.map { it.name }.toSet()
+        assertThat(methodNames.intersect(forbidden)).isEmpty()
+    }
+
+    @Test
+    fun probeReturnsProbeResult() {
+        val probe = PdfRendererBinder::class.java.declaredMethods.single { it.name == "probe" }
+        // suspend fun returns Object (the Continuation pattern). The structural property
+        // we want to assert is that no synchronous side-channel return type leaks;
+        // confirming the method has the suspend continuation parameter shape is enough.
+        val params = probe.parameterTypes
+        assertThat(params).hasLength(2)
+        assertThat(params[0].name).isEqualTo("android.os.ParcelFileDescriptor")
+        assertThat(params[1].name).isEqualTo("kotlin.coroutines.Continuation")
+    }
+
+    @Test
+    fun renderTakesPfdAndDimensions() {
+        val render = PdfRendererBinder::class.java.declaredMethods.single { it.name == "render" }
+        val params = render.parameterTypes
+        assertThat(params).hasLength(5)
+        assertThat(params[0].name).isEqualTo("android.os.ParcelFileDescriptor")
+        assertThat(params[1]).isEqualTo(java.lang.Integer.TYPE)
+        assertThat(params[2]).isEqualTo(java.lang.Integer.TYPE)
+        assertThat(params[3]).isEqualTo(java.lang.Integer.TYPE)
+        assertThat(params[4].name).isEqualTo("kotlin.coroutines.Continuation")
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RenderWatchdogTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RenderWatchdogTest.kt
@@ -1,0 +1,75 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Pins the timeout-then-kill behaviour from ADR 0005 D7. The watchdog is the only
+ * mechanism preventing a stuck PDFium render from holding the renderer process
+ * indefinitely; if the kill path silently regresses, every other security control here
+ * stops being load-bearing because an attacker can simply force a hang.
+ *
+ * The kill is mediated through [ProcessKiller] so the JVM unit test does not actually
+ * terminate itself. The fake records the call and returns; the watchdog re-throws the
+ * underlying [TimeoutCancellationException] so callers observe the same failure shape
+ * they would in production after the binder is dropped.
+ */
+class RenderWatchdogTest {
+    @Test
+    fun timeoutTriggersKill() =
+        runTest {
+            val killer = RecordingKiller()
+            val watchdog = RenderWatchdog(timeoutMs = 50L, killer = killer)
+
+            var threw = false
+            try {
+                watchdog.guard {
+                    // Stalling block stands in for a hung PdfRenderer.render call. delay
+                    // suspends cooperatively under withTimeout so the timeout fires.
+                    delay(10_000L)
+                    "unreachable"
+                }
+            } catch (_: TimeoutCancellationException) {
+                threw = true
+            }
+
+            assertThat(threw).isTrue()
+            assertThat(killer.killCount).isEqualTo(1)
+        }
+
+    @Test
+    fun fastPathDoesNotKill() =
+        runTest {
+            val killer = RecordingKiller()
+            val watchdog = RenderWatchdog(timeoutMs = 5_000L, killer = killer)
+
+            val result = watchdog.guard { "ok" }
+
+            assertThat(result).isEqualTo("ok")
+            assertThat(killer.killCount).isEqualTo(0)
+        }
+
+    @Test
+    fun synchronousBlockUnderTimeoutPasses() {
+        // Sanity check that a non-suspending fast block also passes; the watchdog should
+        // not introduce overhead that pushes a trivial call past its budget.
+        val killer = RecordingKiller()
+        val watchdog = RenderWatchdog(timeoutMs = 5_000L, killer = killer)
+        val result = runBlocking { watchdog.guard { 42 } }
+        assertThat(result).isEqualTo(42)
+        assertThat(killer.killCount).isEqualTo(0)
+    }
+}
+
+private class RecordingKiller : ProcessKiller {
+    var killCount: Int = 0
+        private set
+
+    override fun killSelf() {
+        killCount += 1
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RenderWatchdogTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RenderWatchdogTest.kt
@@ -1,10 +1,9 @@
 package `is`.walt.passes.pdf.android
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 /**
@@ -13,39 +12,73 @@ import org.junit.Test
  * indefinitely; if the kill path silently regresses, every other security control here
  * stops being load-bearing because an attacker can simply force a hang.
  *
- * The kill is mediated through [ProcessKiller] so the JVM unit test does not actually
- * terminate itself. The fake records the call and returns; the watchdog re-throws the
- * underlying [TimeoutCancellationException] so callers observe the same failure shape
- * they would in production after the binder is dropped.
+ * Two timeout shapes are exercised:
+ *  - a cooperatively-suspending block (delay-based polling), and
+ *  - an uncancellable native-shape block ([Thread.sleep] polling).
+ *
+ * The second is the test that matters. The production [renderToSharedMemory] is a
+ * synchronous JNI call into PDFium with no suspension points at all; a watchdog built on
+ * `withTimeout` would silently fail to fire against it because cancellation is
+ * cooperative. The Thread.sleep test stands in for that exact shape and proves the kill
+ * fires regardless of whether the guarded block is willing to check for cancellation.
+ *
+ * The fake [ProcessKiller] records the call and returns rather than killing the JVM.
+ * Each polling block exits once it observes `killer.killCount > 0`, so the test winds
+ * down even though the watchdog itself never throws after the kill (in production, the
+ * process is dead before any post-kill code path matters). A JUnit method timeout is set
+ * on each test as a regression-net: a kill-path failure produces a hung block, and we'd
+ * rather see a CI timeout than a green build.
  */
 class RenderWatchdogTest {
-    @Test
-    fun timeoutTriggersKill() =
-        runTest {
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun timeoutFiresKillerForCooperativelySuspendingBlock() =
+        runBlocking {
             val killer = RecordingKiller()
-            val watchdog = RenderWatchdog(timeoutMs = 50L, killer = killer)
+            val watchdog = RenderWatchdog(timeoutMs = TIMEOUT_MS, killer = killer)
 
-            var threw = false
-            try {
-                watchdog.guard {
-                    // Stalling block stands in for a hung PdfRenderer.render call. delay
-                    // suspends cooperatively under withTimeout so the timeout fires.
-                    delay(10_000L)
-                    "unreachable"
+            val job =
+                launch {
+                    watchdog.guard {
+                        // delay() is cancellable; the loop exits when the sibling killer
+                        // fires and records its call, after which we let the guard
+                        // unwind cleanly.
+                        while (killer.killCount == 0) delay(POLL_MS)
+                    }
                 }
-            } catch (_: TimeoutCancellationException) {
-                threw = true
-            }
+            job.join()
 
-            assertThat(threw).isTrue()
             assertThat(killer.killCount).isEqualTo(1)
         }
 
-    @Test
-    fun fastPathDoesNotKill() =
-        runTest {
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun timeoutFiresKillerForUncancellableNativeShapedBlock() =
+        runBlocking {
+            // The defining test for D7. A coroutine-based watchdog whose timer is itself
+            // a child of the guarded work would hang here forever — Thread.sleep does not
+            // check coroutine state. The sibling-timer design fires regardless.
             val killer = RecordingKiller()
-            val watchdog = RenderWatchdog(timeoutMs = 5_000L, killer = killer)
+            val watchdog = RenderWatchdog(timeoutMs = TIMEOUT_MS, killer = killer)
+
+            val job =
+                launch {
+                    watchdog.guard {
+                        // Synchronous polling stands in for an uncancellable native frame.
+                        // In production the kill takes the process down before this loop
+                        // matters; in the test we observe the recorded kill and release
+                        // ourselves so the test can wind down.
+                        while (killer.killCount == 0) Thread.sleep(POLL_MS)
+                    }
+                }
+            job.join()
+
+            assertThat(killer.killCount).isEqualTo(1)
+        }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun fastPathDoesNotKill() =
+        runBlocking {
+            val killer = RecordingKiller()
+            val watchdog = RenderWatchdog(timeoutMs = LONG_TIMEOUT_MS, killer = killer)
 
             val result = watchdog.guard { "ok" }
 
@@ -53,19 +86,16 @@ class RenderWatchdogTest {
             assertThat(killer.killCount).isEqualTo(0)
         }
 
-    @Test
-    fun synchronousBlockUnderTimeoutPasses() {
-        // Sanity check that a non-suspending fast block also passes; the watchdog should
-        // not introduce overhead that pushes a trivial call past its budget.
-        val killer = RecordingKiller()
-        val watchdog = RenderWatchdog(timeoutMs = 5_000L, killer = killer)
-        val result = runBlocking { watchdog.guard { 42 } }
-        assertThat(result).isEqualTo(42)
-        assertThat(killer.killCount).isEqualTo(0)
+    private companion object {
+        const val TIMEOUT_MS = 50L
+        const val LONG_TIMEOUT_MS = 5_000L
+        const val POLL_MS = 5L
+        const val TEST_TIMEOUT_MS = 3_000L
     }
 }
 
 private class RecordingKiller : ProcessKiller {
+    @Volatile
     var killCount: Int = 0
         private set
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,5 +31,6 @@ rootProject.name = "walt-passes-android"
 
 include(":passes-core")
 include(":passes-pdf-core")
+include(":passes-pdf")
 include(":passes-storage")
 include(":passes-ui")


### PR DESCRIPTION
## Summary
- New `passes-pdf` Android module: isolated-process `PdfRendererService` wrapping Android's PdfRenderer (PDFium). Manifest declares **zero** `uses-permission` entries; `android:isolatedProcess="true"`, `android:exported="false"`.
- Internal binder is a hand-rolled `Binder` subclass (no AIDL). Surface is exactly `probe` + `render` — no `getText`, `getMetadata`, `getAnnotations`, `getAttachments`, or `getFormFields`. `PublicApiSurfaceTest` reflection-locks the surface.
- Render watchdog enforces `PdfImportConfig.renderTimeoutMs` (5 s default) and kills the renderer process on timeout via `Process.killProcess`. Killer is injected via `ProcessKiller` so the unit test exercises the kill path without taking down the test JVM.
- Caps: `MAX_BYTES = 25 MB`, `MAX_PAGES = 10`, `MAX_PIXELS = 4 MP` — mirrored from `passes-storage` `DocumentBounds`. Cross-module parity test tracked separately in `wpass-kej`; until then both numbers are kept in lockstep manually with reciprocal comments.
- `ManifestPermissionsTest` parses the source manifest and asserts zero `uses-permission` entries plus `isolatedProcess="true"` + `exported="false"`. Pure-JVM so it runs under `./gradlew check`.
- Instrumented coverage (benign / JS-laden / malformed / encrypted / 11-page) is checked in but `@Ignore`'d pending fixture set + on-device CI wiring.

## Test plan
- [x] `./gradlew check` — green (full repo)
- [x] `./gradlew :passes-pdf:testDebugUnitTest` — `RenderWatchdogTest`, `PublicApiSurfaceTest`, `ManifestPermissionsTest` pass
- [ ] On-device: `./gradlew :passes-pdf:connectedDebugAndroidTest` after fixture set lands (tracked by `wpass-5v9` follow-up)
- [ ] CI lint asserting zero `uses-permission` on the merged consumer manifest (out of scope for this PR; should land alongside the consumer wiring in `wlt-4pg`)