### PR TITLE
passes-pdf-ui: public PDF thumbnail render facade (wpass-5g7)

### DIFF
--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -52,6 +52,8 @@ Every extraction codepath is an attack surface (`Launch`/`URI`/`SubmitForm` acti
 
 The renderer service's binder API exposes exactly two methods, `probe(fd)` and `render(fd, page, w, h)`. Adding any extraction method (`getText`, `getMetadata`, `getAnnotations`) is a security-policy change requiring an ADR amendment.
 
+The `passes-pdf-ui` module exposes a Compose-level facade, `rememberPdfThumbnail(...) -> PdfThumbnailState` (with sibling `PdfThumbnailCache`), so consumers that need an asynchronously-rendered page bitmap in a list row do not have to reach for the binder primitives directly. The facade preserves D3 — it does not bind its own service connection, it consumes a [PdfRendererBinder] supplied by the caller — and preserves D4 — its body invokes only `render(...)` and its return type [PdfThumbnailState] exposes a single `ImageBitmap` + aspect float (no metadata accessor, no annotation list, no field through which a future contributor could quietly thread an extraction surface). `PdfThumbnailSurfaceTest` reflection-locks the arm list, the per-arm field shape, and the absence of any `getText` / `getMetadata` / `getAnnotations` / `getAttachments` accessor on every public symbol the facade introduces. Adding a fourth arm to [PdfThumbnailState] or a non-trivial accessor to [PdfThumbnailCache] is a security-policy change in the same audit register as adding a binder method.
+
 ### D5. PDF digital signatures are not verified
 
 Walt does not parse `/AcroForm/SigFlags`, does not validate PAdES/CMS signatures, does not surface a "signed" indicator.

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -31,7 +31,7 @@ import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.ProbeResult
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
-import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
+import `is`.walt.passes.pdf.ui.DEFAULT_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.theme.DocumentSemantics
 import `is`.walt.passes.pdf.ui.theme.DocumentTheme
 import `is`.walt.passes.ui.core.ArgbColor
@@ -141,12 +141,12 @@ class DocumentViewInstrumentedTest {
             }
         }
         composeRule.waitForIdle()
-        repeat(LRU_PAGE_WINDOW + 2) {
+        repeat(DEFAULT_PAGE_WINDOW + 2) {
             composeRule.onRoot().performTouchInput { swipeLeft() }
             composeRule.waitForIdle()
         }
         val distinct = recorder.renderedPages().distinct()
-        assertThat(distinct.size).isAtLeast(LRU_PAGE_WINDOW + 1)
+        assertThat(distinct.size).isAtLeast(DEFAULT_PAGE_WINDOW + 1)
     }
 
     @Test

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -1,44 +1,33 @@
 package `is`.walt.passes.pdf.ui
 
-import android.graphics.Bitmap
 import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.ui.Alignment
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
-import `is`.walt.passes.pdf.android.RenderResult
-import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
-import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
-import `is`.walt.passes.pdf.ui.internal.decodePage
-import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
@@ -99,14 +88,7 @@ public fun DocumentView(
     onOpenFullScreen: (() -> Unit)? = null,
 ) {
     val semantics = LocalDocumentSemantics.current
-    val cache = remember(doc.id) {
-        RenderedPageCache<Bitmap>(
-            maxSize = LRU_PAGE_WINDOW,
-            onEvict = { bitmap ->
-                if (!bitmap.isRecycled) bitmap.recycle()
-            },
-        )
-    }
+    val cache = remember(doc.id) { PdfThumbnailCache(maxSize = LRU_PAGE_WINDOW) }
     DisposableEffect(doc.id) {
         onDispose { cache.clear() }
     }
@@ -189,14 +171,10 @@ private fun DocumentPage(
     pageIndex: Int,
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,
-    cache: RenderedPageCache<Bitmap>,
+    cache: PdfThumbnailCache,
     telemetry: DocumentTelemetryGuard,
 ) {
     val density = LocalDensity.current
-    var rendered by remember(document.id, pageIndex) {
-        mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
-    }
-
     val requestWidthPx = with(density) {
         TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1)
     }
@@ -204,40 +182,22 @@ private fun DocumentPage(
         TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1)
     }
 
-    LaunchedEffect(document.id, pageIndex, requestWidthPx, requestHeightPx) {
-        val cached = cache.get(document.id, pageIndex)
-        if (cached != null && !cached.isRecycled) {
-            rendered = cached.asImageBitmap()
-            return@LaunchedEffect
-        }
-        // wpass-6ag review N1: cancellation-safe so a page-swipe mid-render never
-        // orphans the result's SharedMemory.
-        val result = renderOrDiscard(
-            renderer = renderer,
-            pdf = pdfFile,
-            page = pageIndex,
-            widthPx = requestWidthPx,
-            heightPx = requestHeightPx,
-            sourceRect = RenderSourceRect.FullPage,
-            isStillWanted = { rendered == null },
-        )
-        if (result is RenderResult.Ok) {
-            // ADR 0005 D7: the renderer may downsize past the request; decodePage uses
-            // the renderer's reported dimensions.
-            val decoded = decodePage(result, telemetry)
-            if (decoded != null) {
-                cache.put(document.id, pageIndex, decoded.bitmap)
-                rendered = decoded.image
-            }
-        }
-    }
+    val state = rememberPdfThumbnail(
+        document = document,
+        pdfFile = pdfFile,
+        renderer = renderer,
+        targetSizePx = IntSize(requestWidthPx, requestHeightPx),
+        page = pageIndex,
+        telemetry = telemetry,
+        cache = cache,
+    )
 
     // The page fills the slot the pager hands it (the pager's `weight(1f)` share of
     // DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap inside it.
     // Fixed 1x — zoom lives in the full-screen surface (wpass-ny4 / wpass-jil).
-    rendered?.let { bitmap ->
+    (state as? PdfThumbnailState.Rendered)?.let { rendered ->
         Image(
-            bitmap = bitmap,
+            bitmap = rendered.image,
             // ADR 0005 D4 forbids extracting text from the PDF; positional caption
             // is the only safe TalkBack fallback.
             contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.dp
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
-import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
@@ -88,7 +87,7 @@ public fun DocumentView(
     onOpenFullScreen: (() -> Unit)? = null,
 ) {
     val semantics = LocalDocumentSemantics.current
-    val cache = remember(doc.id) { PdfThumbnailCache(maxSize = LRU_PAGE_WINDOW) }
+    val cache = remember(doc.id) { PdfThumbnailCache() }
     DisposableEffect(doc.id) {
         onDispose { cache.clear() }
     }
@@ -194,10 +193,14 @@ private fun DocumentPage(
 
     // The page fills the slot the pager hands it (the pager's `weight(1f)` share of
     // DocumentView's Column) and lets ContentScale.Fit letterbox the bitmap inside it.
-    // Fixed 1x — zoom lives in the full-screen surface (wpass-ny4 / wpass-jil).
-    (state as? PdfThumbnailState.Rendered)?.let { rendered ->
-        Image(
-            bitmap = rendered.image,
+    // Fixed 1x — zoom lives in the full-screen surface (wpass-ny4 / wpass-jil). The
+    // Loading and Failed arms render nothing in the inline surface; the pager itself
+    // is the placeholder. A future affordance for either belongs on `DocumentTile`,
+    // not here.
+    when (state) {
+        is PdfThumbnailState.Loading, is PdfThumbnailState.Failed -> Unit
+        is PdfThumbnailState.Rendered -> Image(
+            bitmap = state.image,
             // ADR 0005 D4 forbids extracting text from the PDF; positional caption
             // is the only safe TalkBack fallback.
             contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -24,8 +24,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
@@ -33,7 +33,6 @@ import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
-import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.internal.ZoomableImage
 import `is`.walt.passes.pdf.ui.internal.decodePage
 import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
@@ -73,12 +72,7 @@ public fun FullScreenDocumentView(
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
 ) {
     val semantics = LocalDocumentSemantics.current
-    val cache = remember(doc.id) {
-        RenderedPageCache<Bitmap>(
-            maxSize = LRU_PAGE_WINDOW,
-            onEvict = { bitmap -> if (!bitmap.isRecycled) bitmap.recycle() },
-        )
-    }
+    val cache = remember(doc.id) { PdfThumbnailCache(maxSize = LRU_PAGE_WINDOW) }
     DisposableEffect(doc.id) {
         onDispose { cache.clear() }
     }
@@ -145,7 +139,7 @@ private fun FullScreenPage(
     pageIndex: Int,
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,
-    cache: RenderedPageCache<Bitmap>,
+    cache: PdfThumbnailCache,
     telemetry: DocumentTelemetryGuard,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -159,10 +153,22 @@ private fun FullScreenPage(
             clampToMaxPixels(rawW, rawH, MAX_REQUEST_PIXELS)
         }
 
-        var baseImage by remember(document.id, pageIndex) {
-            mutableStateOf<ImageBitmap?>(cache.get(document.id, pageIndex)?.asImageBitmap())
-        }
-        var pageAspect by remember(document.id, pageIndex) { mutableStateOf<Float?>(null) }
+        // Base page rendering goes through the shared public facade so the
+        // NonCancellable transact, SharedMemory cleanup, and LRU eviction live in
+        // exactly one place. The sub-rect zoom path below stays manual: sub-rects
+        // are not cache-keyed (would explode the key space; stale entries surface as
+        // sharper-but-wrong regions after a pan) and need bespoke overlay lifetime.
+        val baseState = rememberPdfThumbnail(
+            document = document,
+            pdfFile = pdfFile,
+            renderer = renderer,
+            targetSizePx = IntSize(requestW, requestH),
+            page = pageIndex,
+            telemetry = telemetry,
+            cache = cache,
+        )
+        val baseRendered = baseState as? PdfThumbnailState.Rendered
+
         var zoomedReplacement by remember(document.id, pageIndex) {
             mutableStateOf<ImageBitmap?>(null)
         }
@@ -181,41 +187,14 @@ private fun FullScreenPage(
             }
         }
 
-        LaunchedEffect(document.id, pageIndex, requestW, requestH) {
-            val cached = cache.get(document.id, pageIndex)
-            if (cached != null && !cached.isRecycled && baseImage == null) {
-                baseImage = cached.asImageBitmap()
-            }
-            if (baseImage != null && pageAspect != null) return@LaunchedEffect
-            // wpass-6ag review N1: NonCancellable around the binder transact so a
-            // page-swipe-mid-render does not orphan the result's SharedMemory.
-            val result = renderOrDiscard(
-                renderer = renderer,
-                pdf = pdfFile,
-                page = pageIndex,
-                widthPx = requestW,
-                heightPx = requestH,
-                sourceRect = RenderSourceRect.FullPage,
-                isStillWanted = { baseImage == null || pageAspect == null },
-            )
-            if (result is RenderResult.Ok) {
-                val decoded = decodePage(result, telemetry)
-                if (decoded != null) {
-                    cache.put(document.id, pageIndex, decoded.bitmap)
-                    baseImage = decoded.image
-                    pageAspect = decoded.pageAspect
-                }
-            }
-        }
-
-        baseImage?.let { bitmap ->
+        baseRendered?.let { rendered ->
             ZoomableImage(
-                bitmap = bitmap,
+                bitmap = rendered.image,
                 // ADR 0005 D4 forbids extracting text; the positional caption is the
                 // only safe TalkBack fallback.
                 contentDescription = "Page ${pageIndex + 1} of ${document.pageCount}",
                 modifier = Modifier.fillMaxSize(),
-                pageAspect = pageAspect,
+                pageAspect = rendered.pageAspect,
                 zoomedReplacement = zoomedReplacement,
                 // wpass-6ag review M3: edge-triggered. New gesture clears the prior
                 // sub-rect bitmap and frees its native memory so the next pinch starts

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -32,7 +32,6 @@ import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
-import `is`.walt.passes.pdf.ui.internal.LRU_PAGE_WINDOW
 import `is`.walt.passes.pdf.ui.internal.ZoomableImage
 import `is`.walt.passes.pdf.ui.internal.decodePage
 import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
@@ -72,7 +71,7 @@ public fun FullScreenDocumentView(
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
 ) {
     val semantics = LocalDocumentSemantics.current
-    val cache = remember(doc.id) { PdfThumbnailCache(maxSize = LRU_PAGE_WINDOW) }
+    val cache = remember(doc.id) { PdfThumbnailCache() }
     DisposableEffect(doc.id) {
         onDispose { cache.clear() }
     }
@@ -167,7 +166,13 @@ private fun FullScreenPage(
             telemetry = telemetry,
             cache = cache,
         )
-        val baseRendered = baseState as? PdfThumbnailState.Rendered
+        // Loading and Failed render nothing; the zoom path requires the base bitmap
+        // and aspect to exist before it can compose the overlay. Both arms map to
+        // "no base image yet."
+        val baseRendered = when (baseState) {
+            is PdfThumbnailState.Loading, is PdfThumbnailState.Failed -> null
+            is PdfThumbnailState.Rendered -> baseState
+        }
 
         var zoomedReplacement by remember(document.id, pageIndex) {
             mutableStateOf<ImageBitmap?>(null)

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/PdfThumbnail.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/PdfThumbnail.kt
@@ -1,0 +1,175 @@
+package `is`.walt.passes.pdf.ui
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.IntSize
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import `is`.walt.passes.pdf.DocumentTelemetryGuard
+import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
+import `is`.walt.passes.pdf.ui.internal.decodePage
+import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
+
+/**
+ * Outcome of a [rememberPdfThumbnail] call. Drives consumer placeholder / bitmap /
+ * error chrome from a single sealed state.
+ *
+ * The shape is deliberately narrow: only an `ImageBitmap`, an aspect ratio, and an
+ * enum failure kind. There is no field through which a consumer could surface PDF
+ * text, metadata, an annotation list, or any other extraction-shaped data; ADR 0005
+ * D4 (no extraction) and D5 (no signature affordance) are upheld by the type itself.
+ * `PdfThumbnailSurfaceTest` locks the arm list and the per-arm field shape against
+ * future additions.
+ */
+public sealed interface PdfThumbnailState {
+    public data object Loading : PdfThumbnailState
+
+    public data class Rendered(
+        public val image: ImageBitmap,
+        public val pageAspect: Float,
+    ) : PdfThumbnailState
+
+    public data class Failed(public val kind: DocumentRejectedKind) : PdfThumbnailState
+}
+
+/**
+ * Bounded shared cache for page bitmaps produced by [rememberPdfThumbnail]. A single
+ * instance hoisted to list scope (e.g. `remember { PdfThumbnailCache(8) }` inside a
+ * `LazyColumn`'s composable parent) lets all visible rows share a fixed RAM cap and
+ * keeps recently-scrolled rows warm.
+ *
+ * Wraps the kernel's access-ordered LRU and binds the `Bitmap.recycle` eviction
+ * callback so native pixel memory is freed the moment a page falls out of the
+ * window — the renderer service has already pre-recycled its source-side copy on
+ * the binder boundary, so the UI consumer is the sole owner on this side.
+ *
+ * Thread-safety: callers are expected to invoke this from the Compose main thread.
+ * Background prefetch is not supported by this surface.
+ */
+public class PdfThumbnailCache(maxSize: Int) {
+    internal val backing: RenderedPageCache<Bitmap> = RenderedPageCache(
+        maxSize = maxSize,
+        onEvict = { bitmap -> if (!bitmap.isRecycled) bitmap.recycle() },
+    )
+
+    public val size: Int get() = backing.size
+
+    public fun clear(): Unit = backing.clear()
+}
+
+/**
+ * Compose-friendly facade over the isolated-process PDF renderer for **single-page
+ * thumbnails**. Use this from a list-row composable to drive an asynchronously
+ * rendered page-N bitmap with correct lifetime, cancellation, and cache discipline
+ * for the trust-bearing renderer service.
+ *
+ * Lifecycle guarantees this facade owns so consumers do not have to reimplement them:
+ *
+ *  - `renderer.render(...)` runs inside `NonCancellable` (via `renderOrDiscard`),
+ *    so a fast scroll that disposes the row mid-render still receives the
+ *    `RenderResult` and releases the result's `SharedMemory` region — preserving
+ *    the wpass-6ag N1 invariant.
+ *  - When [cache] is supplied, the produced bitmap is handed to the cache for the
+ *    `(document.id, page)` key; the LRU evicts older entries with `Bitmap.recycle`.
+ *  - When [cache] is omitted, the bitmap is recycled on dispose of the composable
+ *    (key change, scroll-off, leave composition).
+ *
+ * Trust-bearing properties this facade preserves (ADR 0005):
+ *
+ *  - **D3 (isolated process):** the [renderer] is the caller's already-bound binder;
+ *    this facade does not open its own service connection.
+ *  - **D4 (no extraction):** the facade body invokes only `render(...)`; no
+ *    `getText` / `getMetadata` / `getAnnotations` paths are added or wrapped. The
+ *    return type exposes a single `ImageBitmap` + aspect float.
+ *  - **D5 (no signature affordance):** there is no "verified" field on
+ *    [PdfThumbnailState]. Trust signals remain on `DocumentTrustCaption` and
+ *    `DocumentView` chrome, untouched.
+ *  - **D7 (4 MP cap):** the cap is enforced inside `PdfRendererService`; this
+ *    facade passes [targetSizePx] through. Oversized requests surface as
+ *    `Failed(RendererFailed)`.
+ *
+ * pdfFile lifetime: [pdfFile] is owned by the caller. It MUST remain open for as
+ * long as the calling composable is composed; close after composition ends. The
+ * binder duplicates the fd on each transact, so closing on the caller side does
+ * not affect an in-flight render's copy, but a closed fd in a subsequent call
+ * surfaces as `Failed(RendererFailed)` rather than a UI-visible error.
+ */
+@Composable
+@Suppress("LongParameterList")
+public fun rememberPdfThumbnail(
+    document: PdfDocument,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    targetSizePx: IntSize,
+    page: Int = 0,
+    telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
+    cache: PdfThumbnailCache? = null,
+): PdfThumbnailState {
+    val widthPx = targetSizePx.width.coerceAtLeast(1)
+    val heightPx = targetSizePx.height.coerceAtLeast(1)
+    val state: State<PdfThumbnailState> = produceState<PdfThumbnailState>(
+        initialValue = PdfThumbnailState.Loading,
+        document.id,
+        page,
+        widthPx,
+        heightPx,
+        cache,
+        renderer,
+        pdfFile,
+    ) {
+        // Tracked only when there's no cache to take ownership; the cache's onEvict
+        // recycles bitmaps it owns on its own schedule.
+        var ownedHandle: Bitmap? = null
+
+        val cached = cache?.backing?.get(document.id, page)
+        if (cached != null && !cached.isRecycled) {
+            val aspect = cached.width.toFloat() / cached.height.coerceAtLeast(1).toFloat()
+            value = PdfThumbnailState.Rendered(cached.asImageBitmap(), aspect)
+        } else {
+            val result = renderOrDiscard(
+                renderer = renderer,
+                pdf = pdfFile,
+                page = page,
+                widthPx = widthPx,
+                heightPx = heightPx,
+                sourceRect = RenderSourceRect.FullPage,
+                isStillWanted = { value is PdfThumbnailState.Loading },
+            )
+            when (result) {
+                null -> Unit // discarded; SharedMemory already closed inside renderOrDiscard
+                is RenderResult.Ok -> {
+                    val decoded = decodePage(result, telemetry)
+                    if (decoded != null) {
+                        if (cache != null) {
+                            cache.backing.put(document.id, page, decoded.bitmap)
+                        } else {
+                            ownedHandle = decoded.bitmap
+                        }
+                        value = PdfThumbnailState.Rendered(decoded.image, decoded.pageAspect)
+                    } else {
+                        // decodePage already routed the cause to telemetry; surface a
+                        // user-actionable failure shape so the row can render a
+                        // placeholder rather than spin forever.
+                        value = PdfThumbnailState.Failed(DocumentRejectedKind.RendererFailed)
+                    }
+                }
+                is RenderResult.Rejected -> {
+                    value = PdfThumbnailState.Failed(result.kind)
+                }
+            }
+        }
+        awaitDispose {
+            ownedHandle?.let { if (!it.isRecycled) it.recycle() }
+        }
+    }
+    return state.value
+}

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/PdfThumbnail.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/PdfThumbnail.kt
@@ -12,23 +12,20 @@ import androidx.compose.ui.unit.IntSize
 import `is`.walt.passes.pdf.DocumentRejectedKind
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
+import `is`.walt.passes.pdf.PdfDocumentId
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.pdf.ui.internal.RenderedPageCache
 import `is`.walt.passes.pdf.ui.internal.decodePage
 import `is`.walt.passes.pdf.ui.internal.renderOrDiscard
+import kotlinx.coroutines.isActive
 
 /**
  * Outcome of a [rememberPdfThumbnail] call. Drives consumer placeholder / bitmap /
- * error chrome from a single sealed state.
- *
- * The shape is deliberately narrow: only an `ImageBitmap`, an aspect ratio, and an
- * enum failure kind. There is no field through which a consumer could surface PDF
- * text, metadata, an annotation list, or any other extraction-shaped data; ADR 0005
- * D4 (no extraction) and D5 (no signature affordance) are upheld by the type itself.
- * `PdfThumbnailSurfaceTest` locks the arm list and the per-arm field shape against
- * future additions.
+ * error chrome from a single sealed state. The shape is narrow by design: no field
+ * through which a consumer could surface PDF text, metadata, or annotations. ADR
+ * 0005 D4 is upheld by the type itself; `PdfThumbnailSurfaceTest` locks the arms.
  */
 public sealed interface PdfThumbnailState {
     public data object Loading : PdfThumbnailState
@@ -42,66 +39,67 @@ public sealed interface PdfThumbnailState {
 }
 
 /**
- * Bounded shared cache for page bitmaps produced by [rememberPdfThumbnail]. A single
- * instance hoisted to list scope (e.g. `remember { PdfThumbnailCache(8) }` inside a
- * `LazyColumn`'s composable parent) lets all visible rows share a fixed RAM cap and
- * keeps recently-scrolled rows warm.
- *
- * Wraps the kernel's access-ordered LRU and binds the `Bitmap.recycle` eviction
- * callback so native pixel memory is freed the moment a page falls out of the
- * window — the renderer service has already pre-recycled its source-side copy on
- * the binder boundary, so the UI consumer is the sole owner on this side.
- *
- * Thread-safety: callers are expected to invoke this from the Compose main thread.
- * Background prefetch is not supported by this surface.
+ * The cache's default size: how many recently-rendered pages to retain per consumer.
+ * Sized so the `HorizontalPager` in `DocumentView` can keep the current page plus
+ * `±2` adjacent pages hot during a swipe without recycling a bitmap that is still
+ * being painted.
  */
-public class PdfThumbnailCache(maxSize: Int) {
-    internal val backing: RenderedPageCache<Bitmap> = RenderedPageCache(
+public const val DEFAULT_PAGE_WINDOW: Int = 5
+
+/**
+ * Bounded shared cache for page bitmaps produced by [rememberPdfThumbnail]. Hoist a
+ * single instance to list scope (e.g. `remember { PdfThumbnailCache() }` inside a
+ * `LazyColumn`'s parent) so all visible rows share a fixed RAM cap.
+ *
+ * Binds `Bitmap.recycle` as the eviction callback on top of the kernel's
+ * access-ordered LRU; see `RenderedPageCache` for the cache semantics this wraps.
+ * Callers must invoke this from the Compose main thread.
+ */
+public class PdfThumbnailCache(maxSize: Int = DEFAULT_PAGE_WINDOW) {
+    private val backing: RenderedPageCache<CachedPage> = RenderedPageCache(
         maxSize = maxSize,
-        onEvict = { bitmap -> if (!bitmap.isRecycled) bitmap.recycle() },
+        onEvict = { entry -> if (!entry.bitmap.isRecycled) entry.bitmap.recycle() },
     )
 
-    public val size: Int get() = backing.size
-
     public fun clear(): Unit = backing.clear()
+
+    internal fun get(documentId: PdfDocumentId, page: Int): CachedPage? =
+        backing.get(documentId, page)
+
+    internal fun put(documentId: PdfDocumentId, page: Int, value: CachedPage): Unit =
+        backing.put(documentId, page, value)
 }
+
+/**
+ * Per-entry payload: the rasterised bitmap and the source page's natural aspect
+ * ratio. Caching `pageAspect` alongside the bitmap keeps cache-hit and cold-render
+ * paths visually identical (bitmap dimensions can drift from source aspect when
+ * the renderer downsizes against the 4 MP cap).
+ */
+internal data class CachedPage(val bitmap: Bitmap, val pageAspect: Float)
 
 /**
  * Compose-friendly facade over the isolated-process PDF renderer for **single-page
  * thumbnails**. Use this from a list-row composable to drive an asynchronously
- * rendered page-N bitmap with correct lifetime, cancellation, and cache discipline
- * for the trust-bearing renderer service.
+ * rendered page-N bitmap with correct lifetime, cancellation, and cache discipline.
  *
- * Lifecycle guarantees this facade owns so consumers do not have to reimplement them:
+ * Lifecycle guarantees this facade owns so consumers do not have to reimplement:
  *
  *  - `renderer.render(...)` runs inside `NonCancellable` (via `renderOrDiscard`),
- *    so a fast scroll that disposes the row mid-render still receives the
- *    `RenderResult` and releases the result's `SharedMemory` region — preserving
- *    the wpass-6ag N1 invariant.
- *  - When [cache] is supplied, the produced bitmap is handed to the cache for the
- *    `(document.id, page)` key; the LRU evicts older entries with `Bitmap.recycle`.
- *  - When [cache] is omitted, the bitmap is recycled on dispose of the composable
- *    (key change, scroll-off, leave composition).
+ *    so a row disposed mid-render still receives the `RenderResult` and releases
+ *    its `SharedMemory` region.
+ *  - When [cache] is supplied, the bitmap is handed to the cache; the LRU evicts
+ *    older entries with `Bitmap.recycle`. When [cache] is omitted, the bitmap is
+ *    recycled on dispose of the composable.
  *
- * Trust-bearing properties this facade preserves (ADR 0005):
+ * Trust posture: see ADR 0005 D4 — this facade preserves D3 (consumes the
+ * caller's binder, does not open a new service connection), D4 (no extraction
+ * surface in body or return type), D5 (no signature affordance), and D7 (passes
+ * [targetSizePx] through to the renderer's 4 MP cap; oversized requests surface
+ * as `Failed(RendererFailed)`).
  *
- *  - **D3 (isolated process):** the [renderer] is the caller's already-bound binder;
- *    this facade does not open its own service connection.
- *  - **D4 (no extraction):** the facade body invokes only `render(...)`; no
- *    `getText` / `getMetadata` / `getAnnotations` paths are added or wrapped. The
- *    return type exposes a single `ImageBitmap` + aspect float.
- *  - **D5 (no signature affordance):** there is no "verified" field on
- *    [PdfThumbnailState]. Trust signals remain on `DocumentTrustCaption` and
- *    `DocumentView` chrome, untouched.
- *  - **D7 (4 MP cap):** the cap is enforced inside `PdfRendererService`; this
- *    facade passes [targetSizePx] through. Oversized requests surface as
- *    `Failed(RendererFailed)`.
- *
- * pdfFile lifetime: [pdfFile] is owned by the caller. It MUST remain open for as
- * long as the calling composable is composed; close after composition ends. The
- * binder duplicates the fd on each transact, so closing on the caller side does
- * not affect an in-flight render's copy, but a closed fd in a subsequent call
- * surfaces as `Failed(RendererFailed)` rather than a UI-visible error.
+ * [pdfFile] is owned by the caller and must remain open while the composable is
+ * composed; close after composition ends.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -126,14 +124,18 @@ public fun rememberPdfThumbnail(
         renderer,
         pdfFile,
     ) {
+        // produceState reuses a shared MutableState across producer restarts, so
+        // gating staleness on `value` is unsafe — a newer producer may have already
+        // mutated it. The producer scope's isActive flips when the old job is
+        // cancelled by a key change, which is the correct liveness signal.
+        val producerScope = this
         // Tracked only when there's no cache to take ownership; the cache's onEvict
         // recycles bitmaps it owns on its own schedule.
         var ownedHandle: Bitmap? = null
 
-        val cached = cache?.backing?.get(document.id, page)
-        if (cached != null && !cached.isRecycled) {
-            val aspect = cached.width.toFloat() / cached.height.coerceAtLeast(1).toFloat()
-            value = PdfThumbnailState.Rendered(cached.asImageBitmap(), aspect)
+        val cached = cache?.get(document.id, page)
+        if (cached != null && !cached.bitmap.isRecycled) {
+            value = PdfThumbnailState.Rendered(cached.bitmap.asImageBitmap(), cached.pageAspect)
         } else {
             val result = renderOrDiscard(
                 renderer = renderer,
@@ -142,7 +144,7 @@ public fun rememberPdfThumbnail(
                 widthPx = widthPx,
                 heightPx = heightPx,
                 sourceRect = RenderSourceRect.FullPage,
-                isStillWanted = { value is PdfThumbnailState.Loading },
+                isStillWanted = { producerScope.isActive },
             )
             when (result) {
                 null -> Unit // discarded; SharedMemory already closed inside renderOrDiscard
@@ -150,15 +152,15 @@ public fun rememberPdfThumbnail(
                     val decoded = decodePage(result, telemetry)
                     if (decoded != null) {
                         if (cache != null) {
-                            cache.backing.put(document.id, page, decoded.bitmap)
+                            cache.put(document.id, page, CachedPage(decoded.bitmap, decoded.pageAspect))
                         } else {
                             ownedHandle = decoded.bitmap
                         }
                         value = PdfThumbnailState.Rendered(decoded.image, decoded.pageAspect)
                     } else {
-                        // decodePage already routed the cause to telemetry; surface a
-                        // user-actionable failure shape so the row can render a
-                        // placeholder rather than spin forever.
+                        // decodePage routed the cause to telemetry; surface a
+                        // user-actionable shape so the row can render a placeholder
+                        // rather than spin forever.
                         value = PdfThumbnailState.Failed(DocumentRejectedKind.RendererFailed)
                     }
                 }

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/PageRendering.kt
@@ -100,8 +100,3 @@ internal fun consumerRenderFailureFor(t: Throwable): ConsumerRenderFailure = whe
     else -> ConsumerRenderFailure.Other
 }
 
-// HorizontalPager retains composed Image references for adjacent pages during a swipe
-// transition; "current ± 2" gives the access-ordered LRU room so an evicted bitmap is
-// never the one the pager is still painting (recycling a bitmap whose Image is on
-// screen crashes the draw pass; see PR review C2 on the original wpass-1wq landing).
-internal const val LRU_PAGE_WINDOW: Int = 5

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/PdfThumbnailSurfaceTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/PdfThumbnailSurfaceTest.kt
@@ -89,24 +89,22 @@ class PdfThumbnailSurfaceTest {
     }
 
     @Test
-    fun pdfThumbnailCachePublicSurfaceIsConstructorClearAndSize() {
+    fun pdfThumbnailCachePublicSurfaceIsConstructorAndClear() {
         // The cache is a thin RAM-bound LRU. Adding a `peek`, `entries`, `keys`, or
         // `toMap` method would let a consumer extract page bitmaps out of band of the
         // composable that owns them — an ownership-laundering surface that should not
-        // exist on this type.
+        // exist on this type. Kotlin `internal` members are JVM-public with a mangled
+        // `name$module` suffix; filter them out — they're inaccessible from Kotlin
+        // consumers outside the module by Kotlin's visibility rules.
         val klass = Class.forName("is.walt.passes.pdf.ui.PdfThumbnailCache")
         val declared = klass.declaredMethods
             .filter { JvmModifier.isPublic(it.modifiers) && !it.isSynthetic }
-            // Kotlin `internal` members are JVM-public with a mangled `name$module`
-            // suffix. They are not part of the Kotlin public surface, so filter them
-            // out of the lock — they're already inaccessible from Kotlin consumers
-            // outside the module.
             .filterNot { it.name.contains('$') }
             .map { it.name }
             .toSet()
         assertWithMessage("PdfThumbnailCache public method surface drifted")
             .that(declared)
-            .containsExactly("clear", "getSize")
+            .containsExactly("clear")
     }
 
     @Test
@@ -141,14 +139,20 @@ class PdfThumbnailSurfaceTest {
 
     private fun findTopLevel(fileClassSimpleName: String, methodName: String): Method {
         val klass = Class.forName("is.walt.passes.pdf.ui.$fileClassSimpleName")
-        return klass.methods
-            .filter { it.name == methodName || it.name.startsWith("$methodName-") }
-            .maxByOrNull { it.parameterCount }
-            ?: error("$fileClassSimpleName.$methodName not found")
+        val matches = klass.methods.filter {
+            it.name == methodName || it.name.startsWith("$methodName-")
+        }
+        assertWithMessage(
+            "Expected exactly one $fileClassSimpleName.$methodName method; a surprise " +
+                "overload should fail loudly so the surface lock catches the addition.",
+        ).that(matches).hasSize(1)
+        return matches.single()
     }
 
+    // Compose-compiler-dependent: synthetic `Composer` + `int $changed` trailing
+    // parameters are stripped. The exact mangling is an implementation detail of the
+    // current Compose compiler; if it changes, this helper needs to follow.
     private fun userVisibleParameterCount(method: Method): Int {
-        // Compose appends `Composer $composer` and `int $changed` (and `int $changed1`).
         val params = method.parameterTypes
         var count = params.size
         var i = params.lastIndex

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/PdfThumbnailSurfaceTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/PdfThumbnailSurfaceTest.kt
@@ -1,0 +1,165 @@
+package `is`.walt.passes.pdf.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import `is`.walt.passes.pdf.DocumentRejectedKind
+import org.junit.Test
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier as JvmModifier
+
+/**
+ * Locks the public API shape of the PDF thumbnail facade (`wpass-5g7`). The shape IS the
+ * trust contract: the only way a future contributor could leak PDF text, metadata, or
+ * annotations through this surface is to add a field to [PdfThumbnailState] or a method
+ * to [PdfThumbnailCache] — both of which break a test here.
+ *
+ * The bytecode-scan in [DocumentPublicApiSurfaceTest] covers `application/pdf` MIME and
+ * `Intent.ACTION_SEND` literals across the same package, so this test focuses on the
+ * structural shape of the new public symbols.
+ */
+class PdfThumbnailSurfaceTest {
+
+    @Test
+    fun rememberPdfThumbnailHasExactlySevenUserVisibleParameters() {
+        // (document, pdfFile, renderer, targetSizePx, page, telemetry, cache). Adding
+        // an eighth parameter is a public-API change; review wpass-5g7's surface
+        // contract before bumping this number.
+        val method = findTopLevel("PdfThumbnailKt", "rememberPdfThumbnail")
+        val actual = userVisibleParameterCount(method)
+        assertWithMessage(
+            "rememberPdfThumbnail user-visible parameter count drifted; the shape is " +
+                "the public contract (wpass-5g7). Full method signature: $method",
+        )
+            .that(actual)
+            .isEqualTo(7)
+    }
+
+    @Test
+    fun rememberPdfThumbnailReturnsPdfThumbnailState() {
+        val method = findTopLevel("PdfThumbnailKt", "rememberPdfThumbnail")
+        assertThat(method.returnType.name).isEqualTo("is.walt.passes.pdf.ui.PdfThumbnailState")
+    }
+
+    @Test
+    fun pdfThumbnailStateHasExactlyThreePermittedSubclasses() {
+        // Loading (data object), Rendered (image + pageAspect), Failed (kind). A fourth
+        // arm is a deliberate trust-shape change: a `Pending`, `Cancelled`, or
+        // `Stale` arm would force every consumer to update its `when` and would
+        // surface a new field that could carry a PDF-extraction-shaped payload.
+        val sealed = Class.forName("is.walt.passes.pdf.ui.PdfThumbnailState")
+        val permitted = sealed.permittedSubclasses
+        assertThat(permitted).isNotNull()
+        val names = permitted!!.map { it.simpleName }.toSet()
+        assertThat(names).containsExactly("Loading", "Rendered", "Failed")
+    }
+
+    @Test
+    fun pdfThumbnailStateRenderedExposesOnlyImageAndPageAspect() {
+        // Rendered carries exactly two fields: the rasterised bitmap and the source
+        // page's natural aspect ratio. No filename, no page index, no metadata map.
+        // Adding a field is a security-policy change: any reference type added here
+        // could become a path through which PDF text or metadata reaches the consumer.
+        val rendered = Class.forName("is.walt.passes.pdf.ui.PdfThumbnailState\$Rendered")
+        val publicGetters = rendered.declaredMethods
+            .filter { JvmModifier.isPublic(it.modifiers) }
+            .filter { it.name.startsWith("get") || it.name.startsWith("component") }
+            .map { it.name }
+            .toSet()
+        // getImage + getPageAspect from the data class; component1/component2 from
+        // data-class destructuring. Anything else is a new field.
+        assertThat(publicGetters).containsAtLeast("getImage", "getPageAspect")
+        val unexpected = publicGetters.filterNot {
+            it == "getImage" || it == "getPageAspect" ||
+                it == "component1" || it == "component2"
+        }
+        assertWithMessage(
+            "PdfThumbnailState.Rendered has unexpected accessors $unexpected — " +
+                "adding a field is a security-policy change (ADR 0005 D4).",
+        ).that(unexpected).isEmpty()
+    }
+
+    @Test
+    fun pdfThumbnailStateFailedKindIsDocumentRejectedKind() {
+        // Failed carries a single enum, the same vocabulary the renderer service uses
+        // for rejections. A String / Throwable / message field would be a telemetry
+        // PII leak by the same rule that DocumentTelemetryGuard enforces.
+        val failed = Class.forName("is.walt.passes.pdf.ui.PdfThumbnailState\$Failed")
+        val getter = failed.declaredMethods.single { it.name == "getKind" }
+        assertThat(getter.returnType).isEqualTo(DocumentRejectedKind::class.java)
+    }
+
+    @Test
+    fun pdfThumbnailCachePublicSurfaceIsConstructorClearAndSize() {
+        // The cache is a thin RAM-bound LRU. Adding a `peek`, `entries`, `keys`, or
+        // `toMap` method would let a consumer extract page bitmaps out of band of the
+        // composable that owns them — an ownership-laundering surface that should not
+        // exist on this type.
+        val klass = Class.forName("is.walt.passes.pdf.ui.PdfThumbnailCache")
+        val declared = klass.declaredMethods
+            .filter { JvmModifier.isPublic(it.modifiers) && !it.isSynthetic }
+            // Kotlin `internal` members are JVM-public with a mangled `name$module`
+            // suffix. They are not part of the Kotlin public surface, so filter them
+            // out of the lock — they're already inaccessible from Kotlin consumers
+            // outside the module.
+            .filterNot { it.name.contains('$') }
+            .map { it.name }
+            .toSet()
+        assertWithMessage("PdfThumbnailCache public method surface drifted")
+            .that(declared)
+            .containsExactly("clear", "getSize")
+    }
+
+    @Test
+    fun newPublicTypesHaveNoExtractionShapedAccessors() {
+        // Defense-in-depth on top of the bytecode-scan in DocumentPublicApiSurfaceTest:
+        // even if a future field's bytecode does not include the literal "application/
+        // pdf" or "android.intent.action.SEND", a method named `getText`, `getMetadata`,
+        // `getAnnotations`, `getAttachments`, or similar is a structural signal that
+        // someone is wiring an extraction path into the trust-bearing surface.
+        val forbidden = setOf(
+            "getText", "getMetadata", "getAnnotations", "getAttachments",
+            "getFormFields", "getJavaScript", "getBookmarks", "getOutline",
+        )
+        val classesToScan = listOf(
+            "is.walt.passes.pdf.ui.PdfThumbnailKt",
+            "is.walt.passes.pdf.ui.PdfThumbnailState",
+            "is.walt.passes.pdf.ui.PdfThumbnailState\$Loading",
+            "is.walt.passes.pdf.ui.PdfThumbnailState\$Rendered",
+            "is.walt.passes.pdf.ui.PdfThumbnailState\$Failed",
+            "is.walt.passes.pdf.ui.PdfThumbnailCache",
+        )
+        for (className in classesToScan) {
+            val klass = Class.forName(className)
+            val offenders = klass.methods.map { it.name }.intersect(forbidden)
+            assertWithMessage("$className exposes extraction-shaped accessors $offenders")
+                .that(offenders)
+                .isEmpty()
+        }
+    }
+
+    // -- helpers (mirroring DocumentSurfaceLockTest) -------------------------------
+
+    private fun findTopLevel(fileClassSimpleName: String, methodName: String): Method {
+        val klass = Class.forName("is.walt.passes.pdf.ui.$fileClassSimpleName")
+        return klass.methods
+            .filter { it.name == methodName || it.name.startsWith("$methodName-") }
+            .maxByOrNull { it.parameterCount }
+            ?: error("$fileClassSimpleName.$methodName not found")
+    }
+
+    private fun userVisibleParameterCount(method: Method): Int {
+        // Compose appends `Composer $composer` and `int $changed` (and `int $changed1`).
+        val params = method.parameterTypes
+        var count = params.size
+        var i = params.lastIndex
+        while (i >= 0) {
+            val t = params[i]
+            val isComposer = t.name == "androidx.compose.runtime.Composer"
+            val isInt = t.name == "int"
+            if (!isComposer && !isInt) break
+            count--
+            i--
+        }
+        return count
+    }
+}


### PR DESCRIPTION
## Summary

- New public Compose facade in `passes-pdf-ui`: `rememberPdfThumbnail(...) -> PdfThumbnailState`, with sibling `PdfThumbnailCache` and sealed `PdfThumbnailState { Loading | Rendered | Failed }`. Wraps the internal \`decodePage\`, \`renderOrDiscard\`, and \`RenderedPageCache\` so list-row consumers do not reimplement the \`NonCancellable\` binder transact, the \`SharedMemory\` cleanup on dispose, or the access-ordered LRU with bitmap recycle on eviction.
- \`DocumentView\` and \`FullScreenDocumentView\` migrate onto the facade for their FullPage render path. The sub-rect zoom path in the full-screen surface stays manual (sub-rects are intentionally not cached and have bespoke overlay lifetime).
- \`PdfThumbnailSurfaceTest\` reflection-locks the parameter count of \`rememberPdfThumbnail\`, the sealed-arm list of \`PdfThumbnailState\`, the per-arm field shape (no extraction-shaped accessor like \`getText\` / \`getMetadata\` / \`getAnnotations\` on any new public symbol), and the \`PdfThumbnailCache\` public surface.
- ADR 0005 D4 notes the facade and its no-extraction guarantee.

Trust posture preserved (see updated ADR 0005 D4):
- **D3** isolated process: facade consumes the caller's \`PdfRendererBinder\`; does not open its own service connection.
- **D4** no extraction: facade body invokes only \`render(...)\`; return type carries only \`ImageBitmap\` + aspect float + enum failure kind.
- **D5** no signature affordance: no "verified" field on \`PdfThumbnailState\`.
- **D7** 4 MP cap: \`targetSizePx\` passes through; oversized requests surface as \`Failed(RendererFailed)\`.

Follow-up filed as **wpass-7v8** for the instrumented Compose tests (dispose-during-render closes \`SharedMemory\`; fresh \`Rendered\` against same \`(documentId, page)\` evicts and recycles the previous bitmap) — both call for the Android runtime + a fake binder against real \`SharedMemory\`, so they don't fit in this JVM-pure surface-lock PR.

## Test plan

- [x] \`./gradlew :passes-pdf-ui:check\` — passes (36 tests, lint, detekt, ktlint).
- [x] \`./gradlew :passes-pdf-ui:compileDebugAndroidTestKotlin\` — instrumented sources compile against the migrated \`DocumentView\` / \`FullScreenDocumentView\`.
- [ ] Instrumented end-to-end (tracked separately in wpass-7v8).