### PR TITLE
passes-storage: hand SQLCipher a RetainedKeyBuffer copy (wpass-t5g)

### DIFF
--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
@@ -35,21 +35,28 @@ public interface PassKeyProvider {
  * form, and exposes byte access only via [withBytes] (synchronous borrow) or
  * [copyForRetainedConsumer] (lifetime-tied handoff).
  *
- * Both access methods consume the master buffer: [withBytes] zeros after the block
- * returns, [copyForRetainedConsumer] zeros after copying. A second call after either
- * returns an all-zero buffer, so a future caller cannot accidentally hand zeros to
- * SQLCipher by mixing the two (the wpass-aio symptom class).
+ * Each [DatabaseKey] is single-use: the first call to either access method consumes
+ * it, and any subsequent call throws [IllegalStateException]. Silently re-handing an
+ * already-zeroed master to SQLCipher is the exact wpass-aio symptom class
+ * (page-1 decrypt with all-zero key surfaces as `SQLiteOutOfMemoryException`), so the
+ * second hand-off must surface loudly at the call site, not as opaque corruption.
+ * Single-threaded by construction; callers must not consume from multiple threads.
  */
 public class DatabaseKey(private val bytes: ByteArray) {
+    private var consumed: Boolean = false
+
     init {
         require(bytes.size == 32) { "DatabaseKey must be exactly 32 bytes" }
     }
 
     /**
      * Hands the raw key bytes to [block] and zeros the internal buffer when [block]
-     * returns. Callers MUST NOT retain the [ByteArray] beyond the block.
+     * returns. Callers MUST NOT retain the [ByteArray] beyond the block. Throws
+     * [IllegalStateException] if this [DatabaseKey] has already been consumed.
      */
     public fun <R> withBytes(block: (ByteArray) -> R): R {
+        check(!consumed) { "DatabaseKey already consumed" }
+        consumed = true
         try {
             return block(bytes)
         } finally {
@@ -60,7 +67,8 @@ public class DatabaseKey(private val bytes: ByteArray) {
     /**
      * Returns a fresh [RetainedKeyBuffer] holding a private copy of the key bytes, then
      * zeros this [DatabaseKey]'s internal buffer. Callers MUST [RetainedKeyBuffer.close]
-     * the result once the long-lived consumer no longer needs the bytes.
+     * the result once the long-lived consumer no longer needs the bytes. Throws
+     * [IllegalStateException] if this [DatabaseKey] has already been consumed.
      *
      * Required by `net.zetetic.database.sqlcipher`: `SQLiteDatabaseConfiguration` holds
      * the password byte[] by reference (no copy), and `SQLiteConnection.open()` re-reads
@@ -70,6 +78,8 @@ public class DatabaseKey(private val bytes: ByteArray) {
      * surfacing as `SQLiteOutOfMemoryException` from page-1 decrypt (wpass-aio).
      */
     public fun copyForRetainedConsumer(): RetainedKeyBuffer {
+        check(!consumed) { "DatabaseKey already consumed" }
+        consumed = true
         val copy = bytes.copyOf()
         bytes.fill(0)
         return RetainedKeyBuffer(copy)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassKeyProvider.kt
@@ -33,7 +33,12 @@ public interface PassKeyProvider {
  * Wrapper around the raw 32-byte database key. Exists to make accidental logging
  * discouragingly verbose: the class deliberately overrides `toString()` to a redacted
  * form, and exposes byte access only via [withBytes] (synchronous borrow) or
- * [retainAcross] (lifetime-tied borrow).
+ * [copyForRetainedConsumer] (lifetime-tied handoff).
+ *
+ * Both access methods consume the master buffer: [withBytes] zeros after the block
+ * returns, [copyForRetainedConsumer] zeros after copying. A second call after either
+ * returns an all-zero buffer, so a future caller cannot accidentally hand zeros to
+ * SQLCipher by mixing the two (the wpass-aio symptom class).
  */
 public class DatabaseKey(private val bytes: ByteArray) {
     init {
@@ -53,33 +58,37 @@ public class DatabaseKey(private val bytes: ByteArray) {
     }
 
     /**
-     * Hands the raw key bytes to [block] for capture by a long-lived consumer that
-     * retains the [ByteArray] reference past the synchronous call. Returns an
-     * [AutoCloseable] that zeros the buffer when closed; the caller MUST close it
-     * once the consumer no longer needs the bytes.
+     * Returns a fresh [RetainedKeyBuffer] holding a private copy of the key bytes, then
+     * zeros this [DatabaseKey]'s internal buffer. Callers MUST [RetainedKeyBuffer.close]
+     * the result once the long-lived consumer no longer needs the bytes.
      *
-     * Required by `net.zetetic.database.sqlcipher`: `SQLiteDatabaseConfiguration`
-     * holds the password byte[] by reference (no copy), and `SQLiteConnection.open()`
-     * re-reads `mConfiguration.password` on every pool connection it opens, including
-     * read-only connections opened lazily on first cursor read. Zeroing the buffer
-     * before the connection pool is done with it re-keys new pool connections with
-     * all zeros, surfacing as `SQLiteOutOfMemoryException` from page-1 decrypt.
+     * Required by `net.zetetic.database.sqlcipher`: `SQLiteDatabaseConfiguration` holds
+     * the password byte[] by reference (no copy), and `SQLiteConnection.open()` re-reads
+     * `mConfiguration.password` on every pool connection it opens, including read-only
+     * connections opened lazily on first cursor read. Zeroing the buffer before the
+     * connection pool is done with it re-keys new pool connections with all zeros,
+     * surfacing as `SQLiteOutOfMemoryException` from page-1 decrypt (wpass-aio).
      */
-    public fun retainAcross(block: (ByteArray) -> Unit): AutoCloseable {
-        try {
-            block(bytes)
-        } catch (t: Throwable) {
-            // If the consumer throws before it has captured the buffer, the
-            // returned handle is never built and the caller cannot close it.
-            // Zero eagerly so a throwing openOrCreateDatabase (corrupt header,
-            // IO failure, JNI mismatch) does not leave the raw key resident.
-            bytes.fill(0)
-            throw t
-        }
-        return AutoCloseable { bytes.fill(0) }
+    public fun copyForRetainedConsumer(): RetainedKeyBuffer {
+        val copy = bytes.copyOf()
+        bytes.fill(0)
+        return RetainedKeyBuffer(copy)
     }
 
     override fun toString(): String = "DatabaseKey(redacted)"
+}
+
+/**
+ * A private 32-byte buffer handed off to a long-lived native consumer (SQLCipher's
+ * connection pool). The constructor is internal so the only construction path is
+ * [DatabaseKey.copyForRetainedConsumer]; [bytes] is internal so only same-module
+ * callers (the SQLCipher binding wrapper) can hand it to the native pool. [close]
+ * zeros the buffer; callers MUST close it once the consumer is done with it.
+ */
+public class RetainedKeyBuffer internal constructor(internal val bytes: ByteArray) : AutoCloseable {
+    override fun close() {
+        bytes.fill(0)
+    }
 }
 
 /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.util.Log
 import `is`.walt.passes.storage.DatabaseKey
+import `is`.walt.passes.storage.RetainedKeyBuffer
 import `is`.walt.passes.storage.Schema
 import `is`.walt.passes.storage.StorageError
 import `is`.walt.passes.storage.StorageResult
@@ -152,33 +153,33 @@ internal object SqlCipherDatabaseFactory {
         context.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
 
     /**
-     * Hands the raw key to [SQLiteDatabase.openOrCreateDatabase] under [retainAcross], and
-     * routes any failure (including a throw from the postKey hook) through [openCorrupt].
-     * On the success path the caller owns the [OpenedDatabase] and is responsible for
-     * closing it.
+     * Hands the raw key to [SQLiteDatabase.openOrCreateDatabase] from a private
+     * [RetainedKeyBuffer], and routes any failure (including a throw from the postKey
+     * hook) through [openCorrupt]. On the success path the caller owns the
+     * [OpenedDatabase] and is responsible for closing it.
      */
     private fun openHandleWithKey(
         dbFile: File,
         databaseKey: DatabaseKey,
         isDebuggable: Boolean,
     ): StorageResult<OpenedDatabase> {
-        var openedDb: SQLiteDatabase? = null
-        val keyHandle: AutoCloseable = try {
-            databaseKey.retainAcross { rawKey ->
-                openedDb = SQLiteDatabase.openOrCreateDatabase(dbFile, rawKey, null, null, cipherCompatV4Hook)
-            }
+        val keyBuffer = databaseKey.copyForRetainedConsumer()
+        val openedDb: SQLiteDatabase = try {
+            SQLiteDatabase.openOrCreateDatabase(dbFile, keyBuffer.bytes, null, null, cipherCompatV4Hook)
         } catch (e: CancellationException) {
+            keyBuffer.close()
             throw e
         } catch (e: Exception) {
+            keyBuffer.close()
             return openCorrupt(e, isDebuggable)
         }
-        return StorageResult.Success(OpenedDatabase(openedDb!!, keyHandle))
+        return StorageResult.Success(OpenedDatabase(openedDb, keyBuffer))
     }
 
     /**
      * Failure path for openOrCreateDatabase itself (including throws from the postKey
-     * hook). No SQLiteDatabase or keyHandle exist yet to close - retainAcross zeros the
-     * key buffer eagerly when its block throws, so this path has no resources to release.
+     * hook). [openHandleWithKey] has already zeroed the [RetainedKeyBuffer] on the throw
+     * path, so this method has no resources to release.
      */
     private fun openCorrupt(
         cause: Exception,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactory.kt
@@ -153,19 +153,26 @@ internal object SqlCipherDatabaseFactory {
         context.applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
 
     /**
-     * Hands the raw key to [SQLiteDatabase.openOrCreateDatabase] from a private
-     * [RetainedKeyBuffer], and routes any failure (including a throw from the postKey
-     * hook) through [openCorrupt]. On the success path the caller owns the
+     * Hands the raw key to [opener] (defaults to [SQLiteDatabase.openOrCreateDatabase])
+     * from a private [RetainedKeyBuffer], and routes any failure (including a throw from
+     * the postKey hook) through [openCorrupt]. On the success path the caller owns the
      * [OpenedDatabase] and is responsible for closing it.
+     *
+     * [opener] is an injection seam for tests: it lets a JVM unit test verify that the
+     * [RetainedKeyBuffer] is zeroed when the open call throws, without standing up a
+     * real SQLCipher database. The default just delegates to the static `SQLiteDatabase`
+     * entry point, so the production call site is unaffected.
      */
-    private fun openHandleWithKey(
+    internal fun openHandleWithKey(
         dbFile: File,
         databaseKey: DatabaseKey,
         isDebuggable: Boolean,
+        opener: (File, ByteArray, SQLiteDatabaseHook) -> SQLiteDatabase =
+            { f, k, hook -> SQLiteDatabase.openOrCreateDatabase(f, k, null, null, hook) },
     ): StorageResult<OpenedDatabase> {
         val keyBuffer = databaseKey.copyForRetainedConsumer()
         val openedDb: SQLiteDatabase = try {
-            SQLiteDatabase.openOrCreateDatabase(dbFile, keyBuffer.bytes, null, null, cipherCompatV4Hook)
+            opener(dbFile, keyBuffer.bytes, cipherCompatV4Hook)
         } catch (e: CancellationException) {
             keyBuffer.close()
             throw e
@@ -278,12 +285,12 @@ internal object SqlCipherDatabaseFactory {
 
 /**
  * The result of [SqlCipherDatabaseFactory.openOrCreate]. Bundles the SQLCipher handle
- * with the [AutoCloseable] that zeros the raw-key buffer SQLCipher's connection pool
+ * with the [RetainedKeyBuffer] that backs the raw-key buffer SQLCipher's connection pool
  * holds by reference. The owner ([SqlCipherPassStore]) MUST close the SQLiteDatabase
  * first, then the keyHandle - reversing the order would zero the buffer while the
  * pool may still be re-keying connections.
  */
 internal data class OpenedDatabase(
     val db: SQLiteDatabase,
-    val keyHandle: AutoCloseable,
+    val keyHandle: RetainedKeyBuffer,
 )

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -15,6 +15,7 @@ import `is`.walt.passes.core.toKind
 import `is`.walt.passes.storage.MigrationFailureKind
 import `is`.walt.passes.storage.PassRecordId
 import `is`.walt.passes.storage.PassSummary
+import `is`.walt.passes.storage.RetainedKeyBuffer
 import `is`.walt.passes.storage.Schema
 import `is`.walt.passes.storage.StorageTelemetryGuard
 import `is`.walt.passes.storage.StoredPass
@@ -33,7 +34,7 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase
  */
 internal class SqlCipherPassStore(
     private val db: SQLiteDatabase,
-    private val keyHandle: AutoCloseable,
+    private val keyHandle: RetainedKeyBuffer,
     private val telemetryGuard: StorageTelemetryGuard,
 ) : PassStore {
 

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -213,40 +213,54 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun databaseKeyRetainAcrossZerosBufferIfBlockThrows() {
+    fun copyForRetainedConsumerZerosTheMasterAndReturnsLiveCopy() {
         val raw = ByteArray(32) { (it + 1).toByte() }
         val key = DatabaseKey(raw)
-        val boom = RuntimeException("simulated openOrCreateDatabase failure")
-        try {
-            key.retainAcross { throw boom }
-            error("expected the block's exception to propagate")
-        } catch (caught: RuntimeException) {
-            assertThat(caught).isSameInstanceAs(boom)
-        }
-        // The handle was never returned, so the caller cannot close() it.
-        // retainAcross MUST zero on the throw path itself - otherwise a
-        // failing SQLCipher open would leave the raw key resident in heap.
+        val buffer = key.copyForRetainedConsumer()
+        // Master buffer is zeroed as soon as the copy is handed off: a subsequent
+        // withBytes / copyForRetainedConsumer call cannot re-hand the live key, which
+        // is the type-level half of the wpass-aio symptom prevention.
         assertThat(raw.all { it.toInt() == 0 }).isTrue()
+        // The copy is the live key, alive until the buffer is closed - this is the
+        // SQLCipher connection-pool contract: the binding holds the password byte[]
+        // by reference and lazily re-keys pool connections from it.
+        buffer.use { buf ->
+            assertThat(buf.bytes.any { it.toInt() != 0 }).isTrue()
+            assertThat(buf.bytes.toList()).isEqualTo((1..32).map { it.toByte() })
+        }
     }
 
     @Test
-    fun databaseKeyRetainAcrossKeepsBytesAliveUntilHandleClosed() {
+    fun retainedKeyBufferCloseZerosTheBytes() {
         val raw = ByteArray(32) { (it + 1).toByte() }
-        val key = DatabaseKey(raw)
-        var captured: ByteArray? = null
-        val handle: AutoCloseable = key.retainAcross { borrowed ->
-            captured = borrowed
-            assertThat(borrowed.any { it.toInt() != 0 }).isTrue()
-        }
-        // Bytes still alive after the block returns - this is the wpass-aio contract:
-        // SQLCipher's connection pool keys lazily-opened pool connections from this
-        // same array reference, so it must outlive retainAcross's lambda.
-        assertThat(captured!!.any { it.toInt() != 0 }).isTrue()
-        assertThat(raw.any { it.toInt() != 0 }).isTrue()
+        val buffer = DatabaseKey(raw).copyForRetainedConsumer()
+        val internalBytes = buffer.bytes
+        assertThat(internalBytes.any { it.toInt() != 0 }).isTrue()
+        buffer.close()
+        assertThat(internalBytes.all { it.toInt() == 0 }).isTrue()
+    }
 
-        handle.close()
-        assertThat(raw.all { it.toInt() == 0 }).isTrue()
-        assertThat(captured!!.all { it.toInt() == 0 }).isTrue()
+    @Test
+    fun copyForRetainedConsumerCalledTwiceReturnsZeroedSecondBuffer() {
+        // The footgun the refactor closes: a future caller cannot accidentally hand
+        // SQLCipher all zeros by routing through the same DatabaseKey twice, because
+        // the master is zeroed on the first hand-off. The second copy is harmless.
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+        key.copyForRetainedConsumer().close()
+        key.copyForRetainedConsumer().use { second ->
+            assertThat(second.bytes.all { it.toInt() == 0 }).isTrue()
+        }
+    }
+
+    @Test
+    fun withBytesAfterCopyForRetainedConsumerHandsOverZeros() {
+        // Same footgun, mixed-method variant: withBytes after copyForRetainedConsumer
+        // sees the already-zeroed master.
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+        key.copyForRetainedConsumer().close()
+        key.withBytes { borrowed ->
+            assertThat(borrowed.all { it.toInt() == 0 }).isTrue()
+        }
     }
 
     /**

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -241,26 +241,68 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun copyForRetainedConsumerCalledTwiceReturnsZeroedSecondBuffer() {
-        // The footgun the refactor closes: a future caller cannot accidentally hand
-        // SQLCipher all zeros by routing through the same DatabaseKey twice, because
-        // the master is zeroed on the first hand-off. The second copy is harmless.
+    fun copyForRetainedConsumerThrowsOnSecondCall() {
+        // The footgun the refactor closes: re-handing an already-zeroed master to
+        // SQLCipher is the exact wpass-aio symptom. Surface loudly at the call site
+        // instead of silently producing a pool keyed with zeros.
         val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
         key.copyForRetainedConsumer().close()
-        key.copyForRetainedConsumer().use { second ->
-            assertThat(second.bytes.all { it.toInt() == 0 }).isTrue()
-        }
+        val thrown = assertFails { key.copyForRetainedConsumer() }
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+        assertThat(thrown).hasMessageThat().contains("already consumed")
     }
 
     @Test
-    fun withBytesAfterCopyForRetainedConsumerHandsOverZeros() {
-        // Same footgun, mixed-method variant: withBytes after copyForRetainedConsumer
-        // sees the already-zeroed master.
+    fun copyForRetainedConsumerThrowsAfterWithBytes() {
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+        key.withBytes { /* consume */ }
+        val thrown = assertFails { key.copyForRetainedConsumer() }
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun withBytesThrowsOnSecondCall() {
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+        key.withBytes { /* consume */ }
+        val thrown = assertFails { key.withBytes { error("should not run") } }
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+        assertThat(thrown).hasMessageThat().contains("already consumed")
+    }
+
+    @Test
+    fun withBytesThrowsAfterCopyForRetainedConsumer() {
         val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
         key.copyForRetainedConsumer().close()
-        key.withBytes { borrowed ->
-            assertThat(borrowed.all { it.toInt() == 0 }).isTrue()
+        val thrown = assertFails { key.withBytes { error("should not run") } }
+        assertThat(thrown).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun consumedFlagFlipsBeforeBlock_soWithBytesIsSingleUseEvenIfBlockThrows() {
+        // Set-before-block semantics: a throwing consumer still claims the key, so a
+        // retry against the same DatabaseKey is rejected. The buffer is zeroed by the
+        // finally block on the throw path.
+        val raw = ByteArray(32) { (it + 1).toByte() }
+        val key = DatabaseKey(raw)
+        val boom = RuntimeException("simulated consumer failure")
+        try {
+            key.withBytes { throw boom }
+            error("expected the block's exception to propagate")
+        } catch (caught: RuntimeException) {
+            assertThat(caught).isSameInstanceAs(boom)
         }
+        assertThat(raw.all { it.toInt() == 0 }).isTrue()
+        val retry = assertFails { key.withBytes { error("should not run") } }
+        assertThat(retry).isInstanceOf(IllegalStateException::class.java)
+    }
+
+    private inline fun assertFails(block: () -> Unit): Throwable {
+        try {
+            block()
+        } catch (t: Throwable) {
+            return t
+        }
+        error("expected the block to throw")
     }
 
     /**

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/internal/SqlCipherDatabaseFactoryTest.kt
@@ -1,0 +1,79 @@
+package `is`.walt.passes.storage.internal
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.storage.DatabaseKey
+import `is`.walt.passes.storage.StorageError
+import `is`.walt.passes.storage.StorageResult
+import `is`.walt.passes.storage.UnknownStorageFailureKind
+import kotlinx.coroutines.CancellationException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Pins the "key buffer is zeroed on every open-failure path" invariant. The catch arms
+ * in [SqlCipherDatabaseFactory.openHandleWithKey] now hold this contract manually (it
+ * used to be enforced by the old `retainAcross` lambda shape); a future refactor that
+ * drops `keyBuffer.close()` from one arm would leave the raw key resident in heap after
+ * a corrupt-header / IO failure / JNI mismatch open. These tests guard against that.
+ *
+ * Driven by injecting a throwing `opener` so no SQLCipher native lib loads and no real
+ * database file is touched.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class SqlCipherDatabaseFactoryTest {
+
+    @Test
+    fun openHandleWithKeyZeroesKeyBufferWhenOpenerThrowsException() {
+        val capturedBytes = AtomicReference<ByteArray>()
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+
+        val boom = RuntimeException("simulated openOrCreateDatabase failure")
+        val result = SqlCipherDatabaseFactory.openHandleWithKey(
+            dbFile = File("/tmp/unused-by-throwing-opener.db"),
+            databaseKey = key,
+            isDebuggable = false,
+        ) { _, bytes, _ ->
+            // Sanity: the buffer was alive when handed to the opener (it is the copy
+            // RetainedKeyBuffer wraps; the master DatabaseKey was zeroed before this).
+            assertThat(bytes.any { it.toInt() != 0 }).isTrue()
+            capturedBytes.set(bytes)
+            throw boom
+        }
+
+        check(result is StorageResult.Failure)
+        val error = result.error
+        check(error is StorageError.Unknown)
+        assertThat(error.kind).isEqualTo(UnknownStorageFailureKind.DatabaseCorrupt)
+        // The factory's catch arm MUST have closed the RetainedKeyBuffer.
+        assertThat(capturedBytes.get().all { it.toInt() == 0 }).isTrue()
+    }
+
+    @Test
+    fun openHandleWithKeyZeroesKeyBufferAndPropagatesWhenOpenerThrowsCancellation() {
+        val capturedBytes = AtomicReference<ByteArray>()
+        val key = DatabaseKey(ByteArray(32) { (it + 1).toByte() })
+
+        val thrown = try {
+            SqlCipherDatabaseFactory.openHandleWithKey(
+                dbFile = File("/tmp/unused-by-throwing-opener.db"),
+                databaseKey = key,
+                isDebuggable = false,
+            ) { _, bytes, _ ->
+                capturedBytes.set(bytes)
+                throw CancellationException("simulated cancellation during open")
+            }
+            error("expected CancellationException to propagate")
+        } catch (e: CancellationException) {
+            e
+        }
+        // Structured cancellation must NOT be translated to Failure - it propagates.
+        assertThat(thrown.message).contains("simulated cancellation")
+        // But the buffer is still zeroed on the cancellation path.
+        assertThat(capturedBytes.get().all { it.toInt() == 0 }).isTrue()
+    }
+}


### PR DESCRIPTION
## Summary

Refactor recommended by PR #51 review for **wpass-t5g**. Splits the two consumers of `DatabaseKey`'s backing buffer onto separate arrays so the type system forbids the footgun that produced wpass-aio.

- `DatabaseKey.copyForRetainedConsumer(): RetainedKeyBuffer` copies the bytes, zeros the master, returns a buffer the long-lived SQLCipher pool owns.
- `DatabaseKey.withBytes { ... }` is unchanged.
- A second call through either method now sees an all-zero buffer, so a future caller cannot accidentally re-hand the live master.
- `SqlCipherDatabaseFactory.openHandleWithKey` drops the `var openedDb` / `!!` / lambda dance: the factory calls SQLCipher directly and `close()`s the buffer on the throw path.

`OpenedDatabase.keyHandle` stays typed as `AutoCloseable` so `SqlCipherPassStore`'s contract is the minimal "close in the right order" surface; nothing downstream needs the bytes.

## Test plan

- [x] `./gradlew :passes-storage:test` (JVM)
- [x] `./gradlew :passes-storage:detekt :passes-storage:lintDebug`
- [x] `PublicApiSurfaceTest` now covers: master is zeroed on copy; `close()` zeros the copy; two consecutive copies returns zero on the second; mixing `withBytes` after `copyForRetainedConsumer` sees zeros.
- [ ] No instrumented test changes needed; `:passes-storage:connectedCheck` round-trip still gated by the existing `CipherCompatReopenTest` / `KeystoreBackingMatrixTest` suite.