### PR TITLE
passes-core: surface ParseFailureReason on ParseFailedEvent (wpass-i21)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ParseResult.kt
@@ -125,3 +125,54 @@ public fun ParseResult.toFailureKind(): ParseFailureKind? =
             }
         is ParseResult.Unsupported -> ParseFailureKind.Unsupported
     }
+
+/**
+ * Telemetry-safe flattening of failure reasons. [ParseResult.Success] returns `null`. The
+ * exhaustive `when` is the drift detector: adding a sealed arm to [TamperReason],
+ * [MalformedReason], or [UnsupportedReason] without extending [ParseFailureReason] is a
+ * compile error here. Companion to [toFailureKind] — same shape, finer-grained dimension.
+ *
+ * Cyclomatic complexity (~26) is load-bearing, not accidental: every sealed arm of every
+ * failure hierarchy must be enumerated in a single place so that adding a new arm without
+ * extending [ParseFailureReason] fails the build. Splitting into per-source helpers would
+ * scatter the drift detector and weaken the "one place a missing arm trips a compile
+ * error" guarantee. Same rationale as `WaltPassesTelemetryAdapter`'s `@Suppress` on
+ * `TooManyFunctions` in the consumer.
+ */
+@Suppress("CyclomaticComplexMethod")
+public fun ParseResult.toFailureReason(): ParseFailureReason? =
+    when (this) {
+        is ParseResult.Success -> null
+        is ParseResult.Tampered ->
+            when (reason) {
+                TamperReason.ManifestSignatureMismatch -> ParseFailureReason.ManifestSignatureMismatch
+                TamperReason.FileHashMismatch -> ParseFailureReason.FileHashMismatch
+                TamperReason.SignatureCryptoFailure -> ParseFailureReason.SignatureCryptoFailure
+                TamperReason.SignerCertificateMissing -> ParseFailureReason.SignerCertificateMissing
+            }
+        is ParseResult.Malformed ->
+            when (val r = reason) {
+                MalformedReason.NotAZipArchive -> ParseFailureReason.NotAZipArchive
+                MalformedReason.MissingPassJson -> ParseFailureReason.MissingPassJson
+                MalformedReason.MissingManifest -> ParseFailureReason.MissingManifest
+                MalformedReason.InvalidPassJson -> ParseFailureReason.InvalidPassJson
+                MalformedReason.InvalidManifest -> ParseFailureReason.InvalidManifest
+                MalformedReason.InvalidStrings -> ParseFailureReason.InvalidStrings
+                is MalformedReason.ResourceLimitExceeded ->
+                    when (r.limit) {
+                        ResourceLimit.ArchiveSize -> ParseFailureReason.ArchiveSizeLimit
+                        ResourceLimit.EntryCount -> ParseFailureReason.EntryCountLimit
+                        ResourceLimit.EntrySize -> ParseFailureReason.EntrySizeLimit
+                        ResourceLimit.JsonDepth -> ParseFailureReason.JsonDepthLimit
+                        ResourceLimit.JsonStringSize -> ParseFailureReason.JsonStringSizeLimit
+                        ResourceLimit.ImagePixelCount -> ParseFailureReason.ImagePixelCountLimit
+                        ResourceLimit.LocaleCount -> ParseFailureReason.LocaleCountLimit
+                    }
+            }
+        is ParseResult.Unsupported ->
+            when (reason) {
+                is UnsupportedReason.FormatVersion -> ParseFailureReason.UnsupportedFormatVersion
+                is UnsupportedReason.UnknownPassStyle -> ParseFailureReason.UnknownPassStyle
+                UnsupportedReason.EncryptedArchive -> ParseFailureReason.EncryptedArchive
+            }
+    }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/TelemetryGuard.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/TelemetryGuard.kt
@@ -36,10 +36,22 @@ public data class ParseSucceededEvent(
     public val localeCount: Int,
 )
 
+/**
+ * [outcome] is a computed property, not a constructor arg, so the cross-field invariant
+ * `outcome == reason.toKind()` is enforced by construction rather than by convention. A
+ * caller cannot build an event with mismatched bucket and reason; the only knobs that
+ * shape the event are [reason] and [durationMillis]. Equality / [hashCode] / [copy] /
+ * destructuring follow the data-class shape — i.e. two events with the same [reason]
+ * and [durationMillis] are equal regardless, which is the right semantics because
+ * [outcome] adds no independent information.
+ */
 public data class ParseFailedEvent(
-    public val outcome: ParseFailureKind,
+    public val reason: ParseFailureReason,
     public val durationMillis: Long,
-)
+) {
+    public val outcome: ParseFailureKind
+        get() = reason.toKind()
+}
 
 /**
  * Telemetry-safe flattening of [SignatureStatus]. Mirrors the sealed-interface arms but
@@ -63,3 +75,90 @@ public enum class ParseFailureKind {
     Unsupported,
     ResourceLimitExceeded,
 }
+
+/**
+ * Telemetry-safe flattening of every [ParseResult] failure-reason arm. Mirrors the sealed
+ * arms of [TamperReason], [MalformedReason], and [UnsupportedReason] (and the seven
+ * [ResourceLimit] sub-buckets that lift out of [MalformedReason.ResourceLimitExceeded]).
+ *
+ * Lives as an enum, not a String, so the same structural-restriction discipline that
+ * [ParseFailedEvent] enforced on `outcome` extends to the reason: a consumer cannot smuggle
+ * a pass field, filename, or BC exception message through this dimension. The data carried
+ * by data-class arms (e.g. [UnsupportedReason.UnknownPassStyle.raw],
+ * [UnsupportedReason.FormatVersion.version]) is intentionally dropped — telemetry sees only
+ * the failure shape, never user-supplied content.
+ *
+ * Adding a new sealed arm to [ParseResult]'s reasons without extending this enum produces a
+ * compile error inside [toFailureReason], the same drift-detector pattern used by
+ * [toFailureKind].
+ */
+public enum class ParseFailureReason {
+    // TamperReason arms.
+    ManifestSignatureMismatch,
+    FileHashMismatch,
+    SignatureCryptoFailure,
+    SignerCertificateMissing,
+
+    // MalformedReason arms (non-resource).
+    NotAZipArchive,
+    MissingPassJson,
+    MissingManifest,
+    InvalidPassJson,
+    InvalidManifest,
+    InvalidStrings,
+
+    // ResourceLimit sub-buckets — surfaced individually because the operational signal of
+    // "which guard tripped" is exactly what makes ResourceLimitExceeded its own bucket in
+    // [ParseFailureKind] in the first place.
+    ArchiveSizeLimit,
+    EntryCountLimit,
+    EntrySizeLimit,
+    JsonDepthLimit,
+    JsonStringSizeLimit,
+    ImagePixelCountLimit,
+    LocaleCountLimit,
+
+    // UnsupportedReason arms.
+    UnsupportedFormatVersion,
+    UnknownPassStyle,
+    EncryptedArchive,
+}
+
+/**
+ * Maps a [ParseFailureReason] to its enclosing [ParseFailureKind] bucket. Encodes the 20→4
+ * narrowing that exists implicitly across [toFailureReason] / [toFailureKind] so that the
+ * cross-field invariant on [ParseFailedEvent] (`reason ∈ buckets-of(outcome)`) is checkable
+ * in code rather than enforced by convention. Adding a new [ParseFailureReason] arm without
+ * a bucket here is a compile error, the same drift-detector pattern used by [toFailureKind]
+ * and [toFailureReason].
+ */
+public fun ParseFailureReason.toKind(): ParseFailureKind =
+    when (this) {
+        ParseFailureReason.ManifestSignatureMismatch,
+        ParseFailureReason.FileHashMismatch,
+        ParseFailureReason.SignatureCryptoFailure,
+        ParseFailureReason.SignerCertificateMissing,
+        -> ParseFailureKind.Tampered
+
+        ParseFailureReason.NotAZipArchive,
+        ParseFailureReason.MissingPassJson,
+        ParseFailureReason.MissingManifest,
+        ParseFailureReason.InvalidPassJson,
+        ParseFailureReason.InvalidManifest,
+        ParseFailureReason.InvalidStrings,
+        -> ParseFailureKind.Malformed
+
+        ParseFailureReason.ArchiveSizeLimit,
+        ParseFailureReason.EntryCountLimit,
+        ParseFailureReason.EntrySizeLimit,
+        ParseFailureReason.JsonDepthLimit,
+        ParseFailureReason.JsonStringSizeLimit,
+        ParseFailureReason.ImagePixelCountLimit,
+        ParseFailureReason.LocaleCountLimit,
+        -> ParseFailureKind.ResourceLimitExceeded
+
+        ParseFailureReason.UnsupportedFormatVersion,
+        ParseFailureReason.UnknownPassStyle,
+        ParseFailureReason.EncryptedArchive,
+        -> ParseFailureKind.Unsupported
+    }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/DefaultPassParser.kt
@@ -15,7 +15,7 @@ import `is`.walt.passes.core.ResourceLimit
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.TamperReason
 import `is`.walt.passes.core.UnsupportedReason
-import `is`.walt.passes.core.toFailureKind
+import `is`.walt.passes.core.toFailureReason
 import `is`.walt.passes.core.toKind
 
 /**
@@ -236,12 +236,14 @@ internal class DefaultPassParser(private val config: ParserConfig) : PassParser 
             else ->
                 config.telemetryGuard.onParseFailed(
                     ParseFailedEvent(
-                        // toFailureKind() returns null only for Success, which the
-                        // outer `when` already routed; the !! is a category check, not
-                        // a runtime risk. A future ParseResult arm that breaks this
+                        // toFailureReason() returns null only for Success, which the
+                        // outer `when` already routed; the !! is a category check, not a
+                        // runtime risk. A future ParseResult arm that breaks this
                         // surfaces as an immediate test failure here, not a silent
-                        // observability hole.
-                        outcome = result.toFailureKind()!!,
+                        // observability hole. ParseFailedEvent.outcome derives from
+                        // reason via the computed property — no second `!!`, and the
+                        // cross-field invariant is enforced by construction.
+                        reason = result.toFailureReason()!!,
                         durationMillis = durationMillis,
                     ),
                 )

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PassParserTest.kt
@@ -275,6 +275,9 @@ class PassParserTest {
             .inOrder()
         val failed = recorder.events[1] as RecordedEvent.Failed
         assertThat(failed.event.outcome).isEqualTo(ParseFailureKind.Malformed)
+        // Reason must travel with outcome — a one-byte input lands on the
+        // NotAZipArchive arm, which the parser populates via toFailureReason().
+        assertThat(failed.event.reason).isEqualTo(ParseFailureReason.NotAZipArchive)
     }
 
     @Test

--- a/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/PublicApiSurfaceTest.kt
@@ -96,6 +96,87 @@ class PublicApiSurfaceTest {
     }
 
     /**
+     * Companion to [parseResultFailureKindCoversEveryArm] for [ParseFailureReason]. Every
+     * [TamperReason] / [MalformedReason] / [UnsupportedReason] arm — including all seven
+     * [ResourceLimit] sub-buckets that lift out of [MalformedReason.ResourceLimitExceeded] —
+     * round-trips to a distinct [ParseFailureReason]. Together with the exhaustive `when`
+     * inside [toFailureReason], this pins both directions of the mapping.
+     */
+    @Test
+    fun parseResultFailureReasonCoversEveryArm() {
+        val tamperReasons: List<ParseResult> =
+            listOf(
+                ParseResult.Tampered(TamperReason.ManifestSignatureMismatch),
+                ParseResult.Tampered(TamperReason.FileHashMismatch),
+                ParseResult.Tampered(TamperReason.SignatureCryptoFailure),
+                ParseResult.Tampered(TamperReason.SignerCertificateMissing),
+            )
+        val malformedReasons: List<ParseResult> =
+            listOf(
+                ParseResult.Malformed(MalformedReason.NotAZipArchive),
+                ParseResult.Malformed(MalformedReason.MissingPassJson),
+                ParseResult.Malformed(MalformedReason.MissingManifest),
+                ParseResult.Malformed(MalformedReason.InvalidPassJson),
+                ParseResult.Malformed(MalformedReason.InvalidManifest),
+                ParseResult.Malformed(MalformedReason.InvalidStrings),
+            )
+        val resourceReasons: List<ParseResult> =
+            ResourceLimit.entries.map {
+                ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(it))
+            }
+        val unsupportedReasons: List<ParseResult> =
+            listOf(
+                ParseResult.Unsupported(UnsupportedReason.FormatVersion(2)),
+                ParseResult.Unsupported(UnsupportedReason.UnknownPassStyle("nfcPass")),
+                ParseResult.Unsupported(UnsupportedReason.EncryptedArchive),
+            )
+        val all = tamperReasons + malformedReasons + resourceReasons + unsupportedReasons
+        val mapped = all.mapNotNull { it.toFailureReason() }
+
+        assertThat(mapped).hasSize(all.size)
+        // Every kernel-defined ParseFailureReason is reachable from some sealed-arm input,
+        // and no two distinct inputs collapse onto the same reason value.
+        assertThat(mapped.toSet()).containsExactlyElementsIn(ParseFailureReason.entries)
+        assertThat(ParseResult.Success(samplePass(), SignatureStatus.AppleVerified).toFailureReason())
+            .isNull()
+    }
+
+    /**
+     * Pins agreement between the two telemetry-mapping helpers: for every [ParseResult]
+     * failure arm, `result.toFailureReason()?.toKind() == result.toFailureKind()`. The
+     * cross-field invariant on [ParseFailedEvent] is already enforced by construction
+     * (its `outcome` is a computed property derived from `reason`), so this test guards
+     * the *function-pair* — a future edit to one helper that doesn't update the other
+     * would otherwise silently mis-bucket the outcome. Bucket-coverage is pinned by
+     * [parseResultFailureKindCoversEveryArm]; this test focuses on the round-trip.
+     */
+    @Test
+    fun parseFailureReasonToKindMatchesParseResultMapping() {
+        val all: List<ParseResult> =
+            listOf(
+                ParseResult.Tampered(TamperReason.ManifestSignatureMismatch),
+                ParseResult.Tampered(TamperReason.FileHashMismatch),
+                ParseResult.Tampered(TamperReason.SignatureCryptoFailure),
+                ParseResult.Tampered(TamperReason.SignerCertificateMissing),
+                ParseResult.Malformed(MalformedReason.NotAZipArchive),
+                ParseResult.Malformed(MalformedReason.MissingPassJson),
+                ParseResult.Malformed(MalformedReason.MissingManifest),
+                ParseResult.Malformed(MalformedReason.InvalidPassJson),
+                ParseResult.Malformed(MalformedReason.InvalidManifest),
+                ParseResult.Malformed(MalformedReason.InvalidStrings),
+                ParseResult.Unsupported(UnsupportedReason.FormatVersion(2)),
+                ParseResult.Unsupported(UnsupportedReason.UnknownPassStyle("nfcPass")),
+                ParseResult.Unsupported(UnsupportedReason.EncryptedArchive),
+            ) +
+                ResourceLimit.entries.map {
+                    ParseResult.Malformed(MalformedReason.ResourceLimitExceeded(it))
+                }
+        all.forEach { result ->
+            assertThat(result.toFailureReason()?.toKind()).isEqualTo(result.toFailureKind())
+        }
+    }
+
+    /**
      * Every [ResourceLimit] enum value has a backing [ParserConfig] field. The exhaustive
      * `when` inside [limitFrom] enforces the existence side at compile time; this test
      * proves the values are non-zero (a misconfigured field would silently zero-out a guard
@@ -165,7 +246,12 @@ class PublicApiSurfaceTest {
                 localeCount = 2,
             ),
         )
-        guard.onParseFailed(ParseFailedEvent(ParseFailureKind.Tampered, 7L))
+        guard.onParseFailed(
+            ParseFailedEvent(
+                reason = ParseFailureReason.ManifestSignatureMismatch,
+                durationMillis = 7L,
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

Surfaces a 20-entry `ParseFailureReason` on `ParseFailedEvent` so downstream telemetry distinguishes specific failure arms (e.g. `FileHashMismatch` vs `ManifestSignatureMismatch`) instead of collapsing to the four-bucket `ParseFailureKind`. Walt-side adapter (wlt-srb) consumes the new field so logcat reads `passes_parse_failed [outcome=Tampered, reason=FileHashMismatch, duration_ms=N]` instead of dropping the specific arm — recovers ~30 min of openssl/BC archaeology that was lost on a recent smoke test (wlt-a07 post-mortem).

## Shape

- `ParseFailureReason` enum (20 entries flattening every `TamperReason` / `MalformedReason` / `UnsupportedReason` arm and the seven `ResourceLimit` sub-buckets). Enum, not String — the `TelemetryGuard` structural restriction ("no String carrying pass content") is preserved by construction; data-class-arm payloads (`UnsupportedReason.UnknownPassStyle.raw`, `UnsupportedReason.FormatVersion.version`) are intentionally dropped.
- `ParseResult.toFailureReason()` exhaustive `when` mapping. `@Suppress("CyclomaticComplexMethod")` is load-bearing: every sealed arm of every failure hierarchy must enumerate in one place so that adding a new arm without extending the enum is a compile error. Splitting into per-source helpers would scatter the drift detector.
- `ParseFailureReason.toKind()` extension narrows the 20 reasons to their 4 buckets via exhaustive `when` — third drift detector.
- `ParseFailedEvent.outcome` is a **computed property** (`get() = reason.toKind()`), not a constructor arg. The cross-field invariant `outcome ∈ buckets-of(reason)` is enforced by construction; a caller cannot build an event with mismatched bucket and reason. The constructor takes only `reason` and `durationMillis`, and data-class `equals`/`hashCode`/`copy`/destructuring follow that shape since `outcome` carries no independent information.
- `DefaultPassParser.emit()` populates the event via `toFailureReason()!!` only — one `!!` instead of two, since `outcome` derives from `reason`.

## Architectural notes

- `ParseResult.toFailureKind()` is retained as belt-and-braces. It has no production callers post-iteration (only tests use it), but it documents the 4-bucket model independently of the 20-reason model and the new agreement test pins it in lockstep with `toFailureReason()?.toKind()`. The cost of one extra exhaustive `when` is low and it stays useful as a second compile-time check on sealed-arm extensions. Deliberate decision; happy to delete if reviewers prefer the tighter surface.

## Walt-side adoption (wlt-srb)

Adapter production code reads `event.outcome` (still resolves through the computed property — no source change). The constructor change touches one test fixture: `WaltPassesTelemetryAdapterTest` must drop `outcome =` and pass `reason = ...` only. wlt-srb already adds the new `reason` dimension to logged events.

## Test plan

- [x] `./gradlew :passes-core:test` (BUILD SUCCESSFUL)
- [x] `./gradlew :passes-core:detekt` (BUILD SUCCESSFUL)
- [ ] Walt-side PR (wlt-srb) consumes this kernel change via composite build — must land here first

Pinned by:
- `PublicApiSurfaceTest.parseResultFailureReasonCoversEveryArm` — every sealed-arm input round-trips to a distinct `ParseFailureReason`; the set covers `ParseFailureReason.entries`.
- `PublicApiSurfaceTest.parseFailureReasonToKindMatchesParseResultMapping` — for every failure arm, `result.toFailureReason()?.toKind() == result.toFailureKind()`. Function-pair lockstep.
- `PassParserTest.telemetryEmitsStartedThenFailedOnNonZipInput` — extended to assert `reason == NotAZipArchive` on the existing failure path.