### PR TITLE
passes-storage: keep DatabaseKey buffer alive for the SQLCipher pool (wpass-aio)

### DIFF
--- a/passes-storage/detekt-baseline.xml
+++ b/passes-storage/detekt-baseline.xml
@@ -9,7 +9,7 @@
     <ID>NestedBlockDepth:SqlCipherPassStore.kt$SqlCipherPassStore$override fun upsert( pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long, ): UpsertOutcome</ID>
     <ID>ReturnCount:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider$override fun provideDatabaseKey(): StorageResult&lt;DatabaseKey&gt;</ID>
     <ID>ReturnCount:BackupRulesAssertion.kt$BackupRulesAssertion$@JvmStatic public fun assertBackupRulesApplied(context: Context): Outcome</ID>
-    <ID>ReturnCount:SqlCipherDatabaseFactory.kt$SqlCipherDatabaseFactory$fun openOrCreate( context: Context, databaseKey: DatabaseKey, ): StorageResult&lt;SQLiteDatabase&gt;</ID>
+    <ID>ReturnCount:SqlCipherDatabaseFactory.kt$SqlCipherDatabaseFactory$fun openOrCreate( context: Context, databaseKey: DatabaseKey, ): StorageResult&lt;OpenedDatabase&gt;</ID>
     <ID>ReturnCount:SqlCipherPassRepository.kt$SqlCipherPassRepository.Companion$@JvmStatic public fun create( context: Context, keyProvider: PassKeyProvider, telemetryGuard: StorageTelemetryGuard, ioDispatcher: CoroutineDispatcher = Dispatchers.IO, clock: () -&gt; Long = { System.currentTimeMillis() }, ): StorageResult&lt;SqlCipherPassRepository&gt;</ID>
     <ID>ReturnCount:SqlCipherPassStore.kt$SqlCipherPassStore$override fun loadById(id: PassRecordId): StoredPass?</ID>
     <ID>ReturnCount:SqlCipherPassStore.kt$SqlCipherPassStore$private fun Cursor.toSummaryOrNull(): PassSummary?</ID>

--- a/passes-storage/detekt-baseline.xml
+++ b/passes-storage/detekt-baseline.xml
@@ -26,6 +26,7 @@
     <ID>SwallowedException:BackupRulesAssertion.kt$BackupRulesAssertion$e: NoSuchFieldException</ID>
     <ID>SwallowedException:BackupRulesAssertion.kt$BackupRulesAssertion$e: PackageManager.NameNotFoundException</ID>
     <ID>TooGenericExceptionCaught:AndroidKeystorePassKeyProvider.kt$AndroidKeystorePassKeyProvider.Companion$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PassKeyProvider.kt$DatabaseKey$t: Throwable</ID>
     <ID>TooGenericExceptionCaught:SqlCipherDatabaseFactory.kt$SqlCipherDatabaseFactory$e: Exception</ID>
     <ID>TooGenericExceptionCaught:SqlCipherPassRepository.kt$SqlCipherPassRepository$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:SqlCipherPassRepository.kt$SqlCipherPassRepository.Companion$e: Throwable</ID>

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
@@ -66,7 +66,16 @@ public class DatabaseKey(private val bytes: ByteArray) {
      * all zeros, surfacing as `SQLiteOutOfMemoryException` from page-1 decrypt.
      */
     public fun retainAcross(block: (ByteArray) -> Unit): AutoCloseable {
-        block(bytes)
+        try {
+            block(bytes)
+        } catch (t: Throwable) {
+            // If the consumer throws before it has captured the buffer, the
+            // returned handle is never built and the caller cannot close it.
+            // Zero eagerly so a throwing openOrCreateDatabase (corrupt header,
+            // IO failure, JNI mismatch) does not leave the raw key resident.
+            bytes.fill(0)
+            throw t
+        }
         return AutoCloseable { bytes.fill(0) }
     }
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
@@ -32,8 +32,8 @@ public interface PassKeyProvider {
 /**
  * Wrapper around the raw 32-byte database key. Exists to make accidental logging
  * discouragingly verbose: the class deliberately overrides `toString()` to a redacted
- * form, and exposes byte access only via [withBytes], which scopes the lifetime of the
- * borrowed array.
+ * form, and exposes byte access only via [withBytes] (synchronous borrow) or
+ * [retainAcross] (lifetime-tied borrow).
  */
 public class DatabaseKey(private val bytes: ByteArray) {
     init {
@@ -50,6 +50,24 @@ public class DatabaseKey(private val bytes: ByteArray) {
         } finally {
             bytes.fill(0)
         }
+    }
+
+    /**
+     * Hands the raw key bytes to [block] for capture by a long-lived consumer that
+     * retains the [ByteArray] reference past the synchronous call. Returns an
+     * [AutoCloseable] that zeros the buffer when closed; the caller MUST close it
+     * once the consumer no longer needs the bytes.
+     *
+     * Required by `net.zetetic.database.sqlcipher`: `SQLiteDatabaseConfiguration`
+     * holds the password byte[] by reference (no copy), and `SQLiteConnection.open()`
+     * re-reads `mConfiguration.password` on every pool connection it opens, including
+     * read-only connections opened lazily on first cursor read. Zeroing the buffer
+     * before the connection pool is done with it re-keys new pool connections with
+     * all zeros, surfacing as `SQLiteOutOfMemoryException` from page-1 decrypt.
+     */
+    public fun retainAcross(block: (ByteArray) -> Unit): AutoCloseable {
+        block(bytes)
+        return AutoCloseable { bytes.fill(0) }
     }
 
     override fun toString(): String = "DatabaseKey(redacted)"

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -260,7 +260,7 @@ public class SqlCipherPassRepository internal constructor(
                 )
                 return StorageResult.Failure(unknown)
             }
-            val db = when (openResult) {
+            val opened = when (openResult) {
                 is StorageResult.Success -> openResult.value
                 is StorageResult.Failure -> {
                     telemetryGuard.onStorageFailure(
@@ -270,8 +270,8 @@ public class SqlCipherPassRepository internal constructor(
                     return StorageResult.Failure(openResult.error)
                 }
             }
-            val store = SqlCipherPassStore(db, telemetryGuard)
-            val documentStore = SqlCipherDocumentStore(db)
+            val store = SqlCipherPassStore(opened.db, opened.keyHandle, telemetryGuard)
+            val documentStore = SqlCipherDocumentStore(opened.db)
             val repo = SqlCipherPassRepository(
                 store = store,
                 documentStore = documentStore,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -46,18 +46,23 @@ internal object SqlCipherDatabaseFactory {
     fun openOrCreate(
         context: Context,
         databaseKey: DatabaseKey,
-    ): StorageResult<SQLiteDatabase> {
+    ): StorageResult<OpenedDatabase> {
         loadLibsOnce()
         val dbFile: File = context.applicationContext.getDatabasePath(Schema.DATABASE_NAME)
         dbFile.parentFile?.mkdirs()
         val isDebuggable: Boolean = isHostAppDebuggable(context)
 
-        val db: SQLiteDatabase = databaseKey.withBytes { rawKey ->
-            // The withBytes scope zeros our local copy on return; SQLCipher's internal
-            // page-key derivation buffer survives for the lifetime of the open connection,
-            // which is bounded by SqlCipherPassStore.close().
-            SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null)
+        // The byte[] handed to SQLCipher must outlive every pool connection it keys.
+        // SQLiteDatabaseConfiguration retains the array by reference; SQLiteConnection
+        // re-reads it on every lazily-opened pool connection. retainAcross hands a
+        // long-lived buffer to SQLCipher and returns a handle whose close() zeros it.
+        // The handle's lifetime is bounded by SqlCipherPassStore.close(), which closes
+        // the SQLiteDatabase first.
+        var openedDb: SQLiteDatabase? = null
+        val keyHandle: AutoCloseable = databaseKey.retainAcross { rawKey ->
+            openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null)
         }
+        val db: SQLiteDatabase = openedDb!!
 
         // Pin SQLCipher v4 page format defensively against a future major-version default
         // change. Issued before any other DDL/DML so the page format is locked before
@@ -69,21 +74,21 @@ internal object SqlCipherDatabaseFactory {
             readSchemaVersionIfPresent(db)
         } catch (e: CancellationException) {
             // Coroutine cancellation: surface, do NOT map to DatabaseCorrupt. Close
-            // best-effort to release the native handle.
-            closeQuietly(db, isDebuggable, phase = "PRAGMA/schema-probe")
+            // best-effort to release the native handle and zero the key buffer.
+            closeQuietly(db, keyHandle, isDebuggable, phase = "PRAGMA/schema-probe")
             throw e
         } catch (e: Exception) {
-            return databaseCorrupt(db, e, isDebuggable, phase = "PRAGMA/schema-probe")
+            return databaseCorrupt(db, keyHandle, e, isDebuggable, phase = "PRAGMA/schema-probe")
         }
 
         if (onDiskVersion != null && onDiskVersion > Schema.VERSION) {
             // Future schema (user downgraded the wallet app). Close best-effort; if close
             // throws we still want to return Unsupported, NOT DatabaseCorrupt.
-            closeQuietly(db, isDebuggable, phase = "future-schema-close")
+            closeQuietly(db, keyHandle, isDebuggable, phase = "future-schema-close")
             return StorageResult.Failure(StorageError.Unsupported(onDiskVersion))
         }
         if (onDiskVersion == Schema.VERSION) {
-            return StorageResult.Success(db)
+            return StorageResult.Success(OpenedDatabase(db, keyHandle))
         }
 
         val statements: List<String> = if (onDiskVersion == null) {
@@ -96,7 +101,7 @@ internal object SqlCipherDatabaseFactory {
                 // so a throwing close() does not flip the category. The
                 // `migrationsCoverEveryHopFromV1ToCurrent` JVM test catches the mistake
                 // at CI time so this runtime path should never fire in a shipped build.
-                closeQuietly(db, isDebuggable, phase = "missing-migration-close")
+                closeQuietly(db, keyHandle, isDebuggable, phase = "missing-migration-close")
                 return StorageResult.Failure(
                     StorageError.Unknown(kind = UnknownStorageFailureKind.Other),
                 )
@@ -118,12 +123,12 @@ internal object SqlCipherDatabaseFactory {
                 db.endTransaction()
             }
         } catch (e: CancellationException) {
-            closeQuietly(db, isDebuggable, phase = "DDL/migration")
+            closeQuietly(db, keyHandle, isDebuggable, phase = "DDL/migration")
             throw e
         } catch (e: Exception) {
-            return databaseCorrupt(db, e, isDebuggable, phase = "DDL/migration")
+            return databaseCorrupt(db, keyHandle, e, isDebuggable, phase = "DDL/migration")
         }
-        return StorageResult.Success(db)
+        return StorageResult.Success(OpenedDatabase(db, keyHandle))
     }
 
     private fun isHostAppDebuggable(context: Context): Boolean =
@@ -131,14 +136,15 @@ internal object SqlCipherDatabaseFactory {
 
     private fun databaseCorrupt(
         db: SQLiteDatabase,
+        keyHandle: AutoCloseable,
         cause: Exception,
         isDebuggable: Boolean,
         phase: String,
-    ): StorageResult<SQLiteDatabase> {
+    ): StorageResult<OpenedDatabase> {
         if (isDebuggable) {
             Log.w(LOG_TAG, "SqlCipher $phase failed: ${cause.javaClass.name}: ${cause.message}", cause)
         }
-        closeQuietly(db, isDebuggable, phase = "$phase-close")
+        closeQuietly(db, keyHandle, isDebuggable, phase = "$phase-close")
         return StorageResult.Failure(
             StorageError.Unknown(
                 kind = UnknownStorageFailureKind.DatabaseCorrupt,
@@ -147,12 +153,28 @@ internal object SqlCipherDatabaseFactory {
         )
     }
 
-    private fun closeQuietly(db: SQLiteDatabase, isDebuggable: Boolean, phase: String) {
+    private fun closeQuietly(
+        db: SQLiteDatabase,
+        keyHandle: AutoCloseable,
+        isDebuggable: Boolean,
+        phase: String,
+    ) {
         runCatching { db.close() }.onFailure { closeError ->
             if (isDebuggable) {
                 Log.w(
                     LOG_TAG,
                     "Also failed during $phase: ${closeError.javaClass.name}: ${closeError.message}",
+                    closeError,
+                )
+            }
+        }
+        // Zero the key buffer regardless of whether db.close() threw, so the raw key
+        // never outlives a failed setup phase.
+        runCatching { keyHandle.close() }.onFailure { closeError ->
+            if (isDebuggable) {
+                Log.w(
+                    LOG_TAG,
+                    "Also failed zeroing key during $phase: ${closeError.javaClass.name}: ${closeError.message}",
                     closeError,
                 )
             }
@@ -191,3 +213,15 @@ internal object SqlCipherDatabaseFactory {
         }
     }
 }
+
+/**
+ * The result of [SqlCipherDatabaseFactory.openOrCreate]. Bundles the SQLCipher handle
+ * with the [AutoCloseable] that zeros the raw-key buffer SQLCipher's connection pool
+ * holds by reference. The owner ([SqlCipherPassStore]) MUST close the SQLiteDatabase
+ * first, then the keyHandle - reversing the order would zero the buffer while the
+ * pool may still be re-keying connections.
+ */
+internal data class OpenedDatabase(
+    val db: SQLiteDatabase,
+    val keyHandle: AutoCloseable,
+)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -25,9 +25,15 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase
  * lifetime of the repository. Concurrency is single-writer: all callers go through the
  * repository's IO dispatcher. Reads share the same dispatcher to keep the StateFlow +
  * telemetry sequencing deterministic.
+ *
+ * Also owns the [keyHandle] returned by [SqlCipherDatabaseFactory.openOrCreate]. The
+ * SQLCipher connection pool keys lazily-opened pool connections from the same byte[]
+ * the keyHandle wraps, so the buffer must outlive the SQLiteDatabase. [close] enforces
+ * this by closing the database first, then zeroing the buffer.
  */
 internal class SqlCipherPassStore(
     private val db: SQLiteDatabase,
+    private val keyHandle: AutoCloseable,
     private val telemetryGuard: StorageTelemetryGuard,
 ) : PassStore {
 
@@ -192,7 +198,14 @@ internal class SqlCipherPassStore(
     }
 
     override fun close() {
-        db.close()
+        // Close the SQLiteDatabase first, THEN zero the key buffer. The connection
+        // pool may re-key connections during shutdown; zeroing first would corrupt
+        // those re-keyings the same way the boot bug surfaced (wpass-aio).
+        try {
+            db.close()
+        } finally {
+            keyHandle.close()
+        }
     }
 
     private fun readImages(id: PassRecordId): Map<ImageRole, ImageBytes> {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -213,6 +213,23 @@ class PublicApiSurfaceTest {
     }
 
     @Test
+    fun databaseKeyRetainAcrossZerosBufferIfBlockThrows() {
+        val raw = ByteArray(32) { (it + 1).toByte() }
+        val key = DatabaseKey(raw)
+        val boom = RuntimeException("simulated openOrCreateDatabase failure")
+        try {
+            key.retainAcross { throw boom }
+            error("expected the block's exception to propagate")
+        } catch (caught: RuntimeException) {
+            assertThat(caught).isSameInstanceAs(boom)
+        }
+        // The handle was never returned, so the caller cannot close() it.
+        // retainAcross MUST zero on the throw path itself - otherwise a
+        // failing SQLCipher open would leave the raw key resident in heap.
+        assertThat(raw.all { it.toInt() == 0 }).isTrue()
+    }
+
+    @Test
     fun databaseKeyRetainAcrossKeepsBytesAliveUntilHandleClosed() {
         val raw = ByteArray(32) { (it + 1).toByte() }
         val key = DatabaseKey(raw)

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -212,6 +212,26 @@ class PublicApiSurfaceTest {
         assertThat(raw.all { it.toInt() == 0 }).isTrue()
     }
 
+    @Test
+    fun databaseKeyRetainAcrossKeepsBytesAliveUntilHandleClosed() {
+        val raw = ByteArray(32) { (it + 1).toByte() }
+        val key = DatabaseKey(raw)
+        var captured: ByteArray? = null
+        val handle: AutoCloseable = key.retainAcross { borrowed ->
+            captured = borrowed
+            assertThat(borrowed.any { it.toInt() != 0 }).isTrue()
+        }
+        // Bytes still alive after the block returns - this is the wpass-aio contract:
+        // SQLCipher's connection pool keys lazily-opened pool connections from this
+        // same array reference, so it must outlive retainAcross's lambda.
+        assertThat(captured!!.any { it.toInt() != 0 }).isTrue()
+        assertThat(raw.any { it.toInt() != 0 }).isTrue()
+
+        handle.close()
+        assertThat(raw.all { it.toInt() == 0 }).isTrue()
+        assertThat(captured!!.all { it.toInt() == 0 }).isTrue()
+    }
+
     /**
      * Pins the `StorageTelemetryGuard` PII discipline (ADR 0002 D8). Every event method
      * is reachable here with enums-and-primitives-only arguments. Adding a free-form


### PR DESCRIPTION
## Summary

Fixes wpass-aio. On fresh waltDebug install, the Passes screen surfaces "Secure storage is unavailable" with `passes_storage_failure[kind=Unknown, unknown_kind=DatabaseCorrupt]`. With cc41451's diagnostic logging in place, the underlying throw is `SQLiteOutOfMemoryException` from `nativeExecuteForCursorWindow` at the schema-probe `SELECT 1 FROM sqlite_master ...` - the first cursor-backed read after `openOrCreateDatabase`.

### Root cause (verified against `net.zetetic` 4.6.1 source)

- [`SQLiteDatabaseConfiguration.java:93,134`](https://github.com/sqlcipher/sqlcipher-android/blob/master/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteDatabaseConfiguration.java) holds the `password` byte[] **by reference** (`this.password = password`, no copy).
- [`SQLiteConnection.open()`](https://github.com/sqlcipher/sqlcipher-android/blob/master/sqlcipher/src/main/java/net/zetetic/database/sqlcipher/SQLiteConnection.java) re-reads `mConfiguration.password` and calls `nativeKey()` on **every** pool connection it opens - including read-only auxiliaries opened lazily on the first cursor read.

The previous `databaseKey.withBytes { ... openOrCreateDatabase ... }` lifetime zeroed the buffer when the lambda returned. The primary connection got keyed correctly during the open call (so file lands at 61440 bytes, PRAGMA execSQL succeeds), but the first `rawQuery` acquires a fresh pool connection that re-keys with all-zero bytes. Page-1 decrypt fails inside the validation `SELECT COUNT(*) FROM sqlite_schema` and surfaces as the observed `SQLITE_NOMEM`.

### Fix

Make the byte[] outlive the connection pool:

- `DatabaseKey.retainAcross(block) -> AutoCloseable` hands the bytes to a long-lived consumer and returns a handle whose `close()` zeros the buffer. `withBytes` is unchanged - it still zeros synchronously for short-lived borrows (KDFs, JVM-test helpers).
- `SqlCipherDatabaseFactory.openOrCreate` returns `OpenedDatabase(db, keyHandle)` and threads the keyHandle through every failure path so the buffer is zeroed even on setup-phase aborts.
- `SqlCipherPassStore.close()` closes the SQLiteDatabase first, then the keyHandle - reversing the order would zero the buffer while the pool may still be re-keying connections during shutdown.

### Why not the alternative diagnoses

- **PRAGMA cipher_compatibility ordering**: `sqlcipher-android` 4.6.1's default is already compat=4, so the user-issued `PRAGMA cipher_compatibility = 4` is a redundant no-op, not a regime change. No on-disk-vs-runtime mismatch on a fresh install. (Worth a follow-up to drop the redundant PRAGMA, but not the fix for this bug.)
- **`SQLiteDatabaseHook` + `postKey`**: reorders PRAGMAs within a single connection's `open()` but doesn't change which byte[] `nativeKey` reads. Pool-acquired auxiliaries would still re-key with zeros.
- **Move PRAGMA + DDL inside `withBytes` (option 1)**: passes startup but leaves a latent bug. Any future pool connection acquired after setup (concurrent reads, post-resume reconnections) re-keys with zeros and fails the same way.

## Test plan

- [x] `./gradlew :passes-storage:compileDebugKotlin :passes-storage:compileReleaseKotlin`
- [x] `./gradlew :passes-storage:testDebugUnitTest` (includes new `databaseKeyRetainAcrossKeepsBytesAliveUntilHandleClosed` pinning the lifetime contract)
- [x] `./gradlew :passes-storage:detekt` (baseline updated for the changed `openOrCreate` return signature)
- [x] `./gradlew :passes-storage:assembleDebug :passes-storage:assembleRelease`
- [ ] Smoke test on FP4 / Android 16 waltDebug: fresh install -> open Passes screen -> no `passes_storage_failure`; import a pass -> reopen the app -> existing pass renders. (Needs walt-android consumer wiring; will be verified during wlt-4pg integration.)