### PR TITLE
passes-ui: pass.strings substitution + tighten phone detector (wpass-38y, wpass-536)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
@@ -131,7 +131,62 @@ public enum class ImageRole {
 }
 
 /** Contents of a single `<locale>.lproj/pass.strings` file. */
-public data class LocalizedStrings(public val entries: Map<String, String>)
+public data class LocalizedStrings(public val entries: Map<String, String>) {
+    public companion object {
+        /** Empty strings table. Used as the no-op fallback when a pass carries no locales. */
+        public val Empty: LocalizedStrings = LocalizedStrings(emptyMap())
+    }
+}
+
+/**
+ * Looks [raw] up in this strings table; if absent (or [raw] is null), returns [raw]
+ * unchanged. This is Apple's documented PKPASS behavior for `label`, `value`, and
+ * `attributedValue`: the field's literal text is treated as the lookup key, and a
+ * miss falls through to the raw text.
+ *
+ * The "fall through to raw" path is what makes the substitution idempotent and makes
+ * dynamic field values (ticket numbers, dates, codes) safe to pipe through this
+ * function: they will not match any key and emerge unchanged.
+ */
+public fun LocalizedStrings.lookupOrSelf(raw: String?): String? {
+    if (raw == null) return null
+    return entries[raw] ?: raw
+}
+
+/**
+ * Resolves a [LocalizedStrings] from this pass's [Pass.locales] for [preferred], using
+ * Apple's documented PKPASS locale-fallback chain:
+ *
+ *  1. Exact tag match (`en-US` finds `en-US.lproj`).
+ *  2. Language-only fallback (`en-US` -> `en`, `sv-FI` -> `sv`). The split point is
+ *     either `-` (BCP 47) or `_` (legacy `Locale.toString()` form), whichever the
+ *     consumer hands in.
+ *  3. The `en` table, when present. Apple treats English as the implicit project
+ *     fallback.
+ *  4. The first locale declared in archive order. PKPASS does not pin a "default"
+ *     locale; this matches the order [DefaultPassParser.collectLocales] preserves
+ *     and gives the consumer *some* localized substitution rather than reverting
+ *     every label to its raw key.
+ *  5. [LocalizedStrings.Empty] when the pass has no `.lproj/pass.strings` at all.
+ *     The empty table makes [LocalizedStrings.lookupOrSelf] a pure passthrough so
+ *     callers can substitute unconditionally.
+ *
+ * Pure function: passes-core never reads the device locale itself (it is JVM-only by
+ * module boundary and KMP-portable by intent). The consumer module that knows the
+ * platform locale APIs hands the chosen [PassLocale] in.
+ */
+public fun Pass.resolveLocalizedStrings(preferred: PassLocale): LocalizedStrings {
+    if (locales.isEmpty()) return LocalizedStrings.Empty
+    val language = preferred.tag.substringBefore('-').substringBefore('_')
+    val languageFallback =
+        language
+            .takeIf { it.isNotEmpty() && it != preferred.tag }
+            ?.let { locales[PassLocale(it)] }
+    return locales[preferred]
+        ?: languageFallback
+        ?: locales[PassLocale("en")]
+        ?: locales.values.first()
+}
 
 /**
  * BCP-47 language tag, e.g. `en-US`, `de`, `zh-Hant`. Parsing of the tag itself is left to

--- a/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/Pass.kt
@@ -139,19 +139,28 @@ public data class LocalizedStrings(public val entries: Map<String, String>) {
 }
 
 /**
- * Looks [raw] up in this strings table; if absent (or [raw] is null), returns [raw]
- * unchanged. This is Apple's documented PKPASS behavior for `label`, `value`, and
- * `attributedValue`: the field's literal text is treated as the lookup key, and a
+ * Looks [raw] up in this strings table; if absent, returns [raw] unchanged. This is
+ * Apple's documented PKPASS behavior for `label`, `value`, `attributedValue`, and
+ * `organizationName`: the field's literal text is treated as the lookup key, and a
  * miss falls through to the raw text.
  *
  * The "fall through to raw" path is what makes the substitution idempotent and makes
  * dynamic field values (ticket numbers, dates, codes) safe to pipe through this
  * function: they will not match any key and emerge unchanged.
  */
-public fun LocalizedStrings.lookupOrSelf(raw: String?): String? {
-    if (raw == null) return null
-    return entries[raw] ?: raw
-}
+public fun LocalizedStrings.lookupOrSelf(raw: String): String = entries[raw] ?: raw
+
+/**
+ * Nullable overload of [lookupOrSelf]. Returns `null` only when [raw] is `null`; for
+ * present values, behaves exactly like the non-nullable form. Exists so callers
+ * holding a nullable [PassField.label] do not have to lift the null-check themselves.
+ *
+ * `@JvmName` differentiates this from the non-nullable overload — JVM type erasure
+ * collapses `String` and `String?` to the same descriptor, so without an alias the
+ * compiler refuses both declarations.
+ */
+@JvmName("lookupOrSelfNullable")
+public fun LocalizedStrings.lookupOrSelf(raw: String?): String? = raw?.let { lookupOrSelf(it) }
 
 /**
  * Resolves a [LocalizedStrings] from this pass's [Pass.locales] for [preferred], using
@@ -163,10 +172,12 @@ public fun LocalizedStrings.lookupOrSelf(raw: String?): String? {
  *     consumer hands in.
  *  3. The `en` table, when present. Apple treats English as the implicit project
  *     fallback.
- *  4. The first locale declared in archive order. PKPASS does not pin a "default"
- *     locale; this matches the order [DefaultPassParser.collectLocales] preserves
- *     and gives the consumer *some* localized substitution rather than reverting
- *     every label to its raw key.
+ *  4. The locale with the lexicographically-smallest tag. PKPASS does not pin a
+ *     "default" locale; sorting deterministically (rather than relying on map
+ *     iteration order) gives the consumer *some* localized substitution rather than
+ *     reverting every label to its raw key, and is reproducible regardless of how
+ *     [Pass.locales] was constructed. The contract type [Pass.locales] is a plain
+ *     `Map`, so insertion order is not guaranteed and cannot be load-bearing.
  *  5. [LocalizedStrings.Empty] when the pass has no `.lproj/pass.strings` at all.
  *     The empty table makes [LocalizedStrings.lookupOrSelf] a pure passthrough so
  *     callers can substitute unconditionally.
@@ -182,10 +193,12 @@ public fun Pass.resolveLocalizedStrings(preferred: PassLocale): LocalizedStrings
         language
             .takeIf { it.isNotEmpty() && it != preferred.tag }
             ?.let { locales[PassLocale(it)] }
+    val deterministicFallback = locales.entries.minByOrNull { it.key.tag }?.value
     return locales[preferred]
         ?: languageFallback
         ?: locales[PassLocale("en")]
-        ?: locales.values.first()
+        ?: deterministicFallback
+        ?: LocalizedStrings.Empty
 }
 
 /**

--- a/passes-core/src/test/kotlin/is/walt/passes/core/LocalizedStringsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/LocalizedStringsTest.kt
@@ -1,0 +1,148 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LocalizedStringsTest {
+    @Test
+    fun lookupOrSelfReturnsMappedValueWhenKeyPresent() {
+        val strings = LocalizedStrings(mapOf("#LABELTICKETNUMBER#" to "Ticket Number"))
+        assertThat(strings.lookupOrSelf("#LABELTICKETNUMBER#")).isEqualTo("Ticket Number")
+    }
+
+    @Test
+    fun lookupOrSelfReturnsRawWhenKeyAbsent() {
+        val strings = LocalizedStrings(mapOf("#LABELTICKETNUMBER#" to "Ticket Number"))
+        assertThat(strings.lookupOrSelf("52311919")).isEqualTo("52311919")
+    }
+
+    @Test
+    fun lookupOrSelfReturnsNullWhenInputNull() {
+        val strings = LocalizedStrings(mapOf("a" to "b"))
+        assertThat(strings.lookupOrSelf(null)).isNull()
+    }
+
+    @Test
+    fun lookupOrSelfOnEmptyTableIsPassthrough() {
+        assertThat(LocalizedStrings.Empty.lookupOrSelf("anything")).isEqualTo("anything")
+    }
+
+    @Test
+    fun resolveLocalizedStringsExactTagWins() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("en") to LocalizedStrings(mapOf("k" to "english")),
+                PassLocale("en-US") to LocalizedStrings(mapOf("k" to "us-english")),
+            )
+        assertThat(pass.resolveLocalizedStrings(PassLocale("en-US")).entries["k"])
+            .isEqualTo("us-english")
+    }
+
+    @Test
+    fun resolveLocalizedStringsLanguageFallbackBcp47() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("sv") to LocalizedStrings(mapOf("k" to "swedish")),
+                PassLocale("en") to LocalizedStrings(mapOf("k" to "english")),
+            )
+        // Device locale is sv-FI (Swedish in Finland); exact miss falls to language `sv`,
+        // not to the `en` default.
+        assertThat(pass.resolveLocalizedStrings(PassLocale("sv-FI")).entries["k"])
+            .isEqualTo("swedish")
+    }
+
+    @Test
+    fun resolveLocalizedStringsLanguageFallbackLegacyUnderscoreForm() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("de") to LocalizedStrings(mapOf("k" to "german")),
+            )
+        // Java's Locale.toString() emits `de_DE`-style; passes-core does not impose BCP 47
+        // on the consumer, so the underscore form must language-split too.
+        assertThat(pass.resolveLocalizedStrings(PassLocale("de_DE")).entries["k"])
+            .isEqualTo("german")
+    }
+
+    @Test
+    fun resolveLocalizedStringsFallsBackToEnglish() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("en") to LocalizedStrings(mapOf("k" to "english")),
+                PassLocale("de") to LocalizedStrings(mapOf("k" to "german")),
+            )
+        // Device locale is fr-CA; no exact, no `fr` table, so the documented `en`
+        // fallback wins over arbitrary first-locale picking.
+        assertThat(pass.resolveLocalizedStrings(PassLocale("fr-CA")).entries["k"])
+            .isEqualTo("english")
+    }
+
+    @Test
+    fun resolveLocalizedStringsFallsBackToFirstAvailableWhenNoEnglish() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("da") to LocalizedStrings(mapOf("k" to "danish")),
+                PassLocale("nb") to LocalizedStrings(mapOf("k" to "norwegian")),
+            )
+        // No exact match, no language-only match, no `en`. Falling back to the first
+        // declared locale is preferable to returning empty — at least one localized
+        // table is applied so labels are not raw `#KEY#` placeholders.
+        assertThat(pass.resolveLocalizedStrings(PassLocale("fr-CA")).entries["k"])
+            .isEqualTo("danish")
+    }
+
+    @Test
+    fun resolveLocalizedStringsReturnsEmptyWhenPassHasNoLocales() {
+        val pass = sampleLocalizedPass()
+        assertThat(pass.resolveLocalizedStrings(PassLocale("en")))
+            .isEqualTo(LocalizedStrings.Empty)
+    }
+
+    /**
+     * The chroniques pass (pass.com.tixly) regression: 8 lprojs (da, de, en, fi, is, nb,
+     * nl, sv) and labels declared as `#LABELKEY#` placeholders. wpass-38y. After the
+     * fix, the resolved English table substitutes the placeholder to its human label.
+     */
+    @Test
+    fun chroniquesFixtureSubstitutesLabelPlaceholders() {
+        val pass =
+            sampleLocalizedPass(
+                PassLocale("en") to
+                    LocalizedStrings(
+                        mapOf(
+                            "#LABELTICKETNUMBER#" to "Ticket Number",
+                            "#LABELORDERNUMBER#" to "Order Number",
+                            "#LABELPRICEZONE#" to "Price Zone",
+                        ),
+                    ),
+                PassLocale("da") to LocalizedStrings(emptyMap()),
+                PassLocale("de") to LocalizedStrings(emptyMap()),
+                PassLocale("fi") to LocalizedStrings(emptyMap()),
+                PassLocale("is") to LocalizedStrings(emptyMap()),
+                PassLocale("nb") to LocalizedStrings(emptyMap()),
+                PassLocale("nl") to LocalizedStrings(emptyMap()),
+                PassLocale("sv") to LocalizedStrings(emptyMap()),
+            )
+        val strings = pass.resolveLocalizedStrings(PassLocale("en"))
+        assertThat(strings.lookupOrSelf("#LABELTICKETNUMBER#")).isEqualTo("Ticket Number")
+        assertThat(strings.lookupOrSelf("#LABELORDERNUMBER#")).isEqualTo("Order Number")
+        assertThat(strings.lookupOrSelf("#LABELPRICEZONE#")).isEqualTo("Price Zone")
+        // Dynamic values (the actual ticket digits) must pass through unchanged.
+        assertThat(strings.lookupOrSelf("52311919")).isEqualTo("52311919")
+    }
+
+    private fun sampleLocalizedPass(vararg locales: Pair<PassLocale, LocalizedStrings>): Pass =
+        Pass(
+            type = PassType.Generic,
+            serialNumber = "S",
+            description = "D",
+            organizationName = "O",
+            expirationDate = null,
+            voided = false,
+            colors = PassColors(foreground = null, background = null, label = null),
+            frontFields = PassFields(),
+            backFields = emptyList(),
+            barcode = null,
+            images = emptyMap(),
+            locales = linkedMapOf(*locales),
+        )
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/LocalizedStringsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/LocalizedStringsTest.kt
@@ -77,15 +77,47 @@ class LocalizedStringsTest {
     }
 
     @Test
-    fun resolveLocalizedStringsFallsBackToFirstAvailableWhenNoEnglish() {
+    fun resolveLocalizedStringsFallsBackToSmallestTagWhenNoEnglish() {
         val pass =
             sampleLocalizedPass(
-                PassLocale("da") to LocalizedStrings(mapOf("k" to "danish")),
                 PassLocale("nb") to LocalizedStrings(mapOf("k" to "norwegian")),
+                PassLocale("da") to LocalizedStrings(mapOf("k" to "danish")),
             )
-        // No exact match, no language-only match, no `en`. Falling back to the first
-        // declared locale is preferable to returning empty — at least one localized
-        // table is applied so labels are not raw `#KEY#` placeholders.
+        // No exact match, no language-only match, no `en`. Falls back to the locale
+        // with the lexicographically-smallest tag (`da` < `nb`), independent of the
+        // map's iteration order. Picking deterministically (rather than relying on
+        // insertion order, which the Map<,,> contract type does not guarantee) keeps
+        // the visible result stable across parser refactors.
+        assertThat(pass.resolveLocalizedStrings(PassLocale("fr-CA")).entries["k"])
+            .isEqualTo("danish")
+    }
+
+    @Test
+    fun resolveLocalizedStringsFallbackIsStableForHashMapInputs() {
+        // The Pass.locales contract is a plain Map; a future parser that hands a
+        // HashMap (or anything else without insertion-order iteration) must not
+        // change which fallback locale we pick. This test pins the contract.
+        val locales =
+            HashMap<PassLocale, LocalizedStrings>().apply {
+                put(PassLocale("nb"), LocalizedStrings(mapOf("k" to "norwegian")))
+                put(PassLocale("da"), LocalizedStrings(mapOf("k" to "danish")))
+                put(PassLocale("sv"), LocalizedStrings(mapOf("k" to "swedish")))
+            }
+        val pass =
+            Pass(
+                type = PassType.Generic,
+                serialNumber = "S",
+                description = "D",
+                organizationName = "O",
+                expirationDate = null,
+                voided = false,
+                colors = PassColors(foreground = null, background = null, label = null),
+                frontFields = PassFields(),
+                backFields = emptyList(),
+                barcode = null,
+                images = emptyMap(),
+                locales = locales,
+            )
         assertThat(pass.resolveLocalizedStrings(PassLocale("fr-CA")).entries["k"])
             .isEqualTo("danish")
     }

--- a/passes-ui/detekt-baseline.xml
+++ b/passes-ui/detekt-baseline.xml
@@ -2,15 +2,14 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>LongMethod:PassFront.kt$@Composable public fun PassFront( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), nowEpochMillis: Long = System.currentTimeMillis(), )</ID>
     <ID>LongMethod:SecuritySheets.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun SecuritySheet( kind: SecurityIntentKind, passType: PassType, title: String, target: String, source: SourceField, confirmCopy: String, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
     <ID>LongParameterList:BoundedImage.kt$( bytes: ImageBytes, @Suppress("UNUSED_PARAMETER") role: ImageRole, contentDescription: String?, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, bounds: ImageRenderBounds = ImageRenderBounds.Default, )</ID>
-    <ID>LongParameterList:PassBack.kt$( pass: Pass, onUrlIntent: (B3UrlIntent) -&gt; Unit, onPhoneIntent: (PhoneIntent) -&gt; Unit, onEmailIntent: (EmailIntent) -&gt; Unit, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), )</ID>
+    <ID>LongParameterList:PassBack.kt$( pass: Pass, onUrlIntent: (B3UrlIntent) -&gt; Unit, onPhoneIntent: (PhoneIntent) -&gt; Unit, onEmailIntent: (EmailIntent) -&gt; Unit, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, locale: PassLocale = PassLocale("en"), )</ID>
     <ID>LongParameterList:PassFront.kt$( field: PassField, foreground: Color, labelColor: Color, valueStyle: androidx.compose.ui.text.TextStyle, modifier: Modifier = Modifier, textAlign: TextAlign? = null, )</ID>
-    <ID>LongParameterList:PassFront.kt$( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"), nowEpochMillis: Long = System.currentTimeMillis(), )</ID>
+    <ID>LongParameterList:PassFront.kt$( pass: Pass, band: SignatureBand, displayOrganizationName: String, passBackground: Color, passForeground: Color, passLabel: Color, )</ID>
+    <ID>LongParameterList:PassFront.kt$( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, locale: PassLocale = PassLocale("en"), nowEpochMillis: Long = System.currentTimeMillis(), )</ID>
     <ID>LongParameterList:SecuritySheets.kt$( kind: SecurityIntentKind, passType: PassType, title: String, target: String, source: SourceField, confirmCopy: String, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
     <ID>LoopWithTooManyJumpStatements:FieldLinkScanner.kt$FieldLinkScanner$for</ID>
-    <ID>MaxLineLength:SecuritySheets.kt$/** First Strong Isolate (U+2068). Opens an isolate that takes the directional class of the first strong-class character within. */</ID>
     <ID>ReturnCount:ExpiredOverlayState.kt$ExpiredOverlayState.Companion$@JvmStatic public fun from(pass: Pass, nowEpochMillis: Long): ExpiredOverlayState</ID>
     <ID>SwallowedException:BoundedImage.kt$e: IOException</ID>
     <ID>SwallowedException:BoundedImage.kt$e: IllegalArgumentException</ID>

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
@@ -40,6 +40,11 @@ import `is`.walt.passes.ui.internal.LocalLocalizedStrings
  *
  * The three callbacks are NOT defaulted to no-op — see ADR 0003 D5. A host that
  * forgets to wire one of them is a compile error, not a runtime swallow.
+ *
+ * @param locale Drives `pass.strings` substitution via [Pass.resolveLocalizedStrings].
+ *   The default `PassLocale("en")` is a *fallback for tests and previews*; production
+ *   callers (walt-android) MUST thread the device locale through, or the user sees
+ *   English labels regardless of system language.
  */
 @Composable
 public fun PassBack(
@@ -52,7 +57,15 @@ public fun PassBack(
     locale: PassLocale = PassLocale("en"),
 ) {
     LaunchedEffect(pass) { telemetry.onPassBackOpened(pass.type) }
-    val strings = remember(pass, locale) { pass.resolveLocalizedStrings(locale) }
+    // Narrow the remember key to the locales map; Pass.equals walks every image's
+    // contentEquals which is wasted work for a function that only consults locales.
+    val strings = remember(pass.locales, locale) { pass.resolveLocalizedStrings(locale) }
+    // wpass-38y: substitute organizationName here (not just inside BackFieldRow) so
+    // the security confirmation sheets — which read SourceField.organizationName —
+    // see the same display string the front of the pass shows. Without this the
+    // front would render "Tixly" while a tap on a back-field URL would surface
+    // "#ORGNAME#" in the confirm copy.
+    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
 
     CompositionLocalProvider(LocalLocalizedStrings provides strings) {
         Surface(
@@ -67,7 +80,7 @@ public fun PassBack(
                 pass.backFields.forEach { field ->
                     BackFieldRow(
                         field = field,
-                        organizationName = pass.organizationName,
+                        organizationName = displayOrganizationName,
                         onUrlIntent = onUrlIntent,
                         onPhoneIntent = onPhoneIntent,
                         onEmailIntent = onEmailIntent,
@@ -86,13 +99,14 @@ private fun BackFieldRow(
     onPhoneIntent: (PhoneIntent) -> Unit,
     onEmailIntent: (EmailIntent) -> Unit,
 ) {
-    // wpass-38y: every text-bearing field passes through the resolved strings table
-    // so PKPASS placeholder labels (e.g. "#LABELTICKETNUMBER#") render as their
+    // wpass-38y: field label and value pass through the resolved strings table so
+    // PKPASS placeholder labels (e.g. "#LABELTICKETNUMBER#") render as their
     // localized text. A miss falls through to the raw string, which is the right
     // behavior for dynamic values (ticket numbers, codes) that never appear as keys.
+    // organizationName has already been substituted at the PassBack boundary.
     val strings = LocalLocalizedStrings.current
     val displayLabel = strings.lookupOrSelf(field.label)
-    val displayValue = strings.lookupOrSelf(field.value).orEmpty()
+    val displayValue = strings.lookupOrSelf(field.value)
 
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         displayLabel?.takeIf { it.isNotBlank() }?.let { label ->

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
@@ -18,11 +18,16 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassField
 import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.lookupOrSelf
+import `is`.walt.passes.core.resolveLocalizedStrings
 import `is`.walt.passes.ui.internal.FieldLinkScanner
 import `is`.walt.passes.ui.internal.LinkSpan
+import `is`.walt.passes.ui.internal.LocalLocalizedStrings
 
 /**
  * Renders the back of a pass: the list of [Pass.backFields], with detected URLs,
@@ -44,27 +49,30 @@ public fun PassBack(
     onEmailIntent: (EmailIntent) -> Unit,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
-    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    locale: PassLocale = PassLocale("en"),
 ) {
     LaunchedEffect(pass) { telemetry.onPassBackOpened(pass.type) }
+    val strings = remember(pass, locale) { pass.resolveLocalizedStrings(locale) }
 
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-    ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+    CompositionLocalProvider(LocalLocalizedStrings provides strings) {
+        Surface(
+            modifier = modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surface,
+            contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
-            pass.backFields.forEach { field ->
-                BackFieldRow(
-                    field = field,
-                    organizationName = pass.organizationName,
-                    onUrlIntent = onUrlIntent,
-                    onPhoneIntent = onPhoneIntent,
-                    onEmailIntent = onEmailIntent,
-                )
+            Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                pass.backFields.forEach { field ->
+                    BackFieldRow(
+                        field = field,
+                        organizationName = pass.organizationName,
+                        onUrlIntent = onUrlIntent,
+                        onPhoneIntent = onPhoneIntent,
+                        onEmailIntent = onEmailIntent,
+                    )
+                }
             }
         }
     }
@@ -78,8 +86,16 @@ private fun BackFieldRow(
     onPhoneIntent: (PhoneIntent) -> Unit,
     onEmailIntent: (EmailIntent) -> Unit,
 ) {
+    // wpass-38y: every text-bearing field passes through the resolved strings table
+    // so PKPASS placeholder labels (e.g. "#LABELTICKETNUMBER#") render as their
+    // localized text. A miss falls through to the raw string, which is the right
+    // behavior for dynamic values (ticket numbers, codes) that never appear as keys.
+    val strings = LocalLocalizedStrings.current
+    val displayLabel = strings.lookupOrSelf(field.label)
+    val displayValue = strings.lookupOrSelf(field.value).orEmpty()
+
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        field.label?.takeIf { it.isNotBlank() }?.let { label ->
+        displayLabel?.takeIf { it.isNotBlank() }?.let { label ->
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,
@@ -89,11 +105,11 @@ private fun BackFieldRow(
 
         val source = SourceField(
             fieldKey = field.key,
-            fieldLabel = field.label,
+            fieldLabel = displayLabel,
             organizationName = organizationName,
         )
-        val spans = FieldLinkScanner.scan(field.value, source)
-        val annotated = buildAnnotatedFieldValue(field.value, spans)
+        val spans = FieldLinkScanner.scan(displayValue, source)
+        val annotated = buildAnnotatedFieldValue(displayValue, spans)
 
         @Suppress("DEPRECATION")
         ClickableText(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.CompositionLocalProvider
 import `is`.walt.passes.core.ColorValue
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassField
@@ -29,6 +30,9 @@ import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.TextAlignment
+import `is`.walt.passes.core.lookupOrSelf
+import `is`.walt.passes.core.resolveLocalizedStrings
+import `is`.walt.passes.ui.internal.LocalLocalizedStrings
 import `is`.walt.passes.ui.theme.LocalPassesSemantics
 import `is`.walt.passes.ui.theme.toComposeColor
 
@@ -54,13 +58,18 @@ public fun PassFront(
     signatureStatus: SignatureStatus,
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
-    @Suppress("UNUSED_PARAMETER") locale: PassLocale = PassLocale("en"),
+    locale: PassLocale = PassLocale("en"),
     nowEpochMillis: Long = System.currentTimeMillis(),
 ) {
     val band = signatureStatus.toBand()
     val expired = remember(pass, nowEpochMillis) {
         ExpiredOverlayState.from(pass, nowEpochMillis)
     }
+    // wpass-38y: PKPASS allows the front-side organizationName, field labels, and
+    // field values to be pass.strings keys; substitute them through the resolved
+    // strings table so localized labels render instead of raw `#KEY#` placeholders.
+    val strings = remember(pass, locale) { pass.resolveLocalizedStrings(locale) }
+    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName) ?: pass.organizationName
     androidx.compose.runtime.LaunchedEffect(pass, band) {
         telemetry.onPassRendered(pass.type, band)
     }
@@ -69,63 +78,72 @@ public fun PassFront(
     val passForeground = pass.colors.foreground.toComposeOrDefault(MaterialTheme.colorScheme.onSurface)
     val passLabel = pass.colors.label.toComposeOrDefault(passForeground.copy(alpha = 0.7f))
 
-    Box(modifier = modifier) {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = passBackground,
-            contentColor = passForeground,
-            shape = RoundedCornerShape(16.dp),
-            tonalElevation = 0.dp,
-        ) {
-            Column(
-                modifier = Modifier.padding(20.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Text(
-                        text = pass.organizationName,
-                        style = MaterialTheme.typography.labelLarge,
-                        color = passLabel,
-                        modifier = Modifier.weight(1f),
-                    )
-                    SignatureTrustBadge(band = band)
-                }
-
-                when (pass.type) {
-                    PassType.BoardingPass -> BoardingPassBody(
-                        pass.frontFields,
-                        passForeground,
-                        passLabel,
-                    )
-                    PassType.EventTicket -> EventTicketBody(
-                        pass.frontFields,
-                        passForeground,
-                        passLabel,
-                    )
-                    PassType.Coupon, PassType.StoreCard, PassType.Generic -> GenericBody(
-                        pass.frontFields,
-                        passForeground,
-                        passLabel,
-                    )
-                }
-
-                pass.barcode?.let { barcode ->
-                    Box(
-                        modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        BarcodeView(barcode = barcode)
-                    }
-                }
+    CompositionLocalProvider(LocalLocalizedStrings provides strings) {
+        Box(modifier = modifier) {
+            PassFrontSurface(
+                pass = pass,
+                band = band,
+                displayOrganizationName = displayOrganizationName,
+                passBackground = passBackground,
+                passForeground = passForeground,
+                passLabel = passLabel,
+            )
+            if (expired !is ExpiredOverlayState.None) {
+                ExpiredOverlay(state = expired, modifier = Modifier.matchParentSize())
             }
         }
+    }
+}
 
-        if (expired !is ExpiredOverlayState.None) {
-            ExpiredOverlay(state = expired, modifier = Modifier.matchParentSize())
+@Composable
+private fun PassFrontSurface(
+    pass: Pass,
+    band: SignatureBand,
+    displayOrganizationName: String,
+    passBackground: Color,
+    passForeground: Color,
+    passLabel: Color,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = passBackground,
+        contentColor = passForeground,
+        shape = RoundedCornerShape(16.dp),
+        tonalElevation = 0.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = displayOrganizationName,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = passLabel,
+                    modifier = Modifier.weight(1f),
+                )
+                SignatureTrustBadge(band = band)
+            }
+
+            when (pass.type) {
+                PassType.BoardingPass -> BoardingPassBody(pass.frontFields, passForeground, passLabel)
+                PassType.EventTicket -> EventTicketBody(pass.frontFields, passForeground, passLabel)
+                PassType.Coupon, PassType.StoreCard, PassType.Generic ->
+                    GenericBody(pass.frontFields, passForeground, passLabel)
+            }
+
+            pass.barcode?.let { barcode ->
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    BarcodeView(barcode = barcode)
+                }
+            }
         }
     }
 }
@@ -249,8 +267,14 @@ private fun FieldCell(
         TextAlignment.Center -> TextAlign.Center
         TextAlignment.Right -> TextAlign.End
     }
+    // wpass-38y: substitute label and value through the pass.strings table provided
+    // by the enclosing PassFront. Misses fall through to the raw text, so dynamic
+    // values (codes, dates, numbers) emerge unchanged.
+    val strings = LocalLocalizedStrings.current
+    val displayLabel = strings.lookupOrSelf(field.label)
+    val displayValue = strings.lookupOrSelf(field.value).orEmpty()
     Column(modifier = modifier) {
-        field.label?.takeIf { it.isNotBlank() }?.let { label ->
+        displayLabel?.takeIf { it.isNotBlank() }?.let { label ->
             Text(
                 text = label,
                 style = MaterialTheme.typography.labelSmall,
@@ -260,7 +284,7 @@ private fun FieldCell(
             )
         }
         Text(
-            text = field.value,
+            text = displayValue,
             style = valueStyle,
             color = foreground,
             textAlign = align,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -51,6 +51,11 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *
  * The signature trust badge and (when applicable) the expired overlay are composited
  * on top of the pass; neither has a suppression parameter — see ADR 0003 D5.
+ *
+ * @param locale Drives `pass.strings` substitution via [Pass.resolveLocalizedStrings].
+ *   The default `PassLocale("en")` is a *fallback for tests and previews*; production
+ *   callers (walt-android) MUST thread the device locale through, or the user sees
+ *   English labels regardless of system language.
  */
 @Composable
 public fun PassFront(
@@ -68,8 +73,13 @@ public fun PassFront(
     // wpass-38y: PKPASS allows the front-side organizationName, field labels, and
     // field values to be pass.strings keys; substitute them through the resolved
     // strings table so localized labels render instead of raw `#KEY#` placeholders.
-    val strings = remember(pass, locale) { pass.resolveLocalizedStrings(locale) }
-    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName) ?: pass.organizationName
+    //
+    // The remember key is narrowed to the locales map (the only input
+    // resolveLocalizedStrings consults) instead of the full Pass — Pass.equals walks
+    // every image's contentEquals, which is megabytes of work on each recomposition
+    // for a real PKPASS.
+    val strings = remember(pass.locales, locale) { pass.resolveLocalizedStrings(locale) }
+    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
     androidx.compose.runtime.LaunchedEffect(pass, band) {
         telemetry.onPassRendered(pass.type, band)
     }
@@ -272,7 +282,7 @@ private fun FieldCell(
     // values (codes, dates, numbers) emerge unchanged.
     val strings = LocalLocalizedStrings.current
     val displayLabel = strings.lookupOrSelf(field.label)
-    val displayValue = strings.lookupOrSelf(field.value).orEmpty()
+    val displayValue = strings.lookupOrSelf(field.value)
     Column(modifier = modifier) {
         displayLabel?.takeIf { it.isNotBlank() }?.let { label ->
             Text(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
@@ -165,7 +165,13 @@ internal object FieldLinkScanner {
         existing: List<LinkSpan>,
     ): Boolean = existing.any { it.start < endExclusive && start < it.endExclusive }
 
-    private val INTERNAL_PHONE_HINTS = setOf('+', '-', ' ', '(', ')')
+    // The phone regex `(?<!\d)(\+?\d[\d\s\-()]{6,}\d)(?!\d)` cannot start with `(` or
+    // end with `)` (its outer anchors require digits at both edges), so any paren
+    // surrounding a phone number lands *adjacent to* the match, not inside it. The
+    // internal-hint set therefore lists only the characters that can actually appear
+    // inside `match.value` — `+`, `-`, and space. Adjacent parens are picked up via
+    // [PHONE_PREFIX_HINTS] / the trailing-`)` check in [hasPhoneFormattingHint].
+    private val INTERNAL_PHONE_HINTS = setOf('+', '-', ' ')
 
     /** `+` and `(` immediately before a digit run signal an unmatched-paren or international form. */
     private val PHONE_PREFIX_HINTS = setOf('+', '(')

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/FieldLinkScanner.kt
@@ -29,8 +29,13 @@ import `is`.walt.passes.ui.SourceField
  *   spoofing class — e.g. `https://attacker.example/‮gpj.elgoog//:sptth` rendering
  *   visually as a Google asset URL while `Uri.parse` resolves to `attacker.example`.
  *   Tested in `FieldLinkScannerTest`.
- * - A phone number requires at least seven digits and is constrained to ASCII digits,
- *   spaces, hyphens, and parentheses.
+ * - A phone number requires at least seven digits AND at least one formatting hint
+ *   (a leading `+`, an embedded space, dash, or parenthesis) before it is recognised.
+ *   Bare digit runs — ticket numbers, order IDs, member numbers, barcode payloads —
+ *   are left as plain text. This mirrors Apple's data-detector behavior in iOS Wallet
+ *   and prevents two failure modes: (a) accidental "Call this number?" prompts on
+ *   every numeric field of a real pass, and (b) a malicious pass embedding a
+ *   premium-rate dial string in a value that the user reads as a reference number.
  * - An email requires an `@` with non-empty ASCII local and domain parts.
  *
  * Belt-and-suspenders: every match is post-filtered through [containsRenderingHazard],
@@ -99,6 +104,7 @@ internal object FieldLinkScanner {
         for (match in phoneRegex.findAll(fieldValue)) {
             val digitCount = match.value.count { it.isDigit() }
             if (digitCount < 7) continue
+            if (!hasPhoneFormattingHint(match, fieldValue)) continue
             if (overlapsExisting(match.range.first, match.range.last + 1, spans)) continue
             spans += LinkSpan(
                 start = match.range.first,
@@ -125,11 +131,44 @@ internal object FieldLinkScanner {
         c.category == CharCategory.FORMAT || c.isISOControl()
     }
 
+    /**
+     * True if the matched phone candidate carries at least one visible formatting hint:
+     * an internal `+`, dash, space, or parenthesis, OR an immediately adjacent `+` /
+     * `(` before the match or `)` after it. A bare digit run with no formatting and no
+     * adjacent paren or `+` is rejected.
+     *
+     * The two-stage check (internal + adjacent) handles the regex quirk that the inner
+     * pattern starts with `\+?\d`, so a phone written as `(5551234567)` matches only
+     * the digits — the parens stay outside the match. Without an adjacency check those
+     * inputs would lose their hints and be rejected. The space character is *not*
+     * accepted as an adjacency hint: surrounding spaces are the default text rhythm and
+     * would re-admit every numeric reference value (the wpass-536 regression).
+     *
+     * The check matches Apple's data-detector posture: numeric strings without
+     * formatting hints (ticket numbers, order IDs, barcodes, member numbers) are left
+     * non-tappable. This is the wpass-536 regression guard — the prior implementation
+     * fired on any 7+-digit run and turned every reference-number field into an
+     * accidental "Call this number?" prompt. It is also a meaningful narrowing of the
+     * attack surface: a malicious pass author can no longer plant a premium-rate dial
+     * string in a field labeled `ticketNumber` and rely on auto-detection to surface it.
+     */
+    private fun hasPhoneFormattingHint(match: MatchResult, fullText: String): Boolean {
+        if (match.value.any { it in INTERNAL_PHONE_HINTS }) return true
+        val before = fullText.getOrNull(match.range.first - 1)
+        val after = fullText.getOrNull(match.range.last + 1)
+        return before in PHONE_PREFIX_HINTS || after == ')'
+    }
+
     private fun overlapsExisting(
         start: Int,
         endExclusive: Int,
         existing: List<LinkSpan>,
     ): Boolean = existing.any { it.start < endExclusive && start < it.endExclusive }
+
+    private val INTERNAL_PHONE_HINTS = setOf('+', '-', ' ', '(', ')')
+
+    /** `+` and `(` immediately before a digit run signal an unmatched-paren or international form. */
+    private val PHONE_PREFIX_HINTS = setOf('+', '(')
 }
 
 internal data class LinkSpan(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/LocalLocalizedStrings.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/LocalLocalizedStrings.kt
@@ -1,0 +1,22 @@
+package `is`.walt.passes.ui.internal
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import `is`.walt.passes.core.LocalizedStrings
+
+/**
+ * The pass.strings table for the currently-rendering pass, threaded down through
+ * Compose so nested field-cell composables (header rows, primary fields, body rows,
+ * back-field rows) can substitute placeholder labels without taking the table as an
+ * extra parameter. wpass-38y.
+ *
+ * The default is [LocalizedStrings.Empty], which makes reads outside a provider a safe
+ * passthrough: [LocalizedStrings.lookupOrSelf] on the empty table returns the raw
+ * input. The two top-level pass composables ([PassFront], [PassBack]) provide the
+ * resolved table; nested helpers read it through this accessor.
+ *
+ * Internal because it is a render-time scaffolding detail, not a public theming knob —
+ * unlike [LocalPassesSemantics] which the host wires once at app root.
+ */
+internal val LocalLocalizedStrings: ProvidableCompositionLocal<LocalizedStrings> =
+    staticCompositionLocalOf { LocalizedStrings.Empty }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -298,6 +298,88 @@ class TrustClaimSurfaceTest {
         assertThat(rejection!!.name).matches("ExceedsWidth|ExceedsHeight|ExceedsArea")
     }
 
+    // wpass-38y: pass.strings substitution must apply symmetrically on the front and
+    // the back. The chroniques (pass.com.tixly) regression had the back rendering raw
+    // `#LABELKEY#` placeholders; the parallel concern is that organizationName, which
+    // PKPASS allows to be a strings key and which the security confirmation sheets
+    // surface verbatim, gets the same substitution treatment on both surfaces.
+
+    @Test
+    fun passFrontSubstitutesOrganizationNameThroughStrings() {
+        composeRule.setContent {
+            ThemedHost {
+                PassFront(
+                    pass = localizedFixture(
+                        organizationName = "#ORGNAME#",
+                        backFields = emptyList(),
+                    ),
+                    signatureStatus = SignatureStatus.AppleVerified,
+                    nowEpochMillis = 0L,
+                    telemetry = telemetry,
+                )
+            }
+        }
+        composeRule.onNodeWithText("Tixly").assertIsDisplayed()
+    }
+
+    @Test
+    fun passBackSubstitutesFieldLabelsThroughStrings() {
+        composeRule.setContent {
+            ThemedHost {
+                PassBack(
+                    pass = localizedFixture(
+                        organizationName = "#ORGNAME#",
+                        backFields = listOf(
+                            PassField(
+                                key = "ticketNoBack",
+                                label = "#LABELTICKETNUMBER#",
+                                value = "52311919",
+                            ),
+                        ),
+                    ),
+                    onUrlIntent = {},
+                    onPhoneIntent = {},
+                    onEmailIntent = {},
+                    telemetry = telemetry,
+                )
+            }
+        }
+        composeRule.onNodeWithText("Ticket Number").assertIsDisplayed()
+        // Dynamic value (the actual ticket digits) must pass through unchanged.
+        composeRule.onNodeWithText("52311919").assertIsDisplayed()
+    }
+
+    private fun localizedFixture(
+        organizationName: String,
+        backFields: List<PassField>,
+    ): Pass = Pass(
+        type = PassType.Generic,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = organizationName,
+        expirationDate = null,
+        voided = false,
+        colors = PassColors(
+            foreground = ColorValue(0x000000),
+            background = ColorValue(0xFFFFFF),
+            label = ColorValue(0x444444),
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = "From", value = "JFK")),
+        ),
+        backFields = backFields,
+        barcode = null,
+        images = emptyMap(),
+        locales = mapOf(
+            `is`.walt.passes.core.PassLocale("en") to `is`.walt.passes.core.LocalizedStrings(
+                mapOf(
+                    "#ORGNAME#" to "Tixly",
+                    "#LABELTICKETNUMBER#" to "Ticket Number",
+                ),
+            ),
+        ),
+    )
+
     // Document-surface trust assertions (caption, tile bidi-isolation, lane wiring)
     // moved to passes-pdf-ui::DocumentTrustSurfaceTest with the composables (wpass-r4z).
 

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/internal/FieldLinkScannerTest.kt
@@ -63,6 +63,72 @@ class FieldLinkScannerTest {
         assertThat(spans).isEmpty()
     }
 
+    // -- wpass-536: bare digit runs without formatting hints ----------------------
+    //
+    // The chroniques (pass.com.tixly) regression. An 8-digit ticket number rendered
+    // tappable, surfacing a "Call this number?" prompt on a reference value the user
+    // never expected to be a phone number. The fix requires at least one formatting
+    // hint (+, dash, space, paren) before classifying a digit run as a phone number,
+    // matching Apple's data-detector behavior.
+
+    @Test
+    fun rejectsBareEightDigitTicketNumberAsPhone() {
+        // chroniques pass back-field "ticketNoBack" value: "52311919".
+        val spans = FieldLinkScanner.scan("52311919", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun rejectsBareSevenDigitOrderNumberAsPhone() {
+        // chroniques pass back-field "orderNoBack" value: "5847559".
+        val spans = FieldLinkScanner.scan("5847559", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun rejectsLongBareDigitRunAsPhone() {
+        // Barcode payload, member ID, etc. — long bare digit string with no formatting
+        // hint must never fire the phone detector.
+        val spans = FieldLinkScanner.scan("123456789012", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun rejectsBareDigitRunAdjacentToProseAsPhone() {
+        val spans = FieldLinkScanner.scan("Order 52311919 placed.", source)
+        assertThat(spans).isEmpty()
+    }
+
+    @Test
+    fun acceptsPhoneWithOnlySpaceHint() {
+        val spans = FieldLinkScanner.scan("Call 555 123 4567 today.", source)
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().intent).isInstanceOf(PhoneIntent::class.java)
+        assertThat((spans.single().intent as PhoneIntent).phoneNumber).isEqualTo("555 123 4567")
+    }
+
+    @Test
+    fun acceptsPhoneWithOnlyDashHint() {
+        val spans = FieldLinkScanner.scan("555-123-4567", source)
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().intent).isInstanceOf(PhoneIntent::class.java)
+    }
+
+    @Test
+    fun acceptsPhoneWithOnlyParenHint() {
+        val spans = FieldLinkScanner.scan("Call (5551234567) now.", source)
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().intent).isInstanceOf(PhoneIntent::class.java)
+    }
+
+    @Test
+    fun acceptsPhoneWithOnlyPlusHint() {
+        val spans = FieldLinkScanner.scan("+15551234567", source)
+        assertThat(spans).hasSize(1)
+        assertThat(spans.single().intent).isInstanceOf(PhoneIntent::class.java)
+        assertThat((spans.single().intent as PhoneIntent).phoneNumber).isEqualTo("+15551234567")
+    }
+
     @Test
     fun emailInsideUrlIsNotDoubleClaimed() {
         val spans = FieldLinkScanner.scan("https://x@example.com/path", source)


### PR DESCRIPTION
## Summary

- **wpass-38y** — back-side fields rendered raw `#LABELKEY#` placeholders because the .strings parser produced a `Map<PassLocale, LocalizedStrings>` on `Pass` that no UI surface consulted. Added `Pass.resolveLocalizedStrings(preferred)` (Apple's exact-tag → language → en → smallest-tag chain) and `LocalizedStrings.lookupOrSelf(raw)`; `PassFront`/`PassBack` provide the resolved table via internal `LocalLocalizedStrings` CompositionLocal so nested field cells substitute label / value / organizationName uniformly. Misses fall through unchanged so dynamic values (ticket numbers, codes) emerge intact.
- **wpass-536** — bare 8-digit ticket numbers like `52311919` were classified as `tel:` URIs, surfacing accidental "Call this number?" prompts on every numeric back-field. `FieldLinkScanner` now requires at least one formatting hint (internal `+`/`-`/space, or an immediately adjacent `+` / `(` / `)`) before classifying a digit run as a phone. Matches Apple's data-detector posture; bare digit runs render non-tappable.
- Review feedback addressed: `organizationName` substituted symmetrically on front and back; `remember` keys narrowed to `pass.locales` (was triggering full structural equality including image bytes); locale fallback picks lexicographically-smallest tag instead of map iteration order; non-nullable `lookupOrSelf` overload removes `.orEmpty()`/`?:` noise at call sites; kdoc note on the `locale` parameter default; dead paren entries trimmed from `INTERNAL_PHONE_HINTS`.

## Test plan

- [x] `./gradlew check` — passes-core, passes-ui (and all peer modules) green: unit tests, detekt, ktlint, Android lint.
- [x] 16 new unit tests: 8 phone-detector (chroniques regression cases + each formatting-hint shape), 8 locale resolution (exact / language fallback / en fallback / smallest-tag fallback / HashMap-input contract / chroniques fixture).
- [x] 2 new Robolectric Compose tests asserting front-side `organizationName` substitution and back-side `#LABELKEY#` substitution.
- [ ] Manual verification on FP4 / Android 16 / waltDebug with the chroniques (pass.com.tixly) fixture (deferred to consumer-side wiring of the device locale).

Closes wpass-38y, wpass-536.