### PR TITLE
passes-pdf-ui: pinch-zoom + pan in DocumentView (wpass-1wq, wpass-0nn)

### DIFF
--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -362,8 +362,12 @@ constants live in `passes-pdf-ui/.../DocumentView.kt`:
 
 - `MIN_SCALE = 1f` (zooming out below fit is meaningless on a
   single-page surface).
-- `MAX_SCALE = 5f` (brings a typical barcode to slot-filling size).
-- `DOUBLE_TAP_SCALE = 2.5f` (double-tap toggle target).
+- `MAX_SCALE = 3f` (interim ceiling against the current fit-resolution
+  bitmap — at 5x, each source pixel becomes a 5x5 bilinear block and
+  the smearing crosses into "bigger but less scannable" territory for
+  phone-camera barcode decoders. Moves to 5f once `wpass-f4b` lands the
+  viewport-aware renderer so the upsampling cost disappears).
+- `DOUBLE_TAP_SCALE = 2f` (double-tap toggle target).
 
 Gesture priority with the enclosing `HorizontalPager` is the
 load-bearing UX interlock:
@@ -468,6 +472,7 @@ contract is documented in the bead.
 |----------|-------------------------------------------------------------------------------------------------------|
 | Z.1      | `DocumentViewInstrumentedTest.pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible`        |
 | Z.1      | `DocumentViewInstrumentedTest.singleTouchHorizontalDragAtFitScaleStillAdvancesThePager`               |
+| Z.1      | `DocumentViewInstrumentedTest.singleTouchHorizontalDragWhileZoomedDoesNotAdvanceThePager`             |
 | Z.1      | `DocumentViewInstrumentedTest.doubleTapOnThePageDoesNotAdvanceThePager`                               |
 | Z.2      | existing `PdfRendererService.MAX_PIXELS` pin in renderer service code — value unchanged.              |
 | Z.3      | existing `PublicApiSurfaceTest` reflection check on `PdfRendererBinder` — still exactly two methods.  |

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -330,3 +330,146 @@ neither module hosts the forbidden surface.
 
 The Android-side renderer module remains tracked under `wpass-5v9`. Its
 manifest, JNI source, and binder code land there.
+
+## Addendum 2026-05-15: Pinch-zoom + pan in `DocumentView`
+
+Tracks: `wpass-6ag` (parent), `wpass-1wq` (UI gesture surface), `wpass-f4b`
+(renderer zoom-aware path), `wpass-0nn` (this addendum). Cross-repo
+consumer-side tracker: walt-android `wlt-o72.4`. Storage precondition
+verified by walt-android `wlt-o72.3` (imported PDF bytes are persisted at
+full resolution, no re-encode or downscale).
+
+### Context
+
+The original Consequences section framed `DocumentView` as "minimally
+featured", and `DocumentView` shipped as a `HorizontalPager` of
+`ContentScale.Fit`-letterboxed pages with no zoom and no pan. In
+practice, the #1 reason a user imports a PDF into the wallet is to
+scan an embedded barcode (PDF417 / QR / EAN) at a venue or transit
+gate. A fit-resolution rasterised page does not enlarge a typical
+barcode enough for a scanner to read it, so the feature as originally
+shipped fails its primary use case.
+
+This addendum records pinch-to-zoom and single-touch pan-when-zoomed as
+explicit features of `DocumentView`, and reconciles them with the trust
+contracts in D4, D5, D7, and D8.
+
+### Z.1 Pinch-zoom and pan are features; gesture priority interlocks with the pager
+
+Pinch-to-zoom (two-finger) and pan-when-zoomed (single-finger, only when
+`scale > 1`) are part of `DocumentView`'s gesture surface. Implementation
+constants live in `passes-pdf-ui/.../DocumentView.kt`:
+
+- `MIN_SCALE = 1f` (zooming out below fit is meaningless on a
+  single-page surface).
+- `MAX_SCALE = 5f` (brings a typical barcode to slot-filling size).
+- `DOUBLE_TAP_SCALE = 2.5f` (double-tap toggle target).
+
+Gesture priority with the enclosing `HorizontalPager` is the
+load-bearing UX interlock:
+
+- Two-finger pinch is always consumed by the page-scoped zoom surface.
+  It never advances the pager.
+- Single-touch drag is consumed by the zoom surface only when
+  `scale > MIN_SCALE`. At fit, single-touch horizontal drag passes
+  through to the pager — page-swipe behaviour is unchanged from before
+  the addendum.
+- Translation is clamped so the scaled page cannot be panned entirely
+  off the slot. The user cannot lose the barcode by overshooting.
+
+Zoom state is per-page and resets on page change (the
+`remember(document.id, pageIndex)` frame in the rendering composable
+owns it). Paging away from a zoomed-in barcode and back returns the
+page to fit — no cross-page zoom persistence, which keeps the swipe
+gesture's mental model clean.
+
+### Z.2 The 4 MP per-bitmap cap (D7) stands unchanged
+
+`PdfRendererService.MAX_PIXELS = 4 MP` is **not** raised by this
+addendum. The cap is defense-in-depth against
+decompression-bomb-style memory abuse; raising it would be a
+separate security-policy change requiring its own addendum.
+
+Both candidate renderer designs under evaluation in `wpass-f4b` (tiled
+rendering; viewport re-render) fit within the cap:
+
+- Tiled rendering caps **per-tile** at <= 4 MP. Total tile RAM is
+  bounded by how many tiles are visible in the zoomed viewport, not
+  by the zoom factor.
+- Viewport re-render caps the **single** bitmap at <= 4 MP. One
+  bitmap per zoom level; the visible document-rect is what gets
+  rasterised at viewport resolution.
+
+The gesture surface (Z.1) is correct against the existing
+fit-resolution bitmap — pixelated when zoomed past about 1.3-1.5x, but
+functionally correct. The renderer change in `wpass-f4b` is what
+delivers sharp-at-zoom; it can land independently as a follow-up.
+
+### Z.3 The binder API surface does not widen
+
+`PdfRendererBinder` continues to expose exactly two methods: `probe`
+and `render`. The renderer zoom-aware path (`wpass-f4b`) extends
+`render`'s parameter shape with a sub-rect / viewport indicator (see
+that bead for the exact wire shape), but does not add a third
+transaction. D4's no-extraction guarantee is therefore preserved:
+`PublicApiSurfaceTest`'s reflection check still passes after
+`wpass-f4b` lands.
+
+### Z.4 The non-suppressible trust caption (D5) stays docked above the pager
+
+This is the explicit decision the addendum is being filed to record:
+**the trust caption ("User-provided document. Walt has not verified
+the source.") stays docked above the pager and is NOT subject to the
+zoom transform.** It cannot be panned off-screen, and it remains
+visible at every zoom level.
+
+Two implementation options were considered:
+
+- (a) Caption stays in its row in `DocumentView`'s `Column`, above the
+  pager. The zoom transform applies inside the pager slot only.
+- (b) Caption pans / scales with the page. Could be scrolled off
+  screen if the user pans up while zoomed.
+
+Option (a) is adopted. The reasoning:
+
+- D5's "non-suppressible" promise reads naturally as "the user can
+  always see it." Option (b) makes the caption *suppressible by pan*
+  in practice — a user zoomed in on the lower half of a page would
+  not see the caption, which dilutes the trust signal.
+- Option (a) is what the current `DocumentView` layout already does:
+  the caption is a sibling of the pager in a `Column`, and the zoom
+  transform is structurally scoped to the page slot inside the
+  pager. No layout change is needed for the addendum.
+- The cost of option (a) is zero: caption never interferes with the
+  gesture surface, and the gesture surface never interferes with the
+  caption.
+
+### Z.5 No share-out path is introduced (D8 unchanged)
+
+Zoom is a view-side affordance. No new code path moves PDF bytes off
+device or into a sharing intent. D8's classpath-scan test
+(`Intent.ACTION_SEND` is forbidden in `passes-ui`, `passes-pdf-ui`,
+and `passes-pdf`) continues to pass.
+
+### Z.6 Consumer-side integration is the host's responsibility
+
+walt-android embeds `DocumentView` inside a vertical scroll container
+on the document-detail screen. Now that `DocumentView` consumes
+single-touch drags when zoomed, the host screen will need to defer to
+the embedded gesture (nested-scroll or zoom-state-gated suppression).
+Tracked on the consumer side as walt-android `wlt-o72.4`. This
+addendum does not commit `passes-pdf-ui` to a nested-scroll API; the
+gesture surface is self-contained at scale > 1 and the integration
+contract is documented in the bead.
+
+### Tests pinning the addendum
+
+| Decision | Test                                                                                                  |
+|----------|-------------------------------------------------------------------------------------------------------|
+| Z.1      | `DocumentViewInstrumentedTest.pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible`        |
+| Z.1      | `DocumentViewInstrumentedTest.singleTouchHorizontalDragAtFitScaleStillAdvancesThePager`               |
+| Z.1      | `DocumentViewInstrumentedTest.doubleTapOnThePageDoesNotAdvanceThePager`                               |
+| Z.2      | existing `PdfRendererService.MAX_PIXELS` pin in renderer service code — value unchanged.              |
+| Z.3      | existing `PublicApiSurfaceTest` reflection check on `PdfRendererBinder` — still exactly two methods.  |
+| Z.4      | `DocumentViewInstrumentedTest.pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible` asserts caption visibility post-pinch; existing `trustCaptionDoesNotOverlapThePageWhenTheConsumerGivesAShortSlot` pins the structural layout boundary. |
+| Z.5      | existing classpath-scan test for `Intent.ACTION_SEND` — surface unchanged.                            |

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -235,6 +235,46 @@ class DocumentViewInstrumentedTest {
     }
 
     @Test
+    fun singleTouchHorizontalDragWhileZoomedDoesNotAdvanceThePager() {
+        // wpass-1wq: the load-bearing half of the `canPan = { scale > MIN_SCALE }`
+        // contract. A single-touch horizontal drag at fit scale advances the pager
+        // (pinned by singleTouchHorizontalDragAtFitScaleStillAdvancesThePager); the
+        // SAME gesture once the user is zoomed in must instead pan the page and leave
+        // the pager position untouched, or scanning a barcode becomes impossible the
+        // moment the user tries to drag inside the zoomed view. Removing canPan, or
+        // replacing it with `{ true }` / `{ false }`, would silently regress this
+        // direction without the existing three tests catching it.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+
+        // Pinch outward to enter scale > 1, then single-touch swipe-left in the same
+        // pager that the fit-scale test confirms WOULD advance.
+        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput {
+            pinch(
+                start0 = center + Offset(-100f, 0f),
+                end0 = center + Offset(-300f, 0f),
+                start1 = center + Offset(100f, 0f),
+                end1 = center + Offset(300f, 0f),
+            )
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput { swipeLeft() }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+    }
+
+    @Test
     fun singleTouchHorizontalDragAtFitScaleStillAdvancesThePager() {
         // wpass-1wq: gesture priority at scale == 1 must defer to the pager. A
         // single-touch horizontal drag from the fit state has to advance the pager

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -8,13 +8,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pinch
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -167,6 +170,91 @@ class DocumentViewInstrumentedTest {
         composeRule.onNodeWithText(
             "User-provided document. Walt has not verified the source.",
         ).assertIsDisplayed()
+    }
+
+    @Test
+    fun pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible() {
+        // wpass-1wq: pinch-to-zoom is a two-finger gesture; HorizontalPager treats
+        // single-touch horizontal drags as page-swipes. The gesture-priority contract
+        // requires that pinch (multi-touch) be consumed by the page-scoped zoom surface
+        // and never advance the pager. The trust caption (D5 non-suppressible) sits in
+        // DocumentView's Column above the pager and must remain visible regardless of
+        // gesture state — the zoom surface is structurally inside the pager slot, so a
+        // failure here would mean the caption was wrongly nested under the zoom
+        // transform.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput {
+            pinch(
+                start0 = center + Offset(-100f, 0f),
+                end0 = center + Offset(-300f, 0f),
+                start1 = center + Offset(100f, 0f),
+                end1 = center + Offset(300f, 0f),
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun doubleTapOnThePageDoesNotAdvanceThePager() {
+        // wpass-1wq: double-tap toggles between fit and DOUBLE_TAP_SCALE. It must not
+        // bubble as a swipe-equivalent or otherwise change the pager position. Visible
+        // page index unchanged is the contract.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput {
+            doubleClick()
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+    }
+
+    @Test
+    fun singleTouchHorizontalDragAtFitScaleStillAdvancesThePager() {
+        // wpass-1wq: gesture priority at scale == 1 must defer to the pager. A
+        // single-touch horizontal drag from the fit state has to advance the pager
+        // exactly as it did before the zoom surface was added — otherwise the surface
+        // has accidentally swallowed swipe-to-page.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 3),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
+        composeRule.onRoot().performTouchInput { swipeLeft() }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 2 of 3").assertIsDisplayed()
     }
 
     @Test

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -4,7 +4,11 @@ import android.graphics.Bitmap
 import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,14 +20,21 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.pdf.ConsumerRenderFailure
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
@@ -200,17 +211,119 @@ private fun DocumentPage(
     // and a details section), the 3:4 page grew taller than the pager viewport and drew
     // over the trust caption above it. fillMaxSize cannot overflow its slot, so the
     // caption / page boundary is structural regardless of how little height the
-    // consumer gives the surface. No wrapping Box: the Image already fills the slot, so
-    // a Box around it would only add an inert layout node.
+    // consumer gives the surface.
+    //
+    // The wrapping Box is the zoom/pan surface (wpass-1wq). It scopes the gesture and
+    // graphicsLayer transform to the current page so swiping to the next page resets the
+    // zoom state, and so the trust caption — which lives in DocumentView's Column above
+    // the pager — is unaffected by any zoom transform applied here.
     rendered?.let { bitmap ->
+        ZoomableDocumentPage(
+            bitmap = bitmap,
+            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
+        )
+    }
+}
+
+/**
+ * Per-page pinch-zoom + pan surface (wpass-1wq). Scoped strictly to a single page slot:
+ * the [Box]'s state lives in the caller's `remember(document.id, pageIndex)` frame, so
+ * paging away resets `scale` to 1 and `offset` to zero for the next page composition.
+ *
+ * Gesture priority with the enclosing [HorizontalPager]:
+ *
+ *  - Two-finger pinch is always consumed here — [transformable] handles it independently
+ *    of `canPan`, so the user can zoom out to fit even when the pager owns single-touch.
+ *  - Single-touch drag is consumed here only when `scale > 1f` (`canPan = { scale > 1f }`).
+ *    At `scale == 1f` the gesture passes through to the pager so horizontal swipes still
+ *    advance pages. Once zoomed in, single-touch drags pan the page within the slot until
+ *    the user double-taps or pinches back to fit.
+ *  - Double-tap toggles between fit (scale = 1, offset = zero) and the canonical zoomed
+ *    scale ([DOUBLE_TAP_SCALE]).
+ *
+ * Translation is clamped so the scaled page cannot be panned entirely off the slot:
+ * `maxOffset = ((scale - 1) * slotSize / 2)`, which keeps the page centered at fit and
+ * lets the user pan up to the edges of the scaled-up image but no further. Without this
+ * clamp the user could fling the barcode out of frame and lose the slot's contents.
+ *
+ * The graphicsLayer transform applies to the [Image] alone; the trust caption is composed
+ * outside this Box (in [DocumentView]'s Column) and is therefore structurally not part of
+ * any transform applied here. ADR 0005 D5's non-suppressible-trust-caption contract is
+ * preserved by layout, not by gesture-handling discipline.
+ *
+ * The 4 MP raster the renderer hands us (ADR 0005 D7) is sampled into a fit-resolution
+ * bitmap, so it pixelates when scaled above ~1.3-1.5x. The follow-up renderer bead
+ * (wpass-f4b) lifts the sharp-at-zoom property by re-rendering the visible viewport at
+ * higher resolution within the same 4 MP per-bitmap cap; this gesture surface is correct
+ * against the existing bitmap (pixelated but functional) and gets sharper for free once
+ * wpass-f4b lands.
+ */
+@Composable
+private fun ZoomableDocumentPage(
+    bitmap: ImageBitmap,
+    contentDescription: String,
+) {
+    // Local state, not rememberSaveable: zoom state intentionally does not survive a
+    // process death — the page reverts to fit, which matches the user-mental-model of
+    // "the wallet just reopened, show me the page at its natural size."
+    var scale by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+    var slotSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
+        val newScale = (scale * zoomChange).coerceIn(MIN_SCALE, MAX_SCALE)
+        val maxX = ((newScale - 1f) * slotSize.width / 2f).coerceAtLeast(0f)
+        val maxY = ((newScale - 1f) * slotSize.height / 2f).coerceAtLeast(0f)
+        val proposed = offset + panChange
+        offset = Offset(
+            proposed.x.coerceIn(-maxX, maxX),
+            proposed.y.coerceIn(-maxY, maxY),
+        )
+        scale = newScale
+        if (newScale <= MIN_SCALE) offset = Offset.Zero
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .onSizeChanged { slotSize = it }
+            // pointerInput keyed on Unit because the only state the handler reads is the
+            // mutable `scale` (re-read on every callback). Re-keying would tear down and
+            // recreate the gesture detector on every zoom step.
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        if (scale > MIN_SCALE) {
+                            scale = MIN_SCALE
+                            offset = Offset.Zero
+                        } else {
+                            scale = DOUBLE_TAP_SCALE
+                            // Leave offset at zero; the user pans afterward if they need
+                            // to bring a specific region to centre. Centring on the tap
+                            // point would jump the page under the finger and surprise the
+                            // user — see wpass-1wq design notes.
+                        }
+                    },
+                )
+            }
+            .transformable(state = transformableState, canPan = { scale > MIN_SCALE }),
+        contentAlignment = Alignment.Center,
+    ) {
         Image(
             bitmap = bitmap,
             // ADR 0005 D4 forbids extracting text from the PDF; positional caption
             // is the only safe TalkBack fallback. "Page 3 of 7" is non-content but
             // navigationally useful.
-            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
+            contentDescription = contentDescription,
             contentScale = ContentScale.Fit,
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y,
+                ),
         )
     }
 }
@@ -264,3 +377,23 @@ internal const val LRU_PAGE_WINDOW: Int = 5
 // rasterised bitmap into whatever space the consumer gives DocumentView.
 private const val TARGET_PAGE_WIDTH_DP: Int = 360
 private const val TARGET_PAGE_HEIGHT_DP: Int = 480
+
+// Zoom bounds for ZoomableDocumentPage (wpass-1wq).
+//
+// MIN_SCALE = 1f: zooming out below fit is meaningless on a single-page surface — the
+// page is already letterboxed and ContentScale.Fit owns "see the whole page in one
+// glance." Below 1 would just paint a smaller page inside empty slot real estate.
+//
+// MAX_SCALE = 5f: a typical PDF417 / QR / EAN barcode rasterised at fit fills roughly
+// 1/4 of a phone page; 5x brings the barcode to roughly fill the slot, which puts it
+// in the legible range for venue / gate scanners. The follow-up renderer bead
+// (wpass-f4b) re-rasterises at viewport resolution so the zoomed bitmap is sharp,
+// not just larger.
+//
+// DOUBLE_TAP_SCALE = 2.5f: the toggle-target for a double-tap. Picked roughly
+// half-way between fit and the max so a single tap is a clear "zoom in" affordance
+// without immediately committing to the maximum, while still being useful for
+// previewing whether the visible content survives at non-fit scale.
+private const val MIN_SCALE: Float = 1f
+private const val MAX_SCALE: Float = 5f
+private const val DOUBLE_TAP_SCALE: Float = 2.5f

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -384,16 +384,20 @@ private const val TARGET_PAGE_HEIGHT_DP: Int = 480
 // page is already letterboxed and ContentScale.Fit owns "see the whole page in one
 // glance." Below 1 would just paint a smaller page inside empty slot real estate.
 //
-// MAX_SCALE = 5f: a typical PDF417 / QR / EAN barcode rasterised at fit fills roughly
-// 1/4 of a phone page; 5x brings the barcode to roughly fill the slot, which puts it
-// in the legible range for venue / gate scanners. The follow-up renderer bead
-// (wpass-f4b) re-rasterises at viewport resolution so the zoomed bitmap is sharp,
-// not just larger.
+// MAX_SCALE = 3f (interim): held at 3x rather than 5x until wpass-f4b lands the
+// viewport-aware renderer. Against a fit-resolution bitmap, every source pixel
+// becomes a 3x3 block under bilinear filtering at this scale, which is usually
+// still inside the decoder's edge-detection budget for PDF417 / QR / EAN — at 5x
+// each source pixel is a 5x5 block, and the smearing crosses into "looks bigger
+// but actually less scannable" territory for many phone-camera scanners. Once
+// wpass-f4b re-renders the visible viewport at viewport-pixel resolution within
+// the same 4 MP cap, the upsampling cost disappears and this constant can move
+// to 5f without producing a degraded UX at the top end.
 //
-// DOUBLE_TAP_SCALE = 2.5f: the toggle-target for a double-tap. Picked roughly
-// half-way between fit and the max so a single tap is a clear "zoom in" affordance
-// without immediately committing to the maximum, while still being useful for
-// previewing whether the visible content survives at non-fit scale.
+// DOUBLE_TAP_SCALE = 2f: the toggle-target for a double-tap. Held below MAX_SCALE
+// so a single tap is a clear "zoom in" affordance that picks the
+// most-likely-actually-readable point, with the user free to pinch further if a
+// specific scanner needs more.
 private const val MIN_SCALE: Float = 1f
-private const val MAX_SCALE: Float = 5f
-private const val DOUBLE_TAP_SCALE: Float = 2.5f
+private const val MAX_SCALE: Float = 3f
+private const val DOUBLE_TAP_SCALE: Float = 2f


### PR DESCRIPTION
## Summary

- Adds a per-page zoom surface inside `DocumentView`'s `HorizontalPager` so users can enlarge a PDF-embedded barcode (PDF417/QR/EAN) enough for a venue or gate scanner to read it.
- Gesture priority: two-finger pinch always consumed locally; single-touch drag consumed only when `scale > 1` (`Modifier.transformable` with `canPan = { scale > MIN_SCALE }`), so swipe-to-page at fit is unchanged. Double-tap toggles fit ↔ `DOUBLE_TAP_SCALE`. Translation clamped so the page cannot pan off the slot.
- Zoom state lives in the existing `remember(document.id, pageIndex)` frame — paging away resets to fit.
- `DocumentTrustCaption` stays in `DocumentView`'s `Column` row above the pager and is structurally outside the zoom transform (ADR 0005 D5 non-suppressible contract preserved).
- ADR 0005 addendum (Z.1-Z.6) records the policy decision, including: 4 MP per-bitmap cap (D7) unchanged, binder surface (D4) unchanged, trust caption stays docked (option a, not panned with the page).

Renderer-side sharpness at zoom is the follow-up bead `wpass-f4b` (zoom-aware re-render of the visible viewport within the unchanged 4 MP cap). This PR is correct against the existing fit-resolution bitmap — pixelated when zoomed past ~1.3-1.5x, but the gesture surface and policy land here so the consumer integration in walt-android `wlt-o72.4` can move forward in parallel.

Parent epic: `wpass-6ag`.

## Test plan

- [x] `:passes-pdf-ui:compileDebugKotlin` clean
- [x] `:passes-pdf-ui:testDebugUnitTest` green
- [x] `:passes-pdf-ui:check` green (lint, detekt, ktlint)
- [x] `:passes-pdf-ui:compileDebugAndroidTestKotlin` clean
- [ ] Run instrumented tests on a device — needs `:passes-pdf-ui:connectedDebugAndroidTest`:
  - `pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible`
  - `doubleTapOnThePageDoesNotAdvanceThePager`
  - `singleTouchHorizontalDragAtFitScaleStillAdvancesThePager`
- [ ] Smoke-test on a Pixel: pinch a real ticket PDF; verify barcode area enlarges; verify trust caption stays on screen at MAX_SCALE; verify single-finger pan within zoomed page does not advance the pager; verify double-tap toggle.

Cross-repo: consumer integration tracked as walt-android `wlt-o72.4`. The walt-android `DocumentDetailScreen` embeds `DocumentView` in a vertical scroll container; the screen-level scroll will need to defer to the embedded zoom/pan when `scale > 1` (nested-scroll or zoom-state-gated suppression). Z.6 in the ADR addendum notes this as the consumer's responsibility.