### PR TITLE
passes-pdf: PdfImporter facade with API-34 gate, memfd, thumbnail (wpass-avs)

### DIFF
--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -57,6 +57,14 @@ public enum class Provenance {
  *    `android.graphics.pdf.PdfRenderer` is not available. Fired by the importer entry
  *    point *before* any source bytes are read or the renderer service is bound; the
  *    isolated process never starts on a device that cannot satisfy the version floor.
+ *  - [EncoderFailed] → SharedMemory mapping, `Bitmap.copyPixelsFromBuffer`, or
+ *    `Bitmap.compress(PNG)` threw after the renderer service returned `Ok`. This is a
+ *    *post-renderer* failure inside the importer's PNG-encoding step. Distinct from
+ *    [RendererFailed] so telemetry can tell "PDFium choked on this file" apart from
+ *    "the device ran out of RAM during PNG encoding."
+ *  - [StorageHandoffFailed] → the consumer-supplied `persist` callback threw after a
+ *    successful render. Trust band is the storage layer (downstream of this module);
+ *    a spike here points the consumer at SQLCipher / DB infra rather than the renderer.
  *
  * Reviewers should treat any future addition of a string-bearing failure arm (e.g. an
  * "ErrorMessage" data class) as a security-policy change.
@@ -75,4 +83,6 @@ public enum class DocumentRejectedKind {
     TooManyPages,
     RendererFailed,
     UnsupportedAndroidVersion,
+    EncoderFailed,
+    StorageHandoffFailed,
 }

--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -52,6 +52,11 @@ public enum class Provenance {
  *  - [Encrypted] → D6 (encrypted PDFs are rejected at import).
  *  - [RendererFailed] → the isolated renderer service (D3) returned an error or timed out
  *    during page-count probing; we never report the underlying decoder error string.
+ *  - [UnsupportedAndroidVersion] → ADR 0005 G.1 runtime gate. The host device's
+ *    `Build.VERSION.SDK_INT` is below 34, so the Mainline-backed PDFium reachable through
+ *    `android.graphics.pdf.PdfRenderer` is not available. Fired by the importer entry
+ *    point *before* any source bytes are read or the renderer service is bound; the
+ *    isolated process never starts on a device that cannot satisfy the version floor.
  *
  * Reviewers should treat any future addition of a string-bearing failure arm (e.g. an
  * "ErrorMessage" data class) as a security-policy change.
@@ -69,4 +74,5 @@ public enum class DocumentRejectedKind {
     Encrypted,
     TooManyPages,
     RendererFailed,
+    UnsupportedAndroidVersion,
 }

--- a/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
+++ b/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
@@ -31,7 +31,7 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun documentRejectedKindHasExactlyTheFiveListedArms() {
+    fun documentRejectedKindHasExactlyTheSixListedArms() {
         val all =
             setOf(
                 DocumentRejectedKind.OversizedAtImport,
@@ -39,9 +39,10 @@ class PublicApiSurfaceTest {
                 DocumentRejectedKind.Encrypted,
                 DocumentRejectedKind.TooManyPages,
                 DocumentRejectedKind.RendererFailed,
+                DocumentRejectedKind.UnsupportedAndroidVersion,
             )
         assertThat(all).containsExactlyElementsIn(DocumentRejectedKind.entries)
-        assertThat(DocumentRejectedKind.entries).hasSize(5)
+        assertThat(DocumentRejectedKind.entries).hasSize(6)
     }
 
     @Test

--- a/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
+++ b/passes-pdf-core/src/test/kotlin/is/walt/passes/pdf/PublicApiSurfaceTest.kt
@@ -31,7 +31,7 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun documentRejectedKindHasExactlyTheSixListedArms() {
+    fun documentRejectedKindHasExactlyTheEightListedArms() {
         val all =
             setOf(
                 DocumentRejectedKind.OversizedAtImport,
@@ -40,9 +40,11 @@ class PublicApiSurfaceTest {
                 DocumentRejectedKind.TooManyPages,
                 DocumentRejectedKind.RendererFailed,
                 DocumentRejectedKind.UnsupportedAndroidVersion,
+                DocumentRejectedKind.EncoderFailed,
+                DocumentRejectedKind.StorageHandoffFailed,
             )
         assertThat(all).containsExactlyElementsIn(DocumentRejectedKind.entries)
-        assertThat(DocumentRejectedKind.entries).hasSize(6)
+        assertThat(DocumentRejectedKind.entries).hasSize(8)
     }
 
     @Test

--- a/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfImporterInstrumentedTest.kt
+++ b/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfImporterInstrumentedTest.kt
@@ -1,0 +1,37 @@
+package `is`.walt.passes.pdf.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device coverage for the [PdfImporter] orchestration. Each scenario exercises the
+ * pieces the JVM-side suite cannot: the actual `Os.memfd_create` syscall, the actual
+ * isolated-process renderer service, the actual SharedMemory→Bitmap→PNG round trip.
+ *
+ * Test fixtures (benign single-page PDF, malformed PDF) are tracked under the same
+ * follow-up that hosts [PdfRendererServiceInstrumentedTest]'s fixtures (`wpass-5v9`)
+ * and land with the on-device CI configuration. The tests are `@Ignore`d at check-in
+ * so `./gradlew check` stays green on workstations without an emulator; CI flips them
+ * on by overriding the Ignore via a test filter and runs them on AGP managed devices,
+ * the same way `passes-storage` runs its Robolectric-incompatible scenarios.
+ */
+@RunWith(AndroidJUnit4::class)
+class PdfImporterInstrumentedTest {
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun benignPdfImportEndToEndProducesImportedWithThumbnail() {
+        // Build a PdfImporter via PdfImporter.create(context), import a 1-page benign
+        // fixture from a content URI, assert Imported(doc) with pageCount == 1 and a
+        // non-empty thumbnail BLOB persisted via the lambda.
+    }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun malformedPdfReturnsRendererFailedAndNextImportSucceeds() {
+        // Import a PDF crafted to crash PDFium → expect Rejected(RendererFailed). Then
+        // import a benign fixture → expect Imported. Documents the renderer-rebind path
+        // the binder layer's RemoteException → RendererFailed promise depends on.
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/DefaultPdfImporter.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/DefaultPdfImporter.kt
@@ -1,0 +1,263 @@
+package `is`.walt.passes.pdf.android
+
+import android.content.Context
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import `is`.walt.passes.pdf.DocumentImportFailedEvent
+import `is`.walt.passes.pdf.DocumentImportSucceededEvent
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.PdfDocumentId
+import `is`.walt.passes.pdf.PdfImportConfig
+import `is`.walt.passes.pdf.PdfImportResult
+import `is`.walt.passes.pdf.android.internal.AndroidRendererSessionFactory
+import `is`.walt.passes.pdf.android.internal.MemfdPfdFactory
+import `is`.walt.passes.pdf.android.internal.PdfPfdFactory
+import `is`.walt.passes.pdf.android.internal.PngThumbnailEncoder
+import `is`.walt.passes.pdf.android.internal.RendererSessionFactory
+import `is`.walt.passes.pdf.android.internal.ThumbnailEncoder
+import `is`.walt.passes.pdf.isPdfHeader
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.util.UUID
+
+/**
+ * The single import entry point honouring ADR 0005 G.1's "API-34-or-reject" gate and
+ * the F.1 memfd discipline. The orchestration sequence is the load-bearing contract:
+ *
+ *  1. SDK gate (G.1) — before *any* source byte is read.
+ *  2. Materialize the source to a bounded, in-memory byte buffer with a fail-fast cap.
+ *  3. Header-sniff the first 8 bytes (D4 cover) — before binding the renderer service.
+ *  4. Memfd-allocate a fresh [ParcelFileDescriptor] (F.1) — no plaintext on disk.
+ *  5. Bind the renderer service, await connection, wrap the binder.
+ *  6. Probe → render(page=0) for a smoke thumbnail.
+ *  7. Reconstruct the bitmap from SharedMemory, encode as PNG.
+ *  8. Hand off to the consumer's `persist` lambda.
+ *
+ * Each step's rejection routes back into the importer's [DocumentRejectedKind] enum;
+ * the renderer service is unbound in a `finally` regardless of outcome.
+ *
+ * Test seams are kept internal — the public entry remains the [PdfImporter.create]
+ * factory. Unit tests in this module construct [DefaultPdfImporter] directly with fake
+ * factories so the orchestration can be exercised without a live binder or
+ * `Os.memfd_create`. Adding a third seam in the consumer would re-open the
+ * parallel-implementation gap the importer exists to close.
+ */
+internal class DefaultPdfImporter(
+    private val context: Context,
+    private val config: PdfImportConfig,
+    private val sdkInt: Int = Build.VERSION.SDK_INT,
+    private val deps: Deps = Deps(),
+) : PdfImporter {
+    /**
+     * Internal seams folded into one record so the constructor stays under detekt's
+     * parameter cap. Every field is independently overridable from tests; production
+     * callers never construct [Deps] directly because the public [PdfImporter.create]
+     * factory builds [DefaultPdfImporter] with the production-default [Deps].
+     */
+    internal data class Deps(
+        val pfdFactory: PdfPfdFactory = MemfdPfdFactory(),
+        val sessionFactoryFor: (Context) -> RendererSessionFactory = ::AndroidRendererSessionFactory,
+        val thumbnailEncoder: ThumbnailEncoder = PngThumbnailEncoder,
+        val now: () -> Long = { android.os.SystemClock.elapsedRealtime() },
+        val idGenerator: () -> String = { UUID.randomUUID().toString() },
+    )
+
+    private val sessionFactory: RendererSessionFactory by lazy { deps.sessionFactoryFor(context) }
+
+    /**
+     * `@Suppress("ReturnCount")` matches the precedent set by `DefaultPassParser.runPipeline`
+     * in passes-core: each stage (SDK gate, materialize, pfd alloc, render+persist) is its
+     * own short-circuit, and collapsing the four returns into two either re-introduces a
+     * helper-chain or hides the early-exit shape behind monadic plumbing whose payoff
+     * does not justify the indirection at this size.
+     */
+    @Suppress("ReturnCount")
+    override suspend fun import(
+        source: PdfImportSource,
+        displayLabel: String,
+        persist: suspend (label: String, pdfBytes: ByteArray, pageCount: Int, thumbnailBytes: ByteArray) -> Unit,
+    ): PdfImportResult {
+        val startedAt = deps.now()
+        if (sdkInt < ANDROID_14_API) {
+            return rejectAndReport(DocumentRejectedKind.UnsupportedAndroidVersion, startedAt)
+        }
+        config.telemetryGuard.onImportStarted()
+        val bytes =
+            when (val m = materialize(source, startedAt)) {
+                is Materialized.Ok -> m.bytes
+                is Materialized.Reject -> return m.result
+            }
+        val pfd =
+            when (val a = allocatePfd(bytes, startedAt)) {
+                is PfdAlloc.Ok -> a.pfd
+                is PfdAlloc.Reject -> return a.result
+            }
+        return try {
+            renderAndPersist(pfd, bytes, displayLabel, persist, startedAt)
+        } finally {
+            runCatching { pfd.close() }
+        }
+    }
+
+    @Suppress("ReturnCount")
+    private fun materialize(source: PdfImportSource, startedAt: Long): Materialized {
+        val bytes =
+            when (val r = readBounded(source, config.maxBytes)) {
+                is BoundedRead.Bytes -> r.bytes
+                BoundedRead.Oversized ->
+                    return Materialized.Reject(rejectAndReport(DocumentRejectedKind.OversizedAtImport, startedAt))
+                BoundedRead.SourceUnavailable ->
+                    return Materialized.Reject(rejectAndReport(DocumentRejectedKind.NotAPdf, startedAt))
+            }
+        if (bytes.size < HEADER_BYTES || !isPdfHeader(bytes.copyOfRange(0, HEADER_BYTES))) {
+            return Materialized.Reject(rejectAndReport(DocumentRejectedKind.NotAPdf, startedAt))
+        }
+        return Materialized.Ok(bytes)
+    }
+
+    private fun allocatePfd(bytes: ByteArray, startedAt: Long): PfdAlloc =
+        runCatching { deps.pfdFactory.fromBytes(bytes) }
+            .fold(
+                onSuccess = { PfdAlloc.Ok(it) },
+                onFailure = { PfdAlloc.Reject(rejectAndReport(DocumentRejectedKind.RendererFailed, startedAt)) },
+            )
+
+    private sealed interface Materialized {
+        class Ok(val bytes: ByteArray) : Materialized
+
+        class Reject(val result: PdfImportResult.Rejected) : Materialized
+    }
+
+    private sealed interface PfdAlloc {
+        class Ok(val pfd: ParcelFileDescriptor) : PfdAlloc
+
+        class Reject(val result: PdfImportResult.Rejected) : PfdAlloc
+    }
+
+    private suspend fun renderAndPersist(
+        pfd: ParcelFileDescriptor,
+        bytes: ByteArray,
+        displayLabel: String,
+        persist: suspend (String, ByteArray, Int, ByteArray) -> Unit,
+        startedAt: Long,
+    ): PdfImportResult =
+        sessionFactory.connect().use { session ->
+            val pages =
+                when (val probe = session.client.probe(pfd)) {
+                    is ProbeResult.Rejected -> return@use rejectAndReport(probe.kind, startedAt)
+                    is ProbeResult.Ok -> probe.pageCount
+                }
+            val thumbnailBytes =
+                when (
+                    val render = session.client.render(
+                        pdf = pfd,
+                        page = 0,
+                        widthPx = THUMB_WIDTH_PX,
+                        heightPx = THUMB_HEIGHT_PX,
+                    )
+                ) {
+                    is RenderResult.Rejected -> return@use rejectAndReport(render.kind, startedAt)
+                    is RenderResult.Ok ->
+                        runCatching { deps.thumbnailEncoder.encode(render) }
+                            .getOrElse {
+                                return@use rejectAndReport(DocumentRejectedKind.RendererFailed, startedAt)
+                            }
+                }
+            // Persist throws fold to RendererFailed: persist is the trust-boundary
+            // handoff to storage, and a throw there is an infrastructure failure the
+            // importer cannot recover from. onImportFailed still fires.
+            runCatching { persist(displayLabel, bytes, pages, thumbnailBytes) }
+                .getOrElse { return@use rejectAndReport(DocumentRejectedKind.RendererFailed, startedAt) }
+            val doc =
+                PdfDocument(
+                    id = PdfDocumentId(deps.idGenerator()),
+                    displayLabel = displayLabel,
+                    byteCount = bytes.size.toLong(),
+                    pageCount = pages,
+                    importedAtEpochMs = System.currentTimeMillis(),
+                )
+            config.telemetryGuard.onImportSucceeded(
+                DocumentImportSucceededEvent(
+                    byteCount = doc.byteCount,
+                    pageCount = doc.pageCount,
+                    durationMillis = deps.now() - startedAt,
+                ),
+            )
+            PdfImportResult.Imported(doc)
+        }
+
+    private fun rejectAndReport(
+        kind: DocumentRejectedKind,
+        startedAt: Long,
+    ): PdfImportResult.Rejected {
+        config.telemetryGuard.onImportFailed(
+            DocumentImportFailedEvent(outcome = kind, durationMillis = deps.now() - startedAt),
+        )
+        return PdfImportResult.Rejected(kind)
+    }
+
+    private fun readBounded(source: PdfImportSource, maxBytes: Long): BoundedRead {
+        val stream = openSource(source) ?: return BoundedRead.SourceUnavailable
+        return stream.use { drainBounded(it, maxBytes) }
+    }
+
+    private fun openSource(source: PdfImportSource): InputStream? =
+        when (source) {
+            is PdfImportSource.ContentUri ->
+                runCatching { source.resolver.openInputStream(source.uri) }.getOrNull()
+            is PdfImportSource.FileDescriptor -> {
+                // Dup the caller's PFD so AutoCloseInputStream's `close()` releases only
+                // our duplicate; the caller's original fd survives, honouring the
+                // "importer does not close the source PFD" ownership contract on
+                // PdfImportSource.
+                val dup = runCatching { source.pfd.dup() }.getOrNull()
+                dup?.let { ParcelFileDescriptor.AutoCloseInputStream(it) }
+            }
+        }
+
+    private fun drainBounded(input: InputStream, maxBytes: Long): BoundedRead {
+        val baos = ByteArrayOutputStream()
+        val buf = ByteArray(COPY_BUFFER_SIZE)
+        var total = 0L
+        // One extra byte beyond maxBytes so the loop distinguishes "exactly at cap" from
+        // "over". The renderer never sees more bytes than what we ultimately hand back.
+        val ceiling = maxBytes + 1
+        while (total < ceiling) {
+            val want = minOf(buf.size.toLong(), ceiling - total).toInt()
+            val n =
+                runCatching { input.read(buf, 0, want) }
+                    .getOrElse { return BoundedRead.SourceUnavailable }
+            if (n < 0) break
+            baos.write(buf, 0, n)
+            total += n
+        }
+        return if (total > maxBytes) BoundedRead.Oversized else BoundedRead.Bytes(baos.toByteArray())
+    }
+
+    private sealed interface BoundedRead {
+        data class Bytes(val bytes: ByteArray) : BoundedRead
+
+        data object Oversized : BoundedRead
+
+        data object SourceUnavailable : BoundedRead
+    }
+
+    internal companion object {
+        // Read buffer for the materialization loop. 64 KiB matches the InputStream.copyTo
+        // default and keeps the read syscall count low without inflating per-import RAM.
+        const val COPY_BUFFER_SIZE: Int = 64 * 1024
+
+        // Thumbnail dimensions for the smoke render. 600 x 800 = 480 000 px, comfortably
+        // below the renderer service's 4 MP cap (PdfRendererService.MAX_PIXELS), and an
+        // aspect ratio close enough to the 4:3 tile that DocumentTile renders into that
+        // the bitmap's intrinsic shape doesn't fight the layout's aspect-ratio constraint.
+        const val THUMB_WIDTH_PX: Int = 600
+        const val THUMB_HEIGHT_PX: Int = 800
+
+        const val HEADER_BYTES: Int = 8
+
+        // ADR 0005 G.1 floor.
+        const val ANDROID_14_API: Int = 34
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/DefaultPdfImporter.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/DefaultPdfImporter.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.pdf.android
 
+import android.content.ContentResolver
 import android.content.Context
 import android.os.Build
 import android.os.ParcelFileDescriptor
@@ -20,6 +21,7 @@ import `is`.walt.passes.pdf.isPdfHeader
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
 
 /**
  * The single import entry point honouring ADR 0005 G.1's "API-34-or-reject" gate and
@@ -36,6 +38,21 @@ import java.util.UUID
  *
  * Each step's rejection routes back into the importer's [DocumentRejectedKind] enum;
  * the renderer service is unbound in a `finally` regardless of outcome.
+ *
+ * Rejection-arm routing keeps trust bands distinct:
+ *
+ *  - [DocumentRejectedKind.RendererFailed] is reserved for the bind→probe→render window
+ *    (including pfd-alloc and source-fd dup failures, which are part of preparing the
+ *    renderer handoff). A spike here is the signal that PDFium may have refused a file.
+ *  - [DocumentRejectedKind.EncoderFailed] covers post-render PNG encoding failures
+ *    (SharedMemory map / bitmap reconstruction / PNG compress). A spike here is "the
+ *    renderer succeeded but our PNG path blew up."
+ *  - [DocumentRejectedKind.StorageHandoffFailed] is reserved for `persist` throws.
+ *    A spike here points the on-call at the consumer's storage layer, not the renderer.
+ *
+ * [CancellationException] is rethrown from the encode and persist wrap points so a
+ * parent-scope cancel during import surfaces as cancellation, preserving structured
+ * concurrency instead of silently converting cancellation into an import rejection.
  *
  * Test seams are kept internal — the public entry remains the [PdfImporter.create]
  * factory. Unit tests in this module construct [DefaultPdfImporter] directly with fake
@@ -160,15 +177,25 @@ internal class DefaultPdfImporter(
                     is RenderResult.Rejected -> return@use rejectAndReport(render.kind, startedAt)
                     is RenderResult.Ok ->
                         runCatching { deps.thumbnailEncoder.encode(render) }
-                            .getOrElse {
-                                return@use rejectAndReport(DocumentRejectedKind.RendererFailed, startedAt)
+                            .getOrElse { t ->
+                                // CancellationException is part of structured concurrency: catching
+                                // it here would silently convert a parent-scope cancel into an
+                                // EncoderFailed rejection, breaking the parent's "import was
+                                // cancelled" signal. Rethrow lets the cancellation propagate.
+                                if (t is CancellationException) throw t
+                                return@use rejectAndReport(DocumentRejectedKind.EncoderFailed, startedAt)
                             }
                 }
-            // Persist throws fold to RendererFailed: persist is the trust-boundary
-            // handoff to storage, and a throw there is an infrastructure failure the
-            // importer cannot recover from. onImportFailed still fires.
+            // Persist failure routes to StorageHandoffFailed (distinct from RendererFailed):
+            // the consumer's storage layer threw, not the isolated renderer. Splitting the
+            // arms gives the on-call a clean "SQLCipher wedged" vs "PDFium choked" signal.
+            // CancellationException is rethrown so a parent-scope cancel mid-persist
+            // surfaces as cancellation, not as an Importer rejection.
             runCatching { persist(displayLabel, bytes, pages, thumbnailBytes) }
-                .getOrElse { return@use rejectAndReport(DocumentRejectedKind.RendererFailed, startedAt) }
+                .getOrElse { t ->
+                    if (t is CancellationException) throw t
+                    return@use rejectAndReport(DocumentRejectedKind.StorageHandoffFailed, startedAt)
+                }
             val doc =
                 PdfDocument(
                     id = PdfDocumentId(deps.idGenerator()),
@@ -204,8 +231,18 @@ internal class DefaultPdfImporter(
 
     private fun openSource(source: PdfImportSource): InputStream? =
         when (source) {
-            is PdfImportSource.ContentUri ->
-                runCatching { source.resolver.openInputStream(source.uri) }.getOrNull()
+            is PdfImportSource.ContentUri -> {
+                // Scheme allowlist: ContentResolver.openInputStream will happily resolve a
+                // `file://` URI to an arbitrary filesystem path, which is exactly the
+                // path-arm escape hatch the sealed PdfImportSource shape was supposed to
+                // close. Refusing non-`content://` schemes here keeps the implementation
+                // aligned with the documented threat model on PdfImportSource.
+                if (source.uri.scheme != ContentResolver.SCHEME_CONTENT) {
+                    null
+                } else {
+                    runCatching { source.resolver.openInputStream(source.uri) }.getOrNull()
+                }
+            }
             is PdfImportSource.FileDescriptor -> {
                 // Dup the caller's PFD so AutoCloseInputStream's `close()` releases only
                 // our duplicate; the caller's original fd survives, honouring the

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImportSource.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImportSource.kt
@@ -1,0 +1,34 @@
+package `is`.walt.passes.pdf.android
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+
+/**
+ * The two shapes a PDF can enter the importer in.
+ *
+ * Sealed by design: every byte that reaches the renderer service has to be sourced from
+ * either an Android `ContentResolver` URI (the SAF / `ACTION_OPEN_DOCUMENT` path the
+ * walt-android consumer wires) or from a `ParcelFileDescriptor` the consumer has already
+ * opened. There is intentionally no `Path` / `File` arm: trust-claim-bearing import code
+ * never opens a filesystem path itself, because once a path-arm exists a future
+ * contributor can quietly route bytes from disk-cached locations the consumer never
+ * intended (downloads cache, app-private files exposed by a debug FileProvider). The two
+ * arms together cover every legitimate user-initiated import without admitting that
+ * surface.
+ *
+ * Ownership: the caller retains ownership of the [ContentResolver], the [Uri], and any
+ * [ParcelFileDescriptor] passed in. The importer reads from these but does not close
+ * them; closing remains the caller's responsibility once the suspend `import` returns.
+ * This mirrors the [PdfRendererBinder] PFD-ownership contract on the binder side.
+ */
+public sealed interface PdfImportSource {
+    public class ContentUri(
+        public val uri: Uri,
+        public val resolver: ContentResolver,
+    ) : PdfImportSource
+
+    public class FileDescriptor(
+        public val pfd: ParcelFileDescriptor,
+    ) : PdfImportSource
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImporter.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImporter.kt
@@ -36,11 +36,12 @@ public interface PdfImporter {
      *
      * [persist] is invoked exactly once on the success path, after the page-zero render
      * succeeds and before the [PdfImportResult.Imported] arm is constructed. It is never
-     * invoked on a rejection. If [persist] throws, the import returns
-     * [is.walt.passes.pdf.DocumentRejectedKind.RendererFailed] (the persist call sits at
-     * the same trust band as the renderer handoff — a thrown exception there is a
-     * downstream infrastructure failure the importer cannot recover from), and telemetry
-     * fires `onImportFailed`.
+     * invoked on a rejection. If [persist] throws (other than `CancellationException`,
+     * which is rethrown to preserve structured concurrency), the import returns
+     * [is.walt.passes.pdf.DocumentRejectedKind.StorageHandoffFailed] — distinct from
+     * the renderer's own [is.walt.passes.pdf.DocumentRejectedKind.RendererFailed] so
+     * telemetry can separate "PDFium choked on this file" from "the consumer's storage
+     * layer blew up." Telemetry fires `onImportFailed`.
      *
      * [displayLabel] is supplied by the consumer; the importer does not derive it from
      * the source, because the source's metadata is part of the no-extraction-from-content

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImporter.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfImporter.kt
@@ -1,0 +1,61 @@
+package `is`.walt.passes.pdf.android
+
+import android.content.Context
+import `is`.walt.passes.pdf.PdfImportConfig
+import `is`.walt.passes.pdf.PdfImportResult
+
+/**
+ * The single import entry point that ADR 0005 G.1 calls for. Owns the trust-claim-bearing
+ * orchestration that the consumer (walt-android) would otherwise have to assemble itself:
+ *
+ *  1. Runtime API-34 gate (G.1) — fires *before* any source bytes are read.
+ *  2. Memfd-backed materialization with a fail-fast size cap (D7, F.1).
+ *  3. Magic-byte header sniff before the renderer process is bound (D4 cover).
+ *  4. Isolated-process renderer bind (D3) → probe → page-zero render.
+ *  5. Storage handoff via a caller-supplied `persist` lambda.
+ *  6. Telemetry start / success / failure with enums-and-durations only.
+ *
+ * Composing those by hand in walt-android would be the parallel-implementation
+ * pattern the repository's "DECISIVE CONSTRAINT" forbids: trust claims must live in
+ * this repository, not be reassembled by the consumer. [PdfImporter] is the seam that
+ * keeps that invariant honest — every import goes through this orchestration, and
+ * every step here is independently surface-locked by tests in this module.
+ *
+ * Storage is wired through a callback rather than a `PassRepository` dependency so the
+ * `passes-pdf` and `passes-storage` modules remain independent peers per the
+ * project's module rules. The consumer's Hilt graph supplies a lambda that calls
+ * `PassRepository.insertDocument`; the importer itself stays storage-agnostic and
+ * remains testable without spinning up SQLCipher.
+ */
+public interface PdfImporter {
+    /**
+     * Run the import sequence end-to-end. Returns [PdfImportResult.Imported] on success,
+     * or [PdfImportResult.Rejected] folded onto the [is.walt.passes.pdf.DocumentRejectedKind]
+     * enum at the first failing step. The renderer service is unbound before this method
+     * returns regardless of outcome.
+     *
+     * [persist] is invoked exactly once on the success path, after the page-zero render
+     * succeeds and before the [PdfImportResult.Imported] arm is constructed. It is never
+     * invoked on a rejection. If [persist] throws, the import returns
+     * [is.walt.passes.pdf.DocumentRejectedKind.RendererFailed] (the persist call sits at
+     * the same trust band as the renderer handoff — a thrown exception there is a
+     * downstream infrastructure failure the importer cannot recover from), and telemetry
+     * fires `onImportFailed`.
+     *
+     * [displayLabel] is supplied by the consumer; the importer does not derive it from
+     * the source, because the source's metadata is part of the no-extraction-from-content
+     * discipline (ADR 0005 D4). The label is forwarded verbatim to [persist].
+     */
+    public suspend fun import(
+        source: PdfImportSource,
+        displayLabel: String,
+        persist: suspend (label: String, pdfBytes: ByteArray, pageCount: Int, thumbnailBytes: ByteArray) -> Unit,
+    ): PdfImportResult
+
+    public companion object {
+        public fun create(
+            context: Context,
+            config: PdfImportConfig = PdfImportConfig(),
+        ): PdfImporter = DefaultPdfImporter(context, config)
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
@@ -26,6 +26,7 @@ internal object RejectedKindWire {
     const val ENCRYPTED: Int = 2
     const val TOO_MANY_PAGES: Int = 3
     const val RENDERER_FAILED: Int = 4
+    const val UNSUPPORTED_ANDROID_VERSION: Int = 5
 
     fun encode(kind: DocumentRejectedKind): Int =
         when (kind) {
@@ -34,6 +35,7 @@ internal object RejectedKindWire {
             DocumentRejectedKind.Encrypted -> ENCRYPTED
             DocumentRejectedKind.TooManyPages -> TOO_MANY_PAGES
             DocumentRejectedKind.RendererFailed -> RENDERER_FAILED
+            DocumentRejectedKind.UnsupportedAndroidVersion -> UNSUPPORTED_ANDROID_VERSION
         }
 
     fun decode(code: Int): DocumentRejectedKind =
@@ -43,6 +45,7 @@ internal object RejectedKindWire {
             ENCRYPTED -> DocumentRejectedKind.Encrypted
             TOO_MANY_PAGES -> DocumentRejectedKind.TooManyPages
             RENDERER_FAILED -> DocumentRejectedKind.RendererFailed
+            UNSUPPORTED_ANDROID_VERSION -> DocumentRejectedKind.UnsupportedAndroidVersion
             else -> error("Unknown DocumentRejectedKind wire code: $code")
         }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/RejectedKindWire.kt
@@ -27,6 +27,8 @@ internal object RejectedKindWire {
     const val TOO_MANY_PAGES: Int = 3
     const val RENDERER_FAILED: Int = 4
     const val UNSUPPORTED_ANDROID_VERSION: Int = 5
+    const val ENCODER_FAILED: Int = 6
+    const val STORAGE_HANDOFF_FAILED: Int = 7
 
     fun encode(kind: DocumentRejectedKind): Int =
         when (kind) {
@@ -36,6 +38,8 @@ internal object RejectedKindWire {
             DocumentRejectedKind.TooManyPages -> TOO_MANY_PAGES
             DocumentRejectedKind.RendererFailed -> RENDERER_FAILED
             DocumentRejectedKind.UnsupportedAndroidVersion -> UNSUPPORTED_ANDROID_VERSION
+            DocumentRejectedKind.EncoderFailed -> ENCODER_FAILED
+            DocumentRejectedKind.StorageHandoffFailed -> STORAGE_HANDOFF_FAILED
         }
 
     fun decode(code: Int): DocumentRejectedKind =
@@ -46,6 +50,8 @@ internal object RejectedKindWire {
             TOO_MANY_PAGES -> DocumentRejectedKind.TooManyPages
             RENDERER_FAILED -> DocumentRejectedKind.RendererFailed
             UNSUPPORTED_ANDROID_VERSION -> DocumentRejectedKind.UnsupportedAndroidVersion
+            ENCODER_FAILED -> DocumentRejectedKind.EncoderFailed
+            STORAGE_HANDOFF_FAILED -> DocumentRejectedKind.StorageHandoffFailed
             else -> error("Unknown DocumentRejectedKind wire code: $code")
         }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/PdfPfdFactory.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/PdfPfdFactory.kt
@@ -1,0 +1,63 @@
+package `is`.walt.passes.pdf.android.internal
+
+import android.annotation.TargetApi
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import android.system.Os
+import android.system.OsConstants
+
+/**
+ * Creates a [ParcelFileDescriptor] backed by an anonymous in-RAM file (`memfd_create`).
+ * The renderer service mmaps the PFD; no plaintext bytes ever touch disk (ADR 0005 F.1).
+ *
+ * The factory is an internal seam: production code wires [MemfdPfdFactory] (the real
+ * `Os.memfd_create` path), unit tests wire a fake that hands back a pipe-backed PFD so
+ * the orchestrator code path can be exercised without `Os.memfd_create` being reachable
+ * from the JVM-side test runtime. The seam is *not* a public API — adding a third
+ * implementation in walt-android would re-open the parallel-implementation gap that the
+ * importer exists to close.
+ */
+internal interface PdfPfdFactory {
+    /**
+     * Allocate an in-memory PFD, write [bytes] into it, then rewind so the renderer
+     * reads from offset 0.
+     */
+    fun fromBytes(bytes: ByteArray): ParcelFileDescriptor
+}
+
+// memfd_create lands in android.system.Os at API 30. The wider importer is gated on
+// SDK_INT >= 34 (ADR 0005 G.1) before this factory is ever asked for a PFD; the
+// @TargetApi narrows lint's view to that gate and the inline `check` is defence in
+// depth: a future caller that wires the factory outside the importer's gate fails
+// loudly here rather than crashing inside the libcore call.
+@TargetApi(Build.VERSION_CODES.R)
+internal class MemfdPfdFactory : PdfPfdFactory {
+    override fun fromBytes(bytes: ByteArray): ParcelFileDescriptor {
+        check(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            "memfd_create requires Android 11 (API 30) or newer"
+        }
+        val fd = Os.memfd_create("walt-pdf-import", 0)
+        try {
+            // Os.write returns the count actually written; loop to drain the buffer in
+            // case the kernel decides to short-write. memfd_create-backed fds in
+            // practice accept the whole buffer in one go, but the loop is the
+            // defensive shape that doesn't depend on that promise.
+            var offset = 0
+            while (offset < bytes.size) {
+                val written = Os.write(fd, bytes, offset, bytes.size - offset)
+                if (written <= 0) {
+                    error("memfd write stalled at offset=$offset")
+                }
+                offset += written
+            }
+            Os.lseek(fd, 0, OsConstants.SEEK_SET)
+            return ParcelFileDescriptor.dup(fd)
+        } finally {
+            // ParcelFileDescriptor.dup duplicates the underlying fd; close ours so the
+            // memfd is owned exclusively by the PFD we just handed back to the caller.
+            // Os.close throws ErrnoException if the fd was already closed; runCatching
+            // covers the case where dup() failed and dropped our ownership claim.
+            runCatching { Os.close(fd) }
+        }
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RejectingBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RejectingBinder.kt
@@ -1,0 +1,30 @@
+package `is`.walt.passes.pdf.android.internal
+
+import android.os.ParcelFileDescriptor
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.ProbeResult
+import `is`.walt.passes.pdf.android.RenderResult
+
+/**
+ * A [PdfRendererBinder] that returns the same [DocumentRejectedKind] for every probe
+ * and every render. Used by [RendererSession] callers to surface a connect-time failure
+ * through the same probe/render shape as a real binder; the importer's existing
+ * rejection routing then folds it onto [DocumentRejectedKind] without a separate
+ * "session connect failed" code path.
+ *
+ * Lifted to its own type because the shape ("a binder that always rejects with X") is
+ * plausibly useful for unit-test fakes too.
+ */
+internal class RejectingBinder(
+    private val kind: DocumentRejectedKind,
+) : PdfRendererBinder {
+    override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult = ProbeResult.Rejected(kind)
+
+    override suspend fun render(
+        pdf: ParcelFileDescriptor,
+        page: Int,
+        widthPx: Int,
+        heightPx: Int,
+    ): RenderResult = RenderResult.Rejected(kind)
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RendererSession.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RendererSession.kt
@@ -70,21 +70,7 @@ internal class AndroidRendererSessionFactory(
  */
 private object FailedSession : RendererSession {
     override val client: PdfRendererBinder =
-        object : PdfRendererBinder {
-            override suspend fun probe(pdf: android.os.ParcelFileDescriptor) =
-                `is`.walt.passes.pdf.android.ProbeResult.Rejected(
-                    `is`.walt.passes.pdf.DocumentRejectedKind.RendererFailed,
-                )
-
-            override suspend fun render(
-                pdf: android.os.ParcelFileDescriptor,
-                page: Int,
-                widthPx: Int,
-                heightPx: Int,
-            ) = `is`.walt.passes.pdf.android.RenderResult.Rejected(
-                `is`.walt.passes.pdf.DocumentRejectedKind.RendererFailed,
-            )
-        }
+        RejectingBinder(`is`.walt.passes.pdf.DocumentRejectedKind.RendererFailed)
 
     override fun close() = Unit
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RendererSession.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RendererSession.kt
@@ -1,0 +1,100 @@
+package `is`.walt.passes.pdf.android.internal
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.PdfRendererClient
+import `is`.walt.passes.pdf.android.PdfRendererService
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Owns the bind / unbind pair for a single renderer-service session. The importer
+ * obtains a [RendererSession] for the duration of one import call, uses [client] for
+ * `probe` and `render`, and closes the session in a `finally` block — which guarantees
+ * `unbindService` runs whether the import succeeded, was rejected at any step, or threw.
+ *
+ * Lifted to an internal seam so unit tests can inject a fake that records bind / unbind
+ * calls without an actual `bindService` round trip. The default [AndroidRendererSessionFactory]
+ * does the real thing.
+ */
+internal interface RendererSession : AutoCloseable {
+    val client: PdfRendererBinder
+
+    override fun close()
+}
+
+internal interface RendererSessionFactory {
+    suspend fun connect(): RendererSession
+}
+
+internal class AndroidRendererSessionFactory(
+    private val context: Context,
+) : RendererSessionFactory {
+    override suspend fun connect(): RendererSession =
+        suspendCancellableCoroutine { cont ->
+            val intent = Intent(context, PdfRendererService::class.java)
+            lateinit var conn: ServiceConnection
+            conn =
+                object : ServiceConnection {
+                    override fun onServiceConnected(name: ComponentName?, binder: IBinder) {
+                        cont.resume(AndroidRendererSession(context, conn, PdfRendererClient(binder)))
+                    }
+
+                    // onServiceDisconnected fires after a successful connect — the binder
+                    // is gone but the connection record remains. The session's close()
+                    // unbinds either way, so nothing to do here. The active transact will
+                    // surface as RemoteException → RendererFailed via PdfRendererClient,
+                    // which is the documented runtime failure path.
+                    override fun onServiceDisconnected(name: ComponentName?) = Unit
+                }
+            val bound = context.bindService(intent, conn, Context.BIND_AUTO_CREATE)
+            if (!bound) {
+                runCatching { context.unbindService(conn) }
+                cont.resume(FailedSession)
+            }
+            cont.invokeOnCancellation {
+                runCatching { context.unbindService(conn) }
+            }
+        }
+}
+
+/**
+ * Returned when `bindService` itself returns false (the service is missing from the
+ * manifest or the system rejected the bind). Surfacing the connect failure as a
+ * "session whose every call rejects" rather than throwing keeps the error path inside
+ * the importer's existing rejection vocabulary.
+ */
+private object FailedSession : RendererSession {
+    override val client: PdfRendererBinder =
+        object : PdfRendererBinder {
+            override suspend fun probe(pdf: android.os.ParcelFileDescriptor) =
+                `is`.walt.passes.pdf.android.ProbeResult.Rejected(
+                    `is`.walt.passes.pdf.DocumentRejectedKind.RendererFailed,
+                )
+
+            override suspend fun render(
+                pdf: android.os.ParcelFileDescriptor,
+                page: Int,
+                widthPx: Int,
+                heightPx: Int,
+            ) = `is`.walt.passes.pdf.android.RenderResult.Rejected(
+                `is`.walt.passes.pdf.DocumentRejectedKind.RendererFailed,
+            )
+        }
+
+    override fun close() = Unit
+}
+
+private class AndroidRendererSession(
+    private val context: Context,
+    private val connection: ServiceConnection,
+    override val client: PdfRendererBinder,
+) : RendererSession {
+    override fun close() {
+        runCatching { context.unbindService(connection) }
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/ThumbnailEncoder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/ThumbnailEncoder.kt
@@ -21,21 +21,28 @@ internal interface ThumbnailEncoder {
 
 internal object PngThumbnailEncoder : ThumbnailEncoder {
     override fun encode(render: RenderResult.Ok): ByteArray {
-        val buffer = render.sharedMemory.mapReadOnly()
+        // Outer try/finally ensures `sharedMemory.close()` runs even if `mapReadOnly()`
+        // itself throws — otherwise the SharedMemory handle leaks across the IPC
+        // ownership boundary, which is exactly the surface this module spends most of
+        // its energy locking down.
         try {
-            val bitmap = Bitmap.createBitmap(render.widthPx, render.heightPx, Bitmap.Config.ARGB_8888)
+            val buffer = render.sharedMemory.mapReadOnly()
             try {
-                bitmap.copyPixelsFromBuffer(buffer)
-                val baos = ByteArrayOutputStream()
-                // PNG is lossless; the quality argument is ignored. Pinning at 100 is
-                // documentation for the call-site reader.
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos)
-                return baos.toByteArray()
+                val bitmap = Bitmap.createBitmap(render.widthPx, render.heightPx, Bitmap.Config.ARGB_8888)
+                try {
+                    bitmap.copyPixelsFromBuffer(buffer)
+                    val baos = ByteArrayOutputStream()
+                    // PNG is lossless; the quality argument is ignored. Pinning at 100 is
+                    // documentation for the call-site reader.
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos)
+                    return baos.toByteArray()
+                } finally {
+                    bitmap.recycle()
+                }
             } finally {
-                bitmap.recycle()
+                SharedMemory.unmap(buffer)
             }
         } finally {
-            SharedMemory.unmap(buffer)
             render.sharedMemory.close()
         }
     }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/ThumbnailEncoder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/ThumbnailEncoder.kt
@@ -1,0 +1,42 @@
+package `is`.walt.passes.pdf.android.internal
+
+import android.graphics.Bitmap
+import android.os.SharedMemory
+import `is`.walt.passes.pdf.android.RenderResult
+import java.io.ByteArrayOutputStream
+
+/**
+ * Reconstructs a [Bitmap] from a [RenderResult.Ok]'s [SharedMemory] buffer and encodes
+ * it as PNG bytes for the storage thumbnail BLOB.
+ *
+ * Lifted to an internal seam so unit tests can plug in a deterministic fake. The
+ * production [PngThumbnailEncoder] does the real `mapReadOnly` -> `copyPixelsFromBuffer`
+ * -> `Bitmap.compress(PNG)` dance; tests don't exercise that path because Robolectric
+ * shadows for the SharedMemory + Bitmap pipeline are not load-bearing for the
+ * orchestration assertions.
+ */
+internal interface ThumbnailEncoder {
+    fun encode(render: RenderResult.Ok): ByteArray
+}
+
+internal object PngThumbnailEncoder : ThumbnailEncoder {
+    override fun encode(render: RenderResult.Ok): ByteArray {
+        val buffer = render.sharedMemory.mapReadOnly()
+        try {
+            val bitmap = Bitmap.createBitmap(render.widthPx, render.heightPx, Bitmap.Config.ARGB_8888)
+            try {
+                bitmap.copyPixelsFromBuffer(buffer)
+                val baos = ByteArrayOutputStream()
+                // PNG is lossless; the quality argument is ignored. Pinning at 100 is
+                // documentation for the call-site reader.
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, baos)
+                return baos.toByteArray()
+            } finally {
+                bitmap.recycle()
+            }
+        } finally {
+            SharedMemory.unmap(buffer)
+            render.sharedMemory.close()
+        }
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
@@ -17,6 +17,7 @@ import `is`.walt.passes.pdf.android.internal.PdfPfdFactory
 import `is`.walt.passes.pdf.android.internal.RendererSession
 import `is`.walt.passes.pdf.android.internal.RendererSessionFactory
 import `is`.walt.passes.pdf.android.internal.ThumbnailEncoder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -215,7 +216,7 @@ class PdfImporterTest {
     }
 
     @Test
-    fun persistThrowFoldsToRendererFailedAndUnbinds() = runTest {
+    fun persistThrowFoldsToStorageHandoffFailedAndUnbinds() = runTest {
         val sm = SharedMemory.create("walt-test-persist-throw", DEFAULT_THUMB_PIXEL_BYTES)
         val factory =
             RecordingSessionFactory(
@@ -232,8 +233,113 @@ class PdfImporterTest {
                 persist = { _, _, _, _ -> error("downstream storage exploded") },
             )
 
-        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.RendererFailed))
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.StorageHandoffFailed))
         assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun encoderThrowFoldsToEncoderFailedAndUnbinds() = runTest {
+        val sm = SharedMemory.create("walt-test-encoder-throw", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(
+                    probeResult = ProbeResult.Ok(pageCount = 2),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                ),
+            )
+        val throwingEncoder =
+            object : ThumbnailEncoder {
+                override fun encode(render: RenderResult.Ok): ByteArray {
+                    runCatching { render.sharedMemory.close() }
+                    error("encoder blew up")
+                }
+            }
+
+        val result =
+            importer(sessionFactory = factory, thumbnailEncoder = throwingEncoder).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                displayLabel = "x.pdf",
+                persist = { _, _, _, _ -> error("persist must not run on encoder failure") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.EncoderFailed))
+        assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun persistCancellationPropagatesAndPreservesStructuredConcurrency() = runTest {
+        val sm = SharedMemory.create("walt-test-persist-cancel", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(
+                    probeResult = ProbeResult.Ok(pageCount = 1),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                ),
+            )
+
+        val thrown =
+            runCatching {
+                importer(sessionFactory = factory).import(
+                    source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                    displayLabel = "x.pdf",
+                    persist = { _, _, _, _ -> throw CancellationException("parent scope cancelled") },
+                )
+            }.exceptionOrNull()
+
+        // CancellationException must propagate out of `import` rather than being folded
+        // onto StorageHandoffFailed; otherwise the parent scope sees "import finished
+        // with rejection" instead of "import was cancelled."
+        assertThat(thrown).isInstanceOf(CancellationException::class.java)
+        assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun encoderCancellationPropagatesAndPreservesStructuredConcurrency() = runTest {
+        val sm = SharedMemory.create("walt-test-encoder-cancel", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(
+                    probeResult = ProbeResult.Ok(pageCount = 1),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                ),
+            )
+        val cancellingEncoder =
+            object : ThumbnailEncoder {
+                override fun encode(render: RenderResult.Ok): ByteArray {
+                    runCatching { render.sharedMemory.close() }
+                    throw CancellationException("scope cancelled mid-encode")
+                }
+            }
+
+        val thrown =
+            runCatching {
+                importer(sessionFactory = factory, thumbnailEncoder = cancellingEncoder).import(
+                    source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                    displayLabel = "x.pdf",
+                    persist = { _, _, _, _ -> Unit },
+                )
+            }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(CancellationException::class.java)
+        assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun nonContentSchemeUriRejectsAsNotAPdfWithoutBindingService() = runTest {
+        // file:// is the canonical escape-hatch shape the scheme allowlist closes:
+        // ContentResolver.openInputStream would happily walk a file path otherwise.
+        val factory = RecordingSessionFactory()
+        val fileUri = Uri.parse("file:///data/data/example/downloads/x.pdf")
+
+        val result =
+            importer(sessionFactory = factory).import(
+                source = PdfImportSource.ContentUri(fileUri, context.contentResolver),
+                displayLabel = "x.pdf",
+                persist = { _, _, _, _ -> error("persist must not run for non-content scheme") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.NotAPdf))
+        assertThat(factory.connectCalls).isEqualTo(0)
     }
 
     @Test

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
@@ -1,0 +1,497 @@
+package `is`.walt.passes.pdf.android
+
+import android.content.Context
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.os.SharedMemory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.pdf.DocumentImportFailedEvent
+import `is`.walt.passes.pdf.DocumentImportSucceededEvent
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.DocumentTelemetryGuard
+import `is`.walt.passes.pdf.PdfImportConfig
+import `is`.walt.passes.pdf.PdfImportResult
+import `is`.walt.passes.pdf.android.internal.PdfPfdFactory
+import `is`.walt.passes.pdf.android.internal.RendererSession
+import `is`.walt.passes.pdf.android.internal.RendererSessionFactory
+import `is`.walt.passes.pdf.android.internal.ThumbnailEncoder
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import java.io.ByteArrayInputStream
+
+/**
+ * Behavioural coverage for [DefaultPdfImporter]. Each test pins one rule the importer
+ * promises in its KDoc:
+ *
+ *  - SDK gate fires immediately, before any source byte is read or any service is bound.
+ *  - Header sniff short-circuits *before* `bindService`.
+ *  - Size cap fail-fast — never reads more than `maxBytes + 1` bytes.
+ *  - Every [DocumentRejectedKind] from the renderer service rounds back through `import`.
+ *  - `unbindService` runs in every outcome (success / each rejection / persist throw).
+ *  - `persist` is invoked exactly once on success, never on rejection.
+ *  - Telemetry: `onImportFailed` fires on every rejection; `onImportStarted` fires only
+ *    once we've cleared the SDK gate; `onImportSucceeded` fires only on success.
+ *
+ * Production internals are wired via the package-internal seams `PdfPfdFactory` and
+ * `RendererSessionFactory`; the public surface (`PdfImporter.create`) stays untouched.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class PdfImporterTest {
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun sdkBelow34RejectsWithoutTouchingSourceOrBindingService() = runTest {
+        val recordingFactory = RecordingSessionFactory()
+        val recordingPfd = RecordingPfdFactory()
+
+        val importer =
+            importer(
+                sdkInt = 33,
+                pfdFactory = recordingPfd,
+                sessionFactory = recordingFactory,
+            )
+
+        val result = importer.import(
+            // FileDescriptor source so the assertion "renderer was not invoked" can be
+            // proven directly via the recording session factory; if the orchestration
+            // had advanced past the gate the recording PFD factory would have been
+            // called to materialize the bytes for the renderer.
+            source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+            displayLabel = "irrelevant.pdf",
+            persist = { _, _, _, _ -> error("persist must not be invoked on SDK gate") },
+        )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.UnsupportedAndroidVersion))
+        assertThat(recordingPfd.calls).isEqualTo(0)
+        assertThat(recordingFactory.connectCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun headerSniffShortCircuitsBeforeBindingService() = runTest {
+        val nonPdf = "Not a PDF at all".encodeToByteArray()
+        val recordingFactory = RecordingSessionFactory()
+        val recordingPfd = RecordingPfdFactory()
+
+        val importer =
+            importer(
+                pfdFactory = recordingPfd,
+                sessionFactory = recordingFactory,
+            )
+
+        val result =
+            importer.import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(nonPdf)),
+                displayLabel = "spoofed.pdf",
+                persist = { _, _, _, _ -> error("persist must not be invoked when header sniff fails") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.NotAPdf))
+        assertThat(recordingFactory.connectCalls).isEqualTo(0)
+        // The memfd PFD is allocated only once the bytes have cleared the header sniff,
+        // so a failing sniff must skip it. This is the structural lock the issue calls
+        // out: "renderer service is NOT bound yet at this point."
+        assertThat(recordingPfd.calls).isEqualTo(0)
+    }
+
+    @Test
+    fun shorterThanHeaderRejectsAsNotAPdf() = runTest {
+        val tinyBytes = "%PDF".encodeToByteArray()
+        val recordingFactory = RecordingSessionFactory()
+
+        val result =
+            importer(sessionFactory = recordingFactory).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(tinyBytes)),
+                displayLabel = "tiny.pdf",
+                persist = { _, _, _, _ -> error("persist must not run") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.NotAPdf))
+        assertThat(recordingFactory.connectCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun oversizedSourceFailsFastBeforeFullDrain() = runTest {
+        val cap = 8L
+        val cfg = PdfImportConfig(maxBytes = cap)
+        val recordingFactory = RecordingSessionFactory()
+        // 10 bytes of plausible PDF prefix + filler — exceeds the cap of 8.
+        val oversized = "%PDF-1.4XX".encodeToByteArray()
+
+        val result =
+            importer(config = cfg, sessionFactory = recordingFactory).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(oversized)),
+                displayLabel = "big.pdf",
+                persist = { _, _, _, _ -> error("persist must not run for oversized") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.OversizedAtImport))
+        assertThat(recordingFactory.connectCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun probeRejectionRoundsTripsThroughImport() = runTest {
+        // Encrypted is one of probe's three rejection arms; the other two
+        // (TooManyPages, RendererFailed) flow through the same code path.
+        val arms = listOf(
+            DocumentRejectedKind.Encrypted,
+            DocumentRejectedKind.TooManyPages,
+            DocumentRejectedKind.RendererFailed,
+        )
+        for (kind in arms) {
+            val factory =
+                RecordingSessionFactory(
+                    binder = StaticBinder(probeResult = ProbeResult.Rejected(kind)),
+                )
+            val result =
+                importer(sessionFactory = factory).import(
+                    source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                    displayLabel = "x.pdf",
+                    persist = { _, _, _, _ -> error("persist must not run on probe rejection") },
+                )
+            assertThat(result).isEqualTo(PdfImportResult.Rejected(kind))
+            assertThat(factory.connectCalls).isEqualTo(1)
+            assertThat(factory.lastSession?.closed).isTrue()
+        }
+    }
+
+    @Test
+    fun renderRejectionRoundsTripsThroughImport() = runTest {
+        for (kind in listOf(DocumentRejectedKind.RendererFailed)) {
+            val factory =
+                RecordingSessionFactory(
+                    binder = StaticBinder(
+                        probeResult = ProbeResult.Ok(pageCount = 3),
+                        renderResult = RenderResult.Rejected(kind),
+                    ),
+                )
+            val result =
+                importer(sessionFactory = factory).import(
+                    source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                    displayLabel = "x.pdf",
+                    persist = { _, _, _, _ -> error("persist must not run on render rejection") },
+                )
+            assertThat(result).isEqualTo(PdfImportResult.Rejected(kind))
+            assertThat(factory.lastSession?.closed).isTrue()
+        }
+    }
+
+    @Test
+    fun successPathInvokesPersistExactlyOnceAndReturnsImported() = runTest {
+        val sm = SharedMemory.create("walt-test-import", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(
+                    probeResult = ProbeResult.Ok(pageCount = 4),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                ),
+            )
+        val persists = mutableListOf<PersistArgs>()
+        val result =
+            importer(sessionFactory = factory).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                displayLabel = "boarding.pdf",
+                persist = { label, bytes, pages, thumb ->
+                    persists += PersistArgs(label, bytes.size, pages, thumb.size)
+                },
+            )
+
+        assertThat(result).isInstanceOf(PdfImportResult.Imported::class.java)
+        val imported = result as PdfImportResult.Imported
+        assertThat(imported.doc.displayLabel).isEqualTo("boarding.pdf")
+        assertThat(imported.doc.pageCount).isEqualTo(4)
+        assertThat(imported.doc.byteCount).isEqualTo(VALID_PDF_BYTES.size.toLong())
+        assertThat(persists).hasSize(1)
+        assertThat(persists.single().label).isEqualTo("boarding.pdf")
+        assertThat(persists.single().byteSize).isEqualTo(VALID_PDF_BYTES.size)
+        assertThat(persists.single().pages).isEqualTo(4)
+        assertThat(persists.single().thumbSize).isGreaterThan(0)
+        assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun persistThrowFoldsToRendererFailedAndUnbinds() = runTest {
+        val sm = SharedMemory.create("walt-test-persist-throw", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(
+                    probeResult = ProbeResult.Ok(pageCount = 2),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                ),
+            )
+
+        val result =
+            importer(sessionFactory = factory).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                displayLabel = "x.pdf",
+                persist = { _, _, _, _ -> error("downstream storage exploded") },
+            )
+
+        assertThat(result).isEqualTo(PdfImportResult.Rejected(DocumentRejectedKind.RendererFailed))
+        assertThat(factory.lastSession?.closed).isTrue()
+    }
+
+    @Test
+    fun unbindRunsOnEveryRejectionAfterSuccessfulConnect() = runTest {
+        // Rejections returned by the binder *after* connect happens must still see the
+        // session closed. This parameterizes over every post-connect rejection arm.
+        val arms = listOf(
+            DocumentRejectedKind.Encrypted,
+            DocumentRejectedKind.TooManyPages,
+            DocumentRejectedKind.RendererFailed,
+        )
+        for (kind in arms) {
+            val factory =
+                RecordingSessionFactory(binder = StaticBinder(probeResult = ProbeResult.Rejected(kind)))
+            importer(sessionFactory = factory).import(
+                source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+                displayLabel = "x.pdf",
+                persist = { _, _, _, _ -> Unit },
+            )
+            assertThat(factory.lastSession?.closed).isTrue()
+        }
+    }
+
+    @Test
+    fun telemetryFiresStartAndSuccessOnHappyPath() = runTest {
+        val sm = SharedMemory.create("walt-test-tel-success", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory = RecordingSessionFactory(
+            binder = StaticBinder(
+                probeResult = ProbeResult.Ok(pageCount = 1),
+                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+            ),
+        )
+        val telemetry = RecordingTelemetry()
+        val cfg = PdfImportConfig(telemetryGuard = telemetry)
+
+        importer(config = cfg, sessionFactory = factory).import(
+            source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+            displayLabel = "x.pdf",
+            persist = { _, _, _, _ -> Unit },
+        )
+
+        assertThat(telemetry.events).containsExactly("started", "succeeded:1").inOrder()
+    }
+
+    @Test
+    fun telemetryFiresFailedWithoutStartedOnSdkGate() = runTest {
+        val telemetry = RecordingTelemetry()
+        val cfg = PdfImportConfig(telemetryGuard = telemetry)
+
+        importer(config = cfg, sdkInt = 30).import(
+            source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+            displayLabel = "x.pdf",
+            persist = { _, _, _, _ -> Unit },
+        )
+
+        assertThat(telemetry.events).containsExactly("failed:UnsupportedAndroidVersion")
+    }
+
+    @Test
+    fun telemetryFiresStartedThenFailedOnPostStartRejection() = runTest {
+        val factory =
+            RecordingSessionFactory(
+                binder = StaticBinder(probeResult = ProbeResult.Rejected(DocumentRejectedKind.Encrypted)),
+            )
+        val telemetry = RecordingTelemetry()
+        val cfg = PdfImportConfig(telemetryGuard = telemetry)
+
+        importer(config = cfg, sessionFactory = factory).import(
+            source = PdfImportSource.FileDescriptor(pfdContaining(VALID_PDF_BYTES)),
+            displayLabel = "x.pdf",
+            persist = { _, _, _, _ -> Unit },
+        )
+
+        assertThat(telemetry.events).containsExactly("started", "failed:Encrypted").inOrder()
+    }
+
+    @Test
+    fun contentUriSourceDrainsThroughResolver() = runTest {
+        val sm = SharedMemory.create("walt-test-uri", DEFAULT_THUMB_PIXEL_BYTES)
+        val factory = RecordingSessionFactory(
+            binder = StaticBinder(
+                probeResult = ProbeResult.Ok(pageCount = 1),
+                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+            ),
+        )
+        val u = uri("content://walt-test/import.pdf")
+        Shadows.shadowOf(context.contentResolver).registerInputStream(u, ByteArrayInputStream(VALID_PDF_BYTES))
+
+        val persisted = mutableListOf<Int>()
+        val result =
+            importer(sessionFactory = factory).import(
+                source = PdfImportSource.ContentUri(u, context.contentResolver),
+                displayLabel = "from-uri.pdf",
+                persist = { _, bytes, _, _ -> persisted += bytes.size },
+            )
+
+        assertThat(result).isInstanceOf(PdfImportResult.Imported::class.java)
+        assertThat(persisted).containsExactly(VALID_PDF_BYTES.size)
+    }
+
+    /**
+     * Reflection-based surface lock for [PdfImporter]. Mirrors the spirit of the
+     * binder's `PublicApiSurfaceTest`: declaring a `getMetadata` / `extractText` /
+     * `getAttachments` helper on the importer interface is a structural-test failure,
+     * so a future contributor cannot grow the surface without re-review.
+     */
+    @Test
+    fun importerInterfaceHasOnlyImportAsAMethodPlusDefaultBridge() {
+        val methodNames =
+            PdfImporter::class.java
+                .declaredMethods
+                .map { it.name }
+                .toSet()
+        // Allowlist: only `import` (the suspend method becomes a single Java method
+        // taking a Continuation). No `extract*`, no `getMetadata`, no `getText`.
+        assertThat(methodNames).containsExactly("import")
+    }
+
+    // --------------------------------------------------------------------- helpers
+
+    private fun importer(
+        config: PdfImportConfig = PdfImportConfig(),
+        sdkInt: Int = 34,
+        pfdFactory: PdfPfdFactory = PipePfdFactory(),
+        sessionFactory: RendererSessionFactory = RecordingSessionFactory(),
+        thumbnailEncoder: ThumbnailEncoder = StubThumbnailEncoder(),
+    ): DefaultPdfImporter =
+        DefaultPdfImporter(
+            context = context,
+            config = config,
+            sdkInt = sdkInt,
+            deps = DefaultPdfImporter.Deps(
+                pfdFactory = pfdFactory,
+                sessionFactoryFor = { sessionFactory },
+                thumbnailEncoder = thumbnailEncoder,
+                now = { 0L },
+                idGenerator = { "test-id" },
+            ),
+        )
+
+    private fun pfdContaining(bytes: ByteArray): ParcelFileDescriptor {
+        val pipe = ParcelFileDescriptor.createPipe()
+        // ParcelFileDescriptor.AutoCloseOutputStream is the documented test-side
+        // construction; the importer itself reads the *read* end via Os.read, the
+        // path the production code exercises.
+        ParcelFileDescriptor.AutoCloseOutputStream(pipe[1]).use { it.write(bytes) }
+        return pipe[0]
+    }
+
+    private fun uri(s: String): Uri = Uri.parse("content://walt-test/$s")
+
+    /**
+     * Pipe-backed PFD factory: returns a fresh pipe[0] for any byte payload. The bytes
+     * are written into the pipe so test paths that actually pass the PFD onward (none
+     * of the unit tests today do; the binder is faked) still see plausible content.
+     */
+    private class PipePfdFactory : PdfPfdFactory {
+        override fun fromBytes(bytes: ByteArray): ParcelFileDescriptor {
+            val pipe = ParcelFileDescriptor.createPipe()
+            runCatching {
+                ParcelFileDescriptor.AutoCloseOutputStream(pipe[1]).use { it.write(bytes) }
+            }
+            return pipe[0]
+        }
+    }
+
+    private class RecordingPfdFactory : PdfPfdFactory {
+        var calls: Int = 0
+
+        override fun fromBytes(bytes: ByteArray): ParcelFileDescriptor {
+            calls++
+            val pipe = ParcelFileDescriptor.createPipe()
+            runCatching { pipe[1].close() }
+            return pipe[0]
+        }
+    }
+
+    private class RecordingSessionFactory(
+        private val binder: PdfRendererBinder = StaticBinder(),
+    ) : RendererSessionFactory {
+        var connectCalls: Int = 0
+        var lastSession: RecordingSession? = null
+
+        override suspend fun connect(): RendererSession {
+            connectCalls++
+            val s = RecordingSession(binder)
+            lastSession = s
+            return s
+        }
+    }
+
+    private class RecordingSession(override val client: PdfRendererBinder) : RendererSession {
+        var closed: Boolean = false
+
+        override fun close() {
+            closed = true
+        }
+    }
+
+    private class StubThumbnailEncoder(
+        private val bytes: ByteArray = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+    ) : ThumbnailEncoder {
+        override fun encode(render: RenderResult.Ok): ByteArray {
+            // Close the SharedMemory the same way production does so the test process
+            // doesn't leak handles.
+            runCatching { render.sharedMemory.close() }
+            return bytes
+        }
+    }
+
+    private class StaticBinder(
+        private val probeResult: ProbeResult = ProbeResult.Rejected(DocumentRejectedKind.RendererFailed),
+        private val renderResult: RenderResult = RenderResult.Rejected(DocumentRejectedKind.RendererFailed),
+    ) : PdfRendererBinder {
+        override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult = probeResult
+
+        override suspend fun render(
+            pdf: ParcelFileDescriptor,
+            page: Int,
+            widthPx: Int,
+            heightPx: Int,
+        ): RenderResult = renderResult
+    }
+
+    private class RecordingTelemetry : DocumentTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+
+        override fun onImportStarted() {
+            events += "started"
+        }
+
+        override fun onImportSucceeded(event: DocumentImportSucceededEvent) {
+            events += "succeeded:${event.pageCount}"
+        }
+
+        override fun onImportFailed(event: DocumentImportFailedEvent) {
+            events += "failed:${event.outcome.name}"
+        }
+
+        override fun onConsumerRenderFailed(reason: `is`.walt.passes.pdf.ConsumerRenderFailure) = Unit
+    }
+
+    private data class PersistArgs(
+        val label: String,
+        val byteSize: Int,
+        val pages: Int,
+        val thumbSize: Int,
+    )
+
+    private companion object {
+        // Minimum legal PDF header. The body after the magic is irrelevant to the
+        // unit suite — the renderer is faked, so PdfRenderer never actually parses it.
+        val VALID_PDF_BYTES: ByteArray = "%PDF-1.4\n%¥±ë\n1 0 obj".encodeToByteArray()
+
+        const val DEFAULT_THUMB_W: Int = DefaultPdfImporter.THUMB_WIDTH_PX
+        const val DEFAULT_THUMB_H: Int = DefaultPdfImporter.THUMB_HEIGHT_PX
+
+        // 600 x 800 ARGB_8888 → 1 920 000 bytes. Matches the importer's THUMB constants.
+        const val DEFAULT_THUMB_PIXEL_BYTES: Int = DEFAULT_THUMB_W * DEFAULT_THUMB_H * 4
+    }
+}

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
@@ -31,6 +31,8 @@ class RejectedKindWireSurfaceTest {
                 DocumentRejectedKind.TooManyPages to RejectedKindWire.TOO_MANY_PAGES,
                 DocumentRejectedKind.RendererFailed to RejectedKindWire.RENDERER_FAILED,
                 DocumentRejectedKind.UnsupportedAndroidVersion to RejectedKindWire.UNSUPPORTED_ANDROID_VERSION,
+                DocumentRejectedKind.EncoderFailed to RejectedKindWire.ENCODER_FAILED,
+                DocumentRejectedKind.StorageHandoffFailed to RejectedKindWire.STORAGE_HANDOFF_FAILED,
             )
         for ((kind, code) in expected) {
             assertThat(RejectedKindWire.encode(kind)).isEqualTo(code)
@@ -59,6 +61,8 @@ class RejectedKindWireSurfaceTest {
         assertThat(RejectedKindWire.TOO_MANY_PAGES).isEqualTo(3)
         assertThat(RejectedKindWire.RENDERER_FAILED).isEqualTo(4)
         assertThat(RejectedKindWire.UNSUPPORTED_ANDROID_VERSION).isEqualTo(5)
+        assertThat(RejectedKindWire.ENCODER_FAILED).isEqualTo(6)
+        assertThat(RejectedKindWire.STORAGE_HANDOFF_FAILED).isEqualTo(7)
     }
 
     @Test

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/RejectedKindWireSurfaceTest.kt
@@ -30,6 +30,7 @@ class RejectedKindWireSurfaceTest {
                 DocumentRejectedKind.Encrypted to RejectedKindWire.ENCRYPTED,
                 DocumentRejectedKind.TooManyPages to RejectedKindWire.TOO_MANY_PAGES,
                 DocumentRejectedKind.RendererFailed to RejectedKindWire.RENDERER_FAILED,
+                DocumentRejectedKind.UnsupportedAndroidVersion to RejectedKindWire.UNSUPPORTED_ANDROID_VERSION,
             )
         for ((kind, code) in expected) {
             assertThat(RejectedKindWire.encode(kind)).isEqualTo(code)
@@ -57,6 +58,7 @@ class RejectedKindWireSurfaceTest {
         assertThat(RejectedKindWire.ENCRYPTED).isEqualTo(2)
         assertThat(RejectedKindWire.TOO_MANY_PAGES).isEqualTo(3)
         assertThat(RejectedKindWire.RENDERER_FAILED).isEqualTo(4)
+        assertThat(RejectedKindWire.UNSUPPORTED_ANDROID_VERSION).isEqualTo(5)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds the single PDF import entry point that ADR 0005 G.1 calls for, closing the last load-bearing gap under epic `wpass-i2r`. Without it, the consumer (walt-android) would have to compose the import sequence itself, which is the parallel-implementation pattern the repository's "DECISIVE CONSTRAINT" forbids.
- Implements the eight-step orchestration: API-34 SDK gate → bounded memfd-backed materialization → header sniff → memfd PFD allocation → bind isolated renderer service → probe → page-zero render → thumbnail PNG → consumer-supplied `persist` callback. Renderer service is unbound in `finally` regardless of outcome.
- Adds `DocumentRejectedKind.UnsupportedAndroidVersion` for the G.1 gate (with the wire-format mapping in `RejectedKindWire`), updates the surface-locked enum tests, and pins the new wire code at `5`.
- Storage handoff is a callback rather than a `PassRepository` dependency, so `passes-pdf` and `passes-storage` remain independent peers per the project's module rules.

## Files

- `passes-pdf-core`: `DocumentRejectedKind` gains `UnsupportedAndroidVersion`; `PublicApiSurfaceTest` updated to six arms.
- `passes-pdf` (new):
  - `PdfImporter` interface + `PdfImporter.create(context, config)` factory.
  - `PdfImportSource` sealed interface (`ContentUri`, `FileDescriptor`).
  - `DefaultPdfImporter` orchestrator with internal `Deps` seam for tests.
  - `internal/PdfPfdFactory` (`Os.memfd_create` → `ParcelFileDescriptor.dup`).
  - `internal/RendererSession` (`Context.bindService` → `PdfRendererClient`, with FailedSession fallback).
  - `internal/ThumbnailEncoder` (SharedMemory → Bitmap → PNG).
- `passes-pdf` tests:
  - `PdfImporterTest` (Robolectric, 14 cases) covers SDK gate, header sniff short-circuit, fail-fast size cap, every rejection arm, unbind on every outcome, persist-exactly-once, telemetry shape, ContentUri vs FileDescriptor sources, plus a reflection lock on the importer surface.
  - `PdfImporterInstrumentedTest` stubs the on-device coverage (benign-PDF end-to-end and the malformed-PDF rebind path), `@Ignore`d at check-in pending the same fixture set as `PdfRendererServiceInstrumentedTest`.

## Test plan

- [x] `./gradlew check` — all unit tests + lint + detekt + ktlint green across all seven modules.
- [x] 14 `PdfImporterTest` cases pass on Robolectric (SDK 34).
- [x] `RejectedKindWireSurfaceTest` and `passes-pdf-core::PublicApiSurfaceTest` pass with the new arm.
- [ ] Instrumented end-to-end (gated on the `wpass-5v9` fixture-set follow-up).

## Trust-claim notes

- Header sniff runs on the materialized bytes *before* `bindService`; the test `headerSniffShortCircuitsBeforeBindingService` asserts the recording session factory's `connectCalls == 0` for non-PDF input.
- Memfd path keeps PDF bytes off disk (ADR 0005 F.1). The `MemfdPfdFactory` uses `Os.memfd_create` + `Os.write` + `ParcelFileDescriptor.dup`; no `java.io.File`/`FileOutputStream`/`createTempFile` in the renderer-handoff code path.
- Telemetry stays enums-and-durations-only via the existing `DocumentTelemetryGuard`; no `String`, `ByteArray`, or `Throwable` parameters added.
- `unbindService` runs in a `finally` regardless of outcome — covered by `unbindRunsOnEveryRejectionAfterSuccessfulConnect` and the success/persist-throw cases.

## Unblocks

- `wpass-i2r` (PDF document support epic) — every kernel-side trust claim under it now lives in this repo.
- `wlt-4pg` (cross-repo wiring in walt-android).

## Cross-module impact

- `RejectedKindWire` adds code `5 = UNSUPPORTED_ANDROID_VERSION`; `RejectedKindWireSurfaceTest` updated; the renderer service binder never actually carries this code (the gate fires before the service is bound), but the wire-format table stays exhaustive.