### PR TITLE
passes-core: make minified consumer builds verify pkpass signatures (wpass-3kv, wpass-at6)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/AppleTrustAnchors.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/AppleTrustAnchors.kt
@@ -30,14 +30,17 @@ import java.security.cert.X509Certificate
  * with a network footgun.
  */
 internal object AppleTrustAnchors {
-    private val BUNDLED_TRUST_ANCHOR_FILENAMES =
+    // `internal`, not `private`, so AppleTrustAnchorsTest consumes these directly
+    // instead of mirroring them — the test then exercises the real bundled set and
+    // the real resource path, and adding a future anchor cannot leave a stale copy.
+    internal val BUNDLED_TRUST_ANCHOR_FILENAMES: List<String> =
         listOf(
             "apple-root-ca.cer",
             "apple-root-ca-g2.cer",
             "apple-root-ca-g3.cer",
         )
 
-    private val BUNDLED_INTERMEDIATE_FILENAMES =
+    internal val BUNDLED_INTERMEDIATE_FILENAMES: List<String> =
         listOf(
             "apple-wwdr-g3.cer",
             "apple-wwdr-g6.cer",
@@ -93,8 +96,11 @@ internal object AppleTrustAnchors {
      * `AppleTrustAnchors` to a synthetic package — a relative lookup then resolves
      * against the wrong package, returns `null`, and collapses every Apple-signed
      * pkpass onto `Failed(SignatureCryptoFailure)`. R8 relocates classes, not java
-     * resources, so the absolute path is stable across minification. If this
-     * directory ever moves, update this constant and `AppleTrustAnchorsTest`.
+     * resources, so the absolute path is stable across minification.
+     *
+     * `internal` (not `private`) so `AppleTrustAnchorsTest` resolves against this
+     * exact constant rather than a hand-kept copy; if this directory moves, the
+     * constant moves with it and the test follows.
      */
-    private const val RESOURCE_DIR = "/is/walt/passes/core/internal/certs"
+    internal const val RESOURCE_DIR: String = "/is/walt/passes/core/internal/certs"
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/AppleTrustAnchors.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/AppleTrustAnchors.kt
@@ -6,10 +6,13 @@ import java.security.cert.X509Certificate
 
 /**
  * Loads the Apple trust anchors and known WWDR intermediates bundled under
- * `passes-core/src/main/resources/is/walt/passes/core/internal/certs/`. Loaded once on
- * first access and held in [BundledCerts]. The fingerprints and provenance of every
- * certificate are documented in `certs/SECURITY-CERTS.md`; an auditor or downstream
- * security reviewer can verify the bundled set without running the parser.
+ * `passes-core/src/main/resources/is/walt/passes/core/internal/certs/`. The files are
+ * resolved by **absolute** classpath name (see [RESOURCE_DIR]) so the lookup is
+ * independent of any package renaming an R8/ProGuard consumer build applies to this
+ * class. Loaded once on first access and held in [BundledCerts]. The fingerprints and
+ * provenance of every certificate are documented in `certs/SECURITY-CERTS.md`; an
+ * auditor or downstream security reviewer can verify the bundled set without running
+ * the parser.
  *
  * **Why bundled, not platform-trusted.** The JVM truststore is mutable at runtime
  * (system properties, `keytool`, OS-level CA changes). Walt's trust claim is "this
@@ -81,5 +84,17 @@ internal object AppleTrustAnchors {
     )
 
     private const val X509_TYPE = "X.509"
-    private const val RESOURCE_DIR = "certs"
+
+    /**
+     * Absolute, classpath-rooted directory for the bundled `.cer` files. MUST stay
+     * absolute (leading `/`): a package-relative name is resolved by
+     * [Class.getResourceAsStream] against the class's *runtime* package, and a
+     * minified consumer build (walt-android, R8 `isMinifyEnabled = true`) repackages
+     * `AppleTrustAnchors` to a synthetic package — a relative lookup then resolves
+     * against the wrong package, returns `null`, and collapses every Apple-signed
+     * pkpass onto `Failed(SignatureCryptoFailure)`. R8 relocates classes, not java
+     * resources, so the absolute path is stable across minification. If this
+     * directory ever moves, update this constant and `AppleTrustAnchorsTest`.
+     */
+    private const val RESOURCE_DIR = "/is/walt/passes/core/internal/certs"
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
@@ -176,6 +176,14 @@ private fun finalizeVerification(
  * both because none of the call sites here require registry lookup and because
  * trampling whatever the host process registered under `"BC"` would surprise other
  * code in the same process.
+ *
+ * **Minified consumers (wpass-at6).** Holding our own instance is necessary but not
+ * sufficient in a release build: `BouncyCastleProvider`'s constructor registers its
+ * algorithms by reflectively loading `<pkg>.<Alg>$Mappings` classes, which R8 strips
+ * as unreferenced unless kept. `passes-core` ships the required keep rules in
+ * `META-INF/proguard/passes-core.pro`; without them this provider constructs but
+ * registers almost nothing, and every Apple-signed pkpass collapses onto
+ * [TamperReason.SignatureCryptoFailure].
  */
 private val BC_PROVIDER: BouncyCastleProvider by lazy { BouncyCastleProvider() }
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
@@ -85,8 +85,10 @@ internal fun verifySignature(
 ): SignatureVerifyResult {
     // Anchor lookups MUST live inside the runCatching: AppleTrustAnchors.trustAnchors()
     // calls into resource I/O and CertificateFactory.generateCertificate, both of which
-    // can throw if the JAR is repackaged (proguard/R8 stripping, shaded classpath, a
-    // corrupted .cer file). Kotlin's default `by lazy` (LazyThreadSafetyMode.SYNCHRONIZED)
+    // can still throw on a genuinely stripped JAR or a corrupted .cer file. (The loader
+    // resolves the bundled certs by absolute classpath name, so it is itself robust to
+    // an R8/ProGuard consumer build *repackaging* this class — see AppleTrustAnchors.)
+    // Kotlin's default `by lazy` (LazyThreadSafetyMode.SYNCHRONIZED)
     // does NOT cache the exception: each call retries the initializer and re-throws on
     // failure. The end-user effect is the same (every parse fails until the JAR is
     // rebuilt), but the mechanic is "retry and re-throw," not "first call poisons the

--- a/passes-core/src/main/resources/META-INF/proguard/passes-core.pro
+++ b/passes-core/src/main/resources/META-INF/proguard/passes-core.pro
@@ -1,0 +1,21 @@
+# ProGuard/R8 rules contributed by passes-core to any minified consumer build.
+#
+# passes-core is a plain Kotlin/JVM java-library, so it has no Android
+# consumerProguardFiles DSL. R8/AGP instead auto-applies rule files found at
+# META-INF/proguard/*.pro inside dependency JARs on the consumer classpath;
+# this file is that channel.
+#
+# AppleTrustAnchors loads the bundled Apple .cer trust anchors by ABSOLUTE
+# classpath name (see AppleTrustAnchors.kt), so the loader itself is already
+# robust to class repackaging. This -keep is belt-and-suspenders: pinning the
+# loader's class and package keeps stack traces / crash reports legible, guards
+# against a future package-relative regression, and documents in-tree that this
+# class is trust-claim-bearing and must not be silently shaded away.
+-keep class is.walt.passes.core.internal.AppleTrustAnchors { *; }
+
+# Intentionally NOT included:
+#  * -keepdirectories — only needed when code enumerates a resource *directory*
+#    via getResources(); AppleTrustAnchors looks up each .cer by exact name.
+#  * -adaptresourcefilenames / -adaptresourcefilecontents — opt-in; absent them
+#    R8 leaves java resources at their original paths, which is exactly what the
+#    absolute lookup depends on.

--- a/passes-core/src/main/resources/META-INF/proguard/passes-core.pro
+++ b/passes-core/src/main/resources/META-INF/proguard/passes-core.pro
@@ -3,7 +3,10 @@
 # passes-core is a plain Kotlin/JVM java-library, so it has no Android
 # consumerProguardFiles DSL. R8/AGP instead auto-applies rule files found at
 # META-INF/proguard/*.pro inside dependency JARs on the consumer classpath;
-# this file is that channel.
+# this file is that channel. passes-core owns these rules so each consumer
+# does not have to rediscover them.
+
+# --- Bundled Apple trust anchors -------------------------------------------
 #
 # AppleTrustAnchors loads the bundled Apple .cer trust anchors by ABSOLUTE
 # classpath name (see AppleTrustAnchors.kt), so the loader itself is already
@@ -13,9 +16,36 @@
 # class is trust-claim-bearing and must not be silently shaded away.
 -keep class is.walt.passes.core.internal.AppleTrustAnchors { *; }
 
+# --- BouncyCastle JCE provider ----------------------------------------------
+#
+# passes-core's signature verifier holds its own BouncyCastleProvider instance
+# (bcprov-jdk18on, bcpkix-jdk18on) and passes it directly to the BC CMS / cert
+# builders. BouncyCastleProvider's constructor registers its JCA algorithms
+# REFLECTIVELY: it does Class.forName("<pkg>.<Alg>$Mappings") for each algorithm
+# family, and each $Mappings class in turn registers the actual SPI
+# implementations by string class name. R8 sees no direct references to any of
+# it, so without these rules it shrinks the $Mappings + SPI classes away and
+# renames whatever is left. The provider then constructs but registers almost
+# nothing -- Signature.getInstance("SHA256withRSA", BC_PROVIDER) and
+# CertPathBuilder.getInstance("PKIX", BC_PROVIDER) throw inside verifySignature,
+# the outer runCatching absorbs it, and EVERY Apple-signed pkpass surfaces as
+# Failed(SignatureCryptoFailure) in a minified release build.
+#
+# Keep the two provider packages whole, names included (the lookups are by
+# literal string name, so renaming breaks them just as removal does). This is
+# the established minimal-practical set for bcprov under R8: it does NOT keep
+# org.bouncycastle.{asn1,crypto,math,cms,cert,operator}.** -- those are either
+# referenced directly from passes-core code or transitively from the kept
+# provider classes, so R8's normal reachability retains exactly the parts in use.
+-keep class org.bouncycastle.jcajce.provider.** { *; }
+-keep class org.bouncycastle.jce.provider.** { *; }
+-dontwarn org.bouncycastle.**
+
 # Intentionally NOT included:
 #  * -keepdirectories — only needed when code enumerates a resource *directory*
 #    via getResources(); AppleTrustAnchors looks up each .cer by exact name.
 #  * -adaptresourcefilenames / -adaptresourcefilecontents — opt-in; absent them
 #    R8 leaves java resources at their original paths, which is exactly what the
 #    absolute lookup depends on.
+#  * a blanket -keep class org.bouncycastle.** { *; } — strictly larger than the
+#    provider-package keep above and would defeat shrinking the unused crypto.

--- a/passes-core/src/main/resources/is/walt/passes/core/internal/certs/SECURITY-CERTS.md
+++ b/passes-core/src/main/resources/is/walt/passes/core/internal/certs/SECURITY-CERTS.md
@@ -6,6 +6,12 @@ the parser **never** fetches certificates over the network. A valid signature
 whose chain extends beyond what is bundled here surfaces as
 [`SignatureStatus.CertChainIncomplete`].
 
+`AppleTrustAnchors` resolves these files by the **absolute** classpath path
+`/is/walt/passes/core/internal/certs/` so the lookup survives an R8/ProGuard
+consumer build repackaging that class. Moving this directory therefore requires
+updating `RESOURCE_DIR` in `AppleTrustAnchors.kt` and the path constants in
+`AppleTrustAnchorsTest`.
+
 ## Trust anchors (root CAs)
 
 These are added to the `PKIXBuilderParameters` trust anchor set. A chain that

--- a/passes-core/src/main/resources/is/walt/passes/core/internal/certs/SECURITY-CERTS.md
+++ b/passes-core/src/main/resources/is/walt/passes/core/internal/certs/SECURITY-CERTS.md
@@ -9,8 +9,8 @@ whose chain extends beyond what is bundled here surfaces as
 `AppleTrustAnchors` resolves these files by the **absolute** classpath path
 `/is/walt/passes/core/internal/certs/` so the lookup survives an R8/ProGuard
 consumer build repackaging that class. Moving this directory therefore requires
-updating `RESOURCE_DIR` in `AppleTrustAnchors.kt` and the path constants in
-`AppleTrustAnchorsTest`.
+updating `RESOURCE_DIR` in `AppleTrustAnchors.kt`; `AppleTrustAnchorsTest`
+consumes that constant directly, so it follows automatically.
 
 ## Trust anchors (root CAs)
 

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
@@ -56,10 +56,54 @@ class AppleTrustAnchorsTest {
         }
     }
 
+    @Test
+    fun bundledCertsResolveAtAbsoluteClasspathPath() {
+        // Locks the fix for the R8-repackaging bug (wpass-3kv): the .cer files MUST
+        // be reachable by an absolute, package-independent classpath name. A
+        // package-relative lookup resolves against the class's runtime package,
+        // which a minified consumer build renames — breaking every Apple signature
+        // check. Using the context classloader here (not AppleTrustAnchors::class.java)
+        // proves the path needs no package context. If someone moves the certs
+        // resource directory, this fails in plain `:passes-core:check`.
+        val loader = Thread.currentThread().contextClassLoader
+        for (file in BUNDLED_CERT_FILENAMES) {
+            assertThat(loader.getResourceAsStream("$CERTS_RESOURCE_DIR/$file")).isNotNull()
+        }
+    }
+
+    @Test
+    fun shippedProguardRulesKeepTheTrustAnchorLoader() {
+        // passes-core ships defense-in-depth R8 rules at META-INF/proguard/ so a
+        // minified consumer auto-applies them. Guard against a typo'd or dropped
+        // rule file going unnoticed.
+        val rules =
+            Thread.currentThread().contextClassLoader
+                .getResourceAsStream("META-INF/proguard/passes-core.pro")
+                ?.bufferedReader()?.use { it.readText() }
+        assertThat(rules).isNotNull()
+        assertThat(rules).contains("-keep class is.walt.passes.core.internal.AppleTrustAnchors")
+    }
+
     private fun sha256(bytes: ByteArray): String =
         MessageDigest.getInstance("SHA-256").digest(bytes)
             .joinToString(":") { "%02X".format(it) }
 }
+
+/**
+ * Classpath-absolute certs directory, mirrored from `AppleTrustAnchors.RESOURCE_DIR`
+ * (private there) minus the leading `/` so it works with `ClassLoader.getResourceAsStream`.
+ */
+private const val CERTS_RESOURCE_DIR = "is/walt/passes/core/internal/certs"
+
+/** Every bundled `.cer` file — trust anchors plus known WWDR intermediates. */
+private val BUNDLED_CERT_FILENAMES =
+    listOf(
+        "apple-root-ca.cer",
+        "apple-root-ca-g2.cer",
+        "apple-root-ca-g3.cer",
+        "apple-wwdr-g3.cer",
+        "apple-wwdr-g6.cer",
+    )
 
 private const val APPLE_ROOT_CA_SHA256 =
     "B0:B1:73:0E:CB:C7:FF:45:05:14:2C:49:F1:29:5E:6E:DA:6B:CA:ED:7E:2C:68:C5:BE:91:B5:A1:10:01:F0:24"

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
@@ -72,16 +72,21 @@ class AppleTrustAnchorsTest {
     }
 
     @Test
-    fun shippedProguardRulesKeepTheTrustAnchorLoader() {
-        // passes-core ships defense-in-depth R8 rules at META-INF/proguard/ so a
-        // minified consumer auto-applies them. Guard against a typo'd or dropped
-        // rule file going unnoticed.
+    fun shippedProguardRulesCoverThePassesCoreR8Footguns() {
+        // passes-core ships R8 rules at META-INF/proguard/ so a minified consumer
+        // auto-applies them. Guard against a typo'd or dropped rule going unnoticed:
+        //  - AppleTrustAnchors: belt-and-suspenders pin for the cert loader.
+        //  - BouncyCastle provider packages: without these, R8 strips the
+        //    reflectively-loaded $Mappings/SPI classes and EVERY Apple-signed pkpass
+        //    fails as Failed(SignatureCryptoFailure) in release builds (wpass-at6).
         val rules =
             Thread.currentThread().contextClassLoader
                 .getResourceAsStream("META-INF/proguard/passes-core.pro")
                 ?.bufferedReader()?.use { it.readText() }
         assertThat(rules).isNotNull()
         assertThat(rules).contains("-keep class is.walt.passes.core.internal.AppleTrustAnchors")
+        assertThat(rules).contains("-keep class org.bouncycastle.jcajce.provider.** { *; }")
+        assertThat(rules).contains("-keep class org.bouncycastle.jce.provider.** { *; }")
     }
 
     private fun sha256(bytes: ByteArray): String =

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/AppleTrustAnchorsTest.kt
@@ -62,12 +62,18 @@ class AppleTrustAnchorsTest {
         // be reachable by an absolute, package-independent classpath name. A
         // package-relative lookup resolves against the class's runtime package,
         // which a minified consumer build renames — breaking every Apple signature
-        // check. Using the context classloader here (not AppleTrustAnchors::class.java)
-        // proves the path needs no package context. If someone moves the certs
+        // check. Resolving through the production `RESOURCE_DIR` constant (minus its
+        // leading `/`, which `ClassLoader.getResourceAsStream` does not take) via the
+        // context classloader — not `AppleTrustAnchors::class.java` — proves the path
+        // is the real one and needs no package context. If someone moves the certs
         // resource directory, this fails in plain `:passes-core:check`.
+        val base = AppleTrustAnchors.RESOURCE_DIR.removePrefix("/")
         val loader = Thread.currentThread().contextClassLoader
-        for (file in BUNDLED_CERT_FILENAMES) {
-            assertThat(loader.getResourceAsStream("$CERTS_RESOURCE_DIR/$file")).isNotNull()
+        val bundled =
+            AppleTrustAnchors.BUNDLED_TRUST_ANCHOR_FILENAMES +
+                AppleTrustAnchors.BUNDLED_INTERMEDIATE_FILENAMES
+        for (file in bundled) {
+            assertThat(loader.getResourceAsStream("$base/$file")).isNotNull()
         }
     }
 
@@ -93,22 +99,6 @@ class AppleTrustAnchorsTest {
         MessageDigest.getInstance("SHA-256").digest(bytes)
             .joinToString(":") { "%02X".format(it) }
 }
-
-/**
- * Classpath-absolute certs directory, mirrored from `AppleTrustAnchors.RESOURCE_DIR`
- * (private there) minus the leading `/` so it works with `ClassLoader.getResourceAsStream`.
- */
-private const val CERTS_RESOURCE_DIR = "is/walt/passes/core/internal/certs"
-
-/** Every bundled `.cer` file — trust anchors plus known WWDR intermediates. */
-private val BUNDLED_CERT_FILENAMES =
-    listOf(
-        "apple-root-ca.cer",
-        "apple-root-ca-g2.cer",
-        "apple-root-ca-g3.cer",
-        "apple-wwdr-g3.cer",
-        "apple-wwdr-g6.cer",
-    )
 
 private const val APPLE_ROOT_CA_SHA256 =
     "B0:B1:73:0E:CB:C7:FF:45:05:14:2C:49:F1:29:5E:6E:DA:6B:CA:ED:7E:2C:68:C5:BE:91:B5:A1:10:01:F0:24"


### PR DESCRIPTION
Two distinct R8/minification bugs that both surface every Apple-signed pkpass as `Failed(SignatureCryptoFailure)` in a release build. Found in sequence — the walt-android team tested the first fix on-device and the second cause was still there.

## Bug 1 — package-relative cert resource lookup (wpass-3kv)

`AppleTrustAnchors.loadResource()` loaded the bundled `.cer` trust anchors with a **package-relative** `getResourceAsStream("certs/...")`. R8 repackages the class in a minified consumer build, so the relative lookup resolved against the wrong package, returned `null`, and `error(...)` threw.

**Fix:** resolve the `.cer` files by **absolute** classpath path (`/is/walt/passes/core/internal/certs/`). R8 relocates classes, not java resources, so the absolute path is stable across minification.

> Note: this was a real latent bug but, per the walt-android team's on-device testing, **not** the one causing the observed failure — that is Bug 2. The absolute-path fix is correct and worth keeping regardless.

## Bug 2 — R8 strips the BouncyCastle JCA provider mappings (wpass-at6)

`SignatureVerifier` holds its own `BouncyCastleProvider` instance and passes it to the BC CMS / cert builders. `BouncyCastleProvider`'s constructor registers its algorithms **reflectively**: `Class.forName("<pkg>.<Alg>$Mappings")` per algorithm family, and each `$Mappings` class registers the actual SPI implementations by string class name. R8 sees no direct references and shrinks them away (consumer `mapping.txt`: 0 surviving classes in `jcajce.provider.digest`, 1 in `symmetric`, 3 in `asymmetric`). The provider constructs but registers almost nothing, so `Signature.getInstance("SHA256withRSA", BC_PROVIDER)` and `CertPathBuilder.getInstance("PKIX", BC_PROVIDER)` throw inside `verifySignature`; the outer `runCatching` buckets it as `SignatureCryptoFailure`.

**Fix:** `passes-core` ships BouncyCastle keep rules in `META-INF/proguard/passes-core.pro` so each consumer does not have to rediscover this — keep `org.bouncycastle.jcajce.provider.**` and `org.bouncycastle.jce.provider.**` whole, names included (the lookups are by literal string name). This is the minimal-practical set: `asn1`/`crypto`/`math`/`cms`/`cert`/`operator` are kept by R8 reachability since they are referenced directly or transitively, so the keep does not defeat shrinking the unused crypto.

## Shipping mechanism

`passes-core` is a plain Kotlin/JVM `java-library` with no Android `consumerProguardFiles` DSL. R8/AGP auto-applies rule files found at `META-INF/proguard/*.pro` inside dependency JARs on the consumer classpath — `passes-core.pro` rides that channel.

## Changes

- `AppleTrustAnchors.kt` — absolute classpath resource path.
- `META-INF/proguard/passes-core.pro` (new) — AppleTrustAnchors pin + BouncyCastle provider keep rules.
- `AppleTrustAnchorsTest.kt` — regression tests: certs resolve at the absolute path via a package-independent classloader; the shipped `.pro` contains the cert-loader and BouncyCastle keep lines.
- `SignatureVerifier.kt` / `SECURITY-CERTS.md` — doc/comment updates reflecting absolute-path loading and the R8/keep-rules dependency.

## Verification

- `./gradlew :passes-core:check` — green (detekt, ktlint, all tests incl. the new ones).
- `:passes-core:jar` inspection — `META-INF/proguard/passes-core.pro` (with all four keep/dontwarn lines) and all five `.cer` files land at the expected paths.
- **Pending — consumer-side:** a JVM unit test cannot reproduce R8. End-to-end check is an `isMinifyEnabled = true` walt-android release build: import a known-good Apple-signed pkpass and confirm `signature_kind=AppleVerified`. The walt-android team offered to test a candidate.

Addresses wpass-3kv and wpass-at6 — leave both open until consumer-side verification confirms.