### PR TITLE
passes-pdf-ui: restyle DocumentTrustCaption to flat icon+text; add captionIconTint slot (wpass-b6h)

### DIFF
--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -2,14 +2,21 @@ package `is`.walt.passes.pdf.ui
 
 import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.pdf.DocumentRejectedKind
@@ -160,6 +167,41 @@ class DocumentViewInstrumentedTest {
         composeRule.onNodeWithText(
             "User-provided document. Walt has not verified the source.",
         ).assertIsDisplayed()
+    }
+
+    @Test
+    fun trustCaptionDoesNotOverlapThePageWhenTheConsumerGivesAShortSlot() {
+        // Regression for wpass-b6h: walt-android embeds DocumentView in a short slot —
+        // sandwiched between a document title and a details section — not the full
+        // screen. The page must letterbox into whatever height it is given. An earlier
+        // `fillMaxWidth().aspectRatio(3:4)` page derived its height from its width and
+        // ignored the slot height, so in a short slot it grew taller than the pager
+        // viewport and drew up over the non-suppressible trust caption. Pinning
+        // caption.bottom <= page.top keeps that boundary structural.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                Box(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+                    DocumentView(
+                        doc = doc(pageCount = 3),
+                        pdfFile = pipeRead,
+                        renderer = recorder,
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val captionBottom = composeRule
+            .onNodeWithText("User-provided document. Walt has not verified the source.")
+            .getUnclippedBoundsInRoot()
+            .bottom
+        val pageTop = composeRule
+            .onNodeWithContentDescription("Page 1 of 3")
+            .getUnclippedBoundsInRoot()
+            .top
+
+        assertThat(pageTop.value).isAtLeast(captionBottom.value)
     }
 
     private fun doc(pageCount: Int) = PdfDocument(

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentTrustCaption.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentTrustCaption.kt
@@ -1,14 +1,20 @@
 package `is`.walt.passes.pdf.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.ui.internal.InfoOutlineIcon
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
@@ -25,6 +31,22 @@ import `is`.walt.passes.ui.core.toComposeColor
  * (which counts the largest method named `DocumentTrustCaption` and asserts the
  * exact arity).
  *
+ * Layout is a flat [Row] of an info-outline icon followed by the caption text, both
+ * center-aligned, with the [Row] still painting `captionBackground` behind itself. A
+ * consumer that wants the historical filled colour-block keeps a non-transparent
+ * `captionBackground`; a consumer matching a flat, borderless house style sets
+ * `captionBackground` transparent and the caption reads as inline chrome rather than
+ * a separate surface. This is a RESTYLE only — the caption is composed at exactly the
+ * same sites, the wording is byte-for-byte unchanged and still a single [Text] node,
+ * and there is still no way to suppress it (ADR 0005 D5; no ADR amendment needed
+ * because non-suppressibility is unchanged).
+ *
+ * The icon tint is its own theme slot, `DocumentSemantics.captionIconTint`, defaulted
+ * to `captionForeground` so a consumer that does not care gets a consistent
+ * monochrome caption for free, while a consumer that wants an accent-coloured glyph
+ * sets it explicitly. The glyph itself is hand-authored in-module (see
+ * `internal.InfoOutlineIcon`) so this module does not pull in `material-icons-extended`.
+ *
  * The displayed text is a fixed English literal; no part of it comes from the
  * document. There is therefore no BiDi isolation here — nothing user-controlled to
  * isolate. The user-controlled `displayLabel` is wrapped by `DocumentTile` /
@@ -35,15 +57,29 @@ public fun DocumentTrustCaption(
     modifier: Modifier = Modifier,
 ) {
     val semantics = LocalDocumentSemantics.current
-    Text(
-        text = TRUST_CAPTION_TEXT,
-        style = MaterialTheme.typography.labelMedium,
-        color = semantics.captionForeground.toComposeColor(),
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .background(semantics.captionBackground.toComposeColor())
             .padding(PaddingValues(horizontal = 16.dp, vertical = 12.dp)),
-    )
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = InfoOutlineIcon,
+            // Decorative: the verbatim caption text sits immediately beside it and is
+            // the audit-relevant semantics node. A contentDescription here would only
+            // add a redundant TalkBack stop on top of the text.
+            contentDescription = null,
+            tint = semantics.captionIconTint.toComposeColor(),
+            modifier = Modifier.size(16.dp),
+        )
+        Text(
+            text = TRUST_CAPTION_TEXT,
+            style = MaterialTheme.typography.labelMedium,
+            color = semantics.captionForeground.toComposeColor(),
+        )
+    }
 }
 
 /**

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -44,7 +44,10 @@ import java.nio.ByteBuffer
  * does NOT assume a full screen: the caption takes its natural height, the pager takes
  * the rest, and each page is letterboxed into the pager slot rather than sized from a
  * fixed aspect ratio — so a short consumer slot can never make a page overflow upward
- * into the caption. Pages are rasterised on demand by the isolated-process renderer
+ * into the caption. The trust caption is composed on the consumer's own background;
+ * only the pager carries [is.walt.passes.pdf.ui.theme.DocumentSemantics.laneBackground],
+ * so the caption reads as host screen chrome rather than part of the document surface.
+ * Pages are rasterised on demand by the isolated-process renderer
  * reached through [renderer] (the `PdfRendererBinder` interface, never the concrete
  * `PdfRendererClient`, so test fakes substitute cleanly) and held in a small
  * per-document LRU cache to amortise re-render on quick swipes.
@@ -103,22 +106,31 @@ public fun DocumentView(
     val pagerState = rememberPagerState(pageCount = { doc.pageCount })
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(semantics.laneBackground.toComposeColor()),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // The caption is composed directly on whatever background the consumer puts
+        // behind DocumentView — it deliberately does NOT sit on `laneBackground`. The
+        // trust caption reads as host screen chrome; only the pager below carries the
+        // document-surface tone.
         DocumentTrustCaption()
 
         // pageCount = 0 is rejected at import (DocumentRejectedKind.RendererFailed),
         // so the pager renders nothing. HorizontalPager handles a 0-count state
         // gracefully without a placeholder; a custom branch here would only mask a
         // future regression in the import path with a silent empty surface.
+        //
+        // `laneBackground` is painted here, behind the pager only — it is the
+        // document-surface tone the rasterised page sits on (and shows through the
+        // ContentScale.Fit letterbox bars). `.background` before `.padding` so the tone
+        // fills the whole pager slot edge-to-edge and the padding insets only the page
+        // content within it.
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
+                .background(semantics.laneBackground.toComposeColor())
                 .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp)),
         ) { page ->
             DocumentPage(

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -40,10 +39,15 @@ import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer
 
 /**
- * Full-screen presentation of a [PdfDocument]. Pages are rasterised on demand by the
- * isolated-process renderer reached through [renderer] (the `PdfRendererBinder`
- * interface, never the concrete `PdfRendererClient`, so test fakes substitute cleanly)
- * and held in a small per-document LRU cache to amortise re-render on quick swipes.
+ * Presentation of a [PdfDocument] — a non-suppressible trust caption above a swipeable
+ * pager of rasterised pages. `DocumentView` fills the bounds the consumer gives it and
+ * does NOT assume a full screen: the caption takes its natural height, the pager takes
+ * the rest, and each page is letterboxed into the pager slot rather than sized from a
+ * fixed aspect ratio — so a short consumer slot can never make a page overflow upward
+ * into the caption. Pages are rasterised on demand by the isolated-process renderer
+ * reached through [renderer] (the `PdfRendererBinder` interface, never the concrete
+ * `PdfRendererClient`, so test fakes substitute cleanly) and held in a small
+ * per-document LRU cache to amortise re-render on quick swipes.
  *
  * Trust contract:
  *
@@ -178,10 +182,17 @@ private fun DocumentPage(
         }
     }
 
+    // The page fills the slot the pager hands it (which is the pager's `weight(1f)`
+    // share of DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap
+    // inside it. An earlier version sized this Box with `fillMaxWidth().aspectRatio(3:4)`,
+    // which derives height from width and IGNORES the height it is given: when a
+    // consumer hands DocumentView a short slot (e.g. walt-android sandwiches it
+    // between a title and a details section), the 3:4 box grew taller than the pager
+    // viewport and drew over the trust caption above it. fillMaxSize cannot overflow
+    // its slot, so the caption / page boundary is structural regardless of how little
+    // height the consumer gives the surface.
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(TARGET_PAGE_ASPECT_RATIO),
+        modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         rendered?.let { bitmap ->
@@ -192,7 +203,7 @@ private fun DocumentPage(
                 // navigationally useful.
                 contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
                 contentScale = ContentScale.Fit,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
             )
         }
     }
@@ -242,7 +253,8 @@ internal const val LRU_PAGE_WINDOW: Int = 5
 
 // Render budget defaults. The renderer service caps the bitmap area independently
 // (ADR 0005 D7); these are the UI-side request size, picked to look reasonable on
-// phone-class displays without committing to a particular host density.
+// phone-class displays without committing to a particular host density. The on-screen
+// page size is the pager slot, not these values — ContentScale.Fit scales the
+// rasterised bitmap into whatever space the consumer gives DocumentView.
 private const val TARGET_PAGE_WIDTH_DP: Int = 360
 private const val TARGET_PAGE_HEIGHT_DP: Int = 480
-private const val TARGET_PAGE_ASPECT_RATIO: Float = 3f / 4f

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -5,7 +5,6 @@ import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
@@ -194,30 +192,26 @@ private fun DocumentPage(
         }
     }
 
-    // The page fills the slot the pager hands it (which is the pager's `weight(1f)`
-    // share of DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap
-    // inside it. An earlier version sized this Box with `fillMaxWidth().aspectRatio(3:4)`,
-    // which derives height from width and IGNORES the height it is given: when a
-    // consumer hands DocumentView a short slot (e.g. walt-android sandwiches it
-    // between a title and a details section), the 3:4 box grew taller than the pager
-    // viewport and drew over the trust caption above it. fillMaxSize cannot overflow
-    // its slot, so the caption / page boundary is structural regardless of how little
-    // height the consumer gives the surface.
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        rendered?.let { bitmap ->
-            Image(
-                bitmap = bitmap,
-                // ADR 0005 D4 forbids extracting text from the PDF; positional caption
-                // is the only safe TalkBack fallback. "Page 3 of 7" is non-content but
-                // navigationally useful.
-                contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
-                contentScale = ContentScale.Fit,
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
+    // The page fills the slot the pager hands it (the pager's `weight(1f)` share of
+    // DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap inside it.
+    // An earlier version sized the page with `fillMaxWidth().aspectRatio(3:4)`, which
+    // derives height from width and IGNORES the height it is given: when a consumer
+    // hands DocumentView a short slot (e.g. walt-android sandwiches it between a title
+    // and a details section), the 3:4 page grew taller than the pager viewport and drew
+    // over the trust caption above it. fillMaxSize cannot overflow its slot, so the
+    // caption / page boundary is structural regardless of how little height the
+    // consumer gives the surface. No wrapping Box: the Image already fills the slot, so
+    // a Box around it would only add an inert layout node.
+    rendered?.let { bitmap ->
+        Image(
+            bitmap = bitmap,
+            // ADR 0005 D4 forbids extracting text from the PDF; positional caption
+            // is the only safe TalkBack fallback. "Page 3 of 7" is non-content but
+            // navigationally useful.
+            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }
 

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/InfoOutlineIcon.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/InfoOutlineIcon.kt
@@ -1,0 +1,61 @@
+package `is`.walt.passes.pdf.ui.internal
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Hand-authored "info outline" glyph used by [is.walt.passes.pdf.ui.DocumentTrustCaption].
+ *
+ * Kept in-module on purpose: `passes-pdf-ui` does NOT depend on
+ * `androidx.compose.material:material-icons-extended` (a multi-megabyte artifact for a
+ * single 24dp path), and the kernel's policy is to stay dependency-light. The geometry
+ * is the standard Material "info outline" path on a 24×24 viewport.
+ *
+ * The path's [SolidColor] fill is `Color.Black` only because the builder requires a
+ * fill; the actual on-screen colour comes from the `tint` passed to `Icon(...)` at the
+ * call site (sourced from `DocumentSemantics.captionIconTint`). Changing the literal
+ * here has no rendered effect.
+ *
+ * Built once via `lazy` — an `ImageVector` is immutable and safe to share across
+ * recompositions and call sites.
+ */
+internal val InfoOutlineIcon: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "InfoOutline",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(fill = SolidColor(Color.Black)) {
+            // The "i" dot and stem.
+            moveTo(11f, 7f)
+            horizontalLineToRelative(2f)
+            verticalLineToRelative(2f)
+            horizontalLineToRelative(-2f)
+            close()
+            moveTo(11f, 11f)
+            horizontalLineToRelative(2f)
+            verticalLineToRelative(6f)
+            horizontalLineToRelative(-2f)
+            close()
+            // The outer ring: outline circle, drawn as outer then inner contour so the
+            // non-zero fill rule leaves a hollow stroke.
+            moveTo(12f, 2f)
+            curveTo(6.48f, 2f, 2f, 6.48f, 2f, 12f)
+            reflectiveCurveToRelative(4.48f, 10f, 10f, 10f)
+            reflectiveCurveToRelative(10f, -4.48f, 10f, -10f)
+            reflectiveCurveTo(17.52f, 2f, 12f, 2f)
+            close()
+            moveTo(12f, 20f)
+            curveToRelative(-4.41f, 0f, -8f, -3.59f, -8f, -8f)
+            reflectiveCurveToRelative(3.59f, -8f, 8f, -8f)
+            reflectiveCurveToRelative(8f, 3.59f, 8f, 8f)
+            reflectiveCurveToRelative(-3.59f, 8f, -8f, 8f)
+            close()
+        }
+    }.build()
+}

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
@@ -24,7 +24,12 @@ import `is`.walt.passes.ui.core.ArgbColor
  * into a separate accent gets a consistent monochrome caption; a consumer that wants
  * the info glyph in a brand accent colour sets it explicitly. The default is wired in
  * the constructor (Kotlin lets a later parameter's default reference an earlier one),
- * which keeps the slot's addition non-breaking for existing call sites.
+ * which keeps the slot's addition non-breaking for existing call sites. Because that
+ * default references an earlier parameter, the field order is load-bearing here —
+ * [captionIconTint] must stay after [captionForeground]. A future slot that needs no
+ * such cross-reference should prefer the end of the list (the conventional
+ * defaults-last shape), so it does not shift `componentN()` indices for the slots
+ * below it.
  *
  * Color values follow the same packed-ARGB shape as `passes-ui::SignatureBadgeColors`:
  * 32 bits `0xAARRGGBB`. The shared `ArgbColor` value class lives in `passes-ui-core`.

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
@@ -11,12 +11,20 @@ import `is`.walt.passes.ui.core.ArgbColor
  * `DocumentSemantics` alongside; one is not nested inside the other so the modules
  * stay independent peers.
  *
- * The trust-claim slots on this surface are [captionBackground] / [captionForeground]:
- * they style the non-suppressible "user-provided document" caption that mirrors the
- * "Self-signed" pill on signed passes. Because the caption is non-removable (see the
- * KDoc on `DocumentTrustCaption`), its style is fixed by the host theme rather than
- * per-document, and it is the host theme's responsibility to keep contrast legal so
- * the caption stays readable.
+ * The trust-claim slots on this surface are [captionBackground] / [captionForeground]
+ * / [captionIconTint]: they style the non-suppressible "user-provided document"
+ * caption that mirrors the "Self-signed" pill on signed passes. Because the caption is
+ * non-removable (see the KDoc on `DocumentTrustCaption`), its style is fixed by the
+ * host theme rather than per-document, and it is the host theme's responsibility to
+ * keep contrast legal so the caption stays readable. None of these slots can hide the
+ * caption — a host wanting a flat, borderless treatment sets [captionBackground]
+ * transparent, which restyles the caption but does not suppress it.
+ *
+ * [captionIconTint] defaults to [captionForeground] so a consumer that does not opt
+ * into a separate accent gets a consistent monochrome caption; a consumer that wants
+ * the info glyph in a brand accent colour sets it explicitly. The default is wired in
+ * the constructor (Kotlin lets a later parameter's default reference an earlier one),
+ * which keeps the slot's addition non-breaking for existing call sites.
  *
  * Color values follow the same packed-ARGB shape as `passes-ui::SignatureBadgeColors`:
  * 32 bits `0xAARRGGBB`. The shared `ArgbColor` value class lives in `passes-ui-core`.
@@ -24,6 +32,7 @@ import `is`.walt.passes.ui.core.ArgbColor
 public data class DocumentSemantics(
     public val captionBackground: ArgbColor,
     public val captionForeground: ArgbColor,
+    public val captionIconTint: ArgbColor = captionForeground,
     public val tileBackground: ArgbColor,
     public val tileForeground: ArgbColor,
     public val tileLabelForeground: ArgbColor,

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentPublicApiSurfaceTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentPublicApiSurfaceTest.kt
@@ -20,11 +20,16 @@ import java.io.File
 class DocumentPublicApiSurfaceTest {
 
     @Test
-    fun documentSemanticsDataClassExposesAllEightSlots() {
+    fun documentSemanticsDataClassExposesAllNineSlots() {
         val argb = ArgbColor(0xFF000000.toInt())
+        // captionIconTint gets a distinct value so the read below proves it is its own
+        // independent slot, not an alias of captionForeground (it merely *defaults* to
+        // captionForeground when a caller omits it).
+        val iconTint = ArgbColor(0xFFFF8800.toInt())
         val semantics = DocumentSemantics(
             captionBackground = argb,
             captionForeground = argb,
+            captionIconTint = iconTint,
             tileBackground = argb,
             tileForeground = argb,
             tileLabelForeground = argb,
@@ -36,12 +41,33 @@ class DocumentPublicApiSurfaceTest {
         // a rename or removal breaks the test.
         assertThat(semantics.captionBackground).isEqualTo(argb)
         assertThat(semantics.captionForeground).isEqualTo(argb)
+        assertThat(semantics.captionIconTint).isEqualTo(iconTint)
         assertThat(semantics.tileBackground).isEqualTo(argb)
         assertThat(semantics.tileForeground).isEqualTo(argb)
         assertThat(semantics.tileLabelForeground).isEqualTo(argb)
         assertThat(semantics.laneBackground).isEqualTo(argb)
         assertThat(semantics.documentBadgeBackground).isEqualTo(argb)
         assertThat(semantics.documentBadgeForeground).isEqualTo(argb)
+    }
+
+    @Test
+    fun documentSemanticsCaptionIconTintDefaultsToCaptionForeground() {
+        // The slot's default keeps the addition non-breaking: a caller that omits
+        // captionIconTint gets a monochrome caption matching captionForeground. This
+        // pins that default so a later change to it is a deliberate, reviewed edit.
+        val foreground = ArgbColor(0xFF123456.toInt())
+        val other = ArgbColor(0xFF000000.toInt())
+        val semantics = DocumentSemantics(
+            captionBackground = other,
+            captionForeground = foreground,
+            tileBackground = other,
+            tileForeground = other,
+            tileLabelForeground = other,
+            laneBackground = other,
+            documentBadgeBackground = other,
+            documentBadgeForeground = other,
+        )
+        assertThat(semantics.captionIconTint).isEqualTo(foreground)
     }
 
     /**

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentTrustSurfaceTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentTrustSurfaceTest.kt
@@ -37,6 +37,9 @@ class DocumentTrustSurfaceTest {
     private val semantics = DocumentSemantics(
         captionBackground = ArgbColor(0xFF202020.toInt()),
         captionForeground = ArgbColor(0xFFFFFFFF.toInt()),
+        // Set explicitly (rather than relying on the captionForeground default) so the
+        // restyled icon+text caption is exercised with a distinct, non-default tint.
+        captionIconTint = ArgbColor(0xFFFFAA00.toInt()),
         tileBackground = ArgbColor(0xFFF5F5F5.toInt()),
         tileForeground = ArgbColor(0xFF202020.toInt()),
         tileLabelForeground = ArgbColor(0xFF606060.toInt()),


### PR DESCRIPTION
## What

Three changes to `passes-pdf-ui`, all under bead `wpass-b6h`:

1. **Restyle** `DocumentTrustCaption` from a filled colour-block into a flat `Row` of `[info-outline icon] + [caption text]`, and add a `captionIconTint` slot to `DocumentSemantics`.
2. **Page overflow fix** in `DocumentView`/`DocumentPage` so the rasterised page can no longer overflow upward into the trust caption.
3. **Caption background placement** — `DocumentView` paints `laneBackground` behind the pager only, not behind the caption, so the caption reads as host screen chrome.

> Scope note: the bead was originally framed "restyle only." Changes 2 and 3 were folded in by owner decision as the restyle surfaced each underlying issue in turn — see below.

## Why

### 1. Restyle

walt-android's PDF document detail screen showed the "user-provided document" disclaimer **twice**: the kernel's `DocumentTrustCaption` (a filled colour-block inside `DocumentView`) plus a flat Walt-themed banner walt-android added above the PDF (`wlt-o72.5`). The fix moves the flat styling **into** the kernel caption so there is exactly one disclaimer, themeable by the consumer.

### 2. Page overflow fix

Wiring up the restyle made a pre-existing layout bug visible: the caption text was drawn **on top of** the rendered PDF page. Root cause is in `DocumentPage` — the page `Box` was sized `fillMaxWidth().aspectRatio(3f/4f)`, which derives height from width and **ignores the height the pager gives it**. On `android-main` `DocumentView` had the whole screen; on `o72-detail` it is sandwiched between a title and a details section, so the 3:4 page grew taller than the pager viewport and overflowed upward into the caption.

Fix: size the page `Box` and `Image` with `fillMaxSize` and let `ContentScale.Fit` letterbox the bitmap into whatever slot the consumer gives `DocumentView`.

### 3. Caption background placement

After the overflow fix, the caption still sat on a white block. That white is `DocumentView`'s `Column`, which painted `laneBackground` (walt-android maps it to `surface` = white) behind the **whole** surface — caption and pager both. `laneBackground` is also `DocumentsLane`'s background, so a consumer cannot set it transparent without flattening the wallet-root lane too.

Fix: the `Column` no longer paints a background; `laneBackground` moves onto the `HorizontalPager` modifier (before `.padding`, so it fills the pager slot edge-to-edge). The caption now composes on the consumer's screen background; only the pager/PDF area carries the document-surface tone.

## Changes

- **`DocumentTrustCaption.kt`** — body is now a flat `Row` of an info-outline icon + the caption text.
- **`InfoOutlineIcon.kt`** (new) — hand-authored 24dp info-outline `ImageVector`, kept in-module. **No new dependency** — deliberately avoids `material-icons-extended`.
- **`DocumentSemantics.kt`** — new `captionIconTint: ArgbColor` slot, defaulted to `captionForeground` so the addition is non-breaking.
- **`DocumentView.kt`** — `DocumentPage`'s page `Box`/`Image` switched from `fillMaxWidth().aspectRatio(3:4)` to `fillMaxSize`; removed the now-unused `TARGET_PAGE_ASPECT_RATIO`; `laneBackground` moved from the `Column` to the `HorizontalPager`; KDoc updated to state `DocumentView` fills the bounds it is given, does not assume a full screen, and composes the caption on the consumer's background.
- **Tests** — `DocumentPublicApiSurfaceTest`: eight-slots → nine-slots + a default-pinning test. `DocumentTrustSurfaceTest`: sets `captionIconTint` explicitly. `DocumentViewInstrumentedTest`: new regression — renders `DocumentView` in a deliberately short 300dp slot and asserts `caption.bottom <= page.top` (runs under `connectedCheck`, not the JVM unit-test gate, since it needs a real `HorizontalPager` + `SharedMemory` render).

## Trust-contract invariants (reviewer please confirm)

The restyle is a **restyle only**, not a suppressibility change:

- **ADR 0005 D5 non-suppressibility holds** — no new parameter, no overload, no theme flag that removes the caption. `DocumentTrustCaption` signature stays `(modifier: Modifier = Modifier)`. **No ADR amendment needed** — flagging here per the bead so a reviewer can confirm.
- `TRUST_CAPTION_TEXT` literal is **byte-for-byte unchanged** and still rendered in a single `Text` node.
- Caption still composed inside both `DocumentView` and `DocumentsLane` — composition sites unchanged.
- `DocumentSurfaceLockTest` (`documentTrustCaptionHasExactlyOneUserVisibleParameter`, `documentSurfacesHaveNoOverloads`) and `DocumentTrustSurfaceTest` (verbatim-text assertions) stay green.

Changes 2 and 3 touch only `DocumentView`'s internal layout — no surface-shape change, no parameter change.

## Quality gates

`:passes-pdf-ui:testDebugUnitTest`, `:passes-pdf-ui:compileDebugAndroidTestKotlin`, `:passes-pdf-ui:detekt`, and `:passes-pdf-ui:ktlintCheck` all pass.

## Consumer coordination

The consumer change lives in **walt-android branch `o72-detail` (PR #197, `wlt-o72.5`)**: it deletes `DocumentTrustBanner` + `DOCUMENT_TRUST_BANNER_TEXT` and sets `captionBackground = transparent` + `captionIconTint = WaltOrangeAccent` in `buildWaltDocumentSemantics`.

Because walt-android composite-builds this kernel, the two must land together: **walt-android PR #197 must update `-PwaltPassesPath` to this branch, or this PR merges first.** No walt-android files are touched by this PR.