### PR TITLE
passes-core: ScannableCard data model + result family (wpass-lzi.2)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
@@ -1,18 +1,20 @@
 package `is`.walt.passes.core
 
 /**
- * A user-generated, unsigned scannable artifact: a typed-in payload plus a chosen barcode
- * format that renders scannably on screen. Sibling of [Pass], NOT a subtype — the two share
- * no parse pipeline, no signature posture, and no UI lane. The trust UX distinction is
- * load-bearing: a [Pass] has been cryptographically verified before construction; a
- * [ScannableCard] never can be, because the user typed the data.
+ * A user-generated, unsigned scannable artifact. Sibling of [Pass], NOT a subtype: existence
+ * of a [ScannableCard] value asserts that the wrapped payload has cleared the kernel's
+ * validator (length caps, charset rules, bidi/control-character rejection). The constructor
+ * is [internal] so this invariant cannot be bypassed by an outside caller hand-building one
+ * around raw input — the only construction path is via the validator's
+ * [ScannableCardCreateResult.Success].
  *
- * No unifying `DisplayableArtifact` interface exists, deliberately. Re-introducing one would
- * re-create the trust-conflation risk the wpass-lzi epic explicitly avoids — if a single
- * type can hold either kind of artifact, every consumer-side `when` becomes a chance to
- * forget the trust-caption arm.
+ * Where [Pass] carries a sibling [SignatureStatus] to convey trust, [ScannableCard] carries
+ * trust at the type level instead — there is no signature to validate because the user typed
+ * the data. The two artifact classes deliberately share no supertype; introducing one would
+ * re-create the trust-conflation risk the wpass-lzi epic forbids.
  */
-public data class ScannableCard(
+@ConsistentCopyVisibility
+public data class ScannableCard internal constructor(
     public val id: ScannableCardId,
     public val payload: String,
     public val format: ScannableFormat,
@@ -22,22 +24,20 @@ public data class ScannableCard(
 )
 
 /**
- * Type-safe identifier for a [ScannableCard]. Mirrors the value-class pattern used elsewhere
- * in passes-core (see [PassLocale], [PassInstant]) so a raw [String] cannot be mistaken for
- * a card ID at a call site. The wrapped value is opaque on purpose — passes-core does not
- * mint IDs (storage does); this type only conveys "this string identifies a stored card."
+ * Type-safe identifier for a [ScannableCard]. passes-core does not mint IDs; the storage
+ * module assigns one on insert and consumers pass that value back through here for any
+ * subsequent reference.
  */
 @JvmInline
 public value class ScannableCardId(public val value: String)
 
 /**
  * 32-bit packed ARGB color (`0xAARRGGBB`) for the card's background tint. Distinct from
- * [ColorValue] (which is 24-bit RGB for PKPASS color fields) because the two have different
- * semantics: PKPASS colors come from a verified archive and never carry alpha; scannable-card
- * colors are user-chosen and may want translucency for layered UI treatments.
+ * [ColorValue] (24-bit RGB for PKPASS color fields) — that one originates from a verified
+ * archive and never carries alpha; this one is user-chosen and may want translucency.
  *
- * passes-core cannot depend on passes-ui-core's `ArgbColor`, which would invert the module
- * dep direction. The consumer module provides a conversion extension when rendering.
+ * passes-core cannot depend on passes-ui-core's `ArgbColor` (would invert the module dep
+ * direction). The consumer module provides a conversion extension when rendering.
  */
 @JvmInline
 public value class ScannableColor(public val argb: Int)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
@@ -1,0 +1,43 @@
+package `is`.walt.passes.core
+
+/**
+ * A user-generated, unsigned scannable artifact: a typed-in payload plus a chosen barcode
+ * format that renders scannably on screen. Sibling of [Pass], NOT a subtype — the two share
+ * no parse pipeline, no signature posture, and no UI lane. The trust UX distinction is
+ * load-bearing: a [Pass] has been cryptographically verified before construction; a
+ * [ScannableCard] never can be, because the user typed the data.
+ *
+ * No unifying `DisplayableArtifact` interface exists, deliberately. Re-introducing one would
+ * re-create the trust-conflation risk the wpass-lzi epic explicitly avoids — if a single
+ * type can hold either kind of artifact, every consumer-side `when` becomes a chance to
+ * forget the trust-caption arm.
+ */
+public data class ScannableCard(
+    public val id: ScannableCardId,
+    public val payload: String,
+    public val format: ScannableFormat,
+    public val label: String,
+    public val color: ScannableColor?,
+    public val createdAt: PassInstant,
+)
+
+/**
+ * Type-safe identifier for a [ScannableCard]. Mirrors the value-class pattern used elsewhere
+ * in passes-core (see [PassLocale], [PassInstant]) so a raw [String] cannot be mistaken for
+ * a card ID at a call site. The wrapped value is opaque on purpose — passes-core does not
+ * mint IDs (storage does); this type only conveys "this string identifies a stored card."
+ */
+@JvmInline
+public value class ScannableCardId(public val value: String)
+
+/**
+ * 32-bit packed ARGB color (`0xAARRGGBB`) for the card's background tint. Distinct from
+ * [ColorValue] (which is 24-bit RGB for PKPASS color fields) because the two have different
+ * semantics: PKPASS colors come from a verified archive and never carry alpha; scannable-card
+ * colors are user-chosen and may want translucency for layered UI treatments.
+ *
+ * passes-core cannot depend on passes-ui-core's `ArgbColor`, which would invert the module
+ * dep direction. The consumer module provides a conversion extension when rendering.
+ */
+@JvmInline
+public value class ScannableColor(public val argb: Int)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
@@ -6,9 +6,9 @@ package `is`.walt.passes.core
  * type [ScannableCardCreateInput] has NOT been checked against length caps, charset rules,
  * or bidi/control-character hygiene yet, and anything of type [ScannableCard] has.
  *
- * Construction is deliberately permissive — the validator (Child 4) is the choke point. A
- * data class accepts whatever the consumer hands it; rejection lives one layer up in
- * [ScannableCardCreateResult.InvalidPayload] / [ScannableCardCreateResult.InvalidLabel].
+ * Construction is deliberately permissive — the validator (Child 4) is the choke point.
+ * `color = null` means "use the consumer-side default tint," not "no tint" — there is no
+ * untinted render path; the consumer always applies a fallback.
  */
 public data class ScannableCardCreateInput(
     public val payload: String,

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
@@ -1,0 +1,18 @@
+package `is`.walt.passes.core
+
+/**
+ * Raw, pre-validation input the consumer passes in when the user submits the create form.
+ * Separate type from [ScannableCard] so the validation boundary is explicit: anything of
+ * type [ScannableCardCreateInput] has NOT been checked against length caps, charset rules,
+ * or bidi/control-character hygiene yet, and anything of type [ScannableCard] has.
+ *
+ * Construction is deliberately permissive — the validator (Child 4) is the choke point. A
+ * data class accepts whatever the consumer hands it; rejection lives one layer up in
+ * [ScannableCardCreateResult.InvalidPayload] / [ScannableCardCreateResult.InvalidLabel].
+ */
+public data class ScannableCardCreateInput(
+    public val payload: String,
+    public val format: ScannableFormat,
+    public val label: String,
+    public val color: ScannableColor?,
+)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -1,0 +1,48 @@
+package `is`.walt.passes.core
+
+/**
+ * Outcome of attempting to construct a [ScannableCard] from a [ScannableCardCreateInput].
+ * The arms partition along the same trust / recoverability lines [ParseResult] uses, so the
+ * consumer UI can render distinct states without inspecting exception messages:
+ *
+ *  - [Success]: a usable [ScannableCard], ready to persist and render.
+ *  - [InvalidPayload]: the user-typed payload violated a length cap, charset rule, or
+ *    contained bidi/format/control characters that would compromise display safety.
+ *  - [InvalidLabel]: the user-typed label violated the same hygiene rules.
+ *  - [UnsupportedFormat]: a [ScannableFormat] this build does not yet implement encoders
+ *    for. Surfaced separately from validation failures because it is a build-time
+ *    capability gap, not a user-input problem.
+ *  - [EncoderFailure]: the ZXing encoder rejected an otherwise-valid payload at encode time
+ *    (e.g. a Code39 input that passes the input charset check but exceeds the symbology's
+ *    encodable density). Distinct arm so telemetry can distinguish "user typed something
+ *    bad" from "our encoder said no."
+ *
+ * The result family is a no-throw contract. A caller observes outcomes via exhaustive
+ * `when`, never via try/catch.
+ */
+public sealed interface ScannableCardCreateResult {
+    public data class Success(public val card: ScannableCard) : ScannableCardCreateResult
+
+    public data class InvalidPayload(public val reason: PayloadRejection) : ScannableCardCreateResult
+
+    public data class InvalidLabel(public val reason: LabelRejection) : ScannableCardCreateResult
+
+    public data class UnsupportedFormat(public val format: ScannableFormat) : ScannableCardCreateResult
+
+    public data class EncoderFailure(public val reason: String) : ScannableCardCreateResult
+}
+
+/**
+ * Why a user-typed payload was rejected before encoding. Empty here on purpose — the
+ * concrete arms (length caps, charset rules, bidi/control-character rejection) land with
+ * the validator implementation in Child 4 (wpass-lzi.4). Defining the sealed-interface
+ * shape now lets [ScannableCardCreateResult.InvalidPayload] compile and be exhaustively
+ * matched in tests before the validator exists.
+ */
+public sealed interface PayloadRejection
+
+/**
+ * Why a user-typed label was rejected. Same staging as [PayloadRejection]: arms land in
+ * Child 4 (wpass-lzi.4); the shape is defined here so the result family is complete.
+ */
+public sealed interface LabelRejection

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -2,23 +2,9 @@ package `is`.walt.passes.core
 
 /**
  * Outcome of attempting to construct a [ScannableCard] from a [ScannableCardCreateInput].
- * The arms partition along the same trust / recoverability lines [ParseResult] uses, so the
- * consumer UI can render distinct states without inspecting exception messages:
- *
- *  - [Success]: a usable [ScannableCard], ready to persist and render.
- *  - [InvalidPayload]: the user-typed payload violated a length cap, charset rule, or
- *    contained bidi/format/control characters that would compromise display safety.
- *  - [InvalidLabel]: the user-typed label violated the same hygiene rules.
- *  - [UnsupportedFormat]: a [ScannableFormat] this build does not yet implement encoders
- *    for. Surfaced separately from validation failures because it is a build-time
- *    capability gap, not a user-input problem.
- *  - [EncoderFailure]: the ZXing encoder rejected an otherwise-valid payload at encode time
- *    (e.g. a Code39 input that passes the input charset check but exceeds the symbology's
- *    encodable density). Distinct arm so telemetry can distinguish "user typed something
- *    bad" from "our encoder said no."
- *
- * The result family is a no-throw contract. A caller observes outcomes via exhaustive
- * `when`, never via try/catch.
+ * The arms partition along trust / recoverability lines so the consumer UI can render
+ * distinct states without inspecting exception messages. No-throw contract: callers observe
+ * outcomes via exhaustive `when`, never via try/catch.
  */
 public sealed interface ScannableCardCreateResult {
     public data class Success(public val card: ScannableCard) : ScannableCardCreateResult
@@ -27,22 +13,27 @@ public sealed interface ScannableCardCreateResult {
 
     public data class InvalidLabel(public val reason: LabelRejection) : ScannableCardCreateResult
 
+    /** Build-time capability gap — the encoder for [format] is not wired in this kernel build. */
     public data class UnsupportedFormat(public val format: ScannableFormat) : ScannableCardCreateResult
 
-    public data class EncoderFailure(public val reason: String) : ScannableCardCreateResult
+    /**
+     * The encoder rejected an otherwise-valid payload at encode time (e.g. a Code39 input
+     * that passes charset checks but exceeds the symbology's encodable density). Distinct
+     * from validation failures so telemetry can distinguish "user typed something bad"
+     * from "the encoder said no."
+     */
+    public data class EncoderFailure(public val reason: EncoderFailureReason) : ScannableCardCreateResult
 }
 
 /**
- * Why a user-typed payload was rejected before encoding. Empty here on purpose — the
- * concrete arms (length caps, charset rules, bidi/control-character rejection) land with
- * the validator implementation in Child 4 (wpass-lzi.4). Defining the sealed-interface
- * shape now lets [ScannableCardCreateResult.InvalidPayload] compile and be exhaustively
- * matched in tests before the validator exists.
+ * Why a user-typed payload was rejected before encoding. Empty here on purpose — concrete
+ * arms (length caps, charset rules, bidi/control-character rejection) land in Child 4
+ * (wpass-lzi.4).
  */
 public sealed interface PayloadRejection
 
-/**
- * Why a user-typed label was rejected. Same staging as [PayloadRejection]: arms land in
- * Child 4 (wpass-lzi.4); the shape is defined here so the result family is complete.
- */
+/** Why a user-typed label was rejected. Arms land with [PayloadRejection] in Child 4. */
 public sealed interface LabelRejection
+
+/** Why the encoder rejected a structurally valid payload. Arms land in Child 3 (wpass-lzi.3). */
+public sealed interface EncoderFailureReason

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -1,0 +1,27 @@
+package `is`.walt.passes.core
+
+/**
+ * The barcode formats a [ScannableCard] may render. The v1 roster covers the long tail of
+ * physical-world cards real users actually hold:
+ *
+ *  - [Code128] — most modern membership/loyalty cards (alphanumeric, variable length)
+ *  - [Ean13] — European retail barcodes (13 numeric digits)
+ *  - [UpcA] — North American retail barcodes (12 numeric digits)
+ *  - [Code39] — older institutional cards (alphanumeric, fixed charset)
+ *  - [Qr] — modern QR-based loyalty / event / payment cards
+ *
+ * Pdf417 and Aztec are intentionally absent from v1: they are largely vendor-issued
+ * (boarding passes, transit) and arrive via PKPASS already. The few standalone-card use
+ * cases (a few loyalty programs) can be added in a follow-up once user demand is observed.
+ *
+ * Distinct type from [BarcodeFormat] (the PKPASS barcode-on-a-verified-pass enum). The two
+ * are deliberately not unified — a verified PKPASS barcode and a user-typed card barcode
+ * are different trust artifacts that happen to share a rendering technology.
+ */
+public enum class ScannableFormat {
+    Code128,
+    Ean13,
+    UpcA,
+    Code39,
+    Qr,
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -11,12 +11,13 @@ package `is`.walt.passes.core
  *  - [Qr] — modern QR-based loyalty / event / payment cards
  *
  * Pdf417 and Aztec are intentionally absent from v1: they are largely vendor-issued
- * (boarding passes, transit) and arrive via PKPASS already. The few standalone-card use
- * cases (a few loyalty programs) can be added in a follow-up once user demand is observed.
+ * (boarding passes, transit) and arrive via PKPASS already.
  *
- * Distinct type from [BarcodeFormat] (the PKPASS barcode-on-a-verified-pass enum). The two
- * are deliberately not unified — a verified PKPASS barcode and a user-typed card barcode
- * are different trust artifacts that happen to share a rendering technology.
+ * Distinct type from [BarcodeFormat] (the PKPASS-pass barcode enum). The two are
+ * deliberately not unified — a verified PKPASS barcode and a user-typed card barcode are
+ * different trust artifacts that happen to share a rendering technology. Casing also
+ * differs (`Qr` here vs `QR` there): this enum follows Kotlin's PascalCase enum
+ * convention; the PKPASS one predates the convention switch in this repo.
  */
 public enum class ScannableFormat {
     Code128,

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
@@ -5,23 +5,10 @@ import org.junit.Test
 
 /**
  * Locks the public API surface of the [ScannableCard] artifact class. Companion to
- * [PublicApiSurfaceTest] (which locks the PKPASS surface) — kept in a separate file so the
- * two artifact classes stay textually distinct, mirroring the deliberate type-level
- * separation enforced by [ScannableCard] not extending [Pass].
- *
- * The test responsibilities:
- *
- *  1. Drift detection — every arm of [ScannableCardCreateResult], every value of
- *     [ScannableFormat], and every required parameter of [ScannableCard] is exercised, so
- *     removing one breaks compilation here before it breaks a downstream consumer.
- *  2. Trust separation lock — [ScannableCard] must NOT implement any interface in common
- *     with [Pass]. Asserting this at the type level keeps a future refactor from
- *     accidentally re-unifying the two via a shared supertype.
- *
- * Encoder / validator behavior tests land with Children .3 and .4 respectively. The
- * [PayloadRejection] and [LabelRejection] hierarchies are intentionally empty here; this
- * test stands up minimal fakes so the `InvalidPayload` / `InvalidLabel` arms can be
- * exhaustively matched before Child 4 populates the real reasons.
+ * [PublicApiSurfaceTest] (which locks the PKPASS surface). Two load-bearing responsibilities:
+ * drift detection on every arm of [ScannableCardCreateResult] / value of [ScannableFormat] /
+ * required parameter of [ScannableCard], and the trust-separation lock (no shared supertype
+ * with [Pass]). Encoder and validator behavior live in Children .3 and .4.
  */
 class ScannableCardSurfaceTest {
     @Test
@@ -89,11 +76,11 @@ class ScannableCardSurfaceTest {
     }
 
     /**
-     * Covers the three directly-constructible result arms. The remaining two arms wrap
-     * sealed-interface reasons ([PayloadRejection], [LabelRejection]) whose concrete arms
-     * land in Child 4; once they exist, that bead extends this exhaustiveness check. The
-     * Kotlin compiler enforces exhaustiveness at every real `when` site regardless, so a
-     * missing arm fails the build at the call site even before this test runs.
+     * Covers the two directly-constructible result arms. The remaining three arms wrap
+     * sealed reasons ([PayloadRejection], [LabelRejection], [EncoderFailureReason]) whose
+     * concrete arms land in Children .3 and .4. Compile-time `when` exhaustiveness still
+     * fires at every real call site, so this test only needs to prove the constructible
+     * arms reach their branches.
      */
     @Test
     fun scannableCardCreateResultConstructibleArmsAreReachableViaWhen() {
@@ -101,7 +88,6 @@ class ScannableCardSurfaceTest {
             listOf(
                 ScannableCardCreateResult.Success(sampleCard()),
                 ScannableCardCreateResult.UnsupportedFormat(ScannableFormat.Code39),
-                ScannableCardCreateResult.EncoderFailure(reason = "density"),
             )
         val branches =
             results.map { result ->
@@ -113,22 +99,19 @@ class ScannableCardSurfaceTest {
                     is ScannableCardCreateResult.EncoderFailure -> "encoder"
                 }
             }
-        assertThat(branches).containsExactly("success", "format", "encoder").inOrder()
+        assertThat(branches).containsExactly("success", "format").inOrder()
     }
 
     /**
-     * [PayloadRejection] and [LabelRejection] exist as kernel-exported types even though
-     * their arms are pending Child 4. Removing either type breaks this test before it
-     * breaks Child 4's compile. Sealedness itself is enforced at compile time by the
-     * Kotlin compiler — cross-module subclasses fail to compile, so an explicit runtime
-     * sealedness check would be redundant.
+     * The three sealed-reason families exist as kernel-exported types even though their
+     * arms land later (Child 3 for [EncoderFailureReason], Child 4 for the other two).
+     * Removing any of them breaks this test before it breaks the dependent child's compile.
      */
     @Test
     fun rejectionFamiliesAreExported() {
-        val payload: Class<PayloadRejection> = PayloadRejection::class.java
-        val label: Class<LabelRejection> = LabelRejection::class.java
-        assertThat(payload.isInterface).isTrue()
-        assertThat(label.isInterface).isTrue()
+        assertThat(PayloadRejection::class.java.isInterface).isTrue()
+        assertThat(LabelRejection::class.java.isInterface).isTrue()
+        assertThat(EncoderFailureReason::class.java.isInterface).isTrue()
     }
 
     /**
@@ -159,6 +142,8 @@ class ScannableCardSurfaceTest {
         assertThat(ScannableColor(0x11223344)).isEqualTo(ScannableColor(0x11223344))
     }
 
+    // Walks superclasses and their declared interfaces. Skips interface-of-interface ancestors
+    // because neither artifact class has any; if that changes, extend this helper.
     private fun ancestorsOf(cls: Class<*>): Set<Class<*>> {
         val out = mutableSetOf<Class<*>>()
         var current: Class<*>? = cls.superclass

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
@@ -1,0 +1,183 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Locks the public API surface of the [ScannableCard] artifact class. Companion to
+ * [PublicApiSurfaceTest] (which locks the PKPASS surface) — kept in a separate file so the
+ * two artifact classes stay textually distinct, mirroring the deliberate type-level
+ * separation enforced by [ScannableCard] not extending [Pass].
+ *
+ * The test responsibilities:
+ *
+ *  1. Drift detection — every arm of [ScannableCardCreateResult], every value of
+ *     [ScannableFormat], and every required parameter of [ScannableCard] is exercised, so
+ *     removing one breaks compilation here before it breaks a downstream consumer.
+ *  2. Trust separation lock — [ScannableCard] must NOT implement any interface in common
+ *     with [Pass]. Asserting this at the type level keeps a future refactor from
+ *     accidentally re-unifying the two via a shared supertype.
+ *
+ * Encoder / validator behavior tests land with Children .3 and .4 respectively. The
+ * [PayloadRejection] and [LabelRejection] hierarchies are intentionally empty here; this
+ * test stands up minimal fakes so the `InvalidPayload` / `InvalidLabel` arms can be
+ * exhaustively matched before Child 4 populates the real reasons.
+ */
+class ScannableCardSurfaceTest {
+    @Test
+    fun scannableCardConstructorIsExercisedWithEveryShape() {
+        val card =
+            ScannableCard(
+                id = ScannableCardId("card-001"),
+                payload = "1234567890128",
+                format = ScannableFormat.Ean13,
+                label = "Grocery loyalty",
+                color = ScannableColor(argb = 0xFF1F4FA0.toInt()),
+                createdAt = PassInstant(epochMillis = 1_800_000_000_000L),
+            )
+
+        assertThat(card.id).isEqualTo(ScannableCardId("card-001"))
+        assertThat(card.format).isEqualTo(ScannableFormat.Ean13)
+        assertThat(card.color?.argb).isEqualTo(0xFF1F4FA0.toInt())
+        // Every ScannableFormat referenced so removal breaks compilation here.
+        val allFormats =
+            setOf(
+                ScannableFormat.Code128,
+                ScannableFormat.Ean13,
+                ScannableFormat.UpcA,
+                ScannableFormat.Code39,
+                ScannableFormat.Qr,
+            )
+        assertThat(allFormats).hasSize(ScannableFormat.entries.size)
+    }
+
+    @Test
+    fun scannableCardEqualityIsStructural() {
+        val a = sampleCard()
+        val b = sampleCard()
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+    }
+
+    @Test
+    fun scannableCardColorIsOptional() {
+        val card = sampleCard(color = null)
+        assertThat(card.color).isNull()
+    }
+
+    @Test
+    fun scannableCardCreateInputAcceptsEdgeValues() {
+        val empty =
+            ScannableCardCreateInput(
+                payload = "",
+                format = ScannableFormat.Qr,
+                label = "",
+                color = null,
+            )
+        assertThat(empty.payload).isEmpty()
+        assertThat(empty.label).isEmpty()
+
+        // Construction is unconditionally permissive; rejection lives in the result family.
+        val maxish =
+            ScannableCardCreateInput(
+                payload = "X".repeat(10_000),
+                format = ScannableFormat.Code128,
+                label = "Y".repeat(1_000),
+                color = ScannableColor(argb = 0),
+            )
+        assertThat(maxish.payload).hasLength(10_000)
+    }
+
+    /**
+     * Covers the three directly-constructible result arms. The remaining two arms wrap
+     * sealed-interface reasons ([PayloadRejection], [LabelRejection]) whose concrete arms
+     * land in Child 4; once they exist, that bead extends this exhaustiveness check. The
+     * Kotlin compiler enforces exhaustiveness at every real `when` site regardless, so a
+     * missing arm fails the build at the call site even before this test runs.
+     */
+    @Test
+    fun scannableCardCreateResultConstructibleArmsAreReachableViaWhen() {
+        val results: List<ScannableCardCreateResult> =
+            listOf(
+                ScannableCardCreateResult.Success(sampleCard()),
+                ScannableCardCreateResult.UnsupportedFormat(ScannableFormat.Code39),
+                ScannableCardCreateResult.EncoderFailure(reason = "density"),
+            )
+        val branches =
+            results.map { result ->
+                when (result) {
+                    is ScannableCardCreateResult.Success -> "success"
+                    is ScannableCardCreateResult.InvalidPayload -> "payload"
+                    is ScannableCardCreateResult.InvalidLabel -> "label"
+                    is ScannableCardCreateResult.UnsupportedFormat -> "format"
+                    is ScannableCardCreateResult.EncoderFailure -> "encoder"
+                }
+            }
+        assertThat(branches).containsExactly("success", "format", "encoder").inOrder()
+    }
+
+    /**
+     * [PayloadRejection] and [LabelRejection] exist as kernel-exported types even though
+     * their arms are pending Child 4. Removing either type breaks this test before it
+     * breaks Child 4's compile. Sealedness itself is enforced at compile time by the
+     * Kotlin compiler — cross-module subclasses fail to compile, so an explicit runtime
+     * sealedness check would be redundant.
+     */
+    @Test
+    fun rejectionFamiliesAreExported() {
+        val payload: Class<PayloadRejection> = PayloadRejection::class.java
+        val label: Class<LabelRejection> = LabelRejection::class.java
+        assertThat(payload.isInterface).isTrue()
+        assertThat(label.isInterface).isTrue()
+    }
+
+    /**
+     * Trust separation lock. The two artifact classes must not share a supertype — neither
+     * [Pass] nor [ScannableCard] is assignable to the other, and neither is assignable to
+     * any kernel-defined interface (the only shared supertype permitted is [Any]).
+     *
+     * If a future refactor introduces a `DisplayableArtifact` (or similar) supertype, this
+     * test fails — which is the point. The epic's pre-ship requirement #1 ("distinct
+     * artifact class end-to-end") depends on the type system enforcing the distinction.
+     */
+    @Test
+    fun scannableCardDoesNotShareSupertypeWithPass() {
+        val passAncestors = ancestorsOf(Pass::class.java)
+        val cardAncestors = ancestorsOf(ScannableCard::class.java)
+        // Both data classes inherit only from `java.lang.Object`; the intersection must
+        // contain that and nothing else. Any other shared ancestor would mean the two
+        // artifact classes have been unified under a common kernel type — exactly the
+        // trust-conflation risk the wpass-lzi epic forbids.
+        val shared = passAncestors.intersect(cardAncestors)
+        assertThat(shared).containsExactly(Any::class.java)
+    }
+
+    @Test
+    fun scannableCardIdAndColorAreValueClasses() {
+        // @JvmInline value classes equate by wrapped value, not reference.
+        assertThat(ScannableCardId("x")).isEqualTo(ScannableCardId("x"))
+        assertThat(ScannableColor(0x11223344)).isEqualTo(ScannableColor(0x11223344))
+    }
+
+    private fun ancestorsOf(cls: Class<*>): Set<Class<*>> {
+        val out = mutableSetOf<Class<*>>()
+        var current: Class<*>? = cls.superclass
+        while (current != null) {
+            out += current
+            out += current.interfaces
+            current = current.superclass
+        }
+        out += cls.interfaces
+        return out
+    }
+
+    private fun sampleCard(color: ScannableColor? = ScannableColor(argb = 0)): ScannableCard =
+        ScannableCard(
+            id = ScannableCardId("card-fixed"),
+            payload = "PAYLOAD",
+            format = ScannableFormat.Code128,
+            label = "label",
+            color = color,
+            createdAt = PassInstant(epochMillis = 1_700_000_000_000L),
+        )
+}


### PR DESCRIPTION
## Summary

- Introduces `ScannableCard` as a deliberate sibling of `Pass` — no shared supertype, no shared parse pipeline, no shared signature posture. Trust UX distinction enforced at the type level.
- Adds `ScannableFormat` (v1 roster: `Code128`, `Ean13`, `UpcA`, `Code39`, `Qr`), `ScannableCardId`, `ScannableColor` (32-bit ARGB), `ScannableCardCreateInput`, and the `ScannableCardCreateResult` sealed family.
- `PayloadRejection` and `LabelRejection` declared as empty sealed interfaces — Child 4 (wpass-lzi.4) populates the arms.

## Decisions

- **Naming.** `Scannable*` not `Barcode*`, locked in by epic notes on the threat-model PR (#80).
- **Package.** Types live directly in `is.walt.passes.core` (same as `Pass`); subpackage felt overkill for one artifact class.
- **Color.** New `@JvmInline value class ScannableColor(argb: Int)` rather than reusing `ColorValue` (which is 24-bit RGB for PKPASS fields with different semantics).
- **Time.** Reuses existing `PassInstant(epochMillis: Long)`.
- **`@Serializable` deferred.** Adding it to `ScannableCard` requires also annotating `PassInstant`, which is out of scope for this bead. Child 6 (storage) can re-evaluate whether kotlinx.serialization is even the right tool — Room/manual SQLCipher are equally viable and the existing `Pass` type isn't `@Serializable` either.

## Trust-separation lock

`ScannableCardSurfaceTest.scannableCardDoesNotShareSupertypeWithPass` asserts that `Pass` and `ScannableCard` share only `java.lang.Object` as an ancestor. Any future refactor that introduces a unifying `DisplayableArtifact` supertype trips this test — which is exactly the wpass-lzi epic's pre-ship requirement #1.

## Test plan

- [x] `./gradlew :passes-core:check` green
- [x] Constructor + equality + optional-color exercised
- [x] Three directly-constructible `ScannableCardCreateResult` arms reachable via `when`
- [x] Trust-separation lock asserts no shared supertype