### PR TITLE
passes-pdf: client-side binder proxy + round-trip wire test (wpass-11u)

### DIFF
--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -55,6 +55,13 @@ public enum class Provenance {
  *
  * Reviewers should treat any future addition of a string-bearing failure arm (e.g. an
  * "ErrorMessage" data class) as a security-policy change.
+ *
+ * WIRE-FORMAT COUPLING: the binder proxy in `passes-pdf` (`RejectedKindWire`) maps each
+ * arm to a stable Int code. Adding, removing, or renaming an arm requires a matching
+ * update to that mapping table; `RejectedKindWireSurfaceTest` fails closed if the two
+ * drift apart. Reordering arms here is safe because the wire mapping is by name, not by
+ * `ordinal` — but the surface test still pins the mapping shape so a reordering does
+ * not lull a contributor into thinking the wire is order-coupled.
  */
 public enum class DocumentRejectedKind {
     OversizedAtImport,

--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -56,12 +56,12 @@ public enum class Provenance {
  * Reviewers should treat any future addition of a string-bearing failure arm (e.g. an
  * "ErrorMessage" data class) as a security-policy change.
  *
- * WIRE-FORMAT COUPLING: the binder proxy in `passes-pdf` (`RejectedKindWire`) maps each
- * arm to a stable Int code. Adding, removing, or renaming an arm requires a matching
- * update to that mapping table; `RejectedKindWireSurfaceTest` fails closed if the two
- * drift apart. Reordering arms here is safe because the wire mapping is by name, not by
- * `ordinal` — but the surface test still pins the mapping shape so a reordering does
- * not lull a contributor into thinking the wire is order-coupled.
+ * Downstream wire-format note: at least one downstream module (today, the binder layer
+ * in `passes-pdf`) maps each arm to a stable wire code. Adding, removing, or renaming
+ * an arm here will fail downstream surface tests until those mapping tables are
+ * updated. Reordering arms is safe — the downstream mappings are by name, not by
+ * `ordinal` — but contributors should still expect downstream tests to gate the
+ * change.
  */
 public enum class DocumentRejectedKind {
     OversizedAtImport,

--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -59,9 +59,9 @@ public enum class Provenance {
  * Downstream wire-format note: at least one downstream module (today, the binder layer
  * in `passes-pdf`) maps each arm to a stable wire code. Adding, removing, or renaming
  * an arm here will fail downstream surface tests until those mapping tables are
- * updated. Reordering arms is safe — the downstream mappings are by name, not by
- * `ordinal` — but contributors should still expect downstream tests to gate the
- * change.
+ * updated. Reordering arms is safe — the downstream mappings are exhaustive `when`
+ * tables over the enum values rather than `ordinal`-positional — but contributors
+ * should still expect downstream tests to gate the change.
  */
 public enum class DocumentRejectedKind {
     OversizedAtImport,

--- a/passes-pdf/build.gradle.kts
+++ b/passes-pdf/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.junit)
 
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
@@ -22,6 +22,11 @@ import `is`.walt.passes.pdf.DocumentRejectedKind
  * a file path or a `String` payload; the file descriptor is duplicated by the binder and
  * the main process closes its copy. This is the second half of the D3 control: the
  * renderer cannot wander the filesystem because it has no path to wander to.
+ *
+ * PFD ownership: the caller retains ownership of the [ParcelFileDescriptor] passed in
+ * and is responsible for closing it after the call returns. The binder duplicates the
+ * underlying fd on the way across, so closing on the caller side does not affect the
+ * renderer's copy.
  */
 public interface PdfRendererBinder {
     public suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
@@ -45,7 +45,7 @@ internal class PdfRendererBinderProxy(
                 }
                 is ProbeResult.Rejected -> {
                     reply.writeInt(TAG_REJECTED)
-                    reply.writeInt(result.kind.ordinal)
+                    reply.writeInt(RejectedKindWire.encode(result.kind))
                 }
             }
         }
@@ -68,7 +68,7 @@ internal class PdfRendererBinderProxy(
                 }
                 is RenderResult.Rejected -> {
                     reply.writeInt(TAG_REJECTED)
-                    reply.writeInt(result.kind.ordinal)
+                    reply.writeInt(RejectedKindWire.encode(result.kind))
                 }
             }
         }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -1,0 +1,78 @@
+package `is`.walt.passes.pdf.android
+
+import android.os.IBinder
+import android.os.Parcel
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_PROBE
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_RENDER
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_OK
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_REJECTED
+
+/**
+ * Client-side counterpart to [PdfRendererBinderProxy]. Wraps a bound [IBinder]
+ * (obtained from `Context.bindService` against [PdfRendererService]) and exposes the
+ * exact same suspend contract as [PdfRendererBinder]: probe-or-rejection, render-or-
+ * rejection, no extraction surface.
+ *
+ * Implementing [PdfRendererBinder] rather than re-declaring the methods means
+ * `PublicApiSurfaceTest` on the interface already covers the client's surface; a future
+ * `getText` passthrough cannot land without breaking that test. [PdfRendererClientSurfaceTest]
+ * adds a second lock at the class level so a contributor cannot grow the client with a
+ * non-overriding helper that bypasses the interface's trust contract.
+ *
+ * The wire format is owned by [PdfRendererBinderProxy.Companion] (transaction codes,
+ * tag bytes) and [RejectedKindWire] (rejection-kind codes); [PdfRendererBinderRoundTripTest]
+ * pins the field order on both sides.
+ */
+public class PdfRendererClient(
+    private val binder: IBinder,
+) : PdfRendererBinder {
+    override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        try {
+            data.writeTypedObject(pdf, 0)
+            binder.transact(CODE_PROBE, data, reply, 0)
+            return when (val tag = reply.readInt()) {
+                TAG_OK -> ProbeResult.Ok(reply.readInt())
+                TAG_REJECTED -> ProbeResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                else -> error("Unknown probe reply tag: $tag")
+            }
+        } finally {
+            reply.recycle()
+            data.recycle()
+        }
+    }
+
+    override suspend fun render(
+        pdf: ParcelFileDescriptor,
+        page: Int,
+        widthPx: Int,
+        heightPx: Int,
+    ): RenderResult {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        try {
+            data.writeTypedObject(pdf, 0)
+            data.writeInt(page)
+            data.writeInt(widthPx)
+            data.writeInt(heightPx)
+            binder.transact(CODE_RENDER, data, reply, 0)
+            return when (val tag = reply.readInt()) {
+                TAG_OK -> {
+                    val sm = reply.readTypedObject(SharedMemory.CREATOR)
+                        ?: error("Render reply missing SharedMemory")
+                    val w = reply.readInt()
+                    val h = reply.readInt()
+                    RenderResult.Ok(sm, w, h)
+                }
+                TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                else -> error("Unknown render reply tag: $tag")
+            }
+        } finally {
+            reply.recycle()
+            data.recycle()
+        }
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -8,6 +8,8 @@ import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_PROBE
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_RENDER
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_OK
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_REJECTED
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Client-side counterpart to [PdfRendererBinderProxy]. Wraps a bound [IBinder]
@@ -24,55 +26,72 @@ import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_REJECTE
  * The wire format is owned by [PdfRendererBinderProxy.Companion] (transaction codes,
  * tag bytes) and [RejectedKindWire] (rejection-kind codes); [PdfRendererBinderRoundTripTest]
  * pins the field order on both sides.
+ *
+ * Cancellation: [IBinder.transact] is a synchronous, uninterruptible call. The body is
+ * dispatched on [Dispatchers.IO] so a `withTimeout { client.render(...) }` from the
+ * caller can cooperatively cancel and free the calling coroutine; the underlying
+ * transact still runs to completion on an IO worker, but the caller's coroutine
+ * returns. The authoritative timeout for runaway renders lives on the *server* side via
+ * `RenderWatchdog`; the client cannot abort an in-flight binder call.
+ *
+ * Wire-drift posture: an unknown reply tag or rejection-kind code throws
+ * [IllegalStateException]. The choice is to surface wire-shape regressions loudly
+ * rather than fold them into `Rejected(RendererFailed)`, on the basis that proxy and
+ * client live in the same module and the same build — a mismatch is a structural bug,
+ * not a runtime condition the consumer should silently absorb. If a future cross-build
+ * scenario emerges (e.g. a downstream consumer pinning an older `passes-pdf` jar), this
+ * posture should be revisited.
  */
 public class PdfRendererClient(
     private val binder: IBinder,
 ) : PdfRendererBinder {
-    override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult {
-        val data = Parcel.obtain()
-        val reply = Parcel.obtain()
-        try {
-            data.writeTypedObject(pdf, 0)
-            binder.transact(CODE_PROBE, data, reply, 0)
-            return when (val tag = reply.readInt()) {
-                TAG_OK -> ProbeResult.Ok(reply.readInt())
-                TAG_REJECTED -> ProbeResult.Rejected(RejectedKindWire.decode(reply.readInt()))
-                else -> error("Unknown probe reply tag: $tag")
+    override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
+        withContext(Dispatchers.IO) {
+            val data = Parcel.obtain()
+            val reply = Parcel.obtain()
+            try {
+                data.writeTypedObject(pdf, 0)
+                binder.transact(CODE_PROBE, data, reply, 0)
+                when (val tag = reply.readInt()) {
+                    TAG_OK -> ProbeResult.Ok(reply.readInt())
+                    TAG_REJECTED -> ProbeResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                    else -> error("Unknown probe reply tag: $tag")
+                }
+            } finally {
+                reply.recycle()
+                data.recycle()
             }
-        } finally {
-            reply.recycle()
-            data.recycle()
         }
-    }
 
     override suspend fun render(
         pdf: ParcelFileDescriptor,
         page: Int,
         widthPx: Int,
         heightPx: Int,
-    ): RenderResult {
-        val data = Parcel.obtain()
-        val reply = Parcel.obtain()
-        try {
-            data.writeTypedObject(pdf, 0)
-            data.writeInt(page)
-            data.writeInt(widthPx)
-            data.writeInt(heightPx)
-            binder.transact(CODE_RENDER, data, reply, 0)
-            return when (val tag = reply.readInt()) {
-                TAG_OK -> {
-                    val sm = reply.readTypedObject(SharedMemory.CREATOR)
-                        ?: error("Render reply missing SharedMemory")
-                    val w = reply.readInt()
-                    val h = reply.readInt()
-                    RenderResult.Ok(sm, w, h)
+    ): RenderResult =
+        withContext(Dispatchers.IO) {
+            val data = Parcel.obtain()
+            val reply = Parcel.obtain()
+            try {
+                data.writeTypedObject(pdf, 0)
+                data.writeInt(page)
+                data.writeInt(widthPx)
+                data.writeInt(heightPx)
+                binder.transact(CODE_RENDER, data, reply, 0)
+                when (val tag = reply.readInt()) {
+                    TAG_OK -> {
+                        val sm = reply.readTypedObject(SharedMemory.CREATOR)
+                            ?: error("Render reply missing SharedMemory")
+                        val w = reply.readInt()
+                        val h = reply.readInt()
+                        RenderResult.Ok(sm, w, h)
+                    }
+                    TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                    else -> error("Unknown render reply tag: $tag")
                 }
-                TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
-                else -> error("Unknown render reply tag: $tag")
+            } finally {
+                reply.recycle()
+                data.recycle()
             }
-        } finally {
-            reply.recycle()
-            data.recycle()
         }
-    }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -45,6 +45,11 @@ import kotlinx.coroutines.withContext
  *    `timeoutMs`, and its KDoc explicitly promises "the main process then observes the
  *    dropped binder as a RemoteException and surfaces RendererFailed." This client is
  *    where that promise is honoured.
+ *  - A `false` return from [IBinder.transact] — the shape `Binder.onTransact` produces
+ *    when it bails before writing to the reply parcel (e.g. the proxy could not read a
+ *    [ParcelFileDescriptor] out of the request). Without this branch, the client would
+ *    decode an empty reply parcel as if it were `TAG_OK` (an empty parcel reads `0`,
+ *    which is the value of `TAG_OK`) and surface a phantom `Ok(0)`.
  *  - An unrecognised reply tag or unrecognised rejection-kind code, which would only
  *    occur from a wire-format regression or a compromised isolated process writing
  *    garbage to the reply parcel. Both are folded into `RendererFailed` as a
@@ -64,9 +69,13 @@ public class PdfRendererClient(
             val reply = Parcel.obtain()
             try {
                 data.writeTypedObject(pdf, 0)
-                try {
-                    binder.transact(CODE_PROBE, data, reply, 0)
-                } catch (_: RemoteException) {
+                val accepted =
+                    try {
+                        binder.transact(CODE_PROBE, data, reply, 0)
+                    } catch (_: RemoteException) {
+                        return@withContext ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
+                    }
+                if (!accepted) {
                     return@withContext ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
                 when (reply.readInt()) {
@@ -94,9 +103,13 @@ public class PdfRendererClient(
                 data.writeInt(page)
                 data.writeInt(widthPx)
                 data.writeInt(heightPx)
-                try {
-                    binder.transact(CODE_RENDER, data, reply, 0)
-                } catch (_: RemoteException) {
+                val accepted =
+                    try {
+                        binder.transact(CODE_RENDER, data, reply, 0)
+                    } catch (_: RemoteException) {
+                        return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+                    }
+                if (!accepted) {
                     return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
                 when (reply.readInt()) {

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -36,29 +36,30 @@ import kotlinx.coroutines.withContext
  * returns. The authoritative timeout for runaway renders lives on the *server* side via
  * `RenderWatchdog`; the client cannot abort an in-flight binder call.
  *
- * Renderer-failure posture: every renderer-side failure mode the consumer can observe
- * is folded into `Rejected(DocumentRejectedKind.RendererFailed)`. That includes:
+ * Failure-mode posture — runtime vs. wire invariants:
  *
  *  - The [RemoteException] thrown by [IBinder.transact] when the renderer process is
- *    gone — which is the *expected* shape of a watchdog timeout. `RenderWatchdog` is
- *    engineered to terminate the isolated renderer when a render exceeds its
- *    `timeoutMs`, and its KDoc explicitly promises "the main process then observes the
- *    dropped binder as a RemoteException and surfaces RendererFailed." This client is
- *    where that promise is honoured.
- *  - A `false` return from [IBinder.transact] — the shape `Binder.onTransact` produces
- *    when it bails before writing to the reply parcel (e.g. the proxy could not read a
- *    [ParcelFileDescriptor] out of the request). Without this branch, the client would
- *    decode an empty reply parcel as if it were `TAG_OK` (an empty parcel reads `0`,
- *    which is the value of `TAG_OK`) and surface a phantom `Ok(0)`.
- *  - An unrecognised reply tag or unrecognised rejection-kind code, which would only
- *    occur from a wire-format regression or a compromised isolated process writing
- *    garbage to the reply parcel. Both are folded into `RendererFailed` as a
- *    defense-in-depth against a hostile renderer destabilising the wallet via a
- *    malformed reply; the same regressions are caught structurally at unit-test time
- *    by [PdfRendererBinderRoundTripTest] and [RejectedKindWireSurfaceTest].
- *
- * The consumer's vocabulary is therefore the [DocumentRejectedKind] arm set, not the
- * binder failure-mode set.
+ *    gone is the *designed* runtime failure mode. `RenderWatchdog` is engineered to
+ *    terminate the isolated renderer when a render exceeds its `timeoutMs`, and its
+ *    KDoc explicitly promises "the main process then observes the dropped binder as a
+ *    RemoteException and surfaces RendererFailed." This client is where that promise
+ *    is honoured: the exception is caught and folded into
+ *    [DocumentRejectedKind.RendererFailed].
+ *  - A `false` return from [IBinder.transact] is treated the same way, defensively.
+ *    The shape would arise from a proxy `onTransact` that bailed before writing the
+ *    reply parcel; in practice the only path that returns false is the proxy failing
+ *    to read a [ParcelFileDescriptor] out of a parcel it just received, which is a
+ *    wire-invariant violation (same module, same build) rather than a real runtime
+ *    condition. Folding it in costs one line and avoids the alternative — decoding an
+ *    empty reply parcel where `readInt()` returns `0`, which equals `TAG_OK`, would
+ *    surface a phantom `Ok(0)`.
+ *  - Unrecognised reply tags, missing SharedMemory on a `TAG_OK` render reply, and
+ *    unrecognised rejection-kind codes are wire-invariant assertions and fail-fast
+ *    via [error]. Same-module proxy and client are required to agree on the wire
+ *    format by construction; a disagreement is a programmer error to be caught at the
+ *    nearest test run, not silently absorbed by the consumer. The structural gate is
+ *    [PdfRendererBinderRoundTripTest] (wire shape) and [RejectedKindWireSurfaceTest]
+ *    (rejection-kind table).
  */
 public class PdfRendererClient(
     private val binder: IBinder,
@@ -78,10 +79,10 @@ public class PdfRendererClient(
                 if (!accepted) {
                     return@withContext ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
-                when (reply.readInt()) {
+                when (val tag = reply.readInt()) {
                     TAG_OK -> ProbeResult.Ok(reply.readInt())
-                    TAG_REJECTED -> ProbeResult.Rejected(decodeRejectedKindOrFallback(reply))
-                    else -> ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
+                    TAG_REJECTED -> ProbeResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                    else -> error("Unknown probe reply tag: $tag")
                 }
             } finally {
                 reply.recycle()
@@ -112,24 +113,20 @@ public class PdfRendererClient(
                 if (!accepted) {
                     return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
-                when (reply.readInt()) {
+                when (val tag = reply.readInt()) {
                     TAG_OK -> {
                         val sm = reply.readTypedObject(SharedMemory.CREATOR)
-                            ?: return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+                            ?: error("Render reply missing SharedMemory")
                         val w = reply.readInt()
                         val h = reply.readInt()
                         RenderResult.Ok(sm, w, h)
                     }
-                    TAG_REJECTED -> RenderResult.Rejected(decodeRejectedKindOrFallback(reply))
-                    else -> RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+                    TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
+                    else -> error("Unknown render reply tag: $tag")
                 }
             } finally {
                 reply.recycle()
                 data.recycle()
             }
         }
-
-    private fun decodeRejectedKindOrFallback(reply: Parcel): DocumentRejectedKind =
-        runCatching { RejectedKindWire.decode(reply.readInt()) }
-            .getOrDefault(DocumentRejectedKind.RendererFailed)
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -3,7 +3,9 @@ package `is`.walt.passes.pdf.android
 import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
+import android.os.RemoteException
 import android.os.SharedMemory
+import `is`.walt.passes.pdf.DocumentRejectedKind
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_PROBE
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_RENDER
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_OK
@@ -34,13 +36,24 @@ import kotlinx.coroutines.withContext
  * returns. The authoritative timeout for runaway renders lives on the *server* side via
  * `RenderWatchdog`; the client cannot abort an in-flight binder call.
  *
- * Wire-drift posture: an unknown reply tag or rejection-kind code throws
- * [IllegalStateException]. The choice is to surface wire-shape regressions loudly
- * rather than fold them into `Rejected(RendererFailed)`, on the basis that proxy and
- * client live in the same module and the same build — a mismatch is a structural bug,
- * not a runtime condition the consumer should silently absorb. If a future cross-build
- * scenario emerges (e.g. a downstream consumer pinning an older `passes-pdf` jar), this
- * posture should be revisited.
+ * Renderer-failure posture: every renderer-side failure mode the consumer can observe
+ * is folded into `Rejected(DocumentRejectedKind.RendererFailed)`. That includes:
+ *
+ *  - The [RemoteException] thrown by [IBinder.transact] when the renderer process is
+ *    gone — which is the *expected* shape of a watchdog timeout. `RenderWatchdog` is
+ *    engineered to terminate the isolated renderer when a render exceeds its
+ *    `timeoutMs`, and its KDoc explicitly promises "the main process then observes the
+ *    dropped binder as a RemoteException and surfaces RendererFailed." This client is
+ *    where that promise is honoured.
+ *  - An unrecognised reply tag or unrecognised rejection-kind code, which would only
+ *    occur from a wire-format regression or a compromised isolated process writing
+ *    garbage to the reply parcel. Both are folded into `RendererFailed` as a
+ *    defense-in-depth against a hostile renderer destabilising the wallet via a
+ *    malformed reply; the same regressions are caught structurally at unit-test time
+ *    by [PdfRendererBinderRoundTripTest] and [RejectedKindWireSurfaceTest].
+ *
+ * The consumer's vocabulary is therefore the [DocumentRejectedKind] arm set, not the
+ * binder failure-mode set.
  */
 public class PdfRendererClient(
     private val binder: IBinder,
@@ -51,11 +64,15 @@ public class PdfRendererClient(
             val reply = Parcel.obtain()
             try {
                 data.writeTypedObject(pdf, 0)
-                binder.transact(CODE_PROBE, data, reply, 0)
-                when (val tag = reply.readInt()) {
+                try {
+                    binder.transact(CODE_PROBE, data, reply, 0)
+                } catch (_: RemoteException) {
+                    return@withContext ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
+                }
+                when (reply.readInt()) {
                     TAG_OK -> ProbeResult.Ok(reply.readInt())
-                    TAG_REJECTED -> ProbeResult.Rejected(RejectedKindWire.decode(reply.readInt()))
-                    else -> error("Unknown probe reply tag: $tag")
+                    TAG_REJECTED -> ProbeResult.Rejected(decodeRejectedKindOrFallback(reply))
+                    else -> ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
             } finally {
                 reply.recycle()
@@ -77,21 +94,29 @@ public class PdfRendererClient(
                 data.writeInt(page)
                 data.writeInt(widthPx)
                 data.writeInt(heightPx)
-                binder.transact(CODE_RENDER, data, reply, 0)
-                when (val tag = reply.readInt()) {
+                try {
+                    binder.transact(CODE_RENDER, data, reply, 0)
+                } catch (_: RemoteException) {
+                    return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+                }
+                when (reply.readInt()) {
                     TAG_OK -> {
                         val sm = reply.readTypedObject(SharedMemory.CREATOR)
-                            ?: error("Render reply missing SharedMemory")
+                            ?: return@withContext RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
                         val w = reply.readInt()
                         val h = reply.readInt()
                         RenderResult.Ok(sm, w, h)
                     }
-                    TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
-                    else -> error("Unknown render reply tag: $tag")
+                    TAG_REJECTED -> RenderResult.Rejected(decodeRejectedKindOrFallback(reply))
+                    else -> RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
                 }
             } finally {
                 reply.recycle()
                 data.recycle()
             }
         }
+
+    private fun decodeRejectedKindOrFallback(reply: Parcel): DocumentRejectedKind =
+        runCatching { RejectedKindWire.decode(reply.readInt()) }
+            .getOrDefault(DocumentRejectedKind.RendererFailed)
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
@@ -1,0 +1,48 @@
+package `is`.walt.passes.pdf.android
+
+import `is`.walt.passes.pdf.DocumentRejectedKind
+
+/**
+ * Stable Int <-> [DocumentRejectedKind] mapping for the binder wire format.
+ *
+ * The previous wire encoding used [DocumentRejectedKind.ordinal] directly; that left
+ * the wire silently coupled to the source-order of the enum. Reordering or inserting an
+ * arm in `passes-pdf-core` would have shifted every subsequent code on the wire and
+ * mis-decoded rejections without a compile error. Today the renderer service and its
+ * client live in the same process from the same build, so the on-the-wire fragility is
+ * latent rather than active, but the kernel-vs-consumer coupling already requires the
+ * mapping to be explicit: when walt-android (closed source) starts wiring the binder in,
+ * a contributor reordering the enum in this repository must not silently break decoding
+ * downstream.
+ *
+ * Add a new arm: extend [DocumentRejectedKind] in passes-pdf-core, append a new code
+ * here, and update [encode] / [decode]. [RejectedKindWireSurfaceTest] fails closed if
+ * the mapping table drifts from the enum; that gates the change behind a structural
+ * test rather than a code-review judgement call.
+ */
+internal object RejectedKindWire {
+    const val OVERSIZED_AT_IMPORT: Int = 0
+    const val NOT_A_PDF: Int = 1
+    const val ENCRYPTED: Int = 2
+    const val TOO_MANY_PAGES: Int = 3
+    const val RENDERER_FAILED: Int = 4
+
+    fun encode(kind: DocumentRejectedKind): Int =
+        when (kind) {
+            DocumentRejectedKind.OversizedAtImport -> OVERSIZED_AT_IMPORT
+            DocumentRejectedKind.NotAPdf -> NOT_A_PDF
+            DocumentRejectedKind.Encrypted -> ENCRYPTED
+            DocumentRejectedKind.TooManyPages -> TOO_MANY_PAGES
+            DocumentRejectedKind.RendererFailed -> RENDERER_FAILED
+        }
+
+    fun decode(code: Int): DocumentRejectedKind =
+        when (code) {
+            OVERSIZED_AT_IMPORT -> DocumentRejectedKind.OversizedAtImport
+            NOT_A_PDF -> DocumentRejectedKind.NotAPdf
+            ENCRYPTED -> DocumentRejectedKind.Encrypted
+            TOO_MANY_PAGES -> DocumentRejectedKind.TooManyPages
+            RENDERER_FAILED -> DocumentRejectedKind.RendererFailed
+            else -> error("Unknown DocumentRejectedKind wire code: $code")
+        }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -1,0 +1,134 @@
+package `is`.walt.passes.pdf.android
+
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Round-trip coverage for the binder wire format: a real [PdfRendererBinderProxy]
+ * wrapping a fake [PdfRendererBinder] is bound to a [PdfRendererClient], and every
+ * arm of every reply shape is exercised through `Binder.transact -> onTransact`.
+ *
+ * Why JVM (Robolectric) rather than instrumented? The wire-format coupling between
+ * the proxy and the client is the load-bearing piece for `./gradlew check`. Pinning
+ * field-order on both sides at unit-test time means a contributor reordering writes
+ * in [PdfRendererBinderProxy] cannot ship without flipping a green local build red.
+ * The on-device tests in [PdfRendererServiceInstrumentedTest] cover the parts this
+ * test cannot — the actual PDFium decoder, the actual isolated-process binder, the
+ * actual cross-process SharedMemory handoff.
+ *
+ * Same-process [Binder.transact] is documented to dispatch to [onTransact]
+ * synchronously and reset parcel positions; the parcels themselves are written and
+ * read with the production paths, so wire-shape regressions surface here.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class PdfRendererBinderRoundTripTest {
+    private lateinit var pipeRead: ParcelFileDescriptor
+    private lateinit var pipeWrite: ParcelFileDescriptor
+
+    @Before
+    fun openPipe() {
+        // Use a real pipe rather than ParcelFileDescriptor.adoptFd: a pipe gives us a
+        // closeable, parcellable PFD without touching the JVM cwd or filesystem.
+        val pipe = ParcelFileDescriptor.createPipe()
+        pipeRead = pipe[0]
+        pipeWrite = pipe[1]
+    }
+
+    @After
+    fun closePipe() {
+        runCatching { pipeRead.close() }
+        runCatching { pipeWrite.close() }
+    }
+
+    @Test
+    fun probeOkRoundTripCarriesPageCount() = runTest {
+        val client = clientFor(StaticImpl(probeResult = ProbeResult.Ok(pageCount = 7)))
+        val result = client.probe(pipeRead)
+        assertThat(result).isEqualTo(ProbeResult.Ok(7))
+    }
+
+    @Test
+    fun probeRejectedRoundTripCarriesEachKind() = runTest {
+        for (kind in DocumentRejectedKind.entries) {
+            val client = clientFor(StaticImpl(probeResult = ProbeResult.Rejected(kind)))
+            val result = client.probe(pipeRead)
+            assertThat(result).isEqualTo(ProbeResult.Rejected(kind))
+        }
+    }
+
+    @Test
+    fun renderOkRoundTripCarriesSharedMemoryAndDimensions() = runTest {
+        val sm = SharedMemory.create("walt-test-render", PIXEL_BYTES)
+        val client = clientFor(
+            StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX)),
+        )
+        val result = client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
+        assertThat(result).isInstanceOf(RenderResult.Ok::class.java)
+        val ok = result as RenderResult.Ok
+        // SharedMemory parcelling produces a fresh handle on the receiver side; size is
+        // the stable property we can compare across the marshall boundary. Width/height
+        // are written *after* SharedMemory in the wire format, so checking them
+        // double-checks the field order: any swap in PdfRendererBinderProxy.handleRender
+        // would surface as the wrong int landing in widthPx vs heightPx (or worse,
+        // landing in the SharedMemory parcel reader).
+        assertThat(ok.sharedMemory.size).isEqualTo(PIXEL_BYTES)
+        assertThat(ok.widthPx).isEqualTo(WIDTH_PX)
+        assertThat(ok.heightPx).isEqualTo(HEIGHT_PX)
+        // Intentionally not calling close() on the SharedMemory handles: Robolectric's
+        // FileDescriptor interceptor cannot manipulate raw fd internals under JDK 17
+        // (the reflective access path is blocked). The test process exits and reclaims
+        // the descriptor regardless; the CloseGuard log line that surfaces is a
+        // Robolectric-side artefact, not a leak in production code.
+    }
+
+    @Test
+    fun renderRejectedRoundTripCarriesEachKind() = runTest {
+        for (kind in DocumentRejectedKind.entries) {
+            val client = clientFor(StaticImpl(renderResult = RenderResult.Rejected(kind)))
+            val result = client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
+            assertThat(result).isEqualTo(RenderResult.Rejected(kind))
+        }
+    }
+
+    @Test
+    fun probeAndRenderUseDistinctTransactionCodes() {
+        // Pin the codes from the consumer's vantage: a contributor flipping
+        // CODE_PROBE / CODE_RENDER would silently swap probe and render on the wire.
+        assertThat(PdfRendererBinderProxy.CODE_PROBE)
+            .isNotEqualTo(PdfRendererBinderProxy.CODE_RENDER)
+    }
+
+    private fun clientFor(impl: PdfRendererBinder): PdfRendererClient =
+        PdfRendererClient(PdfRendererBinderProxy(impl))
+
+    private class StaticImpl(
+        private val probeResult: ProbeResult = ProbeResult.Rejected(DocumentRejectedKind.RendererFailed),
+        private val renderResult: RenderResult = RenderResult.Rejected(DocumentRejectedKind.RendererFailed),
+    ) : PdfRendererBinder {
+        override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult = probeResult
+
+        override suspend fun render(
+            pdf: ParcelFileDescriptor,
+            page: Int,
+            widthPx: Int,
+            heightPx: Int,
+        ): RenderResult = renderResult
+    }
+
+    private companion object {
+        const val WIDTH_PX = 32
+        const val HEIGHT_PX = 16
+        const val BYTES_PER_PIXEL = 4
+        const val PIXEL_BYTES = WIDTH_PX * HEIGHT_PX * BYTES_PER_PIXEL
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -1,6 +1,10 @@
 package `is`.walt.passes.pdf.android
 
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
 import android.os.ParcelFileDescriptor
+import android.os.RemoteException
 import android.os.SharedMemory
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -101,6 +105,26 @@ class PdfRendererBinderRoundTripTest {
     }
 
     @Test
+    fun probeFoldsRemoteExceptionIntoRendererFailed() = runTest {
+        // RenderWatchdog.guard kills the renderer process on timeout; the main process
+        // observes the dropped binder as a RemoteException from `transact`. The
+        // watchdog's KDoc explicitly promises consumers see RendererFailed; this test
+        // is where that promise is honoured for the probe path.
+        val client = PdfRendererClient(DeadBinder())
+        val result = client.probe(pipeRead)
+        assertThat(result).isEqualTo(ProbeResult.Rejected(DocumentRejectedKind.RendererFailed))
+    }
+
+    @Test
+    fun renderFoldsRemoteExceptionIntoRendererFailed() = runTest {
+        // Same contract as probe; the render path is the more common watchdog target
+        // (probe is bounded by page-count, render is bounded by render time).
+        val client = PdfRendererClient(DeadBinder())
+        val result = client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
+        assertThat(result).isEqualTo(RenderResult.Rejected(DocumentRejectedKind.RendererFailed))
+    }
+
+    @Test
     fun transactionCodesArePinnedToTheirDocumentedValues() {
         // Pin the absolute codes, not just their distinctness: a contributor flipping
         // the +1 direction (or rebasing CODE_PROBE off a different IBinder constant)
@@ -113,6 +137,20 @@ class PdfRendererBinderRoundTripTest {
 
     private fun clientFor(impl: PdfRendererBinder): PdfRendererClient =
         PdfRendererClient(PdfRendererBinderProxy(impl))
+
+    /**
+     * Stand-in for an [IBinder] whose remote process is gone: every transact throws
+     * [RemoteException]. Same shape the consumer would observe after `RenderWatchdog`
+     * kills the isolated renderer.
+     */
+    private class DeadBinder : Binder() {
+        override fun onTransact(
+            code: Int,
+            data: Parcel,
+            reply: Parcel?,
+            flags: Int,
+        ): Boolean = throw RemoteException("simulated watchdog kill")
+    }
 
     private class StaticImpl(
         private val probeResult: ProbeResult = ProbeResult.Rejected(DocumentRejectedKind.RendererFailed),

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -125,6 +125,25 @@ class PdfRendererBinderRoundTripTest {
     }
 
     @Test
+    fun probeFoldsTransactFalseIntoRendererFailed() = runTest {
+        // Binder.transact returns the boolean from onTransact. The proxy returns false
+        // when it cannot read a PFD out of the request parcel — at which point the
+        // reply was never written. Decoding an empty reply parcel as TAG_OK (an empty
+        // parcel reads 0, which is TAG_OK) would surface a phantom ProbeResult.Ok(0);
+        // the client must instead translate the false return into RendererFailed.
+        val client = PdfRendererClient(RejectingBinder())
+        val result = client.probe(pipeRead)
+        assertThat(result).isEqualTo(ProbeResult.Rejected(DocumentRejectedKind.RendererFailed))
+    }
+
+    @Test
+    fun renderFoldsTransactFalseIntoRendererFailed() = runTest {
+        val client = PdfRendererClient(RejectingBinder())
+        val result = client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
+        assertThat(result).isEqualTo(RenderResult.Rejected(DocumentRejectedKind.RendererFailed))
+    }
+
+    @Test
     fun transactionCodesArePinnedToTheirDocumentedValues() {
         // Pin the absolute codes, not just their distinctness: a contributor flipping
         // the +1 direction (or rebasing CODE_PROBE off a different IBinder constant)
@@ -150,6 +169,21 @@ class PdfRendererBinderRoundTripTest {
             reply: Parcel?,
             flags: Int,
         ): Boolean = throw RemoteException("simulated watchdog kill")
+    }
+
+    /**
+     * Stand-in for the proxy's "couldn't read the request parcel" path: onTransact
+     * returns false without writing to reply, so [IBinder.transact] also returns false
+     * and the reply parcel is empty. The client must translate that into
+     * RendererFailed rather than decoding an empty parcel.
+     */
+    private class RejectingBinder : Binder() {
+        override fun onTransact(
+            code: Int,
+            data: Parcel,
+            reply: Parcel?,
+            flags: Int,
+        ): Boolean = false
     }
 
     private class StaticImpl(

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -101,11 +101,14 @@ class PdfRendererBinderRoundTripTest {
     }
 
     @Test
-    fun probeAndRenderUseDistinctTransactionCodes() {
-        // Pin the codes from the consumer's vantage: a contributor flipping
-        // CODE_PROBE / CODE_RENDER would silently swap probe and render on the wire.
+    fun transactionCodesArePinnedToTheirDocumentedValues() {
+        // Pin the absolute codes, not just their distinctness: a contributor flipping
+        // the +1 direction (or rebasing CODE_PROBE off a different IBinder constant)
+        // would silently swap probe and render on the wire.
         assertThat(PdfRendererBinderProxy.CODE_PROBE)
-            .isNotEqualTo(PdfRendererBinderProxy.CODE_RENDER)
+            .isEqualTo(android.os.IBinder.FIRST_CALL_TRANSACTION)
+        assertThat(PdfRendererBinderProxy.CODE_RENDER)
+            .isEqualTo(android.os.IBinder.FIRST_CALL_TRANSACTION + 1)
     }
 
     private fun clientFor(impl: PdfRendererBinder): PdfRendererClient =

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
@@ -18,10 +18,17 @@ import org.junit.Test
 class PdfRendererClientSurfaceTest {
     @Test
     fun clientHasExactlyProbeAndRender() {
+        // Filter synthetics: Kotlin generates `access$<field>$p` accessors when an
+        // anonymous lambda (e.g. the body of `withContext { ... }`) closes over a
+        // private property. Those are not part of the public surface — they are JVM
+        // visibility plumbing — and conflating them with author-written methods would
+        // make this test fragile to refactors that have nothing to do with the
+        // extraction-surface trust claim.
         val methodNames =
             PdfRendererClient::class
                 .java
                 .declaredMethods
+                .filterNot { it.isSynthetic }
                 .map { it.name }
                 .toSet()
         assertThat(methodNames).containsExactly("probe", "render")
@@ -31,23 +38,5 @@ class PdfRendererClientSurfaceTest {
     fun clientImplementsBinderContract() {
         val interfaces = PdfRendererClient::class.java.interfaces.map { it.name }.toSet()
         assertThat(interfaces).contains(PdfRendererBinder::class.java.name)
-    }
-
-    @Test
-    fun clientHasNoExtractionSurface() {
-        val forbidden =
-            setOf(
-                "getText",
-                "getMetadata",
-                "getAnnotations",
-                "getAttachments",
-                "getFormFields",
-                "extractText",
-                "extractMetadata",
-                "text",
-                "metadata",
-            )
-        val methodNames = PdfRendererClient::class.java.declaredMethods.map { it.name }.toSet()
-        assertThat(methodNames.intersect(forbidden)).isEmpty()
     }
 }

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
@@ -2,6 +2,7 @@ package `is`.walt.passes.pdf.android
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.lang.reflect.Modifier
 
 /**
  * Locks the public surface of [PdfRendererClient] to the exact [PdfRendererBinder]
@@ -18,16 +19,19 @@ import org.junit.Test
 class PdfRendererClientSurfaceTest {
     @Test
     fun clientHasExactlyProbeAndRender() {
-        // Filter synthetics: Kotlin generates `access$<field>$p` accessors when an
-        // anonymous lambda (e.g. the body of `withContext { ... }`) closes over a
-        // private property. Those are not part of the public surface — they are JVM
-        // visibility plumbing — and conflating them with author-written methods would
-        // make this test fragile to refactors that have nothing to do with the
-        // extraction-surface trust claim.
+        // Restrict to the *callable* surface: public, non-synthetic methods. Private
+        // helpers (e.g. a Parcel-decoding utility) are implementation details of the
+        // contract this test pins, not extensions of the contract itself; a contributor
+        // adding a `getText` passthrough would have to make it public to be useful as
+        // an extraction backdoor, so the trust claim is preserved by checking only the
+        // public surface. Synthetics are filtered for the same reason — Kotlin's
+        // `access$<field>$p` accessor (generated when a lambda closes over a private
+        // property) is JVM visibility plumbing, not author surface.
         val methodNames =
             PdfRendererClient::class
                 .java
                 .declaredMethods
+                .filter { Modifier.isPublic(it.modifiers) }
                 .filterNot { it.isSynthetic }
                 .map { it.name }
                 .toSet()

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererClientSurfaceTest.kt
@@ -1,0 +1,53 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Locks the public surface of [PdfRendererClient] to the exact [PdfRendererBinder]
+ * contract. The interface-level lock in [PublicApiSurfaceTest] is the central trust
+ * claim of ADR 0005 D4 (no extraction); this test is its companion at the *class* level
+ * so a contributor cannot quietly grow the client with a passthrough helper
+ * (`getText(pfd)`, `extract(pfd)`, etc) that does not appear on the interface and
+ * therefore would not have tripped the interface surface test.
+ *
+ * Allowlist over denylist for the same reason as the interface test: a denylist test
+ * leaks past synonyms (`extractText`, `text`, `documentText`); allowlisting the
+ * exactly-two-methods-by-name closes the gap structurally.
+ */
+class PdfRendererClientSurfaceTest {
+    @Test
+    fun clientHasExactlyProbeAndRender() {
+        val methodNames =
+            PdfRendererClient::class
+                .java
+                .declaredMethods
+                .map { it.name }
+                .toSet()
+        assertThat(methodNames).containsExactly("probe", "render")
+    }
+
+    @Test
+    fun clientImplementsBinderContract() {
+        val interfaces = PdfRendererClient::class.java.interfaces.map { it.name }.toSet()
+        assertThat(interfaces).contains(PdfRendererBinder::class.java.name)
+    }
+
+    @Test
+    fun clientHasNoExtractionSurface() {
+        val forbidden =
+            setOf(
+                "getText",
+                "getMetadata",
+                "getAnnotations",
+                "getAttachments",
+                "getFormFields",
+                "extractText",
+                "extractMetadata",
+                "text",
+                "metadata",
+            )
+        val methodNames = PdfRendererClient::class.java.declaredMethods.map { it.name }.toSet()
+        assertThat(methodNames.intersect(forbidden)).isEmpty()
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
@@ -31,24 +31,6 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun binderHasNoExtractionSurface() {
-        val forbidden =
-            setOf(
-                "getText",
-                "getMetadata",
-                "getAnnotations",
-                "getAttachments",
-                "getFormFields",
-                "extractText",
-                "extractMetadata",
-                "text",
-                "metadata",
-            )
-        val methodNames = PdfRendererBinder::class.java.declaredMethods.map { it.name }.toSet()
-        assertThat(methodNames.intersect(forbidden)).isEmpty()
-    }
-
-    @Test
     fun probeReturnsProbeResult() {
         val probe = PdfRendererBinder::class.java.declaredMethods.single { it.name == "probe" }
         // suspend fun returns Object (the Continuation pattern). The structural property

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
@@ -1,0 +1,74 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import org.junit.Test
+
+/**
+ * Pins the binder-wire encoding of [DocumentRejectedKind] to its explicit code table.
+ *
+ * The wire format used to be `kind.ordinal`. That left every consumer of this binder
+ * (eventually walt-android, post-`wlt-4pg`) coupled to the source-order of the enum: a
+ * benign-looking refactor in `passes-pdf-core` that reorders or inserts an arm would
+ * have shifted every code on the wire and silently mis-decoded rejections. Today the
+ * proxy and client live in the same process from the same build, so the on-the-wire
+ * fragility is latent rather than active — but the kernel-vs-consumer coupling is real,
+ * and this test is the structural gate that keeps the mapping honest.
+ *
+ * Allowlist by explicit pair (mirrors `PublicApiSurfaceTest` in `passes-pdf-core`): the
+ * exhaustive `when` in [RejectedKindWire.encode] ensures every enum arm has a code, and
+ * this test ensures the codes are the documented ones. Adding an arm requires touching
+ * the enum, the mapping table, and this test in lockstep.
+ */
+class RejectedKindWireSurfaceTest {
+    @Test
+    fun encodeMapsEachArmToItsDocumentedCode() {
+        val expected =
+            mapOf(
+                DocumentRejectedKind.OversizedAtImport to RejectedKindWire.OVERSIZED_AT_IMPORT,
+                DocumentRejectedKind.NotAPdf to RejectedKindWire.NOT_A_PDF,
+                DocumentRejectedKind.Encrypted to RejectedKindWire.ENCRYPTED,
+                DocumentRejectedKind.TooManyPages to RejectedKindWire.TOO_MANY_PAGES,
+                DocumentRejectedKind.RendererFailed to RejectedKindWire.RENDERER_FAILED,
+            )
+        for ((kind, code) in expected) {
+            assertThat(RejectedKindWire.encode(kind)).isEqualTo(code)
+        }
+        // Drift detection: every enum arm must have a documented code in the table
+        // above. If a new arm is added without updating this test, the assertion below
+        // catches the gap.
+        assertThat(expected.keys).containsExactlyElementsIn(DocumentRejectedKind.entries)
+    }
+
+    @Test
+    fun decodeIsInverseOfEncode() {
+        for (kind in DocumentRejectedKind.entries) {
+            assertThat(RejectedKindWire.decode(RejectedKindWire.encode(kind))).isEqualTo(kind)
+        }
+    }
+
+    @Test
+    fun codesAreStableIntegers() {
+        // Pin the actual integer values. A contributor reordering the constants in
+        // RejectedKindWire would silently shift the wire even with the encode `when` in
+        // place; this test catches that.
+        assertThat(RejectedKindWire.OVERSIZED_AT_IMPORT).isEqualTo(0)
+        assertThat(RejectedKindWire.NOT_A_PDF).isEqualTo(1)
+        assertThat(RejectedKindWire.ENCRYPTED).isEqualTo(2)
+        assertThat(RejectedKindWire.TOO_MANY_PAGES).isEqualTo(3)
+        assertThat(RejectedKindWire.RENDERER_FAILED).isEqualTo(4)
+    }
+
+    @Test
+    fun codesAreUnique() {
+        val codes =
+            DocumentRejectedKind.entries.map(RejectedKindWire::encode)
+        assertThat(codes.toSet()).hasSize(codes.size)
+    }
+
+    @Test
+    fun decodeRejectsUnknownCode() {
+        runCatching { RejectedKindWire.decode(99) }
+            .onSuccess { error("Expected decode(99) to throw, got $it") }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `PdfRendererClient`, the consumer-facing counterpart to `PdfRendererBinderProxy` that wraps a bound `IBinder` and exposes the same suspend `probe` / `render` contract as `PdfRendererBinder`. Implements the interface so the existing surface lock covers it; `PdfRendererClientSurfaceTest` adds a class-level allowlist so a contributor cannot bypass the trust contract with a non-overriding helper.
- Replaces the wire's `DocumentRejectedKind.ordinal` encoding with an explicit `RejectedKindWire` Int <-> kind mapping. The previous encoding silently coupled the wire to source-order of the enum in `passes-pdf-core`; reordering an arm would have shifted every code without a compile error. `RejectedKindWireSurfaceTest` fails closed if the table drifts from the enum, and a wire-format coupling note on the enum makes the constraint visible to future reviewers.
- Adds `PdfRendererBinderRoundTripTest`, a Robolectric round-trip that binds a real `PdfRendererBinderProxy` (over a fake impl) to the new client and exercises probe-ok / probe-rejected (each kind) / render-ok / render-rejected (each kind) through `Binder.transact` with real `Parcel`, `ParcelFileDescriptor`, and `SharedMemory`. Wire-shape regressions on either side now surface under `./gradlew check` rather than waiting for on-device CI. The `@Ignore`'d instrumented suite continues to cover what JVM cannot — the actual PDFium decoder and cross-process binder.

Unblocks `wpass-7wn` (passes-ui DocumentView) and `wlt-4pg` (walt-android-side wiring), which are the consumers of this client.

## Test plan

- [x] `./gradlew check` (all modules green, includes 22 unit tests in `:passes-pdf:testDebugUnitTest`)
- [x] `RejectedKindWireSurfaceTest` pins each Int <-> kind pair, rejects unknown codes, and asserts arm-set parity with `DocumentRejectedKind.entries`
- [x] `PdfRendererClientSurfaceTest` allowlists exactly `probe` + `render` and asserts the client implements `PdfRendererBinder`
- [x] `PdfRendererBinderRoundTripTest` covers all 5 rejection arms × {probe, render} plus probe-ok and render-ok paths
- [ ] Instrumented `PdfRendererServiceInstrumentedTest` remains `@Ignore`'d pending the on-device fixture set + CI wiring (separate follow-up; same scope as `wpass-5v9`)