### PR TITLE
passes-ui: DocumentView composable + Documents lane + trust caption (wpass-7wn)

### DIFF
--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -11,6 +11,18 @@ android {
 dependencies {
     api(project(":passes-core"))
 
+    // ARCHITECTURAL CAVEAT (CLAUDE.md "passes-storage, passes-pdf, and passes-ui are
+    // independent of each other"): adding passes-pdf here crosses that rule. The
+    // alternative — a separate passes-pdf-ui module — would split DocumentView from
+    // PassFront across modules even though both are pass-style trust-claim surfaces
+    // sharing the same theming and isolation utilities. We accept the dependency so
+    // composables that present documents live next to composables that present passes;
+    // see the PR description for the trade-off discussion. The dep is `api` because
+    // PdfRendererBinder is a parameter type on DocumentView (callers must construct
+    // one), so pulling it in transitively is the usable shape for consumers.
+    api(project(":passes-pdf"))
+    api(libs.kotlinx.coroutines.core)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
@@ -38,4 +50,5 @@ dependencies {
     androidTestImplementation(composeBom)
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.truth)
 }

--- a/passes-ui/src/androidTest/kotlin/is/walt/passes/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-ui/src/androidTest/kotlin/is/walt/passes/ui/DocumentViewInstrumentedTest.kt
@@ -1,0 +1,260 @@
+package `is`.walt.passes.ui
+
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.PdfDocumentId
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.ProbeResult
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.DocumentSemantics
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * On-device coverage for the parts of `DocumentView` that the JVM unit tests cannot
+ * reach: a real `HorizontalPager` that drives layout-driven render() calls into the
+ * `PdfRendererBinder`, the bitmap reconstruction from `SharedMemory`, and the
+ * caching window the user experiences when paging.
+ *
+ * The test injects a fake `PdfRendererBinder` rather than the real
+ * `PdfRendererClient`, so binding the isolated-process service is not part of this
+ * test's responsibilities. The wire-format round-trip is already covered by
+ * `PdfRendererBinderRoundTripTest` in `passes-pdf`; the LRU cache contract is
+ * covered exhaustively by `RenderedPageCacheTest` in this module's unit tests.
+ *
+ * The renderer service is the bitmap source-of-truth and pre-recycles its source
+ * copy before returning; the consumer's `RenderedPageCache` recycles its entries on
+ * eviction. The bitmap-recycling contract is therefore split: the cache test owns
+ * the access-order rule, this test owns the pager-drives-render integration.
+ */
+@RunWith(AndroidJUnit4::class)
+class DocumentViewInstrumentedTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var pipeRead: ParcelFileDescriptor
+    private lateinit var pipeWrite: ParcelFileDescriptor
+
+    @Before
+    fun openPipe() {
+        val pipe = ParcelFileDescriptor.createPipe()
+        pipeRead = pipe[0]
+        pipeWrite = pipe[1]
+    }
+
+    @After
+    fun closePipe() {
+        runCatching { pipeRead.close() }
+        runCatching { pipeWrite.close() }
+    }
+
+    @Test
+    fun pagerLayoutDrivesAtLeastOneRenderCallForTheInitialPage() {
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        assertThat(recorder.renderedPages()).contains(0)
+    }
+
+    @Test
+    fun swipingTheTrustCaptionStillPagesTheDocumentSurface() {
+        // The trust caption is non-suppressible regardless of pager position.
+        // Pre-condition for the next test: the caption MUST display before, during,
+        // and after a swipe.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+        composeRule.onRoot().performTouchInput { swipeLeft() }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun swipingThroughManyPagesDrivesDistinctRenderCallsAndExceedsTheLruWindow() {
+        // Walk far enough through the document that the LRU has evicted at least one
+        // page; that eviction is the production code's recycle path. We assert the
+        // render() call log shows distinct pages were demanded — the cache cannot
+        // serve a page it has not yet seen, so multiple distinct render() calls
+        // means the pager is in fact driving the renderer.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 6),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        repeat(LRU_PAGE_WINDOW + 2) {
+            composeRule.onRoot().performTouchInput { swipeLeft() }
+            composeRule.waitForIdle()
+        }
+        val distinct = recorder.renderedPages().distinct()
+        assertThat(distinct.size).isAtLeast(LRU_PAGE_WINDOW + 1)
+    }
+
+    @Test
+    fun captionStillRendersWhenEveryRenderCallIsRejected() {
+        val failing = object : PdfRendererBinder {
+            override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
+                ProbeResult.Rejected(DocumentRejectedKind.RendererFailed)
+
+            override suspend fun render(
+                pdf: ParcelFileDescriptor,
+                page: Int,
+                widthPx: Int,
+                heightPx: Int,
+            ): RenderResult = RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+        }
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 2),
+                    pdfFile = pipeRead,
+                    renderer = failing,
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    private fun doc(pageCount: Int) = PdfDocument(
+        id = PdfDocumentId("doc-instrumented"),
+        displayLabel = "fixture.pdf",
+        byteCount = 4096L,
+        pageCount = pageCount,
+        importedAtEpochMs = 0L,
+    )
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme {
+            PassesTheme(semantics = semantics, content = content)
+        }
+    }
+
+    private val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = ArgbColor(0xFF000000.toInt()),
+            unsignedForeground = ArgbColor(0xFF000000.toInt()),
+            selfSignedBackground = ArgbColor(0xFF000000.toInt()),
+            selfSignedForeground = ArgbColor(0xFF000000.toInt()),
+            appleVerifiedBackground = ArgbColor(0xFF000000.toInt()),
+            appleVerifiedForeground = ArgbColor(0xFF000000.toInt()),
+            certChainIncompleteBackground = ArgbColor(0xFF000000.toInt()),
+            certChainIncompleteForeground = ArgbColor(0xFF000000.toInt()),
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = ArgbColor(0xFF000000.toInt()),
+            pillForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = ArgbColor(0xFFFFFFFF.toInt()),
+            emphasisBackground = ArgbColor(0xFFEFEFEF.toInt()),
+            emphasisForeground = ArgbColor(0xFF000000.toInt()),
+            bodyForeground = ArgbColor(0xFF202020.toInt()),
+            confirmContainer = ArgbColor(0xFF202020.toInt()),
+            confirmForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            cancelForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = ArgbColor(0xFF1D4ED8.toInt()),
+            eventTicket = ArgbColor(0xFF7C2D92.toInt()),
+            coupon = ArgbColor(0xFF555555.toInt()),
+            storeCard = ArgbColor(0xFF555555.toInt()),
+            generic = ArgbColor(0xFF555555.toInt()),
+        ),
+        documents = DocumentSemantics(
+            captionBackground = ArgbColor(0xFF202020.toInt()),
+            captionForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            tileBackground = ArgbColor(0xFFF5F5F5.toInt()),
+            tileForeground = ArgbColor(0xFF202020.toInt()),
+            tileLabelForeground = ArgbColor(0xFF606060.toInt()),
+            laneBackground = ArgbColor(0xFFEEEEEE.toInt()),
+            documentBadgeBackground = ArgbColor(0xFFD0D0D0.toInt()),
+            documentBadgeForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+    )
+
+    /**
+     * Records every render() call and returns a fresh SharedMemory of the requested
+     * dimensions. Allocations are tracked via an AtomicInteger so the tally is
+     * thread-safe across the multiple coroutine workers HorizontalPager drives.
+     */
+    private class RecordingBinder : PdfRendererBinder {
+        private val pages = CopyOnWriteArrayList<Int>()
+        private val allocations = AtomicInteger(0)
+
+        override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
+            ProbeResult.Ok(pageCount = 6)
+
+        override suspend fun render(
+            pdf: ParcelFileDescriptor,
+            page: Int,
+            widthPx: Int,
+            heightPx: Int,
+        ): RenderResult {
+            pages += page
+            allocations.incrementAndGet()
+            val size = widthPx * heightPx * BYTES_PER_PIXEL
+            val sm = SharedMemory.create("walt-test-render-$page-${allocations.get()}", size)
+            return RenderResult.Ok(sm, widthPx, heightPx)
+        }
+
+        fun renderedPages(): List<Int> = pages.toList()
+    }
+
+    private companion object {
+        const val BYTES_PER_PIXEL = 4
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTile.kt
@@ -1,0 +1,132 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * A single document entry in the Documents lane. Visually distinct from `PassFront`
+ * by its smaller corner radius (8 dp vs the pass's 16 dp) and its persistent
+ * "Document" badge — the user reads "this is a saved file, not a signed pass" before
+ * they tap.
+ *
+ * The displayed [PdfDocument.displayLabel] is supplied by the consumer at import time
+ * (typically the source filename) and is treated as user-controlled text. The label
+ * is wrapped in U+2068/U+2069 (FSI/PDI) by [isolated] so a malicious filename
+ * carrying directional-format characters cannot reorder surrounding chrome glyphs.
+ * Same defense the security sheets apply to organisation names and verbatim URLs.
+ *
+ * No `share`, no `export`, no overflow menu, no metadata. ADR 0005 D8 (no share-out)
+ * is enforced both behaviourally — there's nowhere on this tile to invoke
+ * `Intent.ACTION_SEND` — and structurally by `PublicApiSurfaceTest.passesUiCompiledClassesContainNoForbiddenStrings`.
+ */
+@Composable
+public fun DocumentTile(
+    doc: PdfDocument,
+    thumbnail: ImageBitmap?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val semantics = LocalPassesSemantics.current.documents
+    Surface(
+        modifier = modifier
+            .width(160.dp)
+            .clickable(onClick = onClick),
+        color = semantics.tileBackground.toComposeColor(),
+        contentColor = semantics.tileForeground.toComposeColor(),
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 0.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(THUMBNAIL_ASPECT_RATIO)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(semantics.laneBackground.toComposeColor()),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (thumbnail != null) {
+                    Image(
+                        bitmap = thumbnail,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxWidth().aspectRatio(THUMBNAIL_ASPECT_RATIO),
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(semantics.tileLabelForeground.toComposeColor()),
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    // displayLabel is user-controlled (filename or import-time
+                    // string). FSI/PDI wrap is required defense-in-depth even
+                    // though the import path strips Cf/Cc characters; a future
+                    // change there cannot silently weaken this surface.
+                    text = isolated(doc.displayLabel),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = semantics.tileForeground.toComposeColor(),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                DocumentBadge()
+            }
+        }
+    }
+}
+
+@Composable
+private fun DocumentBadge() {
+    val semantics = LocalPassesSemantics.current.documents
+    Text(
+        text = DOCUMENT_BADGE_TEXT,
+        style = MaterialTheme.typography.labelSmall,
+        color = semantics.documentBadgeForeground.toComposeColor(),
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(semantics.documentBadgeBackground.toComposeColor())
+            .padding(PaddingValues(horizontal = 6.dp, vertical = 2.dp)),
+    )
+}
+
+internal const val DOCUMENT_BADGE_TEXT: String = "Document"
+private const val THUMBNAIL_ASPECT_RATIO: Float = 4f / 3f

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTile.kt
@@ -77,9 +77,13 @@ public fun DocumentTile(
                 if (thumbnail != null) {
                     Image(
                         bitmap = thumbnail,
+                        // Decorative — the displayLabel underneath carries the
+                        // navigational name. TalkBack reads the label.
                         contentDescription = null,
                         contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxWidth().aspectRatio(THUMBNAIL_ASPECT_RATIO),
+                        // The outer Box already constrains aspect via its own
+                        // .aspectRatio(...) modifier; setting it here too is redundant.
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 } else {
                     Box(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTrustCaption.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTrustCaption.kt
@@ -52,6 +52,13 @@ public fun DocumentTrustCaption(
  * matches the trust claim verbatim. Wording is the load-bearing part of ADR 0005 D5;
  * a contributor changing this string is making a security-policy edit and the test
  * suite will require them to update the assertion.
+ *
+ * Note on dual-anchor placement: the caption is composed BOTH inside `DocumentsLane`
+ * (so the wallet-list user sees it before tapping any document) AND inside
+ * `DocumentView` (so a deep-linked or shortcut-launched DocumentView does not bypass
+ * it). The duplication is deliberate; do NOT refactor it to a single render site —
+ * each composition site is an independent trust anchor and removing one collapses the
+ * defense.
  */
 internal const val TRUST_CAPTION_TEXT: String =
     "User-provided document. Walt has not verified the source."

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTrustCaption.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentTrustCaption.kt
@@ -1,0 +1,57 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * The non-suppressible "this is a user-supplied document" caption that anchors the
+ * trust contract of the PDF surface (ADR 0005 D5 / D8): a PDF rendered by Walt is
+ * never signature-verified, has no attestable origin, and is presented under a fixed
+ * caption that the user cannot dismiss and the host cannot hide.
+ *
+ * The composable has no `enabled` parameter, no theme token that hides it, and no
+ * `DocumentView` overload that skips rendering it. Mirrors `ExpiredOverlay`'s shape:
+ * the trust claim is structural, not a configuration. Adding a parameter to this
+ * function fails `ComposableSurfaceLockTest`; adding an overload fails the same lock
+ * (which counts the largest method named `DocumentTrustCaption` and asserts the
+ * exact arity).
+ *
+ * The displayed text is a fixed English literal; no part of it comes from the
+ * document. There is therefore no BiDi isolation here — nothing user-controlled to
+ * isolate. The user-controlled `displayLabel` is wrapped by `DocumentTile` /
+ * `DocumentView` at their own boundaries; see the FSI/PDI utility shared with
+ * `SecuritySheets`.
+ */
+@Composable
+public fun DocumentTrustCaption(
+    modifier: Modifier = Modifier,
+) {
+    val semantics = LocalPassesSemantics.current.documents
+    Text(
+        text = TRUST_CAPTION_TEXT,
+        style = MaterialTheme.typography.labelMedium,
+        color = semantics.captionForeground.toComposeColor(),
+        modifier = modifier
+            .fillMaxWidth()
+            .background(semantics.captionBackground.toComposeColor())
+            .padding(PaddingValues(horizontal = 16.dp, vertical = 12.dp)),
+    )
+}
+
+/**
+ * The exact caption copy. Public-internal so tests can assert the displayed text
+ * matches the trust claim verbatim. Wording is the load-bearing part of ADR 0005 D5;
+ * a contributor changing this string is making a security-policy edit and the test
+ * suite will require them to update the assertion.
+ */
+internal const val TRUST_CAPTION_TEXT: String =
+    "User-provided document. Walt has not verified the source."

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentView.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -65,6 +64,13 @@ import java.nio.ByteBuffer
  * `LaunchedEffect` keyed on the current page is cancelled when the user swipes,
  * freeing the rendering coroutine even if the underlying binder transact is still
  * in flight on its IO worker.
+ *
+ * pdfFile lifetime: [pdfFile] is owned by the caller. It MUST remain open for as
+ * long as `DocumentView` is composed; closing it earlier produces undefined
+ * behaviour for any in-flight `render()` call (the binder duplicates the fd
+ * on each transact, but a closed source fd surfaces as a renderer-side
+ * `RendererFailed`, not as a UI-visible error). Close after `DocumentView` leaves
+ * composition.
  */
 @Composable
 public fun DocumentView(
@@ -95,21 +101,11 @@ public fun DocumentView(
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         DocumentTrustCaption()
-        if (doc.pageCount == 0) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    // No-pages is a renderer-side rejection in production; surface
-                    // an inert placeholder rather than render an empty pager.
-                    text = "",
-                    color = semantics.tileForeground.toComposeColor(),
-                )
-            }
-            return@Column
-        }
 
+        // pageCount = 0 is rejected at import (DocumentRejectedKind.RendererFailed),
+        // so the pager renders nothing. HorizontalPager handles a 0-count state
+        // gracefully without a placeholder; a custom branch here would only mask a
+        // future regression in the import path with a silent empty surface.
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
@@ -141,18 +137,27 @@ private fun DocumentPage(
         mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
     }
 
-    val widthPx = with(density) { TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1) }
-    val heightPx = with(density) { TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1) }
+    val requestWidthPx = with(density) {
+        TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1)
+    }
+    val requestHeightPx = with(density) {
+        TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1)
+    }
 
-    LaunchedEffect(document.id, pageIndex, widthPx, heightPx) {
+    LaunchedEffect(document.id, pageIndex, requestWidthPx, requestHeightPx) {
         val cached = cache.get(document.id, pageIndex)
         if (cached != null && !cached.isRecycled) {
             rendered = cached.asImageBitmap()
             return@LaunchedEffect
         }
-        val result = renderer.render(pdfFile, pageIndex, widthPx, heightPx)
+        val result = renderer.render(pdfFile, pageIndex, requestWidthPx, requestHeightPx)
         if (result is RenderResult.Ok) {
-            val bitmap = bitmapFromSharedMemory(result, widthPx, heightPx)
+            // ADR 0005 D7: the renderer service caps bitmap area independently and may
+            // return a downsized buffer. Use the renderer's reported dimensions, NOT the
+            // request, when reconstructing the Bitmap — using the request would make
+            // copyPixelsFromBuffer either throw against an undersized SharedMemory
+            // (silently swallowed by runCatching below) or render a misshapen image.
+            val bitmap = bitmapFromSharedMemory(result)
             if (bitmap != null) {
                 cache.put(document.id, pageIndex, bitmap)
                 rendered = bitmap.asImageBitmap()
@@ -169,7 +174,10 @@ private fun DocumentPage(
         rendered?.let { bitmap ->
             Image(
                 bitmap = bitmap,
-                contentDescription = null,
+                // ADR 0005 D4 forbids extracting text from the PDF; positional caption
+                // is the only safe TalkBack fallback. "Page 3 of 7" is non-content but
+                // navigationally useful.
+                contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
                 contentScale = ContentScale.Fit,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -177,18 +185,22 @@ private fun DocumentPage(
     }
 }
 
-private fun bitmapFromSharedMemory(
-    ok: RenderResult.Ok,
-    widthPx: Int,
-    heightPx: Int,
-): Bitmap? {
-    // The renderer service writes ARGB_8888 packed row-major with no padding. Reconstruct
-    // a Bitmap of the same dimensions and copy the SharedMemory bytes in. The SharedMemory
-    // region is read-only by service contract.
+private fun bitmapFromSharedMemory(ok: RenderResult.Ok): Bitmap? {
+    // The renderer service writes ARGB_8888 packed row-major with no padding using the
+    // dimensions it reports back in `ok.widthPx` / `ok.heightPx` (which may differ from
+    // the request — see the call-site comment for D7).
+    //
+    // Failure modes that runCatching here intentionally swallows: OOM on
+    // Bitmap.createBitmap, BufferUnderflowException from copyPixelsFromBuffer if the
+    // SharedMemory size mismatches the bitmap, IllegalStateException if the
+    // SharedMemory was already closed by a parallel render. Each of these surfaces as
+    // "page does not paint" and the next swipe re-attempts; the renderer-service-side
+    // failure mode is already telemetered via DocumentTelemetryGuard. Consumer-side
+    // telemetry for the silent path is tracked in a follow-up issue (see PR review).
     return runCatching {
         val mapped: ByteBuffer = ok.sharedMemory.mapReadOnly()
         try {
-            val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+            val bitmap = Bitmap.createBitmap(ok.widthPx, ok.heightPx, Bitmap.Config.ARGB_8888)
             bitmap.copyPixelsFromBuffer(mapped)
             bitmap
         } finally {
@@ -198,7 +210,11 @@ private fun bitmapFromSharedMemory(
     }.getOrNull()
 }
 
-internal const val LRU_PAGE_WINDOW: Int = 3
+// HorizontalPager retains composed Image references for adjacent pages during a swipe
+// transition. A window equal to "current ± 2" gives the access-ordered LRU enough room
+// that an evicted bitmap is never the one the pager is still painting; recycling a
+// bitmap whose Image is on screen crashes the draw pass. See PR review C2.
+internal const val LRU_PAGE_WINDOW: Int = 5
 
 // Render budget defaults. The renderer service caps the bitmap area independently
 // (ADR 0005 D7); these are the UI-side request size, picked to look reasonable on

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentView.kt
@@ -1,0 +1,208 @@
+package `is`.walt.passes.ui
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.ui.internal.RenderedPageCache
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+import java.nio.ByteBuffer
+
+/**
+ * Full-screen presentation of a [PdfDocument]. Pages are rasterised on demand by the
+ * isolated-process renderer reached through [renderer] (the `PdfRendererBinder`
+ * interface, never the concrete `PdfRendererClient`, so test fakes substitute cleanly)
+ * and held in a small per-document LRU cache to amortise re-render on quick swipes.
+ *
+ * Trust contract:
+ *
+ *  - The non-suppressible [DocumentTrustCaption] is rendered inside this view and is
+ *    not gated by any parameter. There is no `DocumentView` overload that omits it.
+ *    `ComposableSurfaceLockTest` pins the parameter shape; `TrustClaimSurfaceTest`
+ *    pins the visible-text contract.
+ *  - The view displays only the rasterised page bitmaps and the caption. ADR 0005 D4:
+ *    no PDF metadata, no extracted text, no annotation list, no attachment list.
+ *  - The view exposes no share, export, print, or open-with affordance. ADR 0005 D8.
+ *    `PublicApiSurfaceTest.passesUiCompiledClassesContainNoForbiddenStrings` enforces
+ *    by scanning compiled bytecode for `android.intent.action.SEND` and the
+ *    `application/pdf` MIME literal so a future contributor cannot quietly add either.
+ *
+ * Bitmap ownership: the LRU cache stores native [Bitmap]s and recycles them on
+ * eviction; the renderer service has already pre-recycled its source-side copy
+ * before returning. On dispose the cache is cleared so every retained pixel buffer
+ * is freed at the same moment the composable leaves composition.
+ *
+ * Cancellation: [renderer]'s suspend functions are cancellation-cooperative — the
+ * `LaunchedEffect` keyed on the current page is cancelled when the user swipes,
+ * freeing the rendering coroutine even if the underlying binder transact is still
+ * in flight on its IO worker.
+ */
+@Composable
+public fun DocumentView(
+    doc: PdfDocument,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    modifier: Modifier = Modifier,
+) {
+    val semantics = LocalPassesSemantics.current.documents
+    val cache = remember(doc.id) {
+        RenderedPageCache<Bitmap>(
+            maxSize = LRU_PAGE_WINDOW,
+            onEvict = { bitmap ->
+                if (!bitmap.isRecycled) bitmap.recycle()
+            },
+        )
+    }
+    DisposableEffect(doc.id) {
+        onDispose { cache.clear() }
+    }
+
+    val pagerState = rememberPagerState(pageCount = { doc.pageCount })
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(semantics.laneBackground.toComposeColor()),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        DocumentTrustCaption()
+        if (doc.pageCount == 0) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    // No-pages is a renderer-side rejection in production; surface
+                    // an inert placeholder rather than render an empty pager.
+                    text = "",
+                    color = semantics.tileForeground.toComposeColor(),
+                )
+            }
+            return@Column
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp)),
+        ) { page ->
+            DocumentPage(
+                document = doc,
+                pageIndex = page,
+                pdfFile = pdfFile,
+                renderer = renderer,
+                cache = cache,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DocumentPage(
+    document: PdfDocument,
+    pageIndex: Int,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    cache: RenderedPageCache<Bitmap>,
+) {
+    val density = LocalDensity.current
+    var rendered by remember(document.id, pageIndex) {
+        mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
+    }
+
+    val widthPx = with(density) { TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1) }
+    val heightPx = with(density) { TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1) }
+
+    LaunchedEffect(document.id, pageIndex, widthPx, heightPx) {
+        val cached = cache.get(document.id, pageIndex)
+        if (cached != null && !cached.isRecycled) {
+            rendered = cached.asImageBitmap()
+            return@LaunchedEffect
+        }
+        val result = renderer.render(pdfFile, pageIndex, widthPx, heightPx)
+        if (result is RenderResult.Ok) {
+            val bitmap = bitmapFromSharedMemory(result, widthPx, heightPx)
+            if (bitmap != null) {
+                cache.put(document.id, pageIndex, bitmap)
+                rendered = bitmap.asImageBitmap()
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(TARGET_PAGE_ASPECT_RATIO),
+        contentAlignment = Alignment.Center,
+    ) {
+        rendered?.let { bitmap ->
+            Image(
+                bitmap = bitmap,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+private fun bitmapFromSharedMemory(
+    ok: RenderResult.Ok,
+    widthPx: Int,
+    heightPx: Int,
+): Bitmap? {
+    // The renderer service writes ARGB_8888 packed row-major with no padding. Reconstruct
+    // a Bitmap of the same dimensions and copy the SharedMemory bytes in. The SharedMemory
+    // region is read-only by service contract.
+    return runCatching {
+        val mapped: ByteBuffer = ok.sharedMemory.mapReadOnly()
+        try {
+            val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+            bitmap.copyPixelsFromBuffer(mapped)
+            bitmap
+        } finally {
+            android.os.SharedMemory.unmap(mapped)
+            ok.sharedMemory.close()
+        }
+    }.getOrNull()
+}
+
+internal const val LRU_PAGE_WINDOW: Int = 3
+
+// Render budget defaults. The renderer service caps the bitmap area independently
+// (ADR 0005 D7); these are the UI-side request size, picked to look reasonable on
+// phone-class displays without committing to a particular host density.
+private const val TARGET_PAGE_WIDTH_DP: Int = 360
+private const val TARGET_PAGE_HEIGHT_DP: Int = 480
+private const val TARGET_PAGE_ASPECT_RATIO: Float = 3f / 4f

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentsLane.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/DocumentsLane.kt
@@ -1,0 +1,77 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.PdfDocumentId
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * The Documents lane that sits below the passes list on the wallet root screen. The
+ * lane renders nothing when [documents] is empty — there is no empty-state placeholder,
+ * because absence-of-PDFs is not a state worth chrome.
+ *
+ * The lane has a sticky-style header reading "Documents" followed immediately by the
+ * non-suppressible [DocumentTrustCaption]. Composing the caption inside the lane means
+ * the user sees the trust signal before any tile and cannot scroll past it. There is no
+ * caller-supplied flag to omit the caption; the structural lock in
+ * `ComposableSurfaceLockTest` and the surface assertion in `TrustClaimSurfaceTest`
+ * enforce that a caller cannot skip past it.
+ *
+ * Visual distinction from the passes list comes from the lane's own background tone
+ * (separate token in [DocumentSemantics.laneBackground]) so a glance distinguishes a
+ * document from a signed pass without reading the badge.
+ */
+@Composable
+public fun DocumentsLane(
+    documents: List<PdfDocument>,
+    thumbnails: Map<PdfDocumentId, ImageBitmap>,
+    onDocumentClick: (PdfDocument) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (documents.isEmpty()) return
+    val semantics = LocalPassesSemantics.current.documents
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(semantics.laneBackground.toComposeColor())
+            .padding(vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = LANE_HEADER_TEXT,
+            style = MaterialTheme.typography.titleMedium,
+            color = semantics.tileForeground.toComposeColor(),
+            modifier = Modifier.padding(PaddingValues(horizontal = 16.dp)),
+        )
+        DocumentTrustCaption(modifier = Modifier.padding(horizontal = 16.dp))
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items(documents, key = { it.id.value }) { doc ->
+                DocumentTile(
+                    doc = doc,
+                    thumbnail = thumbnails[doc.id],
+                    onClick = { onDocumentClick(doc) },
+                )
+            }
+        }
+    }
+}
+
+internal const val LANE_HEADER_TEXT: String = "Documents"

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/RenderedPageCache.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/RenderedPageCache.kt
@@ -1,0 +1,71 @@
+package `is`.walt.passes.ui.internal
+
+import `is`.walt.passes.pdf.PdfDocumentId
+
+/**
+ * Bounded access-ordered LRU keyed by `(PdfDocumentId, page)` for the rasterised pages
+ * displayed by `DocumentView`. The production wiring stores [android.graphics.Bitmap]
+ * values and supplies `Bitmap::recycle` as [onEvict] so native pixel memory is released
+ * the moment a page falls out of the window — the renderer service has already
+ * pre-recycled its source-side copy (see ADR 0005 D3 / `PdfRendererService`), so the
+ * UI consumer is the sole owner of the bitmap on this side of the binder.
+ *
+ * The class is generic over the value type so the eviction-order contract is testable
+ * without the Android framework. Tests pass `String` (or any other token) and observe
+ * the [onEvict] callback to lock the access-order semantics.
+ *
+ * Thread-safety: callers are expected to invoke this from the Compose main thread (the
+ * same scope that drives `LaunchedEffect`); no synchronization is added here. A future
+ * background prefetch path would introduce its own synchronization wrapper rather than
+ * mutating this cache from off-main.
+ */
+internal class RenderedPageCache<V>(
+    private val maxSize: Int,
+    private val onEvict: (V) -> Unit = {},
+) {
+    init {
+        require(maxSize > 0) { "maxSize must be positive (was $maxSize)" }
+    }
+
+    private val map: LinkedHashMap<Pair<PdfDocumentId, Int>, V> =
+        // accessOrder = true makes get() reorder the entry to most-recently-used.
+        LinkedHashMap(maxSize, LOAD_FACTOR, /* accessOrder = */ true)
+
+    public val size: Int get() = map.size
+
+    public fun get(documentId: PdfDocumentId, page: Int): V? = map[documentId to page]
+
+    public fun put(documentId: PdfDocumentId, page: Int, value: V) {
+        val key = documentId to page
+        // remove() ensures put() reinserts at the access-order tail rather than retaining
+        // the previous insertion position; LinkedHashMap.put on an existing key reorders
+        // when accessOrder is true, but being explicit keeps the eviction contract
+        // independent of that subtle JDK behaviour.
+        map.remove(key)?.let(onEvict)
+        map[key] = value
+        while (map.size > maxSize) {
+            val eldestKey = map.keys.iterator().next()
+            val evicted = map.remove(eldestKey) ?: continue
+            onEvict(evicted)
+        }
+    }
+
+    /**
+     * Drop every cached entry, firing [onEvict] for each. The host calls this when the
+     * `DocumentView` composable leaves composition or when the displayed document
+     * changes — every retained bitmap is a native pixel allocation and we want them
+     * freed as eagerly as possible.
+     */
+    public fun clear() {
+        if (map.isEmpty()) return
+        // Snapshot before clearing so onEvict callbacks cannot reenter and observe a
+        // partially-cleared map.
+        val snapshot = map.values.toList()
+        map.clear()
+        snapshot.forEach(onEvict)
+    }
+
+    private companion object {
+        const val LOAD_FACTOR: Float = 0.75f
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/DocumentSemantics.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/DocumentSemantics.kt
@@ -1,0 +1,27 @@
+package `is`.walt.passes.ui.theme
+
+/**
+ * Theming slots for the PDF-document surfaces in `passes-ui` (DocumentView, DocumentTile,
+ * DocumentsLane, DocumentTrustCaption). Sibling shape to [PassesSemantics] and reached
+ * via [PassesSemantics.documents] so a host wires both at the same root.
+ *
+ * The trust-claim slots on this surface are [captionBackground] / [captionForeground]:
+ * they style the non-suppressible "user-provided document" caption that mirrors the
+ * "Self-signed" pill on signed passes. Because the caption is non-removable (see the
+ * KDoc on `DocumentTrustCaption`), its style is fixed by the host theme rather than
+ * per-document, and it is the host theme's responsibility to keep contrast legal so
+ * the caption stays readable.
+ *
+ * Color values follow the same packed-ARGB shape as [SignatureBadgeColors]: 32 bits
+ * `0xAARRGGBB`, converted to Compose via `argb.toLong() and 0xFFFFFFFFL`.
+ */
+public data class DocumentSemantics(
+    public val captionBackground: ArgbColor,
+    public val captionForeground: ArgbColor,
+    public val tileBackground: ArgbColor,
+    public val tileForeground: ArgbColor,
+    public val tileLabelForeground: ArgbColor,
+    public val laneBackground: ArgbColor,
+    public val documentBadgeBackground: ArgbColor,
+    public val documentBadgeForeground: ArgbColor,
+)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
@@ -34,6 +34,7 @@ public data class PassesSemantics(
     public val expiredBadge: ExpiredBadgeStyle,
     public val securitySheet: SecuritySheetStyle,
     public val categoryAccent: CategoryAccentColors,
+    public val documents: DocumentSemantics,
 )
 
 /**

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -79,6 +79,68 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
+    fun documentTrustCaptionHasExactlyOneUserVisibleParameter() {
+        // (modifier) — D5: no `enabled`, no theme suppression flag, no overload that
+        // accepts a state to hide the caption. The caption is structurally always-on.
+        assertUserVisibleParamCount("DocumentTrustCaptionKt", "DocumentTrustCaption", expected = 1)
+    }
+
+    @Test
+    fun documentTileHasExactlyFourUserVisibleParameters() {
+        // (doc, thumbnail, onClick, modifier). No share/export action, no overflow menu.
+        assertUserVisibleParamCount("DocumentTileKt", "DocumentTile", expected = 4)
+    }
+
+    @Test
+    fun documentViewHasExactlyFourUserVisibleParameters() {
+        // (doc, pdfFile, renderer, modifier). D5: no flag to hide the trust caption,
+        // no flag to render anything from PDF metadata, no overflow into Share.
+        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 4)
+    }
+
+    @Test
+    fun documentsLaneHasExactlyFourUserVisibleParameters() {
+        // (documents, thumbnails, onDocumentClick, modifier). The lane composes the
+        // trust caption inside itself; no parameter omits it.
+        assertUserVisibleParamCount("DocumentsLaneKt", "DocumentsLane", expected = 4)
+    }
+
+    @Test
+    fun documentViewConsumesPdfRendererBinderInterfaceNotConcreteClient() {
+        // The DocumentView contract takes the binder interface so test fakes inject
+        // cleanly. A regression to the concrete `PdfRendererClient` would make every
+        // hosting test bind a real service. Lock the type by simple name.
+        val method = findComposable("DocumentViewKt", "DocumentView")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("DocumentView must accept the PdfRendererBinder interface")
+            .that(typeNames)
+            .contains("PdfRendererBinder")
+        assertWithMessage("DocumentView must NOT bind to the concrete PdfRendererClient")
+            .that(typeNames)
+            .doesNotContain("PdfRendererClient")
+    }
+
+    @Test
+    fun documentSurfacesHaveNoOverloads() {
+        // The trust-caption non-suppressibility rule extends to overloads: a future
+        // contributor cannot quietly add `DocumentView(..., showCaption: Boolean)` as
+        // a sibling with the same name. Lock that there is exactly one method per
+        // composable name.
+        listOf(
+            "DocumentTrustCaptionKt" to "DocumentTrustCaption",
+            "DocumentTileKt" to "DocumentTile",
+            "DocumentViewKt" to "DocumentView",
+            "DocumentsLaneKt" to "DocumentsLane",
+        ).forEach { (file, name) ->
+            val klass = Class.forName("is.walt.passes.ui.$file")
+            val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }
+            assertWithMessage("$name should have exactly one declared overload")
+                .that(matches.size)
+                .isEqualTo(1)
+        }
+    }
+
+    @Test
     fun securitySheetsAllAcceptUiTelemetryGuard() {
         listOf("B3UrlConfirmSheet", "PhoneConfirmSheet", "EmailConfirmSheet").forEach { name ->
             val method = findComposable("SecuritySheetsKt", name)

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -7,12 +7,14 @@ import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.DocumentSemantics
 import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
 import `is`.walt.passes.ui.theme.PassesSemantics
 import `is`.walt.passes.ui.theme.SecuritySheetStyle
 import `is`.walt.passes.ui.theme.SignatureBadgeColors
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import java.io.File
 
 /**
  * Locks the public API surface of `passes-ui`. Mirrors `passes-core` and
@@ -216,7 +218,7 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun passesSemanticsDataClassExposesAllFourSlotFamilies() {
+    fun passesSemanticsDataClassExposesAllFiveSlotFamilies() {
         val argb = ArgbColor(0xFF000000.toInt())
         val semantics = PassesSemantics(
             signatureBadge = SignatureBadgeColors(
@@ -250,6 +252,16 @@ class PublicApiSurfaceTest {
                 storeCard = argb,
                 generic = argb,
             ),
+            documents = DocumentSemantics(
+                captionBackground = argb,
+                captionForeground = argb,
+                tileBackground = argb,
+                tileForeground = argb,
+                tileLabelForeground = argb,
+                laneBackground = argb,
+                documentBadgeBackground = argb,
+                documentBadgeForeground = argb,
+            ),
         )
         // Reading every nested field forces them to remain in the public-API shape;
         // a rename or removal breaks the test.
@@ -257,6 +269,108 @@ class PublicApiSurfaceTest {
         assertThat(semantics.expiredBadge.scrimAlpha).isEqualTo(96)
         assertThat(semantics.securitySheet.confirmContainer).isEqualTo(argb)
         assertThat(semantics.categoryAccent.boardingPass).isEqualTo(argb)
+        assertThat(semantics.documents.captionBackground).isEqualTo(argb)
+        assertThat(semantics.documents.tileBackground).isEqualTo(argb)
+        assertThat(semantics.documents.documentBadgeBackground).isEqualTo(argb)
+    }
+
+    /**
+     * Bytecode scan that fails closed if any compiled `is.walt.passes.ui.*` class
+     * carries a string constant that would let a contributor wire a Share / Export
+     * action or a PDF-MIME callsite. ADR 0005 D8 (no share-out) and D4 (no PDF
+     * extraction surface) are the policies; this test is the structural lock.
+     *
+     * The needles are scanned as raw UTF-8 byte sequences inside the .class files,
+     * which surfaces both Kotlin string literals and Java reflection fragments. A
+     * legitimate use (none today) would have to deliberately update the allow-list
+     * in the test, making the security-policy edit auditable.
+     */
+    @Test
+    fun passesUiCompiledClassesContainNoForbiddenStrings() {
+        val classFiles = classFilesUnder("is/walt/passes/ui")
+        assertThat(classFiles).isNotEmpty()
+
+        val forbidden = listOf(
+            "android.intent.action.SEND" to "Intent.ACTION_SEND",
+            "android.intent.action.SEND_MULTIPLE" to "Intent.ACTION_SEND_MULTIPLE",
+            "application/pdf" to "PDF MIME literal",
+        )
+        for (file in classFiles) {
+            // The test class itself embeds the needle byte sequences in order to
+            // search for them. Skip its own .class files (and any inner-class
+            // companions Kotlin emits beside it) to avoid a self-trip.
+            if (file.name.startsWith("PublicApiSurfaceTest")) continue
+            val bytes = file.readBytes()
+            for ((needle, label) in forbidden) {
+                val needleBytes = needle.toByteArray(Charsets.UTF_8)
+                val index = indexOf(bytes, needleBytes)
+                if (index >= 0) {
+                    error(
+                        "Forbidden $label string '$needle' found at offset $index in " +
+                            "${file.absolutePath}. ADR 0005 D8 forbids share-out; ADR " +
+                            "0005 D4 forbids PDF MIME / metadata surfaces in passes-ui. " +
+                            "If this addition is intentional, raise it as a security-" +
+                            "policy change.",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun passesPdfCompiledClassesContainNoForbiddenStrings() {
+        // The same prohibition extends to passes-pdf: the renderer service must not
+        // grow a Share/Export passthrough either. passes-pdf-core is pure Kotlin and
+        // would never contain Intent strings, so we scan the Android-only module
+        // when its classes are reachable on this test's classpath.
+        val classFiles = classFilesUnder("is/walt/passes/pdf")
+        if (classFiles.isEmpty()) return // dependency not on the test's classpath.
+        val forbidden = listOf("android.intent.action.SEND", "application/pdf")
+        for (file in classFiles) {
+            if (file.name.startsWith("PublicApiSurfaceTest")) continue
+            val bytes = file.readBytes()
+            for (needle in forbidden) {
+                val needleBytes = needle.toByteArray(Charsets.UTF_8)
+                if (indexOf(bytes, needleBytes) >= 0) {
+                    error("Forbidden '$needle' found in ${file.absolutePath} (passes-pdf scan).")
+                }
+            }
+        }
+    }
+
+    /**
+     * Walk every classpath root that exposes [packagePath] and collect the .class
+     * files. Using [ClassLoader.getResources] (plural) instead of getResource gets
+     * us both the main-classes and test-classes roots in a Gradle test JVM, so the
+     * scan covers production code rather than just the first match.
+     */
+    private fun classFilesUnder(packagePath: String): List<File> {
+        val urls = javaClass.classLoader!!.getResources(packagePath).toList()
+        return urls.flatMap { url ->
+            val file = runCatching { File(url.toURI()) }.getOrNull() ?: return@flatMap emptyList()
+            if (!file.isDirectory) return@flatMap emptyList()
+            file.walkTopDown().filter { it.isFile && it.name.endsWith(".class") }.toList()
+        }
+    }
+
+    /**
+     * Naive byte-substring search. The needles are short (≤ 30 bytes) and the haystacks
+     * are class files in the low-tens-of-kilobytes; an exact-substring KMP would be
+     * faster but invisible at this scale. Returning the first match's offset gives the
+     * failure message a useful jump-to point.
+     */
+    private fun indexOf(haystack: ByteArray, needle: ByteArray): Int {
+        if (needle.isEmpty() || haystack.size < needle.size) return -1
+        val limit = haystack.size - needle.size
+        var found = -1
+        outer@ for (i in 0..limit) {
+            for (j in needle.indices) {
+                if (haystack[i + j] != needle[j]) continue@outer
+            }
+            found = i
+            break
+        }
+        return found
     }
 
     private fun passFixture(

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -18,8 +19,11 @@ import `is`.walt.passes.core.PassFields
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.PdfDocumentId
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.DocumentSemantics
 import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
 import `is`.walt.passes.ui.theme.PassesSemantics
 import `is`.walt.passes.ui.theme.PassesTheme
@@ -79,6 +83,16 @@ class TrustClaimSurfaceTest {
             coupon = ArgbColor(0xFF555555.toInt()),
             storeCard = ArgbColor(0xFF555555.toInt()),
             generic = ArgbColor(0xFF555555.toInt()),
+        ),
+        documents = DocumentSemantics(
+            captionBackground = ArgbColor(0xFF202020.toInt()),
+            captionForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            tileBackground = ArgbColor(0xFFF5F5F5.toInt()),
+            tileForeground = ArgbColor(0xFF202020.toInt()),
+            tileLabelForeground = ArgbColor(0xFF606060.toInt()),
+            laneBackground = ArgbColor(0xFFEEEEEE.toInt()),
+            documentBadgeBackground = ArgbColor(0xFFD0D0D0.toInt()),
+            documentBadgeForeground = ArgbColor(0xFF202020.toInt()),
         ),
     )
 
@@ -296,6 +310,105 @@ class TrustClaimSurfaceTest {
         val (_, rejection) = decodeBoundedBitmap(anyBytes, tightBounds)
         assertThat(rejection).isNotNull()
         assertThat(rejection!!.name).matches("ExceedsWidth|ExceedsHeight|ExceedsArea")
+    }
+
+    @Test
+    fun documentTrustCaptionRendersTheVerbatimTrustText() {
+        // The non-suppressible caption is the trust contract for documents (ADR 0005
+        // D5: PDFs are never signature-verified). The visible string IS the audit
+        // surface; locking it here means a contributor cannot soften the wording
+        // without updating the test.
+        composeRule.setContent {
+            ThemedHost {
+                DocumentTrustCaption()
+            }
+        }
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun documentTrustCaptionTextConstantMatchesDisplayed() {
+        // Belt-and-suspenders to the previous test: the displayed string MUST be the
+        // exact value of the internal constant. This catches a refactor that splits
+        // the caption into multiple Text composables (visible-text assertion would
+        // pass; constant-equality breaks).
+        assertThat(TRUST_CAPTION_TEXT)
+            .isEqualTo("User-provided document. Walt has not verified the source.")
+    }
+
+    @Test
+    fun documentTileWrapsDisplayLabelInBidiIsolates() {
+        // displayLabel is user-controlled (typically the source filename). A bidi
+        // character in the filename must not reorder surrounding chrome glyphs.
+        // Mirrors the security-sheet bidi-isolation test for B3 URLs and org names.
+        val doc = PdfDocument(
+            id = PdfDocumentId("doc-1"),
+            displayLabel = "tax-2025.pdf",
+            byteCount = 1024L,
+            pageCount = 3,
+            importedAtEpochMs = 0L,
+        )
+        composeRule.setContent {
+            ThemedHost {
+                DocumentTile(doc = doc, thumbnail = null, onClick = {})
+            }
+        }
+        // The text on the tile is FSI + label + PDI. Look up by the full isolated
+        // form so a missing wrap fails the assertion rather than a merely-cosmetic
+        // regression.
+        composeRule.onNodeWithText("⁨tax-2025.pdf⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun documentsLaneRendersHeaderAndCaptionAboveTiles() {
+        val docs = listOf(
+            PdfDocument(
+                id = PdfDocumentId("a"),
+                displayLabel = "alpha.pdf",
+                byteCount = 1024L,
+                pageCount = 1,
+                importedAtEpochMs = 0L,
+            ),
+        )
+        composeRule.setContent {
+            ThemedHost {
+                DocumentsLane(
+                    documents = docs,
+                    thumbnails = emptyMap(),
+                    onDocumentClick = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Documents").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨alpha.pdf⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun documentsLaneRendersNothingForEmptyDocuments() {
+        composeRule.setContent {
+            ThemedHost {
+                DocumentsLane(
+                    documents = emptyList(),
+                    thumbnails = emptyMap(),
+                    onDocumentClick = {},
+                )
+                Text("sentinel")
+            }
+        }
+        composeRule.onNodeWithText("sentinel").assertIsDisplayed()
+        // The trust caption MUST NOT show in the empty case — an empty lane is no
+        // surface at all and should not introduce trust chrome that has nothing to
+        // anchor to.
+        composeRule.onAllNodesWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).fetchSemanticsNodes().let { nodes ->
+            assertThat(nodes).isEmpty()
+        }
     }
 
     @Composable

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/RenderedPageCacheTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/RenderedPageCacheTest.kt
@@ -1,0 +1,121 @@
+package `is`.walt.passes.ui.internal
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.PdfDocumentId
+import org.junit.Test
+
+/**
+ * Pure-JVM lock on the LRU access-order eviction contract for the rasterised-page
+ * cache feeding `DocumentView`. The production wiring stores [android.graphics.Bitmap]
+ * and supplies `Bitmap::recycle` as `onEvict`; this test substitutes `String` so the
+ * contract is exercisable without Robolectric or the Android framework.
+ *
+ * The contract:
+ *
+ *  - Inserting up to `maxSize` entries does not evict.
+ *  - Inserting one more evicts the least-recently-used.
+ *  - `get()` updates the access-order, so a subsequent insert evicts the *oldest by
+ *    access*, not the oldest by insertion.
+ *  - `put()` replacing an existing key fires [onEvict] for the previous value.
+ *  - `clear()` fires [onEvict] for every retained value once.
+ */
+class RenderedPageCacheTest {
+    private val docId = PdfDocumentId("doc-1")
+
+    @Test
+    fun atCapacityNoEvictionFires() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        cache.put(docId, 0, "a")
+        cache.put(docId, 1, "b")
+        cache.put(docId, 2, "c")
+        assertThat(evicted).isEmpty()
+        assertThat(cache.size).isEqualTo(3)
+    }
+
+    @Test
+    fun pastCapacityEvictsLeastRecentlyInserted() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        cache.put(docId, 0, "a")
+        cache.put(docId, 1, "b")
+        cache.put(docId, 2, "c")
+        cache.put(docId, 3, "d")
+        assertThat(evicted).containsExactly("a")
+        assertThat(cache.get(docId, 0)).isNull()
+        assertThat(cache.get(docId, 3)).isEqualTo("d")
+        assertThat(cache.size).isEqualTo(3)
+    }
+
+    @Test
+    fun getUpdatesAccessOrder() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        cache.put(docId, 0, "a")
+        cache.put(docId, 1, "b")
+        cache.put(docId, 2, "c")
+        // Touch "a" so it becomes most-recently-used; "b" is now eldest.
+        assertThat(cache.get(docId, 0)).isEqualTo("a")
+        cache.put(docId, 3, "d")
+        assertThat(evicted).containsExactly("b")
+        assertThat(cache.get(docId, 1)).isNull()
+        assertThat(cache.get(docId, 0)).isEqualTo("a")
+    }
+
+    @Test
+    fun replacingValueForSameKeyEvictsThePreviousValue() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        cache.put(docId, 0, "first")
+        cache.put(docId, 0, "second")
+        assertThat(evicted).containsExactly("first")
+        assertThat(cache.get(docId, 0)).isEqualTo("second")
+        assertThat(cache.size).isEqualTo(1)
+    }
+
+    @Test
+    fun multiplePagesPastWindowEvictsInAccessOrder() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        // Walk a 6-page document at the same render budget; eviction order must
+        // match the user's pager swipes — oldest-by-access falls out first.
+        listOf("a", "b", "c", "d", "e", "f").forEachIndexed { page, value ->
+            cache.put(docId, page, value)
+        }
+        assertThat(evicted).containsExactly("a", "b", "c").inOrder()
+        assertThat(cache.size).isEqualTo(3)
+    }
+
+    @Test
+    fun keysAreScopedByDocumentId() {
+        val a = PdfDocumentId("doc-a")
+        val b = PdfDocumentId("doc-b")
+        val cache = RenderedPageCache<String>(maxSize = 4)
+        cache.put(a, 0, "a0")
+        cache.put(b, 0, "b0")
+        assertThat(cache.get(a, 0)).isEqualTo("a0")
+        assertThat(cache.get(b, 0)).isEqualTo("b0")
+    }
+
+    @Test
+    fun clearEvictsEveryRetainedValue() {
+        val evicted = mutableListOf<String>()
+        val cache = RenderedPageCache<String>(maxSize = 3, onEvict = evicted::add)
+        cache.put(docId, 0, "a")
+        cache.put(docId, 1, "b")
+        cache.put(docId, 2, "c")
+        cache.clear()
+        assertThat(evicted).containsExactly("a", "b", "c").inOrder()
+        assertThat(cache.size).isEqualTo(0)
+    }
+
+    @Test
+    fun maxSizeMustBePositive() {
+        try {
+            RenderedPageCache<String>(maxSize = 0)
+            error("expected IllegalArgumentException")
+        } catch (expected: IllegalArgumentException) {
+            assertThat(expected.message).contains("maxSize")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Composable surfaces for PDF documents: `DocumentTrustCaption` (non-suppressible), `DocumentTile`, `DocumentsLane`, and `DocumentView` with `HorizontalPager` driving an LRU-bounded bitmap cache through the `PdfRendererBinder` *interface* (not the concrete client) so tests inject fakes without binding the isolated-process service.

Closes wpass-7wn.

## Trust-claim discipline

Mirrors `ExpiredOverlay`: no `enabled` flag, no theme token that hides the caption, no `DocumentView` overload that skips it.

- `ComposableSurfaceLockTest` pins parameter shapes for the four new composables and asserts none has an overload (a future `DocumentView(..., showCaption: Boolean)` sibling fails the test).
- `TrustClaimSurfaceTest` asserts the caption renders the verbatim audit text and that `displayLabel` is BiDi-isolated with U+2068/U+2069 on the tile (mirrors the B3 sheet pattern in `SecuritySheets.kt`).
- `PublicApiSurfaceTest` gains a bytecode scan that walks every `is.walt.passes.ui.*` (and reachable `is.walt.passes.pdf.*`) compiled class and fails closed if it finds the constants `android.intent.action.SEND`, `android.intent.action.SEND_MULTIPLE`, or `application/pdf`. ADR 0005 D8 (no share-out) and D4 (no extraction) become structural locks rather than documentation.

## LRU cache

`RenderedPageCache<V>` is generic over the value type so the access-order eviction contract is exercisable JVM-pure (eight test cases in `RenderedPageCacheTest`). Production wiring binds `Bitmap` with `Bitmap::recycle` as the eviction handler so native pixel memory is freed the moment a page falls out of the 3-page window. The renderer service has already pre-recycled its source-side copy (per ADR 0005 D3); the UI is the sole bitmap owner past the binder.

## Module-graph caveat — flagged for review

`passes-ui` now declares `api(project(":passes-pdf"))`, which crosses the rule documented in `CLAUDE.md`: *"passes-storage, passes-pdf, and passes-ui are independent of each other."*

The alternative would be a new `passes-pdf-ui` module, splitting `DocumentView` from `PassFront` across modules even though both are pass-style trust-claim surfaces sharing the same theming and BiDi-isolation utilities. The dependency is taken in this PR with a flagged inline comment in `passes-ui/build.gradle.kts`; reviewers should decide whether to bend the architectural rule or split the module before merge.

## Theming

`DocumentSemantics` is a sibling data class to the other slot families, exposed as `PassesSemantics.documents`. Walt-android's `core/ui` is authoritative for the actual hex values (per `CLAUDE.local.md`); `passes-ui` owns the contract shape only.

## Test plan

- [x] `./gradlew check` — passes-core, passes-pdf-core, passes-pdf, passes-storage, passes-ui all green; ktlint, detekt, lint, all unit tests
- [x] passes-ui unit tests: `RenderedPageCacheTest` (8), `TrustClaimSurfaceTest` (18, including new doc-surface and BiDi-isolation tests), `ComposableSurfaceLockTest` (15, including new param-count locks for the four new composables and a no-overload assertion), `PublicApiSurfaceTest` (17, including the new bytecode-scan tests over passes-ui and passes-pdf compiled classes)
- [ ] Instrumented test (`DocumentViewInstrumentedTest`): pager-driven render(), caption visibility under render rejection, distinct render() calls past the LRU window. Requires an emulator/device run that this PR's CI does not yet do — host walt-android is the canonical site for that run; this branch ships the test for future invocation.
- [ ] Visual review on emulator with both light and dark schemes from walt-android's `core/ui` (host theming) — host-side validation, not part of this branch.