### PR TITLE
passes-pdf-ui: telemetry arm for consumer-side render failures (wpass-8v4)

### DIFF
--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/DocumentTelemetryGuard.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/DocumentTelemetryGuard.kt
@@ -24,12 +24,28 @@ public interface DocumentTelemetryGuard {
 
     public fun onImportFailed(event: DocumentImportFailedEvent)
 
+    /**
+     * A consumer-side render attempt produced no bitmap. Distinct from the renderer
+     * service's own failure path: this fires inside the hosting UI module after
+     * `RenderResult.Ok` has been received, when reconstructing the bitmap from the
+     * returned `SharedMemory` throws — out of memory, dimension mismatch, or a handle
+     * already closed by a parallel render. The visible outcome is a blank page that
+     * the next swipe re-attempts; without this hook the path is silent.
+     *
+     * The PII discipline is upheld by parameter shape: only the enum [reason] is
+     * accepted. No `Throwable`, no message, no dimensions — see
+     * `DocumentTelemetryGuardSurfaceTest` for the structural lock.
+     */
+    public fun onConsumerRenderFailed(reason: ConsumerRenderFailure)
+
     public object NoOp : DocumentTelemetryGuard {
         override fun onImportStarted(): Unit = Unit
 
         override fun onImportSucceeded(event: DocumentImportSucceededEvent): Unit = Unit
 
         override fun onImportFailed(event: DocumentImportFailedEvent): Unit = Unit
+
+        override fun onConsumerRenderFailed(reason: ConsumerRenderFailure): Unit = Unit
     }
 }
 
@@ -43,3 +59,23 @@ public data class DocumentImportFailedEvent(
     public val outcome: DocumentRejectedKind,
     public val durationMillis: Long,
 )
+
+/**
+ * Why a consumer-side bitmap reconstruction failed. Mirrors the three deterministic
+ * Android-side failure shapes plus a defensive [Other] catch-all:
+ *
+ *  - [OutOfMemory] — `Bitmap.createBitmap` or `copyPixelsFromBuffer` threw `OutOfMemoryError`.
+ *  - [SharedMemoryUnavailable] — `SharedMemory.mapReadOnly()` threw `IllegalStateException`,
+ *    the JDK-typed surface for "the handle was already closed", typically by a parallel
+ *    render coroutine that cancelled and ran the cleanup branch.
+ *  - [DimensionMismatch] — `copyPixelsFromBuffer` threw `BufferUnderflowException`, meaning
+ *    the renderer-reported `widthPx * heightPx * 4` bytes did not match the mapped buffer.
+ *  - [Other] — any other `Throwable`. Preserved to keep the outer `runCatching` surface
+ *    safe against future Android changes; spike here means a new failure class to triage.
+ */
+public enum class ConsumerRenderFailure {
+    OutOfMemory,
+    SharedMemoryUnavailable,
+    DimensionMismatch,
+    Other,
+}

--- a/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/DocumentTelemetryGuardSurfaceTest.kt
+++ b/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/DocumentTelemetryGuardSurfaceTest.kt
@@ -136,7 +136,12 @@ class DocumentTelemetryGuardSurfaceTest {
         // ParameterizedType collapses to its raw and then must clear the same bar.
         val raw = rawClassOrNull() ?: return false
         return when (allowed) {
-            AllowedTypes.GuardMethod -> raw in eventClasses
+            // Guard methods accept either an event class wrapper (the historical
+            // `onImport*` shape) or a bare enum (the `onConsumerRenderFailed(reason)`
+            // shape). Both clear the PII bar — an enum is the leanest legitimate shape
+            // and is already proven safe at the EventCtor level. `String`, `ByteArray`,
+            // `Map`, etc. all collapse to non-enum, non-event-class raws and stay caught.
+            AllowedTypes.GuardMethod -> raw in eventClasses || raw.isEnum
             AllowedTypes.EventCtor ->
                 raw == java.lang.Long.TYPE ||
                     raw == java.lang.Integer.TYPE ||

--- a/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
+++ b/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
@@ -98,5 +98,67 @@ class PublicApiSurfaceTest {
         guard.onImportFailed(
             DocumentImportFailedEvent(outcome = DocumentRejectedKind.Encrypted, durationMillis = 7L),
         )
+        guard.onConsumerRenderFailed(ConsumerRenderFailure.OutOfMemory)
+        guard.onConsumerRenderFailed(ConsumerRenderFailure.SharedMemoryUnavailable)
+        guard.onConsumerRenderFailed(ConsumerRenderFailure.DimensionMismatch)
+        guard.onConsumerRenderFailed(ConsumerRenderFailure.Other)
+    }
+
+    @Test
+    fun consumerRenderFailureHasExactlyTheFourListedArms() {
+        val all =
+            setOf(
+                ConsumerRenderFailure.OutOfMemory,
+                ConsumerRenderFailure.SharedMemoryUnavailable,
+                ConsumerRenderFailure.DimensionMismatch,
+                ConsumerRenderFailure.Other,
+            )
+        assertThat(all).containsExactlyElementsIn(ConsumerRenderFailure.entries)
+        assertThat(ConsumerRenderFailure.entries).hasSize(4)
+    }
+
+    /**
+     * Mirrors `passes-ui::PublicApiSurfaceTest.uiTelemetryGuardEventsAreEnumsAndPrimitivesOnly`:
+     * an exhaustive behavioral exercise that pins every guard method against an
+     * enums-and-primitives-only shape. Adding a free-form `String`, `ByteArray`, or `Throwable`
+     * parameter to any method below would either fail to compile against this fixture or fall
+     * through the `DocumentTelemetryGuardSurfaceTest` allowlist.
+     */
+    @Test
+    fun documentTelemetryGuardEventsAreEnumsAndPrimitivesOnly() {
+        val recorded = mutableListOf<String>()
+        val guard =
+            object : DocumentTelemetryGuard {
+                override fun onImportStarted() {
+                    recorded += "started"
+                }
+
+                override fun onImportSucceeded(event: DocumentImportSucceededEvent) {
+                    recorded += "ok:${event.byteCount}:${event.pageCount}:${event.durationMillis}"
+                }
+
+                override fun onImportFailed(event: DocumentImportFailedEvent) {
+                    recorded += "failed:${event.outcome.name}:${event.durationMillis}"
+                }
+
+                override fun onConsumerRenderFailed(reason: ConsumerRenderFailure) {
+                    recorded += "render:${reason.name}"
+                }
+            }
+        guard.onImportStarted()
+        guard.onImportSucceeded(
+            DocumentImportSucceededEvent(byteCount = 99L, pageCount = 2, durationMillis = 11L),
+        )
+        guard.onImportFailed(
+            DocumentImportFailedEvent(outcome = DocumentRejectedKind.TooManyPages, durationMillis = 3L),
+        )
+        guard.onConsumerRenderFailed(ConsumerRenderFailure.DimensionMismatch)
+
+        assertThat(recorded).containsExactly(
+            "started",
+            "ok:99:2:11",
+            "failed:TooManyPages:3",
+            "render:DimensionMismatch",
+        ).inOrder()
     }
 }

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -129,9 +129,14 @@ public fun DocumentView(
     }
 }
 
+/**
+ * Each parameter is a distinct dependency the page rendering needs; bundling them
+ * into a holder would only relocate the count from a function signature to a
+ * constructor without lowering the conceptual surface, so the LongParameterList
+ * suppression is the lower-cost choice here.
+ */
 @Composable
-@Suppress("LongParameterList") // Each parameter is a distinct dependency; bundling
-// would only relocate the count from a function signature to a holder constructor.
+@Suppress("LongParameterList")
 private fun DocumentPage(
     document: PdfDocument,
     pageIndex: Int,

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -28,12 +28,15 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.ConsumerRenderFailure
+import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
+import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 
 /**
@@ -78,6 +81,7 @@ public fun DocumentView(
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,
     modifier: Modifier = Modifier,
+    telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
 ) {
     val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) {
@@ -119,18 +123,22 @@ public fun DocumentView(
                 pdfFile = pdfFile,
                 renderer = renderer,
                 cache = cache,
+                telemetry = telemetry,
             )
         }
     }
 }
 
 @Composable
+@Suppress("LongParameterList") // Each parameter is a distinct dependency; bundling
+// would only relocate the count from a function signature to a holder constructor.
 private fun DocumentPage(
     document: PdfDocument,
     pageIndex: Int,
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,
     cache: RenderedPageCache<Bitmap>,
+    telemetry: DocumentTelemetryGuard,
 ) {
     val density = LocalDensity.current
     var rendered by remember(document.id, pageIndex) {
@@ -157,7 +165,7 @@ private fun DocumentPage(
             // request, when reconstructing the Bitmap — using the request would make
             // copyPixelsFromBuffer either throw against an undersized SharedMemory
             // (silently swallowed by runCatching below) or render a misshapen image.
-            val bitmap = bitmapFromSharedMemory(result)
+            val bitmap = bitmapFromSharedMemory(result, telemetry)
             if (bitmap != null) {
                 cache.put(document.id, pageIndex, bitmap)
                 rendered = bitmap.asImageBitmap()
@@ -185,18 +193,20 @@ private fun DocumentPage(
     }
 }
 
-private fun bitmapFromSharedMemory(ok: RenderResult.Ok): Bitmap? {
+private fun bitmapFromSharedMemory(
+    ok: RenderResult.Ok,
+    telemetry: DocumentTelemetryGuard,
+): Bitmap? {
     // The renderer service writes ARGB_8888 packed row-major with no padding using the
     // dimensions it reports back in `ok.widthPx` / `ok.heightPx` (which may differ from
     // the request — see the call-site comment for D7).
     //
-    // Failure modes that runCatching here intentionally swallows: OOM on
-    // Bitmap.createBitmap, BufferUnderflowException from copyPixelsFromBuffer if the
-    // SharedMemory size mismatches the bitmap, IllegalStateException if the
-    // SharedMemory was already closed by a parallel render. Each of these surfaces as
-    // "page does not paint" and the next swipe re-attempts; the renderer-service-side
-    // failure mode is already telemetered via DocumentTelemetryGuard. Consumer-side
-    // telemetry for the silent path is tracked in a follow-up issue (see PR review).
+    // The runCatching swallow remains intentional: OOM on Bitmap.createBitmap,
+    // BufferUnderflowException from copyPixelsFromBuffer if the SharedMemory size
+    // mismatches the bitmap, and IllegalStateException if the SharedMemory was already
+    // closed by a parallel render each surface as a blank page that the next swipe
+    // re-attempts. Telemetry is observability, not a user-facing error path; the failure
+    // mapping is what wpass-8v4 added so the silent path stops being invisible.
     return runCatching {
         val mapped: ByteBuffer = ok.sharedMemory.mapReadOnly()
         try {
@@ -207,7 +217,16 @@ private fun bitmapFromSharedMemory(ok: RenderResult.Ok): Bitmap? {
             android.os.SharedMemory.unmap(mapped)
             ok.sharedMemory.close()
         }
+    }.onFailure { t ->
+        telemetry.onConsumerRenderFailed(consumerRenderFailureFor(t))
     }.getOrNull()
+}
+
+internal fun consumerRenderFailureFor(t: Throwable): ConsumerRenderFailure = when (t) {
+    is OutOfMemoryError -> ConsumerRenderFailure.OutOfMemory
+    is BufferUnderflowException -> ConsumerRenderFailure.DimensionMismatch
+    is IllegalStateException -> ConsumerRenderFailure.SharedMemoryUnavailable
+    else -> ConsumerRenderFailure.Other
 }
 
 // HorizontalPager retains composed Image references for adjacent pages during a swipe

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/ConsumerRenderFailureMappingTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/ConsumerRenderFailureMappingTest.kt
@@ -1,0 +1,58 @@
+package `is`.walt.passes.pdf.ui
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.ConsumerRenderFailure
+import org.junit.Test
+import java.nio.BufferUnderflowException
+
+/**
+ * JVM-pure cover for the `Throwable -> ConsumerRenderFailure` mapping inside
+ * `DocumentView.bitmapFromSharedMemory` (wpass-8v4). The instrumented test
+ * `DocumentViewInstrumentedTest.captionStillRendersWhenEveryRenderCallIsRejected`
+ * exercises the renderer-rejection path that does not reach `bitmapFromSharedMemory`
+ * at all; the SharedMemory-side failures (OOM, dimension mismatch, closed handle) only
+ * surface on a real device. Pinning the dispatch table here is what keeps a future
+ * refactor from silently re-routing one of the four legitimate failure shapes through
+ * the `Other` arm — that bucket exists for genuine triage signal, not for absorbing
+ * known cases.
+ */
+class ConsumerRenderFailureMappingTest {
+
+    @Test
+    fun outOfMemoryMapsToOutOfMemory() {
+        assertThat(consumerRenderFailureFor(OutOfMemoryError("bitmap")))
+            .isEqualTo(ConsumerRenderFailure.OutOfMemory)
+    }
+
+    @Test
+    fun bufferUnderflowMapsToDimensionMismatch() {
+        assertThat(consumerRenderFailureFor(BufferUnderflowException()))
+            .isEqualTo(ConsumerRenderFailure.DimensionMismatch)
+    }
+
+    @Test
+    fun illegalStateMapsToSharedMemoryUnavailable() {
+        assertThat(consumerRenderFailureFor(IllegalStateException("closed")))
+            .isEqualTo(ConsumerRenderFailure.SharedMemoryUnavailable)
+    }
+
+    @Test
+    fun unknownThrowableFallsThroughToOther() {
+        // RuntimeException is the canonical "didn't match any of the three deterministic
+        // arms" case. Defensive `Other` exists so a future Android/JDK change that
+        // surfaces a new failure class never crashes the consumer; a spike on this arm
+        // in production telemetry is the signal to add a new mapping.
+        assertThat(consumerRenderFailureFor(RuntimeException("unexpected")))
+            .isEqualTo(ConsumerRenderFailure.Other)
+    }
+
+    @Test
+    fun mostSpecificMatchWins() {
+        // Subclasses of mapped types keep the mapping. This pins that adding a new
+        // catch in `bitmapFromSharedMemory` for, say, `IllegalArgumentException` would
+        // not silently move existing IllegalState callers to `Other`.
+        class CustomISE : IllegalStateException("custom")
+        assertThat(consumerRenderFailureFor(CustomISE()))
+            .isEqualTo(ConsumerRenderFailure.SharedMemoryUnavailable)
+    }
+}

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
@@ -33,10 +33,15 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun documentViewHasExactlyFourUserVisibleParameters() {
-        // (doc, pdfFile, renderer, modifier). D5: no flag to hide the trust caption,
-        // no flag to render anything from PDF metadata, no overflow into Share.
-        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 4)
+    fun documentViewHasExactlyFiveUserVisibleParameters() {
+        // (doc, pdfFile, renderer, modifier, telemetry). D5: no flag to hide the trust
+        // caption, no flag to render anything from PDF metadata, no overflow into
+        // Share. The fifth slot is the wpass-8v4 telemetry guard with a NoOp default;
+        // bumping this count from 4 to 5 is the deliberate change for that issue, not
+        // a slip. Integration coverage of the failure-mapping path lives in
+        // `DocumentViewInstrumentedTest`; the JVM-pure mapping helper is covered by
+        // `ConsumerRenderFailureMappingTest`.
+        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 5)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `DocumentTelemetryGuard.onConsumerRenderFailed(reason)` with a four-arm `ConsumerRenderFailure` enum (`OutOfMemory`, `SharedMemoryUnavailable`, `DimensionMismatch`, `Other`) in `passes-pdf-core`. Wires the dispatch from `DocumentView.bitmapFromSharedMemory`'s `runCatching` boundary so the previously silent blank-page path emits structured telemetry.
- The `runCatching` swallow stays intentional — telemetry is observability, not a user-facing error path; the next swipe still re-attempts. The renderer-service-side path was already telemetered, so consumer-side render failures are no longer the only invisible arm.
- `DocumentView` gains a fifth user-visible parameter (`telemetry`, defaulted to `DocumentTelemetryGuard.NoOp`); `DocumentSurfaceLockTest.documentViewHasExactlyFiveUserVisibleParameters` updates the count from 4 to 5 — the deliberate trust-claim-anchor edit for this issue.
- PII discipline upheld structurally: the new arm accepts the bare enum only, no `Throwable`, no message, no dimensions. `DocumentTelemetryGuardSurfaceTest`'s allowlist now permits enums in guard methods (already proven safe at the EventCtor level); the `String` / `ByteArray` / `List<String>` / `Map<Enum, String>` smuggling shapes remain rejected, with the meta-test still demonstrating the lock is non-vacuous.

Follow-up #1 of three from wpass-r4z. The other two (wpass-8rx, wpass-kej) remain open.

## Test plan
- [x] `./gradlew check` — green across all seven modules.
- [x] New `ConsumerRenderFailureMappingTest` (passes-pdf-ui, JVM-pure) covers all four `Throwable -> ConsumerRenderFailure` arms plus subclass dispatch.
- [x] New `documentTelemetryGuardEventsAreEnumsAndPrimitivesOnly` test (passes-pdf-core, mirrors the passes-ui pattern) exercises every guard method end-to-end.
- [x] New `consumerRenderFailureHasExactlyTheFourListedArms` test pins the enum surface against silent additions.
- [x] `DocumentSurfaceLockTest.documentSurfacesHaveNoOverloads` still green — no `DocumentView` overload was added; the telemetry parameter is a default on the existing single declaration.
- [x] `DocumentViewInstrumentedTest` continues to compile against the new signature (`telemetry` defaults so existing call sites stay unchanged); the existing `captionStillRendersWhenEveryRenderCallIsRejected` integration covers the renderer-rejection path that does not reach `bitmapFromSharedMemory`.