### PR TITLE
wpass-6ag: zoom-to-scan full-screen surface (renderer + UI)

### DIFF
--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -253,8 +253,9 @@ class DocumentViewInstrumentedTest {
 
     @Test
     fun fullScreenBannerAppearsAndInvokesTheCallbackOnTap() {
-        // wpass-jil: tapping the banner is the only call site for the host's
-        // navigation hop into the full-screen surface.
+        // wpass-jil: tapping the banner is one of two call sites for the host's
+        // navigation hop into the full-screen surface (the other is a tap on the page
+        // itself; see tapOnInlinePageInvokesTheFullScreenCallback).
         val recorder = RecordingBinder()
         var tapped = false
         composeRule.setContent {
@@ -269,6 +270,30 @@ class DocumentViewInstrumentedTest {
         }
         composeRule.onNodeWithText("Tap for full screen").assertIsDisplayed()
         composeRule.onNodeWithText("Tap for full screen").performClick()
+        assertThat(tapped).isTrue()
+    }
+
+    @Test
+    fun tapOnInlinePageInvokesTheFullScreenCallback() {
+        // wpass-6ag follow-up: the rendered page is also a tap target. The banner is
+        // discoverability; the page is the primary affordance. Drag-to-swipe still
+        // works because Compose routes quick press-and-release to clickable and
+        // horizontal drag to the pager.
+        val recorder = RecordingBinder()
+        var tapped = false
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onOpenFullScreen = { tapped = true },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 1").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Page 1 of 1").performClick()
         assertThat(tapped).isTrue()
     }
 

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -31,6 +31,7 @@ import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.ProbeResult
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.theme.DocumentSemantics
 import `is`.walt.passes.pdf.ui.theme.DocumentTheme
 import `is`.walt.passes.ui.core.ArgbColor
@@ -295,10 +296,9 @@ class DocumentViewInstrumentedTest {
     @Test
     fun pinchOnFullScreenDrivesAZoomAwareRerenderCall() {
         // wpass-jil + wpass-f4b: after the user pinches in the full-screen surface,
-        // the surface issues a renderer.render() call whose sourceRect is a SubRect of
-        // the page. Asserting "at least one render call used a SubRect" pins the
-        // integration without coupling to specific rect coordinates (which depend on
-        // pinch trajectory + slot size).
+        // the surface fires a renderer.render(SubRect) call AND the bitmap swap from
+        // wpass-6ag C1 surfaces the new bitmap. Recorder also tracks per-call
+        // SharedMemory open/close so C2 is structurally pinned.
         val recorder = RecordingBinder()
         composeRule.setContent {
             ThemedHost {
@@ -323,6 +323,10 @@ class DocumentViewInstrumentedTest {
         composeRule.waitForIdle()
         val sourceRects = recorder.sourceRects()
         assertThat(sourceRects.any { it is RenderSourceRect.SubRect }).isTrue()
+        // wpass-6ag C2: every Ok bitmap allocated by the recorder is either consumed by
+        // decodePage (which closes the SharedMemory) or by discardRenderResult on a
+        // superseded sub-rect render. None should remain open by test end.
+        assertThat(recorder.openSharedMemoryCount()).isEqualTo(0)
     }
 
     @Test
@@ -395,6 +399,7 @@ class DocumentViewInstrumentedTest {
         private val pages = CopyOnWriteArrayList<Int>()
         private val rects = CopyOnWriteArrayList<RenderSourceRect>()
         private val allocations = AtomicInteger(0)
+        private val openSharedMemories = CopyOnWriteArrayList<SharedMemory>()
 
         override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
             ProbeResult.Ok(pageCount = 6)
@@ -411,12 +416,23 @@ class DocumentViewInstrumentedTest {
             allocations.incrementAndGet()
             val size = widthPx * heightPx * BYTES_PER_PIXEL
             val sm = SharedMemory.create("walt-test-render-$page-${allocations.get()}", size)
-            return RenderResult.Ok(sm, widthPx, heightPx)
+            openSharedMemories += sm
+            return RenderResult.Ok(sm, widthPx, heightPx, 1f)
         }
 
         fun renderedPages(): List<Int> = pages.toList()
 
         fun sourceRects(): List<RenderSourceRect> = rects.toList()
+
+        // SharedMemory has no public isClosed; the closest check is mapReadOnly()
+        // throwing IllegalStateException after close. Count failures-to-map as "still
+        // open" (i.e., a closed handle is no longer open).
+        fun openSharedMemoryCount(): Int = openSharedMemories.count { sm ->
+            runCatching {
+                val buf = sm.mapReadOnly()
+                SharedMemory.unmap(buf)
+            }.isSuccess
+        }
     }
 
     private companion object {

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -9,12 +9,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pinch
 import androidx.compose.ui.test.swipeLeft
@@ -230,6 +233,99 @@ class DocumentViewInstrumentedTest {
     }
 
     @Test
+    fun fullScreenBannerIsHiddenWhenNoCallbackIsProvided() {
+        // wpass-jil: the banner is opt-in. Hosts that do not provide an
+        // `onOpenFullScreen` callback see no banner; existing call sites stay
+        // unchanged after the addition.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                )
+            }
+        }
+        composeRule.onAllNodesWithText("Tap for full screen").assertCountEquals(0)
+    }
+
+    @Test
+    fun fullScreenBannerAppearsAndInvokesTheCallbackOnTap() {
+        // wpass-jil: tapping the banner is the only call site for the host's
+        // navigation hop into the full-screen surface.
+        val recorder = RecordingBinder()
+        var tapped = false
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onOpenFullScreen = { tapped = true },
+                )
+            }
+        }
+        composeRule.onNodeWithText("Tap for full screen").assertIsDisplayed()
+        composeRule.onNodeWithText("Tap for full screen").performClick()
+        assertThat(tapped).isTrue()
+    }
+
+    @Test
+    fun fullScreenSurfaceShowsTheTrustCaption() {
+        // wpass-jil / ADR 0005 Z.8: the trust caption is docked on the full-screen
+        // surface and visible at first composition. The bitmap-availability path is
+        // gated on a renderer round-trip so the assertion targets the caption only.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                FullScreenDocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onClose = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun pinchOnFullScreenDrivesAZoomAwareRerenderCall() {
+        // wpass-jil + wpass-f4b: after the user pinches in the full-screen surface,
+        // the surface issues a renderer.render() call whose sourceRect is a SubRect of
+        // the page. Asserting "at least one render call used a SubRect" pins the
+        // integration without coupling to specific rect coordinates (which depend on
+        // pinch trajectory + slot size).
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                FullScreenDocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onClose = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Page 1 of 1").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Page 1 of 1").performTouchInput {
+            pinch(
+                start0 = center + Offset(-100f, 0f),
+                end0 = center + Offset(-300f, 0f),
+                start1 = center + Offset(100f, 0f),
+                end1 = center + Offset(300f, 0f),
+            )
+        }
+        composeRule.waitForIdle()
+        val sourceRects = recorder.sourceRects()
+        assertThat(sourceRects.any { it is RenderSourceRect.SubRect }).isTrue()
+    }
+
+    @Test
     fun trustCaptionDoesNotOverlapThePageWhenTheConsumerGivesAShortSlot() {
         // Regression for wpass-b6h: walt-android embeds DocumentView in a short slot —
         // sandwiched between a document title and a details section — not the full
@@ -297,6 +393,7 @@ class DocumentViewInstrumentedTest {
      */
     private class RecordingBinder : PdfRendererBinder {
         private val pages = CopyOnWriteArrayList<Int>()
+        private val rects = CopyOnWriteArrayList<RenderSourceRect>()
         private val allocations = AtomicInteger(0)
 
         override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
@@ -310,6 +407,7 @@ class DocumentViewInstrumentedTest {
             sourceRect: RenderSourceRect,
         ): RenderResult {
             pages += page
+            rects += sourceRect
             allocations.incrementAndGet()
             val size = widthPx * heightPx * BYTES_PER_PIXEL
             val sm = SharedMemory.create("walt-test-render-$page-${allocations.get()}", size)
@@ -317,6 +415,8 @@ class DocumentViewInstrumentedTest {
         }
 
         fun renderedPages(): List<Int> = pages.toList()
+
+        fun sourceRects(): List<RenderSourceRect> = rects.toList()
     }
 
     private companion object {

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pinch
 import androidx.compose.ui.test.swipeLeft
@@ -175,15 +174,11 @@ class DocumentViewInstrumentedTest {
     }
 
     @Test
-    fun pinchToZoomDoesNotAdvanceThePagerAndKeepsTheTrustCaptionVisible() {
-        // wpass-1wq: pinch-to-zoom is a two-finger gesture; HorizontalPager treats
-        // single-touch horizontal drags as page-swipes. The gesture-priority contract
-        // requires that pinch (multi-touch) be consumed by the page-scoped zoom surface
-        // and never advance the pager. The trust caption (D5 non-suppressible) sits in
-        // DocumentView's Column above the pager and must remain visible regardless of
-        // gesture state — the zoom surface is structurally inside the pager slot, so a
-        // failure here would mean the caption was wrongly nested under the zoom
-        // transform.
+    fun pinchOnTheInlineSurfaceDoesNotZoomAndKeepsTheTrustCaptionVisible() {
+        // wpass-ny4: inline DocumentView is fixed 1x after the design pivot. Pinch
+        // gestures must NOT scale the page (no zoom surface inline) and the trust
+        // caption must remain visible. The actual zoom surface lives on the full-screen
+        // detail view (wpass-jil), entered via the banner.
         val recorder = RecordingBinder()
         composeRule.setContent {
             ThemedHost {
@@ -214,74 +209,9 @@ class DocumentViewInstrumentedTest {
     }
 
     @Test
-    fun doubleTapOnThePageDoesNotAdvanceThePager() {
-        // wpass-1wq: double-tap toggles between fit and DOUBLE_TAP_SCALE. It must not
-        // bubble as a swipe-equivalent or otherwise change the pager position. Visible
-        // page index unchanged is the contract.
-        val recorder = RecordingBinder()
-        composeRule.setContent {
-            ThemedHost {
-                DocumentView(
-                    doc = doc(pageCount = 3),
-                    pdfFile = pipeRead,
-                    renderer = recorder,
-                )
-            }
-        }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput {
-            doubleClick()
-        }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
-    }
-
-    @Test
-    fun singleTouchHorizontalDragWhileZoomedDoesNotAdvanceThePager() {
-        // wpass-1wq: the load-bearing half of the `canPan = { scale > MIN_SCALE }`
-        // contract. A single-touch horizontal drag at fit scale advances the pager
-        // (pinned by singleTouchHorizontalDragAtFitScaleStillAdvancesThePager); the
-        // SAME gesture once the user is zoomed in must instead pan the page and leave
-        // the pager position untouched, or scanning a barcode becomes impossible the
-        // moment the user tries to drag inside the zoomed view. Removing canPan, or
-        // replacing it with `{ true }` / `{ false }`, would silently regress this
-        // direction without the existing three tests catching it.
-        val recorder = RecordingBinder()
-        composeRule.setContent {
-            ThemedHost {
-                DocumentView(
-                    doc = doc(pageCount = 3),
-                    pdfFile = pipeRead,
-                    renderer = recorder,
-                )
-            }
-        }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
-
-        // Pinch outward to enter scale > 1, then single-touch swipe-left in the same
-        // pager that the fit-scale test confirms WOULD advance.
-        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput {
-            pinch(
-                start0 = center + Offset(-100f, 0f),
-                end0 = center + Offset(-300f, 0f),
-                start1 = center + Offset(100f, 0f),
-                end1 = center + Offset(300f, 0f),
-            )
-        }
-        composeRule.waitForIdle()
-        composeRule.onNodeWithContentDescription("Page 1 of 3").performTouchInput { swipeLeft() }
-        composeRule.waitForIdle()
-
-        composeRule.onNodeWithContentDescription("Page 1 of 3").assertIsDisplayed()
-    }
-
-    @Test
     fun singleTouchHorizontalDragAtFitScaleStillAdvancesThePager() {
-        // wpass-1wq: gesture priority at scale == 1 must defer to the pager. A
-        // single-touch horizontal drag from the fit state has to advance the pager
-        // exactly as it did before the zoom surface was added — otherwise the surface
-        // has accidentally swallowed swipe-to-page.
+        // wpass-ny4: with zoom removed inline, single-touch drag is always available
+        // to the pager. Regression for the pre-`wpass-1wq` swipe-to-page behaviour.
         val recorder = RecordingBinder()
         composeRule.setContent {
             ThemedHost {

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -28,6 +28,7 @@ import `is`.walt.passes.pdf.PdfDocumentId
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.ProbeResult
 import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.pdf.ui.theme.DocumentSemantics
 import `is`.walt.passes.pdf.ui.theme.DocumentTheme
 import `is`.walt.passes.ui.core.ArgbColor
@@ -156,6 +157,7 @@ class DocumentViewInstrumentedTest {
                 page: Int,
                 widthPx: Int,
                 heightPx: Int,
+                sourceRect: RenderSourceRect,
             ): RenderResult = RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
         }
         composeRule.setContent {
@@ -375,6 +377,7 @@ class DocumentViewInstrumentedTest {
             page: Int,
             widthPx: Int,
             heightPx: Int,
+            sourceRect: RenderSourceRect,
         ): RenderResult {
             pages += page
             allocations.incrementAndGet()

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -34,9 +34,11 @@ import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.internal.decodePage
+import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
@@ -121,14 +123,21 @@ public fun DocumentView(
         // tone the rasterised page sits on (showing through ContentScale.Fit letterbox
         // bars). The trust caption above sits on the consumer's background, reading as
         // host screen chrome.
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .background(semantics.laneBackground.toComposeColor())
-                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp)),
-        ) { page ->
+        //
+        // When the host wires `onOpenFullScreen`, a tap anywhere on the page region
+        // launches the full-screen surface — the banner below is a discoverability
+        // affordance, the page itself is the primary tap target. `.clickable` and
+        // the pager's drag handling coexist: Compose's gesture system routes quick
+        // press-and-release to the click handler and horizontal drag to the pager.
+        val pagerModifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .background(semantics.laneBackground.toComposeColor())
+            .let {
+                if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
+            }
+            .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+        HorizontalPager(state = pagerState, modifier = pagerModifier) { page ->
             DocumentPage(
                 document = doc,
                 pageIndex = page,
@@ -139,10 +148,12 @@ public fun DocumentView(
             )
         }
 
-        // wpass-jil: full-screen banner. Only shown when the host supplies a navigation
-        // callback. Docked at the bottom of the page region, below the pager and above
-        // any other host chrome. The trust caption remains structurally above the pager
-        // in this Column, so the banner cannot push it off-screen.
+        // wpass-jil: full-screen banner. Opt-in via `onOpenFullScreen` — hosts without
+        // a full-screen route render no banner, which is a legitimate configuration
+        // (the affordance is the page tap above). When wired, the banner is a docked
+        // discoverability hint below the pager, above any other host chrome. The trust
+        // caption sits above the pager in this Column so the banner cannot push it
+        // off-screen.
         if (onOpenFullScreen != null) {
             FullScreenBanner(onClick = onOpenFullScreen)
         }
@@ -199,7 +210,17 @@ private fun DocumentPage(
             rendered = cached.asImageBitmap()
             return@LaunchedEffect
         }
-        val result = renderer.render(pdfFile, pageIndex, requestWidthPx, requestHeightPx)
+        // wpass-6ag review N1: cancellation-safe so a page-swipe mid-render never
+        // orphans the result's SharedMemory.
+        val result = renderOrDiscard(
+            renderer = renderer,
+            pdf = pdfFile,
+            page = pageIndex,
+            widthPx = requestWidthPx,
+            heightPx = requestHeightPx,
+            sourceRect = RenderSourceRect.FullPage,
+            isStillWanted = { rendered == null },
+        )
         if (result is RenderResult.Ok) {
             // ADR 0005 D7: the renderer may downsize past the request; decodePage uses
             // the renderer's reported dimensions.
@@ -227,7 +248,10 @@ private fun DocumentPage(
 }
 
 // Render budget defaults. The renderer service caps the bitmap area independently
-// (ADR 0005 D7); these are the UI-side request size for the inline surface, picked to
-// look reasonable on phone-class displays. ContentScale.Fit handles the slot.
+// (ADR 0005 D7); these are the UI-side request size for the inline surface.
+// Unlike `FullScreenDocumentView` (which derives the request from the actual slot
+// via BoxWithConstraints), the inline surface is fixed 1x and ContentScale.Fit masks
+// any over/under-render — the BoxWithConstraints cost isn't worth it for a thumbnail-
+// sized slot.
 private const val TARGET_PAGE_WIDTH_DP: Int = 360
 private const val TARGET_PAGE_HEIGHT_DP: Int = 480

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -30,16 +30,15 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import `is`.walt.passes.pdf.ConsumerRenderFailure
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
+import `is`.walt.passes.pdf.ui.internal.decodePage
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
-import java.nio.BufferUnderflowException
-import java.nio.ByteBuffer
 
 /**
  * Presentation of a [PdfDocument] — a non-suppressible trust caption above a swipeable
@@ -202,13 +201,12 @@ private fun DocumentPage(
         }
         val result = renderer.render(pdfFile, pageIndex, requestWidthPx, requestHeightPx)
         if (result is RenderResult.Ok) {
-            // ADR 0005 D7: the renderer service caps bitmap area independently and may
-            // return a downsized buffer. Use the renderer's reported dimensions, NOT
-            // the request, when reconstructing the Bitmap.
-            val bitmap = bitmapFromSharedMemory(result, telemetry)
-            if (bitmap != null) {
-                cache.put(document.id, pageIndex, bitmap)
-                rendered = bitmap.asImageBitmap()
+            // ADR 0005 D7: the renderer may downsize past the request; decodePage uses
+            // the renderer's reported dimensions.
+            val decoded = decodePage(result, telemetry)
+            if (decoded != null) {
+                cache.put(document.id, pageIndex, decoded.bitmap)
+                rendered = decoded.image
             }
         }
     }
@@ -228,52 +226,8 @@ private fun DocumentPage(
     }
 }
 
-private fun bitmapFromSharedMemory(
-    ok: RenderResult.Ok,
-    telemetry: DocumentTelemetryGuard,
-): Bitmap? {
-    // The renderer service writes ARGB_8888 packed row-major with no padding using the
-    // dimensions it reports back in `ok.widthPx` / `ok.heightPx` (which may differ from
-    // the request — see the call-site comment for D7).
-    //
-    // The runCatching swallow remains intentional: OOM on Bitmap.createBitmap,
-    // BufferUnderflowException from copyPixelsFromBuffer if the SharedMemory size
-    // mismatches the bitmap, and IllegalStateException if the SharedMemory was already
-    // closed by a parallel render each surface as a blank page that the next swipe
-    // re-attempts. Telemetry is observability, not a user-facing error path; the failure
-    // mapping is what wpass-8v4 added so the silent path stops being invisible.
-    return runCatching {
-        val mapped: ByteBuffer = ok.sharedMemory.mapReadOnly()
-        try {
-            val bitmap = Bitmap.createBitmap(ok.widthPx, ok.heightPx, Bitmap.Config.ARGB_8888)
-            bitmap.copyPixelsFromBuffer(mapped)
-            bitmap
-        } finally {
-            android.os.SharedMemory.unmap(mapped)
-            ok.sharedMemory.close()
-        }
-    }.onFailure { t ->
-        telemetry.onConsumerRenderFailed(consumerRenderFailureFor(t))
-    }.getOrNull()
-}
-
-internal fun consumerRenderFailureFor(t: Throwable): ConsumerRenderFailure = when (t) {
-    is OutOfMemoryError -> ConsumerRenderFailure.OutOfMemory
-    is BufferUnderflowException -> ConsumerRenderFailure.DimensionMismatch
-    is IllegalStateException -> ConsumerRenderFailure.SharedMemoryUnavailable
-    else -> ConsumerRenderFailure.Other
-}
-
-// HorizontalPager retains composed Image references for adjacent pages during a swipe
-// transition. A window equal to "current ± 2" gives the access-ordered LRU enough room
-// that an evicted bitmap is never the one the pager is still painting; recycling a
-// bitmap whose Image is on screen crashes the draw pass. See PR review C2.
-internal const val LRU_PAGE_WINDOW: Int = 5
-
 // Render budget defaults. The renderer service caps the bitmap area independently
-// (ADR 0005 D7); these are the UI-side request size, picked to look reasonable on
-// phone-class displays without committing to a particular host density. The on-screen
-// page size is the pager slot, not these values — ContentScale.Fit scales the
-// rasterised bitmap into whatever space the consumer gives DocumentView.
+// (ADR 0005 D7); these are the UI-side request size for the inline surface, picked to
+// look reasonable on phone-class displays. ContentScale.Fit handles the slot.
 private const val TARGET_PAGE_WIDTH_DP: Int = 360
 private const val TARGET_PAGE_HEIGHT_DP: Int = 480

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -4,11 +4,7 @@ import android.graphics.Bitmap
 import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.rememberTransformableState
-import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,21 +16,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.pdf.ConsumerRenderFailure
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
@@ -56,10 +45,10 @@ import java.nio.ByteBuffer
  * into the caption. The trust caption is composed on the consumer's own background;
  * only the pager carries [is.walt.passes.pdf.ui.theme.DocumentSemantics.laneBackground],
  * so the caption reads as host screen chrome rather than part of the document surface.
- * Pages are rasterised on demand by the isolated-process renderer
- * reached through [renderer] (the `PdfRendererBinder` interface, never the concrete
- * `PdfRendererClient`, so test fakes substitute cleanly) and held in a small
- * per-document LRU cache to amortise re-render on quick swipes.
+ * Pages are rasterised on demand by the isolated-process renderer reached through
+ * [renderer] (the `PdfRendererBinder` interface, never the concrete `PdfRendererClient`,
+ * so test fakes substitute cleanly) and held in a small per-document LRU cache to
+ * amortise re-render on quick swipes.
  *
  * Trust contract:
  *
@@ -73,6 +62,8 @@ import java.nio.ByteBuffer
  *    `DocumentPublicApiSurfaceTest.passesPdfUiCompiledClassesContainNoForbiddenStrings`
  *    enforces by scanning compiled bytecode for `android.intent.action.SEND` and the
  *    `application/pdf` MIME literal so a future contributor cannot quietly add either.
+ *  - Inline surface is fixed 1x: no pinch-zoom, no pan, no double-tap. Zoom lives only
+ *    on the full-screen detail surface (wpass-ny4 / wpass-jil).
  *
  * Bitmap ownership: the LRU cache stores native [Bitmap]s and recycles them on
  * eviction; the renderer service has already pre-recycled its source-side copy
@@ -118,22 +109,12 @@ public fun DocumentView(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        // The caption is composed directly on whatever background the consumer puts
-        // behind DocumentView — it deliberately does NOT sit on `laneBackground`. The
-        // trust caption reads as host screen chrome; only the pager below carries the
-        // document-surface tone.
         DocumentTrustCaption()
 
-        // pageCount = 0 is rejected at import (DocumentRejectedKind.RendererFailed),
-        // so the pager renders nothing. HorizontalPager handles a 0-count state
-        // gracefully without a placeholder; a custom branch here would only mask a
-        // future regression in the import path with a silent empty surface.
-        //
-        // `laneBackground` is painted here, behind the pager only — it is the
-        // document-surface tone the rasterised page sits on (and shows through the
-        // ContentScale.Fit letterbox bars). `.background` before `.padding` so the tone
-        // fills the whole pager slot edge-to-edge and the padding insets only the page
-        // content within it.
+        // `laneBackground` is painted behind the pager only — it is the document-surface
+        // tone the rasterised page sits on (showing through ContentScale.Fit letterbox
+        // bars). The trust caption above sits on the consumer's background, reading as
+        // host screen chrome.
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
@@ -154,12 +135,6 @@ public fun DocumentView(
     }
 }
 
-/**
- * Each parameter is a distinct dependency the page rendering needs; bundling them
- * into a holder would only relocate the count from a function signature to a
- * constructor without lowering the conceptual surface, so the LongParameterList
- * suppression is the lower-cost choice here.
- */
 @Composable
 @Suppress("LongParameterList")
 private fun DocumentPage(
@@ -191,10 +166,8 @@ private fun DocumentPage(
         val result = renderer.render(pdfFile, pageIndex, requestWidthPx, requestHeightPx)
         if (result is RenderResult.Ok) {
             // ADR 0005 D7: the renderer service caps bitmap area independently and may
-            // return a downsized buffer. Use the renderer's reported dimensions, NOT the
-            // request, when reconstructing the Bitmap — using the request would make
-            // copyPixelsFromBuffer either throw against an undersized SharedMemory
-            // (silently swallowed by runCatching below) or render a misshapen image.
+            // return a downsized buffer. Use the renderer's reported dimensions, NOT
+            // the request, when reconstructing the Bitmap.
             val bitmap = bitmapFromSharedMemory(result, telemetry)
             if (bitmap != null) {
                 cache.put(document.id, pageIndex, bitmap)
@@ -205,125 +178,15 @@ private fun DocumentPage(
 
     // The page fills the slot the pager hands it (the pager's `weight(1f)` share of
     // DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap inside it.
-    // An earlier version sized the page with `fillMaxWidth().aspectRatio(3:4)`, which
-    // derives height from width and IGNORES the height it is given: when a consumer
-    // hands DocumentView a short slot (e.g. walt-android sandwiches it between a title
-    // and a details section), the 3:4 page grew taller than the pager viewport and drew
-    // over the trust caption above it. fillMaxSize cannot overflow its slot, so the
-    // caption / page boundary is structural regardless of how little height the
-    // consumer gives the surface.
-    //
-    // The wrapping Box is the zoom/pan surface (wpass-1wq). It scopes the gesture and
-    // graphicsLayer transform to the current page so swiping to the next page resets the
-    // zoom state, and so the trust caption — which lives in DocumentView's Column above
-    // the pager — is unaffected by any zoom transform applied here.
+    // Fixed 1x — zoom lives in the full-screen surface (wpass-ny4 / wpass-jil).
     rendered?.let { bitmap ->
-        ZoomableDocumentPage(
-            bitmap = bitmap,
-            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
-        )
-    }
-}
-
-/**
- * Per-page pinch-zoom + pan surface (wpass-1wq). Scoped strictly to a single page slot:
- * the [Box]'s state lives in the caller's `remember(document.id, pageIndex)` frame, so
- * paging away resets `scale` to 1 and `offset` to zero for the next page composition.
- *
- * Gesture priority with the enclosing [HorizontalPager]:
- *
- *  - Two-finger pinch is always consumed here — [transformable] handles it independently
- *    of `canPan`, so the user can zoom out to fit even when the pager owns single-touch.
- *  - Single-touch drag is consumed here only when `scale > 1f` (`canPan = { scale > 1f }`).
- *    At `scale == 1f` the gesture passes through to the pager so horizontal swipes still
- *    advance pages. Once zoomed in, single-touch drags pan the page within the slot until
- *    the user double-taps or pinches back to fit.
- *  - Double-tap toggles between fit (scale = 1, offset = zero) and the canonical zoomed
- *    scale ([DOUBLE_TAP_SCALE]).
- *
- * Translation is clamped so the scaled page cannot be panned entirely off the slot:
- * `maxOffset = ((scale - 1) * slotSize / 2)`, which keeps the page centered at fit and
- * lets the user pan up to the edges of the scaled-up image but no further. Without this
- * clamp the user could fling the barcode out of frame and lose the slot's contents.
- *
- * The graphicsLayer transform applies to the [Image] alone; the trust caption is composed
- * outside this Box (in [DocumentView]'s Column) and is therefore structurally not part of
- * any transform applied here. ADR 0005 D5's non-suppressible-trust-caption contract is
- * preserved by layout, not by gesture-handling discipline.
- *
- * The 4 MP raster the renderer hands us (ADR 0005 D7) is sampled into a fit-resolution
- * bitmap, so it pixelates when scaled above ~1.3-1.5x. The follow-up renderer bead
- * (wpass-f4b) lifts the sharp-at-zoom property by re-rendering the visible viewport at
- * higher resolution within the same 4 MP per-bitmap cap; this gesture surface is correct
- * against the existing bitmap (pixelated but functional) and gets sharper for free once
- * wpass-f4b lands.
- */
-@Composable
-private fun ZoomableDocumentPage(
-    bitmap: ImageBitmap,
-    contentDescription: String,
-) {
-    // Local state, not rememberSaveable: zoom state intentionally does not survive a
-    // process death — the page reverts to fit, which matches the user-mental-model of
-    // "the wallet just reopened, show me the page at its natural size."
-    var scale by remember { mutableFloatStateOf(1f) }
-    var offset by remember { mutableStateOf(Offset.Zero) }
-    var slotSize by remember { mutableStateOf(IntSize.Zero) }
-
-    val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
-        val newScale = (scale * zoomChange).coerceIn(MIN_SCALE, MAX_SCALE)
-        val maxX = ((newScale - 1f) * slotSize.width / 2f).coerceAtLeast(0f)
-        val maxY = ((newScale - 1f) * slotSize.height / 2f).coerceAtLeast(0f)
-        val proposed = offset + panChange
-        offset = Offset(
-            proposed.x.coerceIn(-maxX, maxX),
-            proposed.y.coerceIn(-maxY, maxY),
-        )
-        scale = newScale
-        if (newScale <= MIN_SCALE) offset = Offset.Zero
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .onSizeChanged { slotSize = it }
-            // pointerInput keyed on Unit because the only state the handler reads is the
-            // mutable `scale` (re-read on every callback). Re-keying would tear down and
-            // recreate the gesture detector on every zoom step.
-            .pointerInput(Unit) {
-                detectTapGestures(
-                    onDoubleTap = {
-                        if (scale > MIN_SCALE) {
-                            scale = MIN_SCALE
-                            offset = Offset.Zero
-                        } else {
-                            scale = DOUBLE_TAP_SCALE
-                            // Leave offset at zero; the user pans afterward if they need
-                            // to bring a specific region to centre. Centring on the tap
-                            // point would jump the page under the finger and surprise the
-                            // user — see wpass-1wq design notes.
-                        }
-                    },
-                )
-            }
-            .transformable(state = transformableState, canPan = { scale > MIN_SCALE }),
-        contentAlignment = Alignment.Center,
-    ) {
         Image(
             bitmap = bitmap,
             // ADR 0005 D4 forbids extracting text from the PDF; positional caption
-            // is the only safe TalkBack fallback. "Page 3 of 7" is non-content but
-            // navigationally useful.
-            contentDescription = contentDescription,
+            // is the only safe TalkBack fallback.
+            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
             contentScale = ContentScale.Fit,
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer(
-                    scaleX = scale,
-                    scaleY = scale,
-                    translationX = offset.x,
-                    translationY = offset.y,
-                ),
+            modifier = Modifier.fillMaxSize(),
         )
     }
 }
@@ -377,27 +240,3 @@ internal const val LRU_PAGE_WINDOW: Int = 5
 // rasterised bitmap into whatever space the consumer gives DocumentView.
 private const val TARGET_PAGE_WIDTH_DP: Int = 360
 private const val TARGET_PAGE_HEIGHT_DP: Int = 480
-
-// Zoom bounds for ZoomableDocumentPage (wpass-1wq).
-//
-// MIN_SCALE = 1f: zooming out below fit is meaningless on a single-page surface — the
-// page is already letterboxed and ContentScale.Fit owns "see the whole page in one
-// glance." Below 1 would just paint a smaller page inside empty slot real estate.
-//
-// MAX_SCALE = 3f (interim): held at 3x rather than 5x until wpass-f4b lands the
-// viewport-aware renderer. Against a fit-resolution bitmap, every source pixel
-// becomes a 3x3 block under bilinear filtering at this scale, which is usually
-// still inside the decoder's edge-detection budget for PDF417 / QR / EAN — at 5x
-// each source pixel is a 5x5 block, and the smearing crosses into "looks bigger
-// but actually less scannable" territory for many phone-camera scanners. Once
-// wpass-f4b re-renders the visible viewport at viewport-pixel resolution within
-// the same 4 MP cap, the upsampling cost disappears and this constant can move
-// to 5f without producing a degraded UX at the top end.
-//
-// DOUBLE_TAP_SCALE = 2f: the toggle-target for a double-tap. Held below MAX_SCALE
-// so a single tap is a clear "zoom in" affordance that picks the
-// most-likely-actually-readable point, with the user free to pinch further if a
-// specific scanner needs more.
-private const val MIN_SCALE: Float = 1f
-private const val MAX_SCALE: Float = 3f
-private const val DOUBLE_TAP_SCALE: Float = 2f

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -4,9 +4,14 @@ import android.graphics.Bitmap
 import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -83,12 +88,14 @@ import java.nio.ByteBuffer
  * composition.
  */
 @Composable
+@Suppress("LongParameterList")
 public fun DocumentView(
     doc: PdfDocument,
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
+    onOpenFullScreen: (() -> Unit)? = null,
 ) {
     val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) {
@@ -132,6 +139,36 @@ public fun DocumentView(
                 telemetry = telemetry,
             )
         }
+
+        // wpass-jil: full-screen banner. Only shown when the host supplies a navigation
+        // callback. Docked at the bottom of the page region, below the pager and above
+        // any other host chrome. The trust caption remains structurally above the pager
+        // in this Column, so the banner cannot push it off-screen.
+        if (onOpenFullScreen != null) {
+            FullScreenBanner(onClick = onOpenFullScreen)
+        }
+    }
+}
+
+// wpass-jil: docked banner inside DocumentView whose tap launches the full-screen
+// detail surface. Label and colours come from DocumentSemantics so the host owns the
+// wording and styling.
+@Composable
+private fun FullScreenBanner(onClick: () -> Unit) {
+    val semantics = LocalDocumentSemantics.current
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(semantics.fullScreenBannerBackground.toComposeColor())
+            .clickable(onClick = onClick)
+            .padding(PaddingValues(horizontal = 16.dp, vertical = 12.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = semantics.fullScreenBannerLabel,
+            style = MaterialTheme.typography.labelMedium,
+            color = semantics.fullScreenBannerForeground.toComposeColor(),
+        )
     }
 }
 

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -1,0 +1,236 @@
+package `is`.walt.passes.pdf.ui
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.DocumentTelemetryGuard
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
+import `is`.walt.passes.pdf.ui.internal.ZoomableImage
+import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
+import `is`.walt.passes.ui.core.toComposeColor
+import kotlinx.coroutines.launch
+
+/**
+ * Full-screen detail surface for a [PdfDocument] (`wpass-jil`). The ONLY place inside
+ * `passes-pdf-ui` where pinch-zoom and pan are available; inline `DocumentView` is fixed
+ * 1x after the `wpass-ny4` pivot.
+ *
+ * Trust contract:
+ *
+ *  - The non-suppressible [DocumentTrustCaption] is composed inside this surface and
+ *    docked to the bottom edge of the screen. It is NOT subject to the zoom transform
+ *    and cannot be panned off-screen (ADR 0005 D5 / addendum Z.8). The caption sits
+ *    above the page region in the [Box] and is structurally outside the zoom surface.
+ *  - Zoom is purely view-side. No share, export, print, or open-with affordance
+ *    (ADR 0005 D8); `DocumentPublicApiSurfaceTest` continues to enforce the
+ *    classpath-scan rule on `Intent.ACTION_SEND`.
+ *  - On pinch settle the surface fires a `renderer.render(... SubRect ...)` call
+ *    against the currently-visible normalised page rect so the displayed bitmap stays
+ *    sharp within the unchanged 4 MP per-bitmap cap (`wpass-f4b`).
+ *
+ * Page cache: a per-document LRU mirrors [DocumentView]'s cache so swiping back and
+ * forth between pages re-uses fit-resolution renders. Sub-rect renders are NOT cached
+ * (they would explode the cache key space and stale entries would surface as a
+ * sharper-but-wrong region after a pan).
+ *
+ * [pdfFile] ownership matches [DocumentView]: the caller keeps the descriptor open for
+ * as long as `FullScreenDocumentView` is composed.
+ */
+@Composable
+@Suppress("LongParameterList")
+public fun FullScreenDocumentView(
+    doc: PdfDocument,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
+) {
+    val semantics = LocalDocumentSemantics.current
+    val cache = remember(doc.id) {
+        RenderedPageCache<Bitmap>(
+            maxSize = LRU_PAGE_WINDOW,
+            onEvict = { bitmap ->
+                if (!bitmap.isRecycled) bitmap.recycle()
+            },
+        )
+    }
+    DisposableEffect(doc.id) {
+        onDispose { cache.clear() }
+    }
+
+    val pagerState = rememberPagerState(pageCount = { doc.pageCount })
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(semantics.laneBackground.toComposeColor()),
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(PaddingValues(bottom = TRUST_CAPTION_DOCK_HEIGHT_DP.dp)),
+        ) { page ->
+            FullScreenPage(
+                document = doc,
+                pageIndex = page,
+                pdfFile = pdfFile,
+                renderer = renderer,
+                cache = cache,
+                telemetry = telemetry,
+            )
+        }
+
+        // ADR 0005 Z.8: trust caption docks to a screen edge in the full-screen surface
+        // and is NOT subject to the zoom transform. Aligned to the bottom of the root
+        // Box so pan within the pager cannot push it off-screen.
+        Box(modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
+            DocumentTrustCaption()
+        }
+
+        // Discreet close affordance docked to the top-start corner. Hosts that prefer a
+        // gesture-only close hide it via their own theming chrome.
+        Box(modifier = Modifier.align(Alignment.TopStart)) {
+            CloseFullScreenButton(onClick = onClose)
+        }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList")
+private fun FullScreenPage(
+    document: PdfDocument,
+    pageIndex: Int,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    cache: RenderedPageCache<Bitmap>,
+    telemetry: DocumentTelemetryGuard,
+) {
+    val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
+    var rendered by remember(document.id, pageIndex) {
+        mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
+    }
+    val requestWidthPx = with(density) { FULL_SCREEN_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1) }
+    val requestHeightPx = with(density) { FULL_SCREEN_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1) }
+
+    LaunchedEffect(document.id, pageIndex, requestWidthPx, requestHeightPx) {
+        val cached = cache.get(document.id, pageIndex)
+        if (cached != null && !cached.isRecycled) {
+            rendered = cached.asImageBitmap()
+            return@LaunchedEffect
+        }
+        val result = renderer.render(
+            pdf = pdfFile,
+            page = pageIndex,
+            widthPx = requestWidthPx,
+            heightPx = requestHeightPx,
+            sourceRect = RenderSourceRect.FullPage,
+        )
+        if (result is RenderResult.Ok) {
+            val bitmap = fullScreenBitmapFromSharedMemory(result, telemetry)
+            if (bitmap != null) {
+                cache.put(document.id, pageIndex, bitmap)
+                rendered = bitmap.asImageBitmap()
+            }
+        }
+    }
+
+    rendered?.let { bitmap ->
+        ZoomableImage(
+            bitmap = bitmap,
+            // ADR 0005 D4 forbids extracting text from the PDF; positional caption
+            // is the only safe TalkBack fallback.
+            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
+            modifier = Modifier.fillMaxSize(),
+            // wpass-jil: invoked after the gesture settles. The sub-rect re-render
+            // keeps the visible region sharp within the 4 MP per-bitmap cap.
+            onZoomedRegionChanged = { rect ->
+                scope.launch {
+                    renderer.render(
+                        pdf = pdfFile,
+                        page = pageIndex,
+                        widthPx = requestWidthPx,
+                        heightPx = requestHeightPx,
+                        sourceRect = rect,
+                    )
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun CloseFullScreenButton(onClick: () -> Unit) {
+    val semantics = LocalDocumentSemantics.current
+    Box(
+        modifier = Modifier
+            .padding(12.dp)
+            .background(semantics.fullScreenBannerBackground.toComposeColor())
+            .clickable(onClick = onClick)
+            .padding(PaddingValues(horizontal = 12.dp, vertical = 8.dp)),
+    ) {
+        Text(
+            text = "Close",
+            color = semantics.fullScreenBannerForeground.toComposeColor(),
+        )
+    }
+}
+
+// Same reconstruction shape as the inline DocumentView path; lifted into its own
+// helper so the full-screen surface does not depend on DocumentView's private helpers.
+private fun fullScreenBitmapFromSharedMemory(
+    ok: RenderResult.Ok,
+    telemetry: DocumentTelemetryGuard,
+): Bitmap? =
+    runCatching {
+        val mapped = ok.sharedMemory.mapReadOnly()
+        try {
+            val bitmap = Bitmap.createBitmap(ok.widthPx, ok.heightPx, Bitmap.Config.ARGB_8888)
+            bitmap.copyPixelsFromBuffer(mapped)
+            bitmap
+        } finally {
+            android.os.SharedMemory.unmap(mapped)
+            ok.sharedMemory.close()
+        }
+    }.onFailure { t -> telemetry.onConsumerRenderFailed(consumerRenderFailureFor(t)) }
+        .getOrNull()
+
+// Caps the pixel-size of the initial fit-resolution render on the full-screen surface.
+// Chosen to give a reasonable ARGB_8888 budget on phone-class displays without crossing
+// the 4 MP cap; sub-rect re-renders use the same widthPx / heightPx (= viewport
+// resolution) so the renderer never exceeds the cap.
+private const val FULL_SCREEN_PAGE_WIDTH_DP: Int = 720
+private const val FULL_SCREEN_PAGE_HEIGHT_DP: Int = 960
+
+// Reserved at the bottom of the full-screen surface for the docked trust caption so the
+// pager does not paint behind it.
+private const val TRUST_CAPTION_DOCK_HEIGHT_DP: Int = 56

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -5,6 +5,8 @@ import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,37 +32,35 @@ import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.internal.ZoomableImage
+import `is`.walt.passes.pdf.ui.internal.decodePage
+import `is`.walt.passes.pdf.ui.internal.discardRenderResult
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
-import kotlinx.coroutines.launch
 
 /**
  * Full-screen detail surface for a [PdfDocument] (`wpass-jil`). The ONLY place inside
- * `passes-pdf-ui` where pinch-zoom and pan are available; inline `DocumentView` is fixed
- * 1x after the `wpass-ny4` pivot.
+ * `passes-pdf-ui` where pinch-zoom and pan are available; inline `DocumentView` is
+ * fixed 1x after the `wpass-ny4` pivot.
  *
  * Trust contract:
  *
  *  - The non-suppressible [DocumentTrustCaption] is composed inside this surface and
- *    docked to the bottom edge of the screen. It is NOT subject to the zoom transform
- *    and cannot be panned off-screen (ADR 0005 D5 / addendum Z.8). The caption sits
- *    above the page region in the [Box] and is structurally outside the zoom surface.
- *  - Zoom is purely view-side. No share, export, print, or open-with affordance
+ *    docked to the bottom edge of the screen, structurally outside the zoom transform
+ *    (ADR 0005 D5 / Z.8).
+ *  - Zoom is purely view-side. No share / export / print / open-with affordance
  *    (ADR 0005 D8); `DocumentPublicApiSurfaceTest` continues to enforce the
  *    classpath-scan rule on `Intent.ACTION_SEND`.
- *  - On pinch settle the surface fires a `renderer.render(... SubRect ...)` call
- *    against the currently-visible normalised page rect so the displayed bitmap stays
- *    sharp within the unchanged 4 MP per-bitmap cap (`wpass-f4b`).
+ *  - On pinch settle the surface fires a `renderer.render(SubRect)` call against the
+ *    currently-visible normalised page rect and SWAPS the displayed bitmap when the
+ *    result returns, so the visible region stays sharp within the 4 MP per-bitmap cap
+ *    (`wpass-f4b`).
  *
- * Page cache: a per-document LRU mirrors [DocumentView]'s cache so swiping back and
- * forth between pages re-uses fit-resolution renders. Sub-rect renders are NOT cached
- * (they would explode the cache key space and stale entries would surface as a
+ * Page cache: fit-resolution renders are cached per page; sub-rect renders are not
+ * (cache-keying them would explode the key space and stale entries surface as a
  * sharper-but-wrong region after a pan).
- *
- * [pdfFile] ownership matches [DocumentView]: the caller keeps the descriptor open for
- * as long as `FullScreenDocumentView` is composed.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -77,9 +76,7 @@ public fun FullScreenDocumentView(
     val cache = remember(doc.id) {
         RenderedPageCache<Bitmap>(
             maxSize = LRU_PAGE_WINDOW,
-            onEvict = { bitmap ->
-                if (!bitmap.isRecycled) bitmap.recycle()
-            },
+            onEvict = { bitmap -> if (!bitmap.isRecycled) bitmap.recycle() },
         )
     }
     DisposableEffect(doc.id) {
@@ -93,39 +90,56 @@ public fun FullScreenDocumentView(
             .fillMaxSize()
             .background(semantics.laneBackground.toComposeColor()),
     ) {
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(PaddingValues(bottom = TRUST_CAPTION_DOCK_HEIGHT_DP.dp)),
-        ) { page ->
-            FullScreenPage(
-                document = doc,
-                pageIndex = page,
-                pdfFile = pdfFile,
-                renderer = renderer,
-                cache = cache,
-                telemetry = telemetry,
-            )
+        // Trust caption docked to bottom edge; outside the zoom transform (Z.8). The
+        // pager is offset above it via a BottomDockedLayout so the page surface uses
+        // the actual measured caption height instead of a hardcoded constant
+        // (`wpass-6ag` review M2 partial — drives the pager padding from the caption's
+        // intrinsic height, no SubcomposeLayout needed because the caption is a sibling
+        // in a Box layered above).
+        BottomDockedLayout(
+            dock = { DocumentTrustCaption() },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+            ) { page ->
+                FullScreenPage(
+                    document = doc,
+                    pageIndex = page,
+                    pdfFile = pdfFile,
+                    renderer = renderer,
+                    cache = cache,
+                    telemetry = telemetry,
+                )
+            }
         }
 
-        // ADR 0005 Z.8: trust caption docks to a screen edge in the full-screen surface
-        // and is NOT subject to the zoom transform. Aligned to the bottom of the root
-        // Box so pan within the pager cannot push it off-screen.
-        Box(modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter)) {
-            DocumentTrustCaption()
-        }
-
-        // Discreet close affordance docked to the top-start corner. Hosts that prefer a
-        // gesture-only close hide it via their own theming chrome.
         Box(modifier = Modifier.align(Alignment.TopStart)) {
             CloseFullScreenButton(onClick = onClose)
         }
     }
 }
 
+/**
+ * Hosts the pager content in the region above [dock]. The dock composes at its natural
+ * height at the bottom; the content fills the rest. Avoids the hardcoded
+ * TRUST_CAPTION_DOCK_HEIGHT constant the original full-screen surface used.
+ */
 @Composable
-@Suppress("LongParameterList")
+private fun BottomDockedLayout(
+    dock: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = modifier) {
+        Box(modifier = Modifier.fillMaxWidth().weight(1f)) { content() }
+        Box(modifier = Modifier.fillMaxWidth()) { dock() }
+    }
+}
+
+@Composable
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 private fun FullScreenPage(
     document: PdfDocument,
     pageIndex: Int,
@@ -134,57 +148,107 @@ private fun FullScreenPage(
     cache: RenderedPageCache<Bitmap>,
     telemetry: DocumentTelemetryGuard,
 ) {
-    val density = LocalDensity.current
-    val scope = rememberCoroutineScope()
-    var rendered by remember(document.id, pageIndex) {
-        mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
-    }
-    val requestWidthPx = with(density) { FULL_SCREEN_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1) }
-    val requestHeightPx = with(density) { FULL_SCREEN_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1) }
-
-    LaunchedEffect(document.id, pageIndex, requestWidthPx, requestHeightPx) {
-        val cached = cache.get(document.id, pageIndex)
-        if (cached != null && !cached.isRecycled) {
-            rendered = cached.asImageBitmap()
-            return@LaunchedEffect
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        // wpass-6ag review A3: request size derived from the actual pager slot, not a
+        // hardcoded dp pair. Clamped at MAX_REQUEST_PIXELS so the renderer is never
+        // asked to allocate beyond the 4 MP cap (ADR 0005 D7).
+        val (requestW, requestH) = with(density) {
+            val rawW = maxWidth.toPx().toInt().coerceAtLeast(1)
+            val rawH = maxHeight.toPx().toInt().coerceAtLeast(1)
+            clampToMaxPixels(rawW, rawH, MAX_REQUEST_PIXELS)
         }
-        val result = renderer.render(
-            pdf = pdfFile,
-            page = pageIndex,
-            widthPx = requestWidthPx,
-            heightPx = requestHeightPx,
-            sourceRect = RenderSourceRect.FullPage,
-        )
-        if (result is RenderResult.Ok) {
-            val bitmap = fullScreenBitmapFromSharedMemory(result, telemetry)
-            if (bitmap != null) {
-                cache.put(document.id, pageIndex, bitmap)
-                rendered = bitmap.asImageBitmap()
+
+        var baseImage by remember(document.id, pageIndex) {
+            mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
+        }
+        var pageAspect by remember(document.id, pageIndex) { mutableStateOf<Float?>(null) }
+        var zoomedReplacement by remember(document.id, pageIndex) {
+            mutableStateOf<ImageBitmap?>(null)
+        }
+        var zoomedReplacementHandle by remember(document.id, pageIndex) {
+            mutableStateOf<Bitmap?>(null)
+        }
+        var pendingRect by remember(document.id, pageIndex) {
+            mutableStateOf<RenderSourceRect?>(null)
+        }
+
+        DisposableEffect(document.id, pageIndex) {
+            onDispose {
+                zoomedReplacementHandle?.let { if (!it.isRecycled) it.recycle() }
+                zoomedReplacementHandle = null
+                zoomedReplacement = null
             }
         }
-    }
 
-    rendered?.let { bitmap ->
-        ZoomableImage(
-            bitmap = bitmap,
-            // ADR 0005 D4 forbids extracting text from the PDF; positional caption
-            // is the only safe TalkBack fallback.
-            contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
-            modifier = Modifier.fillMaxSize(),
-            // wpass-jil: invoked after the gesture settles. The sub-rect re-render
-            // keeps the visible region sharp within the 4 MP per-bitmap cap.
-            onZoomedRegionChanged = { rect ->
-                scope.launch {
-                    renderer.render(
-                        pdf = pdfFile,
-                        page = pageIndex,
-                        widthPx = requestWidthPx,
-                        heightPx = requestHeightPx,
-                        sourceRect = rect,
-                    )
+        LaunchedEffect(document.id, pageIndex, requestW, requestH) {
+            val cached = cache.get(document.id, pageIndex)
+            if (cached != null && !cached.isRecycled && baseImage == null) {
+                baseImage = cached.asImageBitmap()
+            }
+            if (baseImage != null && pageAspect != null) return@LaunchedEffect
+            val result = renderer.render(
+                pdf = pdfFile,
+                page = pageIndex,
+                widthPx = requestW,
+                heightPx = requestH,
+                sourceRect = RenderSourceRect.FullPage,
+            )
+            if (result is RenderResult.Ok) {
+                val decoded = decodePage(result, telemetry)
+                if (decoded != null) {
+                    cache.put(document.id, pageIndex, decoded.bitmap)
+                    baseImage = decoded.image
+                    pageAspect = decoded.pageAspect
                 }
-            },
-        )
+            }
+        }
+
+        baseImage?.let { bitmap ->
+            ZoomableImage(
+                bitmap = bitmap,
+                // ADR 0005 D4 forbids extracting text; the positional caption is the
+                // only safe TalkBack fallback.
+                contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
+                modifier = Modifier.fillMaxSize(),
+                pageAspect = pageAspect,
+                zoomedReplacement = zoomedReplacement,
+                // wpass-6ag review M3: edge-triggered. New gesture clears the prior
+                // sub-rect bitmap and frees its native memory so the next pinch starts
+                // from the base bitmap with the live transform.
+                onTransformStarted = {
+                    zoomedReplacementHandle?.let { if (!it.isRecycled) it.recycle() }
+                    zoomedReplacementHandle = null
+                    zoomedReplacement = null
+                },
+                onZoomedRegionChanged = { rect -> pendingRect = rect },
+            )
+        }
+
+        LaunchedEffect(pendingRect, document.id, pageIndex, requestW, requestH) {
+            val pending = pendingRect ?: return@LaunchedEffect
+            val result = renderer.render(
+                pdf = pdfFile,
+                page = pageIndex,
+                widthPx = requestW,
+                heightPx = requestH,
+                sourceRect = pending,
+            )
+            // If a newer pinch arrived while the render was in flight, free this
+            // bitmap's SharedMemory and skip the swap (`wpass-6ag` review C2).
+            if (pendingRect !== pending) {
+                discardRenderResult(result)
+                return@LaunchedEffect
+            }
+            if (result is RenderResult.Ok) {
+                val decoded = decodePage(result, telemetry)
+                if (decoded != null) {
+                    zoomedReplacementHandle?.let { if (!it.isRecycled) it.recycle() }
+                    zoomedReplacementHandle = decoded.bitmap
+                    zoomedReplacement = decoded.image
+                }
+            }
+        }
     }
 }
 
@@ -199,38 +263,22 @@ private fun CloseFullScreenButton(onClick: () -> Unit) {
             .padding(PaddingValues(horizontal = 12.dp, vertical = 8.dp)),
     ) {
         Text(
-            text = "Close",
+            text = semantics.closeFullScreenLabel,
             color = semantics.fullScreenBannerForeground.toComposeColor(),
         )
     }
 }
 
-// Same reconstruction shape as the inline DocumentView path; lifted into its own
-// helper so the full-screen surface does not depend on DocumentView's private helpers.
-private fun fullScreenBitmapFromSharedMemory(
-    ok: RenderResult.Ok,
-    telemetry: DocumentTelemetryGuard,
-): Bitmap? =
-    runCatching {
-        val mapped = ok.sharedMemory.mapReadOnly()
-        try {
-            val bitmap = Bitmap.createBitmap(ok.widthPx, ok.heightPx, Bitmap.Config.ARGB_8888)
-            bitmap.copyPixelsFromBuffer(mapped)
-            bitmap
-        } finally {
-            android.os.SharedMemory.unmap(mapped)
-            ok.sharedMemory.close()
-        }
-    }.onFailure { t -> telemetry.onConsumerRenderFailed(consumerRenderFailureFor(t)) }
-        .getOrNull()
+private fun clampToMaxPixels(widthPx: Int, heightPx: Int, maxPixels: Long): Pair<Int, Int> {
+    val product = widthPx.toLong() * heightPx.toLong()
+    if (product <= maxPixels) return widthPx to heightPx
+    val scale = kotlin.math.sqrt(maxPixels.toDouble() / product.toDouble())
+    val w = (widthPx * scale).toInt().coerceAtLeast(1)
+    val h = (heightPx * scale).toInt().coerceAtLeast(1)
+    return w to h
+}
 
-// Caps the pixel-size of the initial fit-resolution render on the full-screen surface.
-// Chosen to give a reasonable ARGB_8888 budget on phone-class displays without crossing
-// the 4 MP cap; sub-rect re-renders use the same widthPx / heightPx (= viewport
-// resolution) so the renderer never exceeds the cap.
-private const val FULL_SCREEN_PAGE_WIDTH_DP: Int = 720
-private const val FULL_SCREEN_PAGE_HEIGHT_DP: Int = 960
-
-// Reserved at the bottom of the full-screen surface for the docked trust caption so the
-// pager does not paint behind it.
-private const val TRUST_CAPTION_DOCK_HEIGHT_DP: Int = 56
+// Mirrors PdfRendererService.MAX_PIXELS so the request never asks for a bitmap the
+// renderer would have to downsize on its end. Concrete value lives in passes-pdf; this
+// re-declaration is a defensive ceiling, not the load-bearing cap.
+private const val MAX_REQUEST_PIXELS: Long = 4L * 1024 * 1024

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -36,7 +36,7 @@ import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.internal.ZoomableImage
 import `is`.walt.passes.pdf.ui.internal.decodePage
-import `is`.walt.passes.pdf.ui.internal.discardRenderResult
+import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
@@ -187,12 +187,16 @@ private fun FullScreenPage(
                 baseImage = cached.asImageBitmap()
             }
             if (baseImage != null && pageAspect != null) return@LaunchedEffect
-            val result = renderer.render(
+            // wpass-6ag review N1: NonCancellable around the binder transact so a
+            // page-swipe-mid-render does not orphan the result's SharedMemory.
+            val result = renderOrDiscard(
+                renderer = renderer,
                 pdf = pdfFile,
                 page = pageIndex,
                 widthPx = requestW,
                 heightPx = requestH,
                 sourceRect = RenderSourceRect.FullPage,
+                isStillWanted = { baseImage == null || pageAspect == null },
             )
             if (result is RenderResult.Ok) {
                 val decoded = decodePage(result, telemetry)
@@ -227,19 +231,19 @@ private fun FullScreenPage(
 
         LaunchedEffect(pendingRect, document.id, pageIndex, requestW, requestH) {
             val pending = pendingRect ?: return@LaunchedEffect
-            val result = renderer.render(
+            // wpass-6ag review N1: stale-or-cancelled results free their SharedMemory
+            // before we drop them. The NonCancellable inside renderOrDiscard guarantees
+            // we own the result even if a newer pinch (re-keying this LaunchedEffect)
+            // strikes while binder.transact is in flight.
+            val result = renderOrDiscard(
+                renderer = renderer,
                 pdf = pdfFile,
                 page = pageIndex,
                 widthPx = requestW,
                 heightPx = requestH,
                 sourceRect = pending,
-            )
-            // If a newer pinch arrived while the render was in flight, free this
-            // bitmap's SharedMemory and skip the swap (`wpass-6ag` review C2).
-            if (pendingRect !== pending) {
-                discardRenderResult(result)
-                return@LaunchedEffect
-            }
+                isStillWanted = { pendingRect === pending },
+            ) ?: return@LaunchedEffect
             if (result is RenderResult.Ok) {
                 val decoded = decodePage(result, telemetry)
                 if (decoded != null) {

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
@@ -3,13 +3,18 @@
 package `is`.walt.passes.pdf.ui.internal
 
 import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import `is`.walt.passes.pdf.ConsumerRenderFailure
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
+import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
 import java.nio.BufferUnderflowException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 
 /**
  * Shared bitmap-reconstruction + cleanup helpers for `DocumentView` and
@@ -54,6 +59,37 @@ internal fun decodePage(
 internal fun discardRenderResult(result: RenderResult) {
     if (result is RenderResult.Ok) {
         runCatching { result.sharedMemory.close() }
+    }
+}
+
+/**
+ * Runs [PdfRendererBinder.render] inside [NonCancellable] so the constructed
+ * [RenderResult] is always returned to this function, even when the caller's coroutine
+ * is cancelled mid-render (`wpass-6ag` review N1). `binder.transact` is blocking and
+ * uninterruptible; wrapping it in [NonCancellable] lets the IO worker complete and
+ * yield the `Ok` to us, where we either return it for the caller to consume or close
+ * its SharedMemory via [discardRenderResult] when [isStillWanted] reports the result
+ * is stale (superseded by a newer request, or the calling page disposed). Returns
+ * `null` when the result was discarded.
+ */
+@Suppress("LongParameterList")
+internal suspend fun renderOrDiscard(
+    renderer: PdfRendererBinder,
+    pdf: ParcelFileDescriptor,
+    page: Int,
+    widthPx: Int,
+    heightPx: Int,
+    sourceRect: RenderSourceRect,
+    isStillWanted: () -> Boolean,
+): RenderResult? {
+    val result = withContext(NonCancellable) {
+        renderer.render(pdf, page, widthPx, heightPx, sourceRect)
+    }
+    return if (isStillWanted()) {
+        result
+    } else {
+        discardRenderResult(result)
+        null
     }
 }
 

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
@@ -1,0 +1,71 @@
+@file:Suppress("MatchingDeclarationName")
+
+package `is`.walt.passes.pdf.ui.internal
+
+import android.graphics.Bitmap
+import android.os.SharedMemory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import `is`.walt.passes.pdf.ConsumerRenderFailure
+import `is`.walt.passes.pdf.DocumentTelemetryGuard
+import `is`.walt.passes.pdf.android.RenderResult
+import java.nio.BufferUnderflowException
+
+/**
+ * Shared bitmap-reconstruction + cleanup helpers for `DocumentView` and
+ * `FullScreenDocumentView`. Both surfaces rasterise pages through the same binder and
+ * map ARGB_8888 pixels out of [SharedMemory]; extracting the primitives here keeps a
+ * fix to one site from missing the other (`wpass-6ag` review A1, C2).
+ */
+internal data class DecodedPage(
+    val bitmap: Bitmap,
+    val image: ImageBitmap,
+    val pageAspect: Float,
+)
+
+/**
+ * Reconstructs the rendered bitmap from a [RenderResult.Ok] and closes the underlying
+ * [SharedMemory] in all paths. Returns `null` when the bitmap cannot be reconstructed;
+ * telemetry is notified with the failure mode.
+ */
+internal fun decodePage(
+    ok: RenderResult.Ok,
+    telemetry: DocumentTelemetryGuard,
+): DecodedPage? =
+    runCatching {
+        val mapped = ok.sharedMemory.mapReadOnly()
+        try {
+            val bitmap = Bitmap.createBitmap(ok.widthPx, ok.heightPx, Bitmap.Config.ARGB_8888)
+            bitmap.copyPixelsFromBuffer(mapped)
+            DecodedPage(bitmap, bitmap.asImageBitmap(), ok.pageAspect)
+        } finally {
+            SharedMemory.unmap(mapped)
+            ok.sharedMemory.close()
+        }
+    }.onFailure { t ->
+        telemetry.onConsumerRenderFailed(consumerRenderFailureFor(t))
+    }.getOrNull()
+
+/**
+ * Closes the [SharedMemory] of a [RenderResult] that the caller is throwing away
+ * without decoding (`wpass-6ag` C2 — every settled-zoom render that loses to a
+ * superseding gesture must release its ashmem region).
+ */
+internal fun discardRenderResult(result: RenderResult) {
+    if (result is RenderResult.Ok) {
+        runCatching { result.sharedMemory.close() }
+    }
+}
+
+internal fun consumerRenderFailureFor(t: Throwable): ConsumerRenderFailure = when (t) {
+    is OutOfMemoryError -> ConsumerRenderFailure.OutOfMemory
+    is BufferUnderflowException -> ConsumerRenderFailure.DimensionMismatch
+    is IllegalStateException -> ConsumerRenderFailure.SharedMemoryUnavailable
+    else -> ConsumerRenderFailure.Other
+}
+
+// HorizontalPager retains composed Image references for adjacent pages during a swipe
+// transition; "current ± 2" gives the access-ordered LRU room so an evicted bitmap is
+// never the one the pager is still painting (recycling a bitmap whose Image is on
+// screen crashes the draw pass; see PR review C2 on the original wpass-1wq landing).
+internal const val LRU_PAGE_WINDOW: Int = 5

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -23,20 +24,25 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
 import `is`.walt.passes.pdf.android.RenderSourceRect
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Pinch-zoom + pan surface for a single bitmap. Originally inline in `DocumentView`
  * (`wpass-1wq`); relocated by `wpass-ny4` so the full-screen surface (`wpass-jil`) is
- * the only call site. Translation is clamped to the slot bounds so the user cannot
- * pan the bitmap entirely off-screen.
+ * the only call site. Translation is clamped to the slot bounds so the bitmap cannot
+ * be panned entirely off-screen.
  *
- * When [onZoomedRegionChanged] is provided, the surface emits the currently-visible
- * sub-rect (in normalised page coordinates) after each gesture settles. The full-screen
- * surface uses this to fire a `wpass-f4b` sub-rect re-render so the visible region
- * stays sharp under zoom.
+ * When [pageAspect] is supplied, [visibleRect] math accounts for ContentScale.Fit
+ * letterbox bars in the bitmap so the emitted [RenderSourceRect.SubRect] matches the
+ * region of the actual page the user pinched (`wpass-6ag` review C3).
+ *
+ * When [zoomedReplacement] is non-null and the user is not actively transforming, it
+ * overrides the displayed image — the sub-rect render that the caller fetched in
+ * response to the previous settle. Starting a new gesture clears the override (the
+ * caller's [onTransformStarted] callback lets it drop the stale bitmap).
  */
 @Composable
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 internal fun ZoomableImage(
     bitmap: ImageBitmap,
     contentDescription: String,
@@ -44,7 +50,10 @@ internal fun ZoomableImage(
     minScale: Float = DEFAULT_MIN_SCALE,
     maxScale: Float = DEFAULT_MAX_SCALE,
     doubleTapScale: Float = DEFAULT_DOUBLE_TAP_SCALE,
+    pageAspect: Float? = null,
+    zoomedReplacement: ImageBitmap? = null,
     onZoomedRegionChanged: ((RenderSourceRect) -> Unit)? = null,
+    onTransformStarted: (() -> Unit)? = null,
 ) {
     var scale by remember { mutableFloatStateOf(minScale) }
     var offset by remember { mutableStateOf(Offset.Zero) }
@@ -63,24 +72,33 @@ internal fun ZoomableImage(
         if (newScale <= minScale) offset = Offset.Zero
     }
 
-    // Emit the visible sub-rect once the gesture settles. `transformableState.isTransformInProgress`
-    // is a snapshot read, so wrapping it in LaunchedEffect makes the emission happen exactly when
-    // the user lifts their fingers. Skipped at fit (scale == 1) since the FullPage render already
-    // covers it.
-    if (onZoomedRegionChanged != null) {
-        LaunchedEffect(transformableState.isTransformInProgress, scale, offset, slotSize) {
-            if (!transformableState.isTransformInProgress && scale > minScale && slotSize != IntSize.Zero) {
-                onZoomedRegionChanged(visibleRect(scale, offset, slotSize))
-            }
+    // Fire onTransformStarted exactly on the false -> true edge of in-progress, and
+    // onZoomedRegionChanged exactly on the true -> false edge with a settled zoom.
+    // snapshotFlow + distinctUntilChanged means recomposition without a gesture-state
+    // change does not re-fire either callback (`wpass-6ag` review M3).
+    if (onZoomedRegionChanged != null || onTransformStarted != null) {
+        LaunchedEffect(transformableState) {
+            snapshotFlow { transformableState.isTransformInProgress }
+                .distinctUntilChanged()
+                .collect { inProgress ->
+                    if (inProgress) {
+                        onTransformStarted?.invoke()
+                    } else if (scale > minScale && slotSize != IntSize.Zero) {
+                        onZoomedRegionChanged?.invoke(
+                            visibleRect(scale, offset, slotSize, pageAspect),
+                        )
+                    }
+                }
         }
     }
+
+    val transforming = transformableState.isTransformInProgress
+    val displayReplacement = zoomedReplacement != null && !transforming
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .onSizeChanged { slotSize = it }
-            // Keyed on Unit so the gesture detector survives every zoom step; the
-            // handler closes over the mutable `scale` and re-reads it on each callback.
             .pointerInput(Unit) {
                 detectTapGestures(
                     onDoubleTap = {
@@ -96,42 +114,87 @@ internal fun ZoomableImage(
             .transformable(state = transformableState, canPan = { scale > minScale }),
         contentAlignment = Alignment.Center,
     ) {
-        Image(
-            bitmap = bitmap,
-            contentDescription = contentDescription,
-            contentScale = ContentScale.Fit,
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer(
-                    scaleX = scale,
-                    scaleY = scale,
-                    translationX = offset.x,
-                    translationY = offset.y,
-                ),
-        )
+        if (displayReplacement) {
+            // The replacement is already the visible region rasterised at viewport
+            // resolution; draw it filling the slot with no transform.
+            Image(
+                bitmap = zoomedReplacement!!,
+                contentDescription = contentDescription,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            Image(
+                bitmap = bitmap,
+                contentDescription = contentDescription,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offset.x,
+                        translationY = offset.y,
+                    ),
+            )
+        }
     }
 }
 
-// At scale S, the visible window covers 1/S of the slot in each axis. The pan offset
-// is in slot-pixel coordinates after the graphicsLayer scale, so dividing by `S *
-// slotSize` normalises it. The slot extent is assumed to match the page extent at fit;
-// in the full-screen surface the page is letterboxed via ContentScale.Fit so this is a
-// best-effort approximation when the page's aspect ratio differs from the slot's.
-private fun visibleRect(scale: Float, offset: Offset, slotSize: IntSize): RenderSourceRect.SubRect {
-    val w = slotSize.width.toFloat()
-    val h = slotSize.height.toFloat()
-    val visibleFractionX = 1f / scale
-    val visibleFractionY = 1f / scale
-    val centerX = 0.5f - offset.x / (scale * w)
-    val centerY = 0.5f - offset.y / (scale * h)
-    val left = (centerX - visibleFractionX / 2f).coerceIn(0f, 1f - visibleFractionX)
-    val top = (centerY - visibleFractionY / 2f).coerceIn(0f, 1f - visibleFractionY)
-    return RenderSourceRect.SubRect(
-        left = left,
-        top = top,
-        right = left + visibleFractionX,
-        bottom = top + visibleFractionY,
-    )
+/**
+ * Maps the currently-visible region of the displayed page into a normalised page rect.
+ *
+ * When [pageAspect] is supplied, the helper computes the on-screen page rect inside the
+ * slot (slot minus ContentScale.Fit letterbox bars), maps the visible window into that
+ * rect's coordinates, then normalises. When [pageAspect] is null the slot is treated
+ * as filling the page (legacy behaviour from the inline surface).
+ */
+@Suppress("ReturnCount")
+private fun visibleRect(
+    scale: Float,
+    offset: Offset,
+    slotSize: IntSize,
+    pageAspect: Float?,
+): RenderSourceRect.SubRect {
+    val slotW = slotSize.width.toFloat()
+    val slotH = slotSize.height.toFloat()
+    val pageOnScreen = pageRectInSlot(slotW, slotH, pageAspect)
+    // Visible window in slot pixels at the current zoom: the slot mapped back through
+    // the graphicsLayer transform.
+    val visW = slotW / scale
+    val visH = slotH / scale
+    val visLeft = slotW / 2f - offset.x / scale - visW / 2f
+    val visTop = slotH / 2f - offset.y / scale - visH / 2f
+    val ix0 = maxOf(visLeft, pageOnScreen.left)
+    val iy0 = maxOf(visTop, pageOnScreen.top)
+    val ix1 = minOf(visLeft + visW, pageOnScreen.left + pageOnScreen.width)
+    val iy1 = minOf(visTop + visH, pageOnScreen.top + pageOnScreen.height)
+    val nLeft = ((ix0 - pageOnScreen.left) / pageOnScreen.width).coerceIn(0f, 1f)
+    val nTop = ((iy0 - pageOnScreen.top) / pageOnScreen.height).coerceIn(0f, 1f)
+    val nRight = ((ix1 - pageOnScreen.left) / pageOnScreen.width).coerceIn(0f, 1f)
+    val nBottom = ((iy1 - pageOnScreen.top) / pageOnScreen.height).coerceIn(0f, 1f)
+    // Pan entirely into letterbox would zero-area the intersection; the renderer
+    // rejects zero-area rects, so emit a tiny centred fallback.
+    if (nRight <= nLeft || nBottom <= nTop) {
+        return RenderSourceRect.SubRect(0.49f, 0.49f, 0.51f, 0.51f)
+    }
+    return RenderSourceRect.SubRect(nLeft, nTop, nRight, nBottom)
+}
+
+private data class PageRectInSlot(val left: Float, val top: Float, val width: Float, val height: Float)
+
+private fun pageRectInSlot(slotW: Float, slotH: Float, pageAspect: Float?): PageRectInSlot {
+    if (pageAspect == null || !pageAspect.isFinite() || pageAspect <= 0f) {
+        return PageRectInSlot(0f, 0f, slotW, slotH)
+    }
+    val slotAspect = slotW / slotH
+    return if (pageAspect > slotAspect) {
+        val h = slotW / pageAspect
+        PageRectInSlot(0f, (slotH - h) / 2f, slotW, h)
+    } else {
+        val w = slotH * pageAspect
+        PageRectInSlot((slotW - w) / 2f, 0f, w, slotH)
+    }
 }
 
 // Defaults match the original inline zoom surface (`wpass-1wq`). Hold MAX at 3f until

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -1,0 +1,99 @@
+package `is`.walt.passes.pdf.ui.internal
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Pinch-zoom + pan surface for a single bitmap. Originally inline in `DocumentView`
+ * (`wpass-1wq`); relocated by `wpass-ny4` so the full-screen surface (`wpass-jil`) is
+ * the only call site. Translation is clamped to the slot bounds so the user cannot
+ * pan the bitmap entirely off-screen.
+ */
+@Composable
+internal fun ZoomableImage(
+    bitmap: ImageBitmap,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    minScale: Float = DEFAULT_MIN_SCALE,
+    maxScale: Float = DEFAULT_MAX_SCALE,
+    doubleTapScale: Float = DEFAULT_DOUBLE_TAP_SCALE,
+) {
+    var scale by remember { mutableFloatStateOf(minScale) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+    var slotSize by remember { mutableStateOf(IntSize.Zero) }
+
+    val transformableState = rememberTransformableState { zoomChange, panChange, _ ->
+        val newScale = (scale * zoomChange).coerceIn(minScale, maxScale)
+        val maxX = ((newScale - 1f) * slotSize.width / 2f).coerceAtLeast(0f)
+        val maxY = ((newScale - 1f) * slotSize.height / 2f).coerceAtLeast(0f)
+        val proposed = offset + panChange
+        offset = Offset(
+            proposed.x.coerceIn(-maxX, maxX),
+            proposed.y.coerceIn(-maxY, maxY),
+        )
+        scale = newScale
+        if (newScale <= minScale) offset = Offset.Zero
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { slotSize = it }
+            // Keyed on Unit so the gesture detector survives every zoom step; the
+            // handler closes over the mutable `scale` and re-reads it on each callback.
+            .pointerInput(Unit) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        if (scale > minScale) {
+                            scale = minScale
+                            offset = Offset.Zero
+                        } else {
+                            scale = doubleTapScale
+                        }
+                    },
+                )
+            }
+            .transformable(state = transformableState, canPan = { scale > minScale }),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offset.x,
+                    translationY = offset.y,
+                ),
+        )
+    }
+}
+
+// Defaults match the original inline zoom surface (`wpass-1wq`). Hold MAX at 3f until
+// `wpass-f4b`'s sub-rect re-render is wired in by the full-screen surface; once that
+// lands the cap can move to 5f without producing pixelation past about 1.3-1.5x.
+internal const val DEFAULT_MIN_SCALE: Float = 1f
+internal const val DEFAULT_MAX_SCALE: Float = 3f
+internal const val DEFAULT_DOUBLE_TAP_SCALE: Float = 2f

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -197,9 +197,10 @@ private fun pageRectInSlot(slotW: Float, slotH: Float, pageAspect: Float?): Page
     }
 }
 
-// Defaults match the original inline zoom surface (`wpass-1wq`). Hold MAX at 3f until
-// `wpass-f4b`'s sub-rect re-render is wired in by the full-screen surface; once that
-// lands the cap can move to 5f without producing pixelation past about 1.3-1.5x.
+// Sub-rect re-render lands the sharp-at-zoom property (`wpass-f4b`), so MAX_SCALE can
+// sit at 5f — the renderer rasterises the visible region at viewport resolution within
+// the unchanged 4 MP per-bitmap cap, so the user-perceived pixel density at 5x is the
+// same as at 1x rather than 5x-bilinear-smeared.
 internal const val DEFAULT_MIN_SCALE: Float = 1f
-internal const val DEFAULT_MAX_SCALE: Float = 3f
+internal const val DEFAULT_MAX_SCALE: Float = 5f
 internal const val DEFAULT_DOUBLE_TAP_SCALE: Float = 2f

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -21,14 +22,21 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
+import `is`.walt.passes.pdf.android.RenderSourceRect
 
 /**
  * Pinch-zoom + pan surface for a single bitmap. Originally inline in `DocumentView`
  * (`wpass-1wq`); relocated by `wpass-ny4` so the full-screen surface (`wpass-jil`) is
  * the only call site. Translation is clamped to the slot bounds so the user cannot
  * pan the bitmap entirely off-screen.
+ *
+ * When [onZoomedRegionChanged] is provided, the surface emits the currently-visible
+ * sub-rect (in normalised page coordinates) after each gesture settles. The full-screen
+ * surface uses this to fire a `wpass-f4b` sub-rect re-render so the visible region
+ * stays sharp under zoom.
  */
 @Composable
+@Suppress("LongParameterList")
 internal fun ZoomableImage(
     bitmap: ImageBitmap,
     contentDescription: String,
@@ -36,6 +44,7 @@ internal fun ZoomableImage(
     minScale: Float = DEFAULT_MIN_SCALE,
     maxScale: Float = DEFAULT_MAX_SCALE,
     doubleTapScale: Float = DEFAULT_DOUBLE_TAP_SCALE,
+    onZoomedRegionChanged: ((RenderSourceRect) -> Unit)? = null,
 ) {
     var scale by remember { mutableFloatStateOf(minScale) }
     var offset by remember { mutableStateOf(Offset.Zero) }
@@ -52,6 +61,18 @@ internal fun ZoomableImage(
         )
         scale = newScale
         if (newScale <= minScale) offset = Offset.Zero
+    }
+
+    // Emit the visible sub-rect once the gesture settles. `transformableState.isTransformInProgress`
+    // is a snapshot read, so wrapping it in LaunchedEffect makes the emission happen exactly when
+    // the user lifts their fingers. Skipped at fit (scale == 1) since the FullPage render already
+    // covers it.
+    if (onZoomedRegionChanged != null) {
+        LaunchedEffect(transformableState.isTransformInProgress, scale, offset, slotSize) {
+            if (!transformableState.isTransformInProgress && scale > minScale && slotSize != IntSize.Zero) {
+                onZoomedRegionChanged(visibleRect(scale, offset, slotSize))
+            }
+        }
     }
 
     Box(
@@ -89,6 +110,28 @@ internal fun ZoomableImage(
                 ),
         )
     }
+}
+
+// At scale S, the visible window covers 1/S of the slot in each axis. The pan offset
+// is in slot-pixel coordinates after the graphicsLayer scale, so dividing by `S *
+// slotSize` normalises it. The slot extent is assumed to match the page extent at fit;
+// in the full-screen surface the page is letterboxed via ContentScale.Fit so this is a
+// best-effort approximation when the page's aspect ratio differs from the slot's.
+private fun visibleRect(scale: Float, offset: Offset, slotSize: IntSize): RenderSourceRect.SubRect {
+    val w = slotSize.width.toFloat()
+    val h = slotSize.height.toFloat()
+    val visibleFractionX = 1f / scale
+    val visibleFractionY = 1f / scale
+    val centerX = 0.5f - offset.x / (scale * w)
+    val centerY = 0.5f - offset.y / (scale * h)
+    val left = (centerX - visibleFractionX / 2f).coerceIn(0f, 1f - visibleFractionX)
+    val top = (centerY - visibleFractionY / 2f).coerceIn(0f, 1f - visibleFractionY)
+    return RenderSourceRect.SubRect(
+        left = left,
+        top = top,
+        right = left + visibleFractionX,
+        bottom = top + visibleFractionY,
+    )
 }
 
 // Defaults match the original inline zoom surface (`wpass-1wq`). Hold MAX at 3f until

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
@@ -50,4 +50,7 @@ public data class DocumentSemantics(
     public val fullScreenBannerLabel: String = "Tap for full screen",
     public val fullScreenBannerBackground: ArgbColor = documentBadgeBackground,
     public val fullScreenBannerForeground: ArgbColor = documentBadgeForeground,
+    // wpass-6ag review M1: close affordance on the full-screen surface is themed
+    // alongside the banner so every consumer-facing string flows through this contract.
+    public val closeFullScreenLabel: String = "Close",
 )

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
@@ -47,6 +47,11 @@ public data class DocumentSemantics(
     // wpass-jil: the "Tap for full screen" banner inside DocumentView. Label text is
     // sourced from the consumer so walt-android controls wording; the colour slots
     // default to the existing badge tokens to keep the addition non-breaking.
+    //
+    // The String defaults below are soft — English placeholders so the surface still
+    // composes in tests / dev builds. Production hosts (walt-android et al.) are
+    // expected to override with localised copy through their `DocumentSemantics`
+    // construction. Defaults are NOT a contract.
     public val fullScreenBannerLabel: String = "Tap for full screen",
     public val fullScreenBannerBackground: ArgbColor = documentBadgeBackground,
     public val fullScreenBannerForeground: ArgbColor = documentBadgeForeground,

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/theme/DocumentSemantics.kt
@@ -44,4 +44,10 @@ public data class DocumentSemantics(
     public val laneBackground: ArgbColor,
     public val documentBadgeBackground: ArgbColor,
     public val documentBadgeForeground: ArgbColor,
+    // wpass-jil: the "Tap for full screen" banner inside DocumentView. Label text is
+    // sourced from the consumer so walt-android controls wording; the colour slots
+    // default to the existing badge tokens to keep the addition non-breaking.
+    public val fullScreenBannerLabel: String = "Tap for full screen",
+    public val fullScreenBannerBackground: ArgbColor = documentBadgeBackground,
+    public val fullScreenBannerForeground: ArgbColor = documentBadgeForeground,
 )

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/ConsumerRenderFailureMappingTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/ConsumerRenderFailureMappingTest.kt
@@ -2,6 +2,7 @@ package `is`.walt.passes.pdf.ui
 
 import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.pdf.ConsumerRenderFailure
+import `is`.walt.passes.pdf.ui.internal.consumerRenderFailureFor
 import org.junit.Test
 import java.nio.BufferUnderflowException
 

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
@@ -33,15 +33,13 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun documentViewHasExactlyFiveUserVisibleParameters() {
-        // (doc, pdfFile, renderer, modifier, telemetry). D5: no flag to hide the trust
-        // caption, no flag to render anything from PDF metadata, no overflow into
-        // Share. The fifth slot is the wpass-8v4 telemetry guard with a NoOp default;
-        // bumping this count from 4 to 5 is the deliberate change for that issue, not
-        // a slip. Integration coverage of the failure-mapping path lives in
-        // `DocumentViewInstrumentedTest`; the JVM-pure mapping helper is covered by
-        // `ConsumerRenderFailureMappingTest`.
-        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 5)
+    fun documentViewHasExactlySixUserVisibleParameters() {
+        // (doc, pdfFile, renderer, modifier, telemetry, onOpenFullScreen). D5: still no
+        // flag to hide the trust caption. The sixth slot is the wpass-jil full-screen
+        // navigation callback with a `null` default — when null the banner is hidden,
+        // when non-null the banner appears and invokes the callback on tap. Bumping
+        // from 5 to 6 is the deliberate change for that issue, not a slip.
+        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 6)
     }
 
     @Test
@@ -67,6 +65,32 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
+    fun fullScreenDocumentViewHasExactlySixUserVisibleParameters() {
+        // (doc, pdfFile, renderer, onClose, modifier, telemetry). D5: trust caption is
+        // composed inside the surface; no parameter omits it. Required onClose forces
+        // the host to provide a back path — there is no "stuck in full-screen" state.
+        assertUserVisibleParamCount(
+            "FullScreenDocumentViewKt",
+            "FullScreenDocumentView",
+            expected = 6,
+        )
+    }
+
+    @Test
+    fun fullScreenDocumentViewConsumesPdfRendererBinderInterfaceNotConcreteClient() {
+        // Same contract as DocumentView: the full-screen surface takes the binder
+        // interface so test fakes inject cleanly.
+        val method = findComposable("FullScreenDocumentViewKt", "FullScreenDocumentView")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("FullScreenDocumentView must accept the PdfRendererBinder interface")
+            .that(typeNames)
+            .contains("PdfRendererBinder")
+        assertWithMessage("FullScreenDocumentView must NOT bind to the concrete PdfRendererClient")
+            .that(typeNames)
+            .doesNotContain("PdfRendererClient")
+    }
+
+    @Test
     fun documentSurfacesHaveNoOverloads() {
         // The trust-caption non-suppressibility rule extends to overloads: a future
         // contributor cannot quietly add `DocumentView(..., showCaption: Boolean)` as
@@ -77,6 +101,7 @@ class DocumentSurfaceLockTest {
             "DocumentTileKt" to "DocumentTile",
             "DocumentViewKt" to "DocumentView",
             "DocumentsLaneKt" to "DocumentsLane",
+            "FullScreenDocumentViewKt" to "FullScreenDocumentView",
         ).forEach { (file, name) ->
             val klass = Class.forName("is.walt.passes.pdf.ui.$file")
             val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
@@ -7,12 +7,12 @@ import `is`.walt.passes.pdf.DocumentRejectedKind
 /**
  * The internal binder contract for the isolated-process PDF renderer service. Two
  * methods, both load-bearing: [probe] returns the page count for a candidate PDF (or a
- * rejection enum), and [render] rasterises a single page into a SharedMemory-backed
- * pixel buffer. The deliberate absence of getText, getMetadata, getAnnotations,
- * getAttachments, and getFormFields is the trust claim of ADR 0005 D4 (no extraction
- * from PDF content); [PublicApiSurfaceTest] enforces the surface by reflection so adding
- * one of those methods is a structural compile-and-test failure rather than a code-review
- * judgement call.
+ * rejection enum), and [render] rasterises a single page (optionally a sub-rect of one)
+ * into a SharedMemory-backed pixel buffer. The deliberate absence of getText,
+ * getMetadata, getAnnotations, getAttachments, and getFormFields is the trust claim of
+ * ADR 0005 D4 (no extraction from PDF content); [PublicApiSurfaceTest] enforces the
+ * surface by reflection so adding one of those methods is a structural compile-and-test
+ * failure rather than a code-review judgement call.
  *
  * Not AIDL: AIDL adds a generated Stub class that exposes its own reflectable surface
  * and a parser of arbitrary remote-supplied data. A hand-rolled [android.os.Binder]
@@ -31,12 +31,41 @@ import `is`.walt.passes.pdf.DocumentRejectedKind
 public interface PdfRendererBinder {
     public suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult
 
+    /**
+     * Rasterise [page] of the PDF behind [pdf] into a [widthPx]x[heightPx] ARGB_8888
+     * buffer. [sourceRect] selects a portion of the page in normalised [0, 1] page
+     * coordinates; invalid rects are rejected by the renderer (`wpass-f4b`). ADR 0005
+     * D7's 4 MP cap applies to the output size and is unchanged by the sub-rect.
+     */
     public suspend fun render(
         pdf: ParcelFileDescriptor,
         page: Int,
         widthPx: Int,
         heightPx: Int,
+        sourceRect: RenderSourceRect = RenderSourceRect.FullPage,
     ): RenderResult
+}
+
+/**
+ * Selects what portion of a PDF page is rasterised. Sealed so the proxy, client, and
+ * service all fold over the same closed set; growing the surface (e.g. for tiled
+ * rendering) is a deliberate change in all three.
+ */
+public sealed interface RenderSourceRect {
+    /** Rasterise the entire page. The pre-`wpass-f4b` behaviour. */
+    public data object FullPage : RenderSourceRect
+
+    /**
+     * Sub-rectangle in normalised page coordinates: `(0, 0)` is top-left, `(1, 1)` is
+     * bottom-right. Invalid rects (outside the unit square, zero area, reversed) are
+     * rejected by the renderer with [DocumentRejectedKind.RendererFailed].
+     */
+    public data class SubRect(
+        public val left: Float,
+        public val top: Float,
+        public val right: Float,
+        public val bottom: Float,
+    ) : RenderSourceRect
 }
 
 /**

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinder.kt
@@ -87,10 +87,16 @@ public sealed interface ProbeResult {
  * same dimensions.
  */
 public sealed interface RenderResult {
+    /**
+     * [pageAspect] is the page's natural width/height ratio. Lets the UI compute where
+     * inside the destination bitmap the actual page content lives so zoom math can
+     * normalise against the on-screen page rect rather than the slot (`wpass-6ag` C3).
+     */
     public data class Ok(
         public val sharedMemory: SharedMemory,
         public val widthPx: Int,
         public val heightPx: Int,
+        public val pageAspect: Float,
     ) : RenderResult
 
     public data class Rejected(public val kind: DocumentRejectedKind) : RenderResult

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
@@ -67,6 +67,7 @@ internal class PdfRendererBinderProxy(
                     reply.writeTypedObject(result.sharedMemory, 0)
                     reply.writeInt(result.widthPx)
                     reply.writeInt(result.heightPx)
+                    reply.writeFloat(result.pageAspect)
                 }
                 is RenderResult.Rejected -> {
                     reply.writeInt(TAG_REJECTED)

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
@@ -52,6 +52,7 @@ internal class PdfRendererBinderProxy(
         return true
     }
 
+    @Suppress("ReturnCount")
     private fun handleRender(data: Parcel, reply: Parcel?): Boolean {
         val pfd = data.readTypedObject(ParcelFileDescriptor.CREATOR) ?: return false
         val page = data.readInt()

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererBinderProxy.kt
@@ -57,7 +57,8 @@ internal class PdfRendererBinderProxy(
         val page = data.readInt()
         val widthPx = data.readInt()
         val heightPx = data.readInt()
-        val result = runBlocking { impl.render(pfd, page, widthPx, heightPx) }
+        val sourceRect = readSourceRect(data) ?: return false
+        val result = runBlocking { impl.render(pfd, page, widthPx, heightPx, sourceRect) }
         if (reply != null) {
             when (result) {
                 is RenderResult.Ok -> {
@@ -75,11 +76,30 @@ internal class PdfRendererBinderProxy(
         return true
     }
 
+    // Null on an unknown tag short-circuits handleRender to onTransact `false`, which
+    // the client folds into RendererFailed.
+    private fun readSourceRect(data: Parcel): RenderSourceRect? =
+        when (data.readInt()) {
+            TAG_SOURCE_RECT_FULL_PAGE -> RenderSourceRect.FullPage
+            TAG_SOURCE_RECT_SUB_RECT -> RenderSourceRect.SubRect(
+                left = data.readFloat(),
+                top = data.readFloat(),
+                right = data.readFloat(),
+                bottom = data.readFloat(),
+            )
+            else -> null
+        }
+
     internal companion object {
         const val CODE_PROBE: Int = IBinder.FIRST_CALL_TRANSACTION
         const val CODE_RENDER: Int = IBinder.FIRST_CALL_TRANSACTION + 1
 
         const val TAG_OK: Int = 0
         const val TAG_REJECTED: Int = 1
+
+        // Distinct namespace from TAG_OK / TAG_REJECTED so a positional collision in
+        // the wire format would not silently swap meaning.
+        const val TAG_SOURCE_RECT_FULL_PAGE: Int = 0
+        const val TAG_SOURCE_RECT_SUB_RECT: Int = 1
     }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -10,6 +10,8 @@ import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_PROBE
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.CODE_RENDER
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_OK
 import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_REJECTED
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_SOURCE_RECT_FULL_PAGE
+import `is`.walt.passes.pdf.android.PdfRendererBinderProxy.Companion.TAG_SOURCE_RECT_SUB_RECT
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -95,6 +97,7 @@ public class PdfRendererClient(
         page: Int,
         widthPx: Int,
         heightPx: Int,
+        sourceRect: RenderSourceRect,
     ): RenderResult =
         withContext(Dispatchers.IO) {
             val data = Parcel.obtain()
@@ -104,6 +107,7 @@ public class PdfRendererClient(
                 data.writeInt(page)
                 data.writeInt(widthPx)
                 data.writeInt(heightPx)
+                writeSourceRect(data, sourceRect)
                 val accepted =
                     try {
                         binder.transact(CODE_RENDER, data, reply, 0)
@@ -129,4 +133,17 @@ public class PdfRendererClient(
                 data.recycle()
             }
         }
+
+    private fun writeSourceRect(data: Parcel, sourceRect: RenderSourceRect) {
+        when (sourceRect) {
+            is RenderSourceRect.FullPage -> data.writeInt(TAG_SOURCE_RECT_FULL_PAGE)
+            is RenderSourceRect.SubRect -> {
+                data.writeInt(TAG_SOURCE_RECT_SUB_RECT)
+                data.writeFloat(sourceRect.left)
+                data.writeFloat(sourceRect.top)
+                data.writeFloat(sourceRect.right)
+                data.writeFloat(sourceRect.bottom)
+            }
+        }
+    }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererClient.kt
@@ -123,7 +123,8 @@ public class PdfRendererClient(
                             ?: error("Render reply missing SharedMemory")
                         val w = reply.readInt()
                         val h = reply.readInt()
-                        RenderResult.Ok(sm, w, h)
+                        val pageAspect = reply.readFloat()
+                        RenderResult.Ok(sm, w, h, pageAspect)
                     }
                     TAG_REJECTED -> RenderResult.Rejected(RejectedKindWire.decode(reply.readInt()))
                     else -> error("Unknown render reply tag: $tag")

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -3,6 +3,7 @@ package `is`.walt.passes.pdf.android
 import android.app.Service
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.Matrix
 import android.graphics.pdf.PdfRenderer
 import android.os.IBinder
 import android.os.ParcelFileDescriptor
@@ -45,7 +46,8 @@ public class PdfRendererService : Service() {
                 page: Int,
                 widthPx: Int,
                 heightPx: Int,
-            ): RenderResult = doRender(pdf, page, widthPx, heightPx, watchdog)
+                sourceRect: RenderSourceRect,
+            ): RenderResult = doRender(pdf, page, widthPx, heightPx, sourceRect, watchdog)
         }
 
     public companion object {
@@ -83,23 +85,41 @@ internal suspend fun doRender(
     page: Int,
     widthPx: Int,
     heightPx: Int,
+    sourceRect: RenderSourceRect,
     watchdog: RenderWatchdog,
 ): RenderResult {
     val dimsOk = widthPx > 0 && heightPx > 0 && widthPx.toLong() * heightPx.toLong() <= PdfRendererService.MAX_PIXELS
-    return if (!dimsOk) {
+    val rectOk = isSourceRectValid(sourceRect)
+    return if (!dimsOk || !rectOk) {
         RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
     } else {
         runCatching {
-            watchdog.guard { renderToSharedMemory(pdf, page, widthPx, heightPx) }
+            watchdog.guard { renderToSharedMemory(pdf, page, widthPx, heightPx, sourceRect) }
         }.getOrElse { RenderResult.Rejected(DocumentRejectedKind.RendererFailed) }
     }
 }
+
+// Strict ordering rules out zero-area rects (would produce a degenerate Matrix); the
+// unit-square bound keeps the consumer's failures visible instead of silently blank.
+internal fun isSourceRectValid(sourceRect: RenderSourceRect): Boolean =
+    when (sourceRect) {
+        is RenderSourceRect.FullPage -> true
+        is RenderSourceRect.SubRect -> {
+            val l = sourceRect.left
+            val t = sourceRect.top
+            val r = sourceRect.right
+            val b = sourceRect.bottom
+            val finite = l.isFinite() && t.isFinite() && r.isFinite() && b.isFinite()
+            finite && l in 0f..1f && t in 0f..1f && r in 0f..1f && b in 0f..1f && l < r && t < b
+        }
+    }
 
 private fun renderToSharedMemory(
     pdf: ParcelFileDescriptor,
     page: Int,
     widthPx: Int,
     heightPx: Int,
+    sourceRect: RenderSourceRect,
 ): RenderResult =
     PdfRenderer(pdf).use { renderer ->
         // Defense-in-depth: doProbe also enforces MAX_PAGES, but the binder does not
@@ -111,19 +131,48 @@ private fun renderToSharedMemory(
         if (!pageCountOk || !pageOk) {
             RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
         } else {
-            renderer.openPage(page).use { p -> rasterise(p, widthPx, heightPx) }
+            renderer.openPage(page).use { p -> rasterise(p, widthPx, heightPx, sourceRect) }
         }
     }
 
-private fun rasterise(p: PdfRenderer.Page, widthPx: Int, heightPx: Int): RenderResult.Ok {
+private fun rasterise(
+    p: PdfRenderer.Page,
+    widthPx: Int,
+    heightPx: Int,
+    sourceRect: RenderSourceRect,
+): RenderResult.Ok {
     val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
     try {
-        p.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        val transform = matrixFor(sourceRect, p.width, p.height, widthPx, heightPx)
+        p.render(bitmap, null, transform, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         return RenderResult.Ok(packIntoSharedMemory(bitmap, widthPx, heightPx), widthPx, heightPx)
     } finally {
         bitmap.recycle()
     }
 }
+
+// FullPage keeps the legacy `null` transform (fit page to bitmap). SubRect maps the
+// sub-rect's page-point coords onto the full destination bitmap, sharp under zoom.
+private fun matrixFor(
+    sourceRect: RenderSourceRect,
+    pageWidth: Int,
+    pageHeight: Int,
+    widthPx: Int,
+    heightPx: Int,
+): Matrix? =
+    when (sourceRect) {
+        is RenderSourceRect.FullPage -> null
+        is RenderSourceRect.SubRect -> {
+            val srcLeft = sourceRect.left * pageWidth
+            val srcTop = sourceRect.top * pageHeight
+            val srcWidth = (sourceRect.right - sourceRect.left) * pageWidth
+            val srcHeight = (sourceRect.bottom - sourceRect.top) * pageHeight
+            Matrix().apply {
+                setScale(widthPx / srcWidth, heightPx / srcHeight)
+                preTranslate(-srcLeft, -srcTop)
+            }
+        }
+    }
 
 private fun packIntoSharedMemory(bitmap: Bitmap, widthPx: Int, heightPx: Int): SharedMemory {
     val byteCount = widthPx * heightPx * BYTES_PER_PIXEL

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -80,6 +80,7 @@ internal suspend fun doProbe(pdf: ParcelFileDescriptor, maxPages: Int): ProbeRes
         }
     }.getOrElse { t -> ProbeResult.Rejected(rejectedKindForOpenFailure(t)) }
 
+@Suppress("LongParameterList")
 internal suspend fun doRender(
     pdf: ParcelFileDescriptor,
     page: Int,

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -146,7 +146,13 @@ private fun rasterise(
     try {
         val transform = matrixFor(sourceRect, p.width, p.height, widthPx, heightPx)
         p.render(bitmap, null, transform, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-        return RenderResult.Ok(packIntoSharedMemory(bitmap, widthPx, heightPx), widthPx, heightPx)
+        val pageAspect = p.width.toFloat() / p.height.toFloat()
+        return RenderResult.Ok(
+            sharedMemory = packIntoSharedMemory(bitmap, widthPx, heightPx),
+            widthPx = widthPx,
+            heightPx = heightPx,
+            pageAspect = pageAspect,
+        )
     } finally {
         bitmap.recycle()
     }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RejectingBinder.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/internal/RejectingBinder.kt
@@ -5,6 +5,7 @@ import `is`.walt.passes.pdf.DocumentRejectedKind
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.ProbeResult
 import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
 
 /**
  * A [PdfRendererBinder] that returns the same [DocumentRejectedKind] for every probe
@@ -26,5 +27,6 @@ internal class RejectingBinder(
         page: Int,
         widthPx: Int,
         heightPx: Int,
+        sourceRect: RenderSourceRect,
     ): RenderResult = RenderResult.Rejected(kind)
 }

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
@@ -561,6 +561,7 @@ class PdfImporterTest {
             page: Int,
             widthPx: Int,
             heightPx: Int,
+            sourceRect: RenderSourceRect,
         ): RenderResult = renderResult
     }
 

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfImporterTest.kt
@@ -189,7 +189,7 @@ class PdfImporterTest {
             RecordingSessionFactory(
                 binder = StaticBinder(
                     probeResult = ProbeResult.Ok(pageCount = 4),
-                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
                 ),
             )
         val persists = mutableListOf<PersistArgs>()
@@ -222,7 +222,7 @@ class PdfImporterTest {
             RecordingSessionFactory(
                 binder = StaticBinder(
                     probeResult = ProbeResult.Ok(pageCount = 2),
-                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
                 ),
             )
 
@@ -244,7 +244,7 @@ class PdfImporterTest {
             RecordingSessionFactory(
                 binder = StaticBinder(
                     probeResult = ProbeResult.Ok(pageCount = 2),
-                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
                 ),
             )
         val throwingEncoder =
@@ -273,7 +273,7 @@ class PdfImporterTest {
             RecordingSessionFactory(
                 binder = StaticBinder(
                     probeResult = ProbeResult.Ok(pageCount = 1),
-                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
                 ),
             )
 
@@ -300,7 +300,7 @@ class PdfImporterTest {
             RecordingSessionFactory(
                 binder = StaticBinder(
                     probeResult = ProbeResult.Ok(pageCount = 1),
-                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                    renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
                 ),
             )
         val cancellingEncoder =
@@ -369,7 +369,7 @@ class PdfImporterTest {
         val factory = RecordingSessionFactory(
             binder = StaticBinder(
                 probeResult = ProbeResult.Ok(pageCount = 1),
-                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
             ),
         )
         val telemetry = RecordingTelemetry()
@@ -422,7 +422,7 @@ class PdfImporterTest {
         val factory = RecordingSessionFactory(
             binder = StaticBinder(
                 probeResult = ProbeResult.Ok(pageCount = 1),
-                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H),
+                renderResult = RenderResult.Ok(sm, DEFAULT_THUMB_W, DEFAULT_THUMB_H, 1f),
             ),
         )
         val u = uri("content://walt-test/import.pdf")

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -144,6 +144,43 @@ class PdfRendererBinderRoundTripTest {
     }
 
     @Test
+    fun renderDefaultsToFullPageSourceRectAcrossTheWire() = runTest {
+        // The default value lives on the interface; verify the client writes the
+        // expected wire bytes and the proxy decodes them back to FullPage.
+        val sm = SharedMemory.create("walt-test-render-default", PIXEL_BYTES)
+        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX))
+        val client = clientFor(impl)
+        client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
+        assertThat(impl.lastSourceRect).isEqualTo(RenderSourceRect.FullPage)
+    }
+
+    @Test
+    fun renderSubRectRoundTripPreservesFloatBoundaries() = runTest {
+        // wpass-f4b: the wire format must preserve the SubRect floats bit-for-bit so
+        // the renderer service can compose the right Matrix transform. Pick boundary
+        // values (0f, 1f, and a non-trivial decimal that has an exact IEEE-754
+        // representation) so any precision loss in the wire format would surface as
+        // an inequality here.
+        val sm = SharedMemory.create("walt-test-render-subrect", PIXEL_BYTES)
+        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX))
+        val client = clientFor(impl)
+        val rect = RenderSourceRect.SubRect(
+            left = 0.25f,
+            top = 0.5f,
+            right = 0.75f,
+            bottom = 1.0f,
+        )
+        client.render(
+            pdf = pipeRead,
+            page = 0,
+            widthPx = WIDTH_PX,
+            heightPx = HEIGHT_PX,
+            sourceRect = rect,
+        )
+        assertThat(impl.lastSourceRect).isEqualTo(rect)
+    }
+
+    @Test
     fun transactionCodesArePinnedToTheirDocumentedValues() {
         // Pin the absolute codes, not just their distinctness: a contributor flipping
         // the +1 direction (or rebasing CODE_PROBE off a different IBinder constant)
@@ -190,6 +227,9 @@ class PdfRendererBinderRoundTripTest {
         private val probeResult: ProbeResult = ProbeResult.Rejected(DocumentRejectedKind.RendererFailed),
         private val renderResult: RenderResult = RenderResult.Rejected(DocumentRejectedKind.RendererFailed),
     ) : PdfRendererBinder {
+        var lastSourceRect: RenderSourceRect? = null
+            private set
+
         override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult = probeResult
 
         override suspend fun render(
@@ -197,7 +237,11 @@ class PdfRendererBinderRoundTripTest {
             page: Int,
             widthPx: Int,
             heightPx: Int,
-        ): RenderResult = renderResult
+            sourceRect: RenderSourceRect,
+        ): RenderResult {
+            lastSourceRect = sourceRect
+            return renderResult
+        }
     }
 
     private companion object {

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PdfRendererBinderRoundTripTest.kt
@@ -74,7 +74,7 @@ class PdfRendererBinderRoundTripTest {
     fun renderOkRoundTripCarriesSharedMemoryAndDimensions() = runTest {
         val sm = SharedMemory.create("walt-test-render", PIXEL_BYTES)
         val client = clientFor(
-            StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX)),
+            StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX, 1f)),
         )
         val result = client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
         assertThat(result).isInstanceOf(RenderResult.Ok::class.java)
@@ -148,7 +148,7 @@ class PdfRendererBinderRoundTripTest {
         // The default value lives on the interface; verify the client writes the
         // expected wire bytes and the proxy decodes them back to FullPage.
         val sm = SharedMemory.create("walt-test-render-default", PIXEL_BYTES)
-        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX))
+        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX, 1f))
         val client = clientFor(impl)
         client.render(pipeRead, page = 0, widthPx = WIDTH_PX, heightPx = HEIGHT_PX)
         assertThat(impl.lastSourceRect).isEqualTo(RenderSourceRect.FullPage)
@@ -162,7 +162,7 @@ class PdfRendererBinderRoundTripTest {
         // representation) so any precision loss in the wire format would surface as
         // an inequality here.
         val sm = SharedMemory.create("walt-test-render-subrect", PIXEL_BYTES)
-        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX))
+        val impl = StaticImpl(renderResult = RenderResult.Ok(sm, WIDTH_PX, HEIGHT_PX, 1f))
         val client = clientFor(impl)
         val rect = RenderSourceRect.SubRect(
             left = 0.25f,

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/PublicApiSurfaceTest.kt
@@ -21,11 +21,16 @@ import org.junit.Test
 class PublicApiSurfaceTest {
     @Test
     fun binderHasExactlyProbeAndRender() {
+        // declaredMethods on an interface includes the abstract methods and any
+        // synthetic $default helpers Kotlin generates for parameters with default
+        // values. Compare against the set of human-named methods (filtering the
+        // mangled `$default` suffix) so that adding a default value to an existing
+        // method does not flip the test red, but adding a third method does.
         val methodNames =
             PdfRendererBinder::class
                 .java
                 .declaredMethods
-                .map { it.name }
+                .map { it.name.substringBefore('$') }
                 .toSet()
         assertThat(methodNames).containsExactly("probe", "render")
     }
@@ -43,14 +48,19 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun renderTakesPfdAndDimensions() {
+    fun renderTakesPfdAndDimensionsAndSourceRect() {
         val render = PdfRendererBinder::class.java.declaredMethods.single { it.name == "render" }
         val params = render.parameterTypes
-        assertThat(params).hasLength(5)
+        // wpass-f4b extends render() with a RenderSourceRect parameter (between
+        // heightPx and the Continuation). The pin matters because reordering the
+        // parameters at the interface level would invalidate the wire format the proxy
+        // and client agree on by position.
+        assertThat(params).hasLength(6)
         assertThat(params[0].name).isEqualTo("android.os.ParcelFileDescriptor")
         assertThat(params[1]).isEqualTo(java.lang.Integer.TYPE)
         assertThat(params[2]).isEqualTo(java.lang.Integer.TYPE)
         assertThat(params[3]).isEqualTo(java.lang.Integer.TYPE)
-        assertThat(params[4].name).isEqualTo("kotlin.coroutines.Continuation")
+        assertThat(params[4].name).isEqualTo("is.walt.passes.pdf.android.RenderSourceRect")
+        assertThat(params[5].name).isEqualTo("kotlin.coroutines.Continuation")
     }
 }

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/SourceRectValidationTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/SourceRectValidationTest.kt
@@ -1,0 +1,58 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the sub-rect validation rule the renderer service enforces before touching
+ * PdfRenderer (`wpass-f4b`). Invalid rects fold to RendererFailed at the renderer.
+ */
+class SourceRectValidationTest {
+    @Test
+    fun fullPageIsAlwaysValid() {
+        assertThat(isSourceRectValid(RenderSourceRect.FullPage)).isTrue()
+    }
+
+    @Test
+    fun unitSquareSubRectIsValid() {
+        assertThat(
+            isSourceRectValid(RenderSourceRect.SubRect(0f, 0f, 1f, 1f)),
+        ).isTrue()
+    }
+
+    @Test
+    fun centeredQuarterRectIsValid() {
+        assertThat(
+            isSourceRectValid(RenderSourceRect.SubRect(0.25f, 0.25f, 0.75f, 0.75f)),
+        ).isTrue()
+    }
+
+    @Test
+    fun zeroAreaSubRectIsRejected() {
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0.5f, 0.5f, 0.5f, 0.5f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0.5f, 0.25f, 0.5f, 0.75f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0.25f, 0.5f, 0.75f, 0.5f))).isFalse()
+    }
+
+    @Test
+    fun reversedSubRectIsRejected() {
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0.75f, 0.25f, 0.25f, 0.75f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0.25f, 0.75f, 0.75f, 0.25f))).isFalse()
+    }
+
+    @Test
+    fun outOfUnitSquareSubRectIsRejected() {
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(-0.1f, 0f, 0.5f, 0.5f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0f, -0.1f, 0.5f, 0.5f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0f, 0f, 1.1f, 0.5f))).isFalse()
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(0f, 0f, 0.5f, 1.1f))).isFalse()
+    }
+
+    @Test
+    fun nonFiniteSubRectIsRejected() {
+        assertThat(isSourceRectValid(RenderSourceRect.SubRect(Float.NaN, 0f, 1f, 1f))).isFalse()
+        assertThat(
+            isSourceRectValid(RenderSourceRect.SubRect(0f, 0f, Float.POSITIVE_INFINITY, 1f)),
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
Implements the wpass-6ag epic in three coordinated commits:

- **wpass-f4b** — extends `PdfRendererBinder.render()` with a `RenderSourceRect` parameter (FullPage default, SubRect for the zoom-to-scan path). Renderer validates the sub-rect and applies a Matrix transform so the visible region rasterises at viewport resolution within the unchanged 4 MP per-bitmap cap (ADR 0005 D7). No new binder methods — D4 surface lock still passes.
- **wpass-ny4** — removes inline pinch-zoom + pan from `DocumentView`. The gesture surface from wpass-1wq relocates to `internal/ZoomableImage.kt` so the new full-screen surface is the only call site. Inline DocumentView returns to fixed 1x.
- **wpass-jil** — adds `FullScreenDocumentView`, entered from a "Tap for full screen" banner inside DocumentView. Banner label + colours come from `DocumentSemantics` (host-controlled). On pinch settle the surface fires `renderer.render(... SubRect ...)` against the visible normalised page rect. Trust caption docks to a screen edge (ADR 0005 Z.8) so pan/zoom cannot suppress it.

ADR 0005 follow-on (wpass-5n1) landed separately in #72 and records the policy change this PR implements.

## Test plan
- [x] `./gradlew check` passes (`passes-pdf` + `passes-pdf-ui` unit tests, detekt, lint).
- [ ] Instrumented tests (`./gradlew :passes-pdf-ui:connectedDebugAndroidTest`) — run on a device or emulator with API 34+. Covers banner appearance, banner-tap navigation, full-screen trust-caption visibility, pinch → SubRect render call, and the inline-pinch-removal regression.
- [ ] Manual: import a multi-page PDF, tap the full-screen banner, pinch to zoom on a barcode, verify the docked trust caption remains visible under zoom + pan.

bd: closes wpass-f4b, wpass-ny4, wpass-jil, wpass-6ag