### PR TITLE
passes-ui: in-app pass-import confirm + rejection surfaces (wpass-9bs)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ bouncycastle = "1.79"
 # Android + Compose toolchain (matches walt-android consumer to avoid drift).
 androidxCoreKtx = "1.17.0"
 androidxLifecycle = "2.10.0"
+androidxActivity = "1.10.1"
 composeBom = "2026.01.00"
 zxing = "3.5.4"
 robolectric = "4.16.1"
@@ -47,6 +48,7 @@ bouncycastle-bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref 
 # Android core
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCoreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 
 # Compose (versions sourced from the BOM)
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }

--- a/passes-ui/build.gradle.kts
+++ b/passes-ui/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    // androidx.activity.compose pulls in BackHandler, which the trust-claim-bearing
+    // PassImportConfirm uses so system back-press routes through the same dismiss
+    // telemetry as the Cancel button (no silent escape hatch).
+    implementation(libs.androidx.activity.compose)
 
     val composeBom = platform(libs.androidx.compose.bom)
     api(composeBom)

--- a/passes-ui/detekt-baseline.xml
+++ b/passes-ui/detekt-baseline.xml
@@ -3,7 +3,9 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>LongMethod:SecuritySheets.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun SecuritySheet( kind: SecurityIntentKind, passType: PassType, title: String, target: String, source: SourceField, confirmCopy: String, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, )</ID>
+    <ID>ComplexInterface:UiTelemetryGuard.kt$UiTelemetryGuard</ID>
     <ID>LongParameterList:BoundedImage.kt$( bytes: ImageBytes, @Suppress("UNUSED_PARAMETER") role: ImageRole, contentDescription: String?, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, bounds: ImageRenderBounds = ImageRenderBounds.Default, )</ID>
+    <ID>LongParameterList:PassImportConfirm.kt$( pass: Pass, signatureStatus: SignatureStatus, telemetry: UiTelemetryGuard, onConfirm: () -&gt; Unit, onDismiss: () -&gt; Unit, modifier: Modifier = Modifier, locale: PassLocale = PassLocale("en"), )</ID>
     <ID>LongParameterList:PassBack.kt$( pass: Pass, onUrlIntent: (B3UrlIntent) -&gt; Unit, onPhoneIntent: (PhoneIntent) -&gt; Unit, onEmailIntent: (EmailIntent) -&gt; Unit, telemetry: UiTelemetryGuard, modifier: Modifier = Modifier, locale: PassLocale = PassLocale("en"), )</ID>
     <ID>LongParameterList:PassFront.kt$( field: PassField, foreground: Color, labelColor: Color, valueStyle: androidx.compose.ui.text.TextStyle, modifier: Modifier = Modifier, textAlign: TextAlign? = null, )</ID>
     <ID>LongParameterList:PassFront.kt$( pass: Pass, band: SignatureBand, displayOrganizationName: String, passBackground: Color, passForeground: Color, passLabel: Color, )</ID>

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -33,6 +33,7 @@ import `is`.walt.passes.core.TextAlignment
 import `is`.walt.passes.core.lookupOrSelf
 import `is`.walt.passes.core.resolveLocalizedStrings
 import `is`.walt.passes.ui.internal.LocalLocalizedStrings
+import `is`.walt.passes.ui.internal.toBand
 import `is`.walt.passes.ui.theme.LocalPassesSemantics
 import `is`.walt.passes.ui.theme.toComposeColor
 
@@ -329,13 +330,6 @@ private fun SignatureTrustBadge(band: SignatureBand) {
             .background(background.toComposeColor())
             .padding(PaddingValues(horizontal = 12.dp, vertical = 4.dp)),
     )
-}
-
-private fun SignatureStatus.toBand(): SignatureBand = when (this) {
-    SignatureStatus.Unsigned -> SignatureBand.Untrusted
-    SignatureStatus.SelfSigned -> SignatureBand.SelfSigned
-    SignatureStatus.AppleVerified -> SignatureBand.AppleVerified
-    SignatureStatus.CertChainIncomplete -> SignatureBand.Incomplete
 }
 
 private fun ColorValue?.toComposeOrDefault(default: Color): Color {

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportConfirm.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportConfirm.kt
@@ -1,0 +1,178 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Trust-claim-bearing confirmation surface for the in-app PKPASS import flow.
+ *
+ * Used after the host has read a chosen file's bytes and `PassParser.parse` returned
+ * [is.walt.passes.core.ParseResult.Success]. The user sees the parsed pass exactly as
+ * Walt will store it — preview rendered through [PassFront], signature trust band
+ * captioned in plain copy — before they tap Save. Tapping Cancel discards.
+ *
+ * The trust contract this surface carries (decision-wlt-0tn-q1):
+ *   1. The user MUST see the signature trust band before consenting to store. The
+ *      caption is non-suppressible: there is no `showTrustCaption` parameter, no
+ *      `compact` mode that hides it, no theme slot whose value defeats it.
+ *   2. The pass preview is the parsed, post-localization, post-validation [pass] —
+ *      the same data structure that will be persisted by `PassRepository.upsert`.
+ *      Walt-android cannot show an alternate preview here.
+ *   3. Confirm fires only on the user's explicit Save tap. The host's call to
+ *      `PassRepository.upsert` MUST be the next thing constructed inside [onConfirm].
+ *
+ * This is a leaf composable: walt-android wraps it in its own scaffold / nav back-
+ * stack. The dimensions of the pass preview (PassFront fills available width) make a
+ * bottom sheet awkward; a screen-level layout is preferred.
+ *
+ * [locale] drives `pass.strings` substitution in the preview, identical to [PassFront].
+ * Defaults to `PassLocale("en")` for tests / previews; production callers thread the
+ * device locale through.
+ */
+@Composable
+public fun PassImportConfirm(
+    pass: Pass,
+    signatureStatus: SignatureStatus,
+    telemetry: UiTelemetryGuard,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+    locale: PassLocale = PassLocale("en"),
+) {
+    val band = remember(signatureStatus) { signatureStatus.toBand() }
+    val emphasis = LocalPassesSemantics.current.securitySheet
+
+    LaunchedEffect(pass.type, band) {
+        telemetry.onImportConfirmShown(pass.type, band)
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(PaddingValues(horizontal = 24.dp, vertical = 16.dp)),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "Add this pass?",
+            style = MaterialTheme.typography.headlineSmall,
+            color = emphasis.bodyForeground.toComposeColor(),
+        )
+
+        ImportTrustCaption(band = band)
+
+        PassFront(
+            pass = pass,
+            signatureStatus = signatureStatus,
+            telemetry = telemetry,
+            modifier = Modifier.fillMaxWidth(),
+            locale = locale,
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
+        ) {
+            TextButton(
+                onClick = {
+                    telemetry.onImportDismissed(pass.type, band)
+                    onDismiss()
+                },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = emphasis.cancelForeground.toComposeColor(),
+                ),
+            ) {
+                Text("Cancel")
+            }
+            Button(
+                onClick = {
+                    telemetry.onImportConfirmed(pass.type, band)
+                    onConfirm()
+                },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = emphasis.confirmContainer.toComposeColor(),
+                    contentColor = emphasis.confirmForeground.toComposeColor(),
+                ),
+            ) {
+                Text("Save pass")
+            }
+        }
+    }
+}
+
+@Composable
+private fun ImportTrustCaption(band: SignatureBand) {
+    val emphasis = LocalPassesSemantics.current.securitySheet
+
+    // The four copy lines mirror decision-wlt-0tn-q1 (1a): "Verified Apple issuer" /
+    // "Self-signed" / "Cert chain incomplete" / "No signature". Issuer name is shown
+    // by the PassFront preview directly below; repeating it here would duplicate
+    // user-controlled text without adding signal.
+    val (title, body) = when (band) {
+        SignatureBand.AppleVerified ->
+            "Verified Apple issuer" to
+                "Walt verified this pass's signature against Apple's issuer chain."
+        SignatureBand.SelfSigned ->
+            "Self-signed issuer" to
+                "The signature is valid but Walt cannot verify who issued this pass."
+        SignatureBand.Incomplete ->
+            "Issuer chain incomplete" to
+                "The pass is signed but Walt could not complete the issuer chain."
+        SignatureBand.Untrusted ->
+            "No signature" to
+                "This pass is unsigned. Walt cannot verify who created it."
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(emphasis.emphasisBackground.toComposeColor())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = emphasis.emphasisForeground.toComposeColor(),
+        )
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = emphasis.emphasisForeground.toComposeColor(),
+        )
+    }
+}
+
+// PassFront's private toBand() is duplicated here so this file does not need a
+// passes-core extension or a cross-file private. The mapping is total over
+// SignatureStatus (four arms in, four arms out); a new arm in either type is a
+// compile error.
+private fun SignatureStatus.toBand(): SignatureBand = when (this) {
+    SignatureStatus.Unsigned -> SignatureBand.Untrusted
+    SignatureStatus.SelfSigned -> SignatureBand.SelfSigned
+    SignatureStatus.AppleVerified -> SignatureBand.AppleVerified
+    SignatureStatus.CertChainIncomplete -> SignatureBand.Incomplete
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportConfirm.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportConfirm.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.ui.internal.toBand
 import `is`.walt.passes.ui.theme.LocalPassesSemantics
 import `is`.walt.passes.ui.theme.toComposeColor
 
@@ -46,7 +48,17 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *
  * This is a leaf composable: walt-android wraps it in its own scaffold / nav back-
  * stack. The dimensions of the pass preview (PassFront fills available width) make a
- * bottom sheet awkward; a screen-level layout is preferred.
+ * bottom sheet awkward; a screen-level layout is preferred. Hosts whose target
+ * viewport may be shorter than the pass preview + caption + action row (small phones
+ * in landscape, foldable inner screens) MUST wrap this composable in a vertically
+ * scrollable container; this composable does not impose its own scroll because the
+ * host's scaffold typically owns the scroll axis.
+ *
+ * Android system back is wired to the same dismissal pair as the Cancel button —
+ * [onImportDismissed] telemetry fires, then [onDismiss] is invoked. Hosts cannot
+ * silence this: the [BackHandler] is registered unconditionally inside this
+ * composable. A future flag that lets back-press bypass dismissal would invalidate
+ * the trust contract by allowing imports to be cancelled without telemetry.
  *
  * [locale] drives `pass.strings` substitution in the preview, identical to [PassFront].
  * Defaults to `PassLocale("en")` for tests / previews; production callers thread the
@@ -65,8 +77,19 @@ public fun PassImportConfirm(
     val band = remember(signatureStatus) { signatureStatus.toBand() }
     val emphasis = LocalPassesSemantics.current.securitySheet
 
+    // Keys are (pass.type, band), not Unit, because navigating back to this screen
+    // for a *different* pass — same composable instance, different inputs — should
+    // re-emit the shown event. A Unit key would coalesce the two views into one.
     LaunchedEffect(pass.type, band) {
         telemetry.onImportConfirmShown(pass.type, band)
+    }
+
+    // System back must mirror Cancel: same telemetry, same callback. Without this
+    // the host loses dismissal symmetry and confirm-shown counts drift away from
+    // confirm/dismiss tallies for any user who back-presses out of the screen.
+    BackHandler {
+        telemetry.onImportDismissed(pass.type, band)
+        onDismiss()
     }
 
     Column(
@@ -166,13 +189,3 @@ private fun ImportTrustCaption(band: SignatureBand) {
     }
 }
 
-// PassFront's private toBand() is duplicated here so this file does not need a
-// passes-core extension or a cross-file private. The mapping is total over
-// SignatureStatus (four arms in, four arms out); a new arm in either type is a
-// compile error.
-private fun SignatureStatus.toBand(): SignatureBand = when (this) {
-    SignatureStatus.Unsigned -> SignatureBand.Untrusted
-    SignatureStatus.SelfSigned -> SignatureBand.SelfSigned
-    SignatureStatus.AppleVerified -> SignatureBand.AppleVerified
-    SignatureStatus.CertChainIncomplete -> SignatureBand.Incomplete
-}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportRejection.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassImportRejection.kt
@@ -1,0 +1,127 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.ParseFailureKind
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Trust-claim-bearing rejection sheet shown when an in-app pass import fails. Used
+ * after the host's `PassParser.parse` returned [is.walt.passes.core.ParseResult.Tampered],
+ * `Malformed`, or `Unsupported`. The sheet's copy is the user-facing trust message
+ * walt-android cannot reimplement: a future refactor that swapped this for a
+ * generic toast would silently drop the "we detected tampering" disclosure.
+ *
+ * The four [ParseFailureKind] arms map to four distinct messages — collapsing them
+ * defeats the lenient-with-disclosure signature policy (decision-wlt-0tn-q1 1a). A
+ * tampered pass is a security event; a malformed file is not. The user must see the
+ * difference.
+ *
+ * The sheet is dismiss-only: there is no Save / Open / Anyway button. Tampered, malformed,
+ * unsupported, and resource-limit failures are all unconditional rejections at v1; ADR
+ * 0001's parser-hardening posture is "fail closed and explain."
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+public fun PassImportRejectionSheet(
+    kind: ParseFailureKind,
+    telemetry: UiTelemetryGuard,
+    onDismiss: () -> Unit,
+) {
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val emphasis = LocalPassesSemantics.current.securitySheet
+
+    LaunchedEffect(kind) {
+        telemetry.onImportRejected(kind)
+    }
+
+    val copy = rejectionCopy(kind)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = emphasis.sheetBackground.toComposeColor(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(horizontal = 24.dp, vertical = 16.dp)),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = copy.title,
+                style = MaterialTheme.typography.headlineSmall,
+                color = emphasis.bodyForeground.toComposeColor(),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(emphasis.emphasisBackground.toComposeColor())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = copy.body,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = emphasis.emphasisForeground.toComposeColor(),
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
+            ) {
+                TextButton(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = emphasis.cancelForeground.toComposeColor(),
+                    ),
+                ) {
+                    Text("Close")
+                }
+            }
+        }
+    }
+}
+
+private data class RejectionCopy(val title: String, val body: String)
+
+private fun rejectionCopy(kind: ParseFailureKind): RejectionCopy = when (kind) {
+    ParseFailureKind.Tampered -> RejectionCopy(
+        title = "This pass appears to have been tampered with",
+        body = "The signature does not match the file's contents. Walt did not save this pass.",
+    )
+    ParseFailureKind.Malformed -> RejectionCopy(
+        title = "This file is not a valid pass",
+        body = "Walt could not read this file as a PKPASS archive.",
+    )
+    ParseFailureKind.Unsupported -> RejectionCopy(
+        title = "Walt cannot open this pass",
+        body = "This pass uses a format Walt does not support.",
+    )
+    ParseFailureKind.ResourceLimitExceeded -> RejectionCopy(
+        title = "This pass is too large to open safely",
+        body = "The pass exceeded Walt's safety limits and was not loaded.",
+    )
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.ui
 
+import `is`.walt.passes.core.ParseFailureKind
 import `is`.walt.passes.core.PassType
 
 /**
@@ -58,6 +59,36 @@ public interface UiTelemetryGuard {
      * tuning.
      */
     public fun onImageDecodeRejected(reason: ImageDecodeRejection)
+
+    /**
+     * The in-app pass-import confirmation surface ([PassImportConfirm]) was shown to
+     * the user after a successful parse. [signatureBand] is the trust band the user is
+     * being asked to consent to; a sustained shift toward [SignatureBand.Untrusted] or
+     * [SignatureBand.SelfSigned] is operationally meaningful.
+     */
+    public fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand)
+
+    /**
+     * The user tapped Save on the import-confirm surface. The host's call to
+     * `PassRepository.upsert` is the next thing constructed after this event.
+     */
+    public fun onImportConfirmed(type: PassType, signatureBand: SignatureBand)
+
+    /**
+     * The user tapped Cancel on the import-confirm surface, or dismissed it. A
+     * sustained rise — especially scoped to [SignatureBand.SelfSigned] — is a useful
+     * UX or social-engineering signal.
+     */
+    public fun onImportDismissed(type: PassType, signatureBand: SignatureBand)
+
+    /**
+     * An import attempt was rejected by [PassImportRejectionSheet] because the parser
+     * returned a non-success arm. [kind] is the coarse failure family; the underlying
+     * `ParseFailureReason` is intentionally not surfaced to the UI guard, since
+     * `passes-core`'s `TelemetryGuard.onParseFailed` already records that dimension and
+     * a duplicate-with-narrower-shape would only invite drift.
+     */
+    public fun onImportRejected(kind: ParseFailureKind)
 }
 
 /**
@@ -107,4 +138,8 @@ public object NoopUiTelemetryGuard : UiTelemetryGuard {
     override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
     override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
     override fun onImageDecodeRejected(reason: ImageDecodeRejection): Unit = Unit
+    override fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand): Unit = Unit
+    override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand): Unit = Unit
+    override fun onImportDismissed(type: PassType, signatureBand: SignatureBand): Unit = Unit
+    override fun onImportRejected(kind: ParseFailureKind): Unit = Unit
 }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
@@ -24,6 +24,14 @@ public interface UiTelemetryGuard {
     /**
      * A pass front rendered. Useful as a baseline against which sheet-display rates
      * can be normalized.
+     *
+     * NB: this fires for every [PassFront] composition, including the preview embedded
+     * in [PassImportConfirm]. A successful import therefore records both
+     * [onImportConfirmShown] and at least one [onPassRendered]; consumers that want a
+     * "library views only" baseline should subtract import-flow renders or filter on a
+     * scope they track separately. The signal is not split here because the only
+     * Walt-side dashboard that consumes this event already aggregates per-day, and the
+     * inflation is bounded by the import volume.
      */
     public fun onPassRendered(type: PassType, signatureBand: SignatureBand)
 

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/SignatureBandMapping.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/SignatureBandMapping.kt
@@ -1,0 +1,21 @@
+package `is`.walt.passes.ui.internal
+
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.ui.SignatureBand
+
+/**
+ * The single mapping from `passes-core`'s [SignatureStatus] sealed type to the
+ * UI-facing [SignatureBand] enum. Lifted out of any specific composable so the
+ * mapping is in exactly one place — a security-load-bearing rule (the band the
+ * user sees IS the trust claim for that pass) does not tolerate two copies that
+ * could drift on a `s/Incomplete/SelfSigned/` rename in a single file.
+ *
+ * Adding an arm to either type is still a compile error here; the win is that
+ * a *semantic* edit (mapping changes, not arm adds) only happens in one spot.
+ */
+internal fun SignatureStatus.toBand(): SignatureBand = when (this) {
+    SignatureStatus.Unsigned -> SignatureBand.Untrusted
+    SignatureStatus.SelfSigned -> SignatureBand.SelfSigned
+    SignatureStatus.AppleVerified -> SignatureBand.AppleVerified
+    SignatureStatus.CertChainIncomplete -> SignatureBand.Incomplete
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -93,6 +93,43 @@ class ComposableSurfaceLockTest {
         }
     }
 
+    @Test
+    fun passImportConfirmHasExactlySevenUserVisibleParameters() {
+        // (pass, signatureStatus, telemetry, onConfirm, onDismiss, modifier, locale).
+        // No `enabled`, no `skipConfirmation`, no `showTrustCaption` — drift here is a
+        // trust-claim regression (decision-wlt-0tn-q1 1a).
+        assertUserVisibleParamCount("PassImportConfirmKt", "PassImportConfirm", expected = 7)
+    }
+
+    @Test
+    fun passImportConfirmAcceptsUiTelemetryGuard() {
+        val method = findComposable("PassImportConfirmKt", "PassImportConfirm")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("PassImportConfirm must declare a UiTelemetryGuard parameter")
+            .that(typeNames)
+            .contains("UiTelemetryGuard")
+    }
+
+    @Test
+    fun passImportRejectionSheetHasExactlyThreeUserVisibleParameters() {
+        // (kind, telemetry, onDismiss). The sheet is dismiss-only by design (no Save /
+        // Open / Anyway button); a future addition of a fourth callback would be a
+        // policy change to the lenient-with-disclosure signature stance.
+        assertUserVisibleParamCount("PassImportRejectionKt", "PassImportRejectionSheet", expected = 3)
+    }
+
+    @Test
+    fun passImportRejectionSheetAcceptsParseFailureKindAndUiTelemetryGuard() {
+        val method = findComposable("PassImportRejectionKt", "PassImportRejectionSheet")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("PassImportRejectionSheet must declare a ParseFailureKind parameter")
+            .that(typeNames)
+            .contains("ParseFailureKind")
+        assertWithMessage("PassImportRejectionSheet must declare a UiTelemetryGuard parameter")
+            .that(typeNames)
+            .contains("UiTelemetryGuard")
+    }
+
     // -- helpers -------------------------------------------------------------------
 
     private fun findComposable(fileClassSimpleName: String, methodName: String): Method {

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassImportConfirmBackPressTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassImportConfirmBackPressTest.kt
@@ -1,0 +1,165 @@
+package `is`.walt.passes.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.ParseFailureKind
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Verifies the trust contract that Android system back-press behaves identically to
+ * Cancel on [PassImportConfirm]: same telemetry, same callback. Lives in its own
+ * file because the back-press path needs `createAndroidComposeRule<ComponentActivity>()`
+ * to reach the activity's `OnBackPressedDispatcher`, while the rest of the UI suite
+ * uses `createComposeRule()`.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class PassImportConfirmBackPressTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val telemetry = RecordingGuard()
+
+    @Test
+    fun backPressFiresDismissedTelemetryAndCallback() {
+        var dismissed = 0
+        var confirmed = 0
+        composeRule.setContent {
+            ThemedHost {
+                PassImportConfirm(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.SelfSigned,
+                    telemetry = telemetry,
+                    onConfirm = { confirmed++ },
+                    onDismiss = { dismissed++ },
+                )
+            }
+        }
+
+        composeRule.activity.runOnUiThread {
+            composeRule.activity.onBackPressedDispatcher.onBackPressed()
+        }
+        composeRule.waitForIdle()
+
+        assertThat(dismissed).isEqualTo(1)
+        assertThat(confirmed).isEqualTo(0)
+        assertThat(telemetry.events).contains("import-dismiss:Generic:SelfSigned")
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme {
+            PassesTheme(semantics = semantics, content = content)
+        }
+    }
+
+    private val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = ArgbColor(0xFFFFE0E0.toInt()),
+            unsignedForeground = ArgbColor(0xFF101010.toInt()),
+            selfSignedBackground = ArgbColor(0xFFFFF0E0.toInt()),
+            selfSignedForeground = ArgbColor(0xFF101010.toInt()),
+            appleVerifiedBackground = ArgbColor(0xFFE0FFE0.toInt()),
+            appleVerifiedForeground = ArgbColor(0xFF101010.toInt()),
+            certChainIncompleteBackground = ArgbColor(0xFFFFFFE0.toInt()),
+            certChainIncompleteForeground = ArgbColor(0xFF101010.toInt()),
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = ArgbColor(0xFF202020.toInt()),
+            pillForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = ArgbColor(0xFFFFFFFF.toInt()),
+            emphasisBackground = ArgbColor(0xFFEFEFEF.toInt()),
+            emphasisForeground = ArgbColor(0xFF000000.toInt()),
+            bodyForeground = ArgbColor(0xFF202020.toInt()),
+            confirmContainer = ArgbColor(0xFF202020.toInt()),
+            confirmForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            cancelForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = ArgbColor(0xFF1D4ED8.toInt()),
+            eventTicket = ArgbColor(0xFF7C2D92.toInt()),
+            coupon = ArgbColor(0xFF555555.toInt()),
+            storeCard = ArgbColor(0xFF555555.toInt()),
+            generic = ArgbColor(0xFF555555.toInt()),
+        ),
+    )
+
+    private fun passFixture(): Pass = Pass(
+        type = PassType.Generic,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = "Acme",
+        expirationDate = null as PassInstant?,
+        voided = false,
+        colors = PassColors(
+            foreground = ColorValue(0x000000),
+            background = ColorValue(0xFFFFFF),
+            label = ColorValue(0x444444),
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = "From", value = "JFK")),
+        ),
+        backFields = emptyList(),
+        barcode = null,
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+
+    private class RecordingGuard : UiTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+        override fun onPassRendered(type: PassType, signatureBand: SignatureBand) {
+            events += "rendered:${type.name}:${signatureBand.name}"
+        }
+        override fun onPassBackOpened(type: PassType) { events += "back:${type.name}" }
+        override fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType) {
+            events += "shown:${intentKind.name}:${type.name}"
+        }
+        override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType) {
+            events += "confirm:${intentKind.name}:${type.name}"
+        }
+        override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType) {
+            events += "dismiss:${intentKind.name}:${type.name}"
+        }
+        override fun onImageDecodeRejected(reason: ImageDecodeRejection) {
+            events += "decode:${reason.name}"
+        }
+        override fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand) {
+            events += "import-shown:${type.name}:${signatureBand.name}"
+        }
+        override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand) {
+            events += "import-confirm:${type.name}:${signatureBand.name}"
+        }
+        override fun onImportDismissed(type: PassType, signatureBand: SignatureBand) {
+            events += "import-dismiss:${type.name}:${signatureBand.name}"
+        }
+        override fun onImportRejected(kind: ParseFailureKind) {
+            events += "import-rejected:${kind.name}"
+        }
+    }
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.ui
 
+import `is`.walt.passes.core.ParseFailureKind
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassColors
 import `is`.walt.passes.core.PassFields
@@ -187,6 +188,22 @@ class PublicApiSurfaceTest {
             override fun onImageDecodeRejected(reason: ImageDecodeRejection) {
                 recorded += "decode:${reason.name}"
             }
+
+            override fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand) {
+                recorded += "import-shown:${type.name}:${signatureBand.name}"
+            }
+
+            override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand) {
+                recorded += "import-confirm:${type.name}:${signatureBand.name}"
+            }
+
+            override fun onImportDismissed(type: PassType, signatureBand: SignatureBand) {
+                recorded += "import-dismiss:${type.name}:${signatureBand.name}"
+            }
+
+            override fun onImportRejected(kind: ParseFailureKind) {
+                recorded += "import-rejected:${kind.name}"
+            }
         }
         guard.onPassRendered(PassType.BoardingPass, SignatureBand.AppleVerified)
         guard.onPassBackOpened(PassType.EventTicket)
@@ -194,6 +211,10 @@ class PublicApiSurfaceTest {
         guard.onSecuritySheetConfirmed(SecurityIntentKind.Phone, PassType.StoreCard)
         guard.onSecuritySheetDismissed(SecurityIntentKind.Email, PassType.Coupon)
         guard.onImageDecodeRejected(ImageDecodeRejection.ExceedsArea)
+        guard.onImportConfirmShown(PassType.Generic, SignatureBand.SelfSigned)
+        guard.onImportConfirmed(PassType.Generic, SignatureBand.SelfSigned)
+        guard.onImportDismissed(PassType.BoardingPass, SignatureBand.Untrusted)
+        guard.onImportRejected(ParseFailureKind.Tampered)
 
         assertThat(recorded).containsExactly(
             "rendered:BoardingPass:AppleVerified",
@@ -202,6 +223,10 @@ class PublicApiSurfaceTest {
             "confirm:Phone:StoreCard",
             "dismiss:Email:Coupon",
             "decode:ExceedsArea",
+            "import-shown:Generic:SelfSigned",
+            "import-confirm:Generic:SelfSigned",
+            "import-dismiss:BoardingPass:Untrusted",
+            "import-rejected:Tampered",
         ).inOrder()
     }
 
@@ -214,6 +239,10 @@ class PublicApiSurfaceTest {
         guard.onSecuritySheetConfirmed(SecurityIntentKind.Url, PassType.BoardingPass)
         guard.onSecuritySheetDismissed(SecurityIntentKind.Url, PassType.BoardingPass)
         guard.onImageDecodeRejected(ImageDecodeRejection.Other)
+        guard.onImportConfirmShown(PassType.BoardingPass, SignatureBand.AppleVerified)
+        guard.onImportConfirmed(PassType.BoardingPass, SignatureBand.AppleVerified)
+        guard.onImportDismissed(PassType.BoardingPass, SignatureBand.Incomplete)
+        guard.onImportRejected(ParseFailureKind.Malformed)
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -7,8 +7,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.ParseFailureKind
 import `is`.walt.passes.core.ImageBytes
 import `is`.walt.passes.core.ImageRole
 import `is`.walt.passes.core.Pass
@@ -383,6 +385,132 @@ class TrustClaimSurfaceTest {
     // Document-surface trust assertions (caption, tile bidi-isolation, lane wiring)
     // moved to passes-pdf-ui::DocumentTrustSurfaceTest with the composables (wpass-r4z).
 
+    @Test
+    fun importConfirmShowsTrustCaptionForAppleVerified() {
+        composeRule.setContent {
+            ThemedHost {
+                PassImportConfirm(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.AppleVerified,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Verified Apple issuer").assertIsDisplayed()
+        composeRule.onNodeWithText("Add this pass?").assertIsDisplayed()
+        composeRule.onNodeWithText("Save pass").assertIsDisplayed()
+        composeRule.onNodeWithText("Cancel").assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertThat(telemetry.events).contains("import-shown:Generic:AppleVerified")
+    }
+
+    @Test
+    fun importConfirmTrustCaptionUnsigned() = importConfirmCaption(SignatureStatus.Unsigned, "No signature")
+
+    @Test
+    fun importConfirmTrustCaptionSelfSigned() =
+        importConfirmCaption(SignatureStatus.SelfSigned, "Self-signed issuer")
+
+    @Test
+    fun importConfirmTrustCaptionIncomplete() =
+        importConfirmCaption(SignatureStatus.CertChainIncomplete, "Issuer chain incomplete")
+
+    private fun importConfirmCaption(status: SignatureStatus, expected: String) {
+        composeRule.setContent {
+            ThemedHost {
+                PassImportConfirm(
+                    pass = passFixture(),
+                    signatureStatus = status,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(expected).assertIsDisplayed()
+    }
+
+    @Test
+    fun importConfirmFiresConfirmedTelemetryAndCallback() {
+        var confirmed = 0
+        composeRule.setContent {
+            ThemedHost {
+                PassImportConfirm(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.SelfSigned,
+                    telemetry = telemetry,
+                    onConfirm = { confirmed++ },
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Save pass").performClick()
+        composeRule.waitForIdle()
+        assertThat(confirmed).isEqualTo(1)
+        assertThat(telemetry.events).contains("import-confirm:Generic:SelfSigned")
+    }
+
+    @Test
+    fun importConfirmFiresDismissedTelemetryAndCallback() {
+        var dismissed = 0
+        composeRule.setContent {
+            ThemedHost {
+                PassImportConfirm(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.Unsigned,
+                    telemetry = telemetry,
+                    onConfirm = {},
+                    onDismiss = { dismissed++ },
+                )
+            }
+        }
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.waitForIdle()
+        assertThat(dismissed).isEqualTo(1)
+        assertThat(telemetry.events).contains("import-dismiss:Generic:Untrusted")
+    }
+
+    @Test
+    fun importRejectionSheetTamperedCopy() = importRejectionCopy(
+        ParseFailureKind.Tampered,
+        "This pass appears to have been tampered with",
+    )
+
+    @Test
+    fun importRejectionSheetMalformedCopy() = importRejectionCopy(
+        ParseFailureKind.Malformed,
+        "This file is not a valid pass",
+    )
+
+    @Test
+    fun importRejectionSheetUnsupportedCopy() = importRejectionCopy(
+        ParseFailureKind.Unsupported,
+        "Walt cannot open this pass",
+    )
+
+    @Test
+    fun importRejectionSheetResourceLimitCopy() = importRejectionCopy(
+        ParseFailureKind.ResourceLimitExceeded,
+        "This pass is too large to open safely",
+    )
+
+    private fun importRejectionCopy(kind: ParseFailureKind, expectedTitle: String) {
+        composeRule.setContent {
+            ThemedHost {
+                PassImportRejectionSheet(
+                    kind = kind,
+                    telemetry = telemetry,
+                    onDismiss = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(expectedTitle).assertIsDisplayed()
+        composeRule.waitForIdle()
+        assertThat(telemetry.events).contains("import-rejected:${kind.name}")
+    }
+
     @Composable
     private fun ThemedHost(content: @Composable () -> Unit) {
         MaterialTheme {
@@ -433,5 +561,17 @@ private class RecordingGuard : UiTelemetryGuard {
     }
     override fun onImageDecodeRejected(reason: ImageDecodeRejection) {
         events += "decode:${reason.name}"
+    }
+    override fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand) {
+        events += "import-shown:${type.name}:${signatureBand.name}"
+    }
+    override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand) {
+        events += "import-confirm:${type.name}:${signatureBand.name}"
+    }
+    override fun onImportDismissed(type: PassType, signatureBand: SignatureBand) {
+        events += "import-dismiss:${type.name}:${signatureBand.name}"
+    }
+    override fun onImportRejected(kind: ParseFailureKind) {
+        events += "import-rejected:${kind.name}"
     }
 }


### PR DESCRIPTION
## Summary

Walt currently has no in-app way to add a pass; users can only reach the import path via the OS-level intent filter (decision-wlt-0tn-q1 1b). This adds the trust-claim-bearing kernel surfaces for an in-app picker flow:

- `PassImportConfirm` — post-parse confirmation. Trust-band caption (4 distinct copy lines per signature status) above the `PassFront` preview, Save / Cancel. `BackHandler` mirrors Cancel so dismissal telemetry stays balanced.
- `PassImportRejectionSheet` — dismiss-only `ModalBottomSheet` for the four `ParseFailureKind` buckets, each with its own trust-correct copy.
- `UiTelemetryGuard` gains four enums-only events (`onImportConfirmShown / Confirmed / Dismissed / Rejected`).
- `SignatureStatus.toBand()` lifted to `passes-ui/internal/` so the security-load-bearing mapping lives in one place (was duplicated in `PassFront` and `PassImportConfirm`).

Walt-android side (FAB / picker / `ContentResolver` / nav) is owned separately.

Follow-up filed as `wpass-pk5`: localize the trust-bearing chrome strings.

## Test plan

- [x] `./gradlew check` passes (307 tasks)
- [x] `passes-ui` unit tests (87 tests including new back-press + per-band + per-failure copy assertions)
- [x] Detekt baseline updated for new `LongParameterList` (PassImportConfirm) and `ComplexInterface` (UiTelemetryGuard)
- [x] Surface lock tests pin the new composable shapes