### PR TITLE
passes-storage: route cipher_compatibility through SQLiteDatabaseHook (wpass-aio)

### DIFF
--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/CipherCompatReopenTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/CipherCompatReopenTest.kt
@@ -31,17 +31,21 @@ import java.security.KeyStore
  * `SQLiteDatabase.openOrCreateDatabase`, which left the binding free to pick a non-v4
  * default KDF on reopen. The lazy page-1 decode then ran with the wrong KDF and the
  * native `sqlite3_malloc` failed, surfacing as `SQLiteOutOfMemoryException` (SQLITE_NOMEM)
- * from `readSchemaVersionIfPresent`'s schema-probe SELECT. Process #1 (create+write)
- * masked the bug because there was nothing on disk to decrypt yet.
- *
- * The fix is to issue the pragma from a [net.zetetic.database.sqlcipher.SQLiteDatabaseHook]
- * preKey/postKey so the KDF regime is locked before the binding decrypts page 1; this
- * test fails on the pre-fix code path and passes once the hook is installed.
+ * from `readSchemaVersionIfPresent`'s schema-probe SELECT.
  *
  * Same-process-fresh-instance is the closest the JUnit harness gets to "fresh JVM";
  * the SQLCipher binding's per-connection KDF state lives on the [SQLiteDatabase] handle,
  * so closing process #1's repo and constructing a new one is sufficient to reproduce
- * the open-time KDF mismatch.
+ * the open-time KDF mismatch on devices whose binding default differs from v4.
+ *
+ * Scope: green-path only. Asymmetric-by-design — there is no negative test that opens
+ * without the hook and asserts a failure, because the failure mode is
+ * binding-default-dependent: the bug deterministically reproduces on FP4 / Android 16
+ * with sqlcipher-android 4.6.1, but not necessarily on every CI emulator (a binding
+ * whose runtime default already aligns with v4 would pass a no-hook reopen). A negative
+ * test would be flaky-by-device, just inverted. The protection against accidental hook
+ * removal lives in code review and the maintenance KDoc on
+ * [is.walt.passes.storage.internal.SqlCipherDatabaseFactory], not here.
  */
 @RunWith(AndroidJUnit4::class)
 class CipherCompatReopenTest {

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/CipherCompatReopenTest.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/CipherCompatReopenTest.kt
@@ -1,0 +1,164 @@
+package `is`.walt.passes.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.Barcode
+import `is`.walt.passes.core.BarcodeFormat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.WrappedKeyStorage
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.security.KeyStore
+
+/**
+ * Pins the wpass-aio reopen path: create a v4 SQLCipher DB, write a row, close, reopen
+ * with a fresh repository instance against the same on-disk file, and read the row back.
+ *
+ * The previous regression: `PRAGMA cipher_compatibility = 4` was applied AFTER
+ * `SQLiteDatabase.openOrCreateDatabase`, which left the binding free to pick a non-v4
+ * default KDF on reopen. The lazy page-1 decode then ran with the wrong KDF and the
+ * native `sqlite3_malloc` failed, surfacing as `SQLiteOutOfMemoryException` (SQLITE_NOMEM)
+ * from `readSchemaVersionIfPresent`'s schema-probe SELECT. Process #1 (create+write)
+ * masked the bug because there was nothing on disk to decrypt yet.
+ *
+ * The fix is to issue the pragma from a [net.zetetic.database.sqlcipher.SQLiteDatabaseHook]
+ * preKey/postKey so the KDF regime is locked before the binding decrypts page 1; this
+ * test fails on the pre-fix code path and passes once the hook is installed.
+ *
+ * Same-process-fresh-instance is the closest the JUnit harness gets to "fresh JVM";
+ * the SQLCipher binding's per-connection KDF state lives on the [SQLiteDatabase] handle,
+ * so closing process #1's repo and constructing a new one is sufficient to reproduce
+ * the open-time KDF mismatch.
+ */
+@RunWith(AndroidJUnit4::class)
+class CipherCompatReopenTest {
+
+    @Before
+    fun resetStorage() {
+        wipeStorageState()
+    }
+
+    @After
+    fun cleanupStorage() {
+        wipeStorageState()
+    }
+
+    @Test
+    fun reopenOfExistingV4DatabaseReadsRowBack() {
+        val recordId = bootstrapAndWriteOnePass()
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val keyResult = AndroidKeystorePassKeyProvider.create(context)
+        check(keyResult is StorageResult.Success) {
+            "Keystore master alias unexpectedly missing after first-process close: $keyResult"
+        }
+        val repoResult = SqlCipherPassRepository.create(
+            context = context,
+            keyProvider = keyResult.value,
+            telemetryGuard = NoOpStorageTelemetryGuard,
+        )
+        check(repoResult is StorageResult.Success) {
+            "Reopen of v4-on-disk DB must succeed; got: $repoResult"
+        }
+        val repo = repoResult.value
+        try {
+            val loadResult = runBlocking { repo.load(recordId) }
+            check(loadResult is StorageResult.Success) {
+                "Reopen succeeded but row load failed: $loadResult"
+            }
+            assertThat(loadResult.value.pass.serialNumber).isEqualTo(SAMPLE_SERIAL)
+            assertThat(loadResult.value.pass.organizationName).isEqualTo(SAMPLE_ORG)
+        } finally {
+            repo.close()
+        }
+    }
+
+    private fun bootstrapAndWriteOnePass(): PassRecordId {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val keyResult = AndroidKeystorePassKeyProvider.create(context)
+        check(keyResult is StorageResult.Success) {
+            "First-time bootstrap of Keystore key provider failed: $keyResult"
+        }
+        val repoResult = SqlCipherPassRepository.create(
+            context = context,
+            keyProvider = keyResult.value,
+            telemetryGuard = NoOpStorageTelemetryGuard,
+        )
+        check(repoResult is StorageResult.Success) {
+            "First-time bootstrap of SqlCipher repo failed: $repoResult"
+        }
+        val repo = repoResult.value
+        val recordId = runBlocking {
+            val outcome = repo.upsert(buildSamplePass(), SignatureStatus.AppleVerified)
+            check(outcome is StorageResult.Success) {
+                "Sample pass upsert failed: $outcome"
+            }
+            outcome.value
+        }
+        repo.close()
+        return recordId
+    }
+
+    private fun wipeStorageState() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        context.getDatabasePath(Schema.DATABASE_NAME).also { db ->
+            db.delete()
+            File(db.absolutePath + "-journal").delete()
+            File(db.absolutePath + "-wal").delete()
+            File(db.absolutePath + "-shm").delete()
+        }
+        val prefs = context.getSharedPreferences(
+            WrappedKeyStorage.PREFS_NAME,
+            android.content.Context.MODE_PRIVATE,
+        )
+        prefs.edit().clear().commit()
+        val keystore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        if (keystore.containsAlias(AndroidKeystorePassKeyProvider.MASTER_KEY_ALIAS)) {
+            keystore.deleteEntry(AndroidKeystorePassKeyProvider.MASTER_KEY_ALIAS)
+        }
+    }
+
+    private fun buildSamplePass(): Pass = Pass(
+        type = PassType.BoardingPass,
+        serialNumber = SAMPLE_SERIAL,
+        description = "Sample pass for cipher_compat reopen round-trip",
+        organizationName = SAMPLE_ORG,
+        expirationDate = null,
+        voided = false,
+        colors = PassColors(
+            foreground = ColorValue(0xFFFFFF),
+            background = ColorValue(0x000000),
+            label = null,
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = null, value = "v")),
+        ),
+        backFields = emptyList(),
+        barcode = Barcode(
+            format = BarcodeFormat.QR,
+            message = "aio-reopen",
+            messageEncoding = "iso-8859-1",
+            altText = null,
+        ),
+        images = emptyMap(),
+        locales = mapOf(PassLocale("en") to LocalizedStrings(emptyMap())),
+    )
+
+    private companion object {
+        const val SAMPLE_SERIAL: String = "aio-test-serial"
+        const val SAMPLE_ORG: String = "Walt Tests"
+    }
+}

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -9,17 +9,28 @@ import `is`.walt.passes.storage.StorageError
 import `is`.walt.passes.storage.StorageResult
 import `is`.walt.passes.storage.UnknownStorageFailureKind
 import kotlinx.coroutines.CancellationException
+import net.zetetic.database.sqlcipher.SQLiteConnection
 import net.zetetic.database.sqlcipher.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteDatabaseHook
 import java.io.File
 
 /**
  * Opens (or creates on first use) the `walt_passes.db` SQLCipher file with the supplied
- * [DatabaseKey], pins the SQLCipher v4 page format, runs [Schema.DDL] under a single
+ * [DatabaseKey], pins the SQLCipher v4 page format via a pre/postKey hook (so the KDF
+ * regime is locked BEFORE the binding decrypts page 1), runs [Schema.DDL] under a single
  * transaction on first use, and enables `PRAGMA foreign_keys=ON` so the `ON DELETE CASCADE`
  * chains for `pass_images` and `pass_locales` actually fire (SQLite/SQLCipher default this off).
  *
  * The native libraries are loaded lazily via `System.loadLibrary("sqlcipher")`, which is
  * idempotent on subsequent calls.
+ *
+ * Maintenance note: any PRAGMA that affects the KDF or page format (cipher_compatibility,
+ * cipher_default_kdf_iter, cipher_page_size, etc.) MUST be issued from the
+ * [SQLiteDatabaseHook] preKey/postKey, NOT after [SQLiteDatabase.openOrCreateDatabase].
+ * On reopen of an existing v4-on-disk database, the binding chooses a default KDF regime
+ * at open time; a post-open `PRAGMA cipher_compatibility = 4` lands too late, the lazy
+ * page-1 decode runs with the wrong KDF, and surfaces as `SQLITE_NOMEM` (wpass-aio).
+ * The create+write path masked this because there are no on-disk pages to decrypt yet.
  */
 internal object SqlCipherDatabaseFactory {
     // Logcat tag for setup-phase diagnosis. Logcat is local-only AND we gate on the host
@@ -28,6 +39,25 @@ internal object SqlCipherDatabaseFactory {
     // telemetry. The cause class and message are needed to root-cause a SQLCipher setup
     // failure on a real device, since the typed StorageFailureKind alone is opaque.
     private const val LOG_TAG: String = "PassesStorage"
+
+    private const val PRAGMA_CIPHER_COMPAT_V4: String = "PRAGMA cipher_compatibility = 4"
+
+    /**
+     * Pins the SQLCipher v4 KDF/MAC regime BEFORE and AFTER the key is consumed by the
+     * binding. preKey runs before the key is set; postKey runs after. Setting the pragma
+     * in both is a defensive belt-and-suspenders against binding builds that ignore one
+     * or the other for cipher_compatibility specifically. Stateless and thread-safe; a
+     * single instance is reused across all opens.
+     */
+    private val cipherCompatV4Hook: SQLiteDatabaseHook = object : SQLiteDatabaseHook {
+        override fun preKey(connection: SQLiteConnection) {
+            connection.execute(PRAGMA_CIPHER_COMPAT_V4, null, null)
+        }
+
+        override fun postKey(connection: SQLiteConnection) {
+            connection.execute(PRAGMA_CIPHER_COMPAT_V4, null, null)
+        }
+    }
 
     @Volatile
     private var librariesLoaded: Boolean = false
@@ -52,24 +82,21 @@ internal object SqlCipherDatabaseFactory {
         dbFile.parentFile?.mkdirs()
         val isDebuggable: Boolean = isHostAppDebuggable(context)
 
-        // The byte[] handed to SQLCipher must outlive every pool connection it keys.
-        // SQLiteDatabaseConfiguration retains the array by reference; SQLiteConnection
-        // re-reads it on every lazily-opened pool connection. retainAcross hands a
-        // long-lived buffer to SQLCipher and returns a handle whose close() zeros it.
-        // The handle's lifetime is bounded by SqlCipherPassStore.close(), which closes
-        // the SQLiteDatabase first.
+        // retainAcross keeps the rawKey buffer alive for the SQLCipher pool's lifetime
+        // (SQLiteConnection re-reads it on every lazily-opened pool connection). The
+        // returned handle zeros the buffer when closed; SqlCipherPassStore.close()
+        // closes the SQLiteDatabase first, then this handle.
         var openedDb: SQLiteDatabase? = null
         val keyHandle: AutoCloseable = databaseKey.retainAcross { rawKey ->
-            openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null)
+            openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null, cipherCompatV4Hook)
         }
         val db: SQLiteDatabase = openedDb!!
 
-        // Pin SQLCipher v4 page format defensively against a future major-version default
-        // change. Issued before any other DDL/DML so the page format is locked before
-        // tables get created. Probe the on-disk schema version after PRAGMA so any failure
-        // here is mapped to DatabaseCorrupt with the cause attached.
+        // cipher_compatibility is locked by [cipherCompatV4Hook] before the first decode
+        // (see file-level KDoc for the wpass-aio reasoning). foreign_keys is
+        // connection-scoped and does not affect the KDF or page format, so it is fine
+        // post-open. Failures from the schema-probe SELECT map to DatabaseCorrupt.
         val onDiskVersion: Int? = try {
-            db.execSQL("PRAGMA cipher_compatibility = 4")
             db.execSQL("PRAGMA foreign_keys = ON")
             readSchemaVersionIfPresent(db)
         } catch (e: CancellationException) {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -16,8 +16,8 @@ import java.io.File
 
 /**
  * Opens (or creates on first use) the `walt_passes.db` SQLCipher file with the supplied
- * [DatabaseKey], pins the SQLCipher v4 page format via a pre/postKey hook (so the KDF
- * regime is locked BEFORE the binding decrypts page 1), runs [Schema.DDL] under a single
+ * [DatabaseKey], pins the SQLCipher v4 page format via a postKey hook (so the KDF regime
+ * is locked BEFORE the binding decrypts page 1), runs [Schema.DDL] under a single
  * transaction on first use, and enables `PRAGMA foreign_keys=ON` so the `ON DELETE CASCADE`
  * chains for `pass_images` and `pass_locales` actually fire (SQLite/SQLCipher default this off).
  *
@@ -26,7 +26,7 @@ import java.io.File
  *
  * Maintenance note: any PRAGMA that affects the KDF or page format (cipher_compatibility,
  * cipher_default_kdf_iter, cipher_page_size, etc.) MUST be issued from the
- * [SQLiteDatabaseHook] preKey/postKey, NOT after [SQLiteDatabase.openOrCreateDatabase].
+ * [SQLiteDatabaseHook] postKey, NOT after [SQLiteDatabase.openOrCreateDatabase].
  * On reopen of an existing v4-on-disk database, the binding chooses a default KDF regime
  * at open time; a post-open `PRAGMA cipher_compatibility = 4` lands too late, the lazy
  * page-1 decode runs with the wrong KDF, and surfaces as `SQLITE_NOMEM` (wpass-aio).
@@ -43,15 +43,15 @@ internal object SqlCipherDatabaseFactory {
     private const val PRAGMA_CIPHER_COMPAT_V4: String = "PRAGMA cipher_compatibility = 4"
 
     /**
-     * Pins the SQLCipher v4 KDF/MAC regime BEFORE and AFTER the key is consumed by the
-     * binding. preKey runs before the key is set; postKey runs after. Setting the pragma
-     * in both is a defensive belt-and-suspenders against binding builds that ignore one
-     * or the other for cipher_compatibility specifically. Stateless and thread-safe; a
-     * single instance is reused across all opens.
+     * Pins the SQLCipher v4 KDF/MAC regime in [postKey], which runs after the binding has
+     * accepted the supplied key but before any decryption work. `cipher_compatibility`
+     * tells the binding how to interpret that key, so it MUST be issued post-key; preKey
+     * (no key yet) is the wrong moment per Zetetic's documented placement. Stateless and
+     * thread-safe; a single instance is reused across all opens.
      */
     private val cipherCompatV4Hook: SQLiteDatabaseHook = object : SQLiteDatabaseHook {
         override fun preKey(connection: SQLiteConnection) {
-            connection.execute(PRAGMA_CIPHER_COMPAT_V4, null, null)
+            // No-op: cipher_compatibility belongs in postKey.
         }
 
         override fun postKey(connection: SQLiteConnection) {
@@ -82,26 +82,16 @@ internal object SqlCipherDatabaseFactory {
         dbFile.parentFile?.mkdirs()
         val isDebuggable: Boolean = isHostAppDebuggable(context)
 
-        // retainAcross keeps the rawKey buffer alive for the SQLCipher pool's lifetime
-        // (SQLiteConnection re-reads it on every lazily-opened pool connection). The
-        // returned handle zeros the buffer when closed; SqlCipherPassStore.close()
-        // closes the SQLiteDatabase first, then this handle.
-        var openedDb: SQLiteDatabase? = null
-        val keyHandle: AutoCloseable = databaseKey.retainAcross { rawKey ->
-            openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null, cipherCompatV4Hook)
-        }
-        val db: SQLiteDatabase = openedDb!!
+        val openOutcome = openHandleWithKey(dbFile, databaseKey, isDebuggable)
+        if (openOutcome !is StorageResult.Success) return openOutcome
+        val (db, keyHandle) = openOutcome.value
 
-        // cipher_compatibility is locked by [cipherCompatV4Hook] before the first decode
-        // (see file-level KDoc for the wpass-aio reasoning). foreign_keys is
-        // connection-scoped and does not affect the KDF or page format, so it is fine
-        // post-open. Failures from the schema-probe SELECT map to DatabaseCorrupt.
+        // cipher_compatibility is set by [cipherCompatV4Hook]; foreign_keys is
+        // connection-scoped and does not affect KDF or page format. See file-level KDoc.
         val onDiskVersion: Int? = try {
             db.execSQL("PRAGMA foreign_keys = ON")
             readSchemaVersionIfPresent(db)
         } catch (e: CancellationException) {
-            // Coroutine cancellation: surface, do NOT map to DatabaseCorrupt. Close
-            // best-effort to release the native handle and zero the key buffer.
             closeQuietly(db, keyHandle, isDebuggable, phase = "PRAGMA/schema-probe")
             throw e
         } catch (e: Exception) {
@@ -160,6 +150,50 @@ internal object SqlCipherDatabaseFactory {
 
     private fun isHostAppDebuggable(context: Context): Boolean =
         context.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+
+    /**
+     * Hands the raw key to [SQLiteDatabase.openOrCreateDatabase] under [retainAcross], and
+     * routes any failure (including a throw from the postKey hook) through [openCorrupt].
+     * On the success path the caller owns the [OpenedDatabase] and is responsible for
+     * closing it.
+     */
+    private fun openHandleWithKey(
+        dbFile: File,
+        databaseKey: DatabaseKey,
+        isDebuggable: Boolean,
+    ): StorageResult<OpenedDatabase> {
+        var openedDb: SQLiteDatabase? = null
+        val keyHandle: AutoCloseable = try {
+            databaseKey.retainAcross { rawKey ->
+                openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null, cipherCompatV4Hook)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            return openCorrupt(e, isDebuggable)
+        }
+        return StorageResult.Success(OpenedDatabase(openedDb!!, keyHandle))
+    }
+
+    /**
+     * Failure path for openOrCreateDatabase itself (including throws from the postKey
+     * hook). No SQLiteDatabase or keyHandle exist yet to close - retainAcross zeros the
+     * key buffer eagerly when its block throws, so this path has no resources to release.
+     */
+    private fun openCorrupt(
+        cause: Exception,
+        isDebuggable: Boolean,
+    ): StorageResult<OpenedDatabase> {
+        if (isDebuggable) {
+            Log.w(LOG_TAG, "SqlCipher openOrCreateDatabase failed: ${cause.javaClass.name}: ${cause.message}", cause)
+        }
+        return StorageResult.Failure(
+            StorageError.Unknown(
+                kind = UnknownStorageFailureKind.DatabaseCorrupt,
+                cause = cause,
+            ),
+        )
+    }
 
     private fun databaseCorrupt(
         db: SQLiteDatabase,


### PR DESCRIPTION
## Summary

Third attempt at fixing wpass-aio. The first two (#49 logcat logging, #51 retainAcross / keyHandle close) didn't address the real failure mode. This one does.

**Bug:** Reopen of an existing v4-on-disk SQLCipher DB fails with `SQLiteOutOfMemoryException` (SQLITE_NOMEM) from page-1 decrypt at `readSchemaVersionIfPresent`. Surfaces in the wallet UI as "Passes unavailable - Secure storage is unavailable."

**Root cause (per bd notes on wpass-aio):** `PRAGMA cipher_compatibility = 4` was applied *after* `SQLiteDatabase.openOrCreateDatabase`. On reopen, the binding has already chosen a default KDF regime by the time the post-open PRAGMA could fire; the lazy page-1 decode runs with the wrong KDF and the native `sqlite3_malloc` fails. Process #1 (create+write) masked the bug because there were no on-disk pages to decrypt yet - the post-open PRAGMA still landed before the schema DDL flushed page 1 with v4 KDF/MAC.

**Fix:**
- Move `cipher_compatibility = 4` into a `SQLiteDatabaseHook` (`preKey` + `postKey`) so the v4 KDF regime is locked before the first decode. Both hooks are belt-and-suspenders against binding builds that ignore one or the other for this pragma.
- Issue the pragma via `SQLiteConnection.execute(...)`, the only API available inside `preKey` (no `SQLiteDatabase` exists yet).
- Keep `PRAGMA foreign_keys = ON` post-open: it is connection-scoped and does not affect KDF or page format.
- File-level KDoc gains a maintenance note that any future KDF/page-format pragma MUST go through the hook.

**What is preserved from #51:** `retainAcross` + the keyHandle close path. Its pool-lifetime hypothesis was wrong about SQLITE_NOMEM (same-process create+write succeeded fully without it; new-process reopen cannot benefit from a "retained" buffer that was never built in process #1 JVM), but it does fix the closeable-leak warning from the original bug report. The cleanup of the `var openedDb` / `!!` awkwardness is tracked separately as wpass-t5g.

## Test plan

- [x] gradlew :passes-storage:detekt - passes
- [x] gradlew :passes-storage:testDebugUnitTest - passes (includes the existing PublicApiSurfaceTest from #51)
- [x] gradlew :passes-storage:compileDebugAndroidTestKotlin - new test compiles
- [ ] **Device test (required to confirm fix)**: on FP4 / Android 16 with waltDebug:
  1. pm clear is.walt.app
  2. Install the build
  3. Open Passes screen - should NOT show "Secure storage is unavailable"
  4. Import golden.pkpass, observe passes_pass_rendered
  5. am force-stop is.walt.app
  6. Relaunch and tap Passes - observe NO passes_storage_failure; the imported pass renders
- [ ] **Instrumentation test on emulator/device**: gradlew :passes-storage:connectedDebugAndroidTest should run the new CipherCompatReopenTest along with the existing instrumentation suite. Same-process fresh-instance is the closest the JUnit harness gets to "fresh JVM"; the SQLCipher binding per-connection KDF state lives on the SQLiteDatabase handle, so closing process #1 repo and constructing a new one is sufficient to reproduce the open-time KDF mismatch.