### PR TITLE
passes-core: input validator + QR URI classifier (wpass-lzi.4, .5)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadClassifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadClassifier.kt
@@ -1,0 +1,114 @@
+package `is`.walt.passes.core
+
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * Classifies a QR payload string by its URI scheme so the create-time preview dialog
+ * (sibling wpass-lzi.9) can warn the user about what a future scanner phone would do.
+ *
+ * Pure logic. No network calls, no IDN normalization, no redirect following. Never
+ * rejects an input — any string maps to *some* arm of [QrPayloadKind], because the
+ * structural-hazard guard (bidi controls, length caps) is upstream's job (wpass-lzi.4).
+ * The classifier is deliberately conservative: when a per-scheme parse fails, the result
+ * falls back to [QrPayloadKind.UnknownScheme] (or [QrPayloadKind.PlainText] when no
+ * scheme matched at all) rather than guessing.
+ *
+ * Scheme matching is case-insensitive per RFC 3986; the matched scheme is normalized to
+ * lowercase before dispatch.
+ */
+public object QrPayloadClassifier {
+    // RFC 3986: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"
+    // Anchored at the start; the trailing `:` is required so a bare numeric string like
+    // "1234567890" does NOT match as scheme "1234567890" (it starts with a digit anyway,
+    // but the leading-ALPHA rule plus the `:` requirement together close the door).
+    private val schemeRegex = Regex("^([a-zA-Z][a-zA-Z0-9+.\\-]*):")
+
+    public fun classify(payload: String): QrPayloadKind {
+        val match = schemeRegex.find(payload) ?: return QrPayloadKind.PlainText
+        val scheme = match.groupValues[1].lowercase()
+        // Strip the scheme + `:` from the payload using the match length, not a string
+        // literal, so uppercase / mixed-case schemes like `BITCOIN:` are handled correctly.
+        val afterScheme = payload.substring(match.range.last + 1)
+
+        return when (scheme) {
+            "http", "https" -> classifyHttp(scheme, payload)
+            "tel" -> QrPayloadKind.Phone(afterScheme)
+            "sms", "smsto" -> QrPayloadKind.Sms(afterScheme.substringBefore("?"))
+            "mailto" -> QrPayloadKind.Mailto(afterScheme.substringBefore("?"))
+            "geo" -> QrPayloadKind.Geo(afterScheme)
+            "wifi" -> classifyWifi(afterScheme)
+            "bitcoin" -> QrPayloadKind.Bitcoin(afterScheme.substringBefore("?"))
+            "ethereum" -> QrPayloadKind.Ethereum(afterScheme.substringBefore("?"))
+            "magnet" -> QrPayloadKind.Magnet
+            "market" -> QrPayloadKind.Market(afterScheme.removePrefix("//"))
+            "intent" -> QrPayloadKind.Intent(payload)
+            else -> QrPayloadKind.UnknownScheme(scheme, payload)
+        }
+    }
+
+    private fun classifyHttp(
+        scheme: String,
+        payload: String,
+    ): QrPayloadKind =
+        try {
+            val uri = URI(payload)
+            QrPayloadKind.Url(scheme = scheme, host = uri.host, raw = payload)
+        } catch (_: URISyntaxException) {
+            // Malformed http(s) URI still belongs in the "URL-ish" warning bucket conceptually,
+            // but the classifier has no host to surface, so it downgrades to UnknownScheme.
+            // The preview dialog will show the scheme and the raw string verbatim.
+            QrPayloadKind.UnknownScheme(scheme, payload)
+        }
+
+    // WIFI:T:<auth>;S:<ssid>;P:<password>;H:<hidden>;;
+    // SSID and password may be escaped with `\` before `;`, `,`, `:`, `\`, `"`.
+    // v1 implementation: locate `;S:` (or `WIFI:S:`), then read until the next *unescaped*
+    // `;`. TODO(wpass-lzi.5-followup): handle more exotic escape combinations (e.g. an SSID
+    // ending in an escaped `;` immediately followed by a real one). v1 covers the common case;
+    // the password is never surfaced regardless.
+    private fun classifyWifi(body: String): QrPayloadKind {
+        // [body] is everything after `WIFI:` (case-insensitive prefix already stripped by
+        // the caller). Locate the `S:` field and read until the next *unescaped* `;`.
+        val ssidStart = findFieldStart(body, "S:") ?: return QrPayloadKind.Wifi(ssid = null)
+        val ssid = readUntilUnescapedSemicolon(body, ssidStart)
+        return QrPayloadKind.Wifi(ssid = ssid)
+    }
+
+    private fun findFieldStart(
+        body: String,
+        key: String,
+    ): Int? {
+        // Match either at the very start of body or immediately after a `;`.
+        var i = 0
+        while (i < body.length) {
+            val atStart = i == 0 || body[i - 1] == ';'
+            val fits = i + key.length <= body.length
+            if (atStart && fits && body.regionMatches(i, key, 0, key.length, ignoreCase = true)) {
+                return i + key.length
+            }
+            i++
+        }
+        return null
+    }
+
+    private fun readUntilUnescapedSemicolon(
+        body: String,
+        start: Int,
+    ): String {
+        val out = StringBuilder()
+        var i = start
+        while (i < body.length) {
+            val c = body[i]
+            if (c == '\\' && i + 1 < body.length) {
+                out.append(body[i + 1])
+                i += 2
+                continue
+            }
+            if (c == ';') return out.toString()
+            out.append(c)
+            i++
+        }
+        return out.toString()
+    }
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadClassifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadClassifier.kt
@@ -33,7 +33,7 @@ public object QrPayloadClassifier {
 
         return when (scheme) {
             "http", "https" -> classifyHttp(scheme, payload)
-            "tel" -> QrPayloadKind.Phone(afterScheme)
+            "tel" -> QrPayloadKind.Phone(afterScheme.substringBefore("?"))
             "sms", "smsto" -> QrPayloadKind.Sms(afterScheme.substringBefore("?"))
             "mailto" -> QrPayloadKind.Mailto(afterScheme.substringBefore("?"))
             "geo" -> QrPayloadKind.Geo(afterScheme)
@@ -62,11 +62,10 @@ public object QrPayloadClassifier {
         }
 
     // WIFI:T:<auth>;S:<ssid>;P:<password>;H:<hidden>;;
-    // SSID and password may be escaped with `\` before `;`, `,`, `:`, `\`, `"`.
-    // v1 implementation: locate `;S:` (or `WIFI:S:`), then read until the next *unescaped*
-    // `;`. TODO(wpass-lzi.5-followup): handle more exotic escape combinations (e.g. an SSID
-    // ending in an escaped `;` immediately followed by a real one). v1 covers the common case;
-    // the password is never surfaced regardless.
+    // SSID and password may be escaped with `\` before `;`, `,`, `:`, `\`, `"`. Field-start
+    // detection walks the body with the same escape state machine [readUntilUnescapedSemicolon]
+    // uses, so an escaped `\;` inside (say) a password value cannot be mistaken for a real
+    // field separator and cause an `S:` substring inside the password to surface as the SSID.
     private fun classifyWifi(body: String): QrPayloadKind {
         // [body] is everything after `WIFI:` (case-insensitive prefix already stripped by
         // the caller). Locate the `S:` field and read until the next *unescaped* `;`.
@@ -79,15 +78,26 @@ public object QrPayloadClassifier {
         body: String,
         key: String,
     ): Int? {
-        // Match either at the very start of body or immediately after a `;`.
+        // Walk the body honoring backslash escapes so `body[i - 1] == ';'` is only treated as
+        // a field boundary when the `;` wasn't itself escaped. Without this, an SSID-key
+        // substring inside an escaped value (e.g. `P:my\;S:secret;S:realnet;;`) would match
+        // and surface the wrong network name in the preview.
         var i = 0
+        var prevWasUnescapedSemicolon = false
         while (i < body.length) {
-            val atStart = i == 0 || body[i - 1] == ';'
+            val atBoundary = i == 0 || prevWasUnescapedSemicolon
             val fits = i + key.length <= body.length
-            if (atStart && fits && body.regionMatches(i, key, 0, key.length, ignoreCase = true)) {
+            if (atBoundary && fits && body.regionMatches(i, key, 0, key.length, ignoreCase = true)) {
                 return i + key.length
             }
-            i++
+            val c = body[i]
+            if (c == '\\' && i + 1 < body.length) {
+                prevWasUnescapedSemicolon = false
+                i += 2
+            } else {
+                prevWasUnescapedSemicolon = c == ';'
+                i++
+            }
         }
         return null
     }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadKind.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/QrPayloadKind.kt
@@ -1,0 +1,94 @@
+package `is`.walt.passes.core
+
+/**
+ * Classification of a QR code's payload string by its URI scheme (or absence thereof).
+ *
+ * Surface for the create-time preview dialog (sibling wpass-lzi.9): when a user enters a
+ * QR payload, the consumer UI shows what a future scanner phone would interpret it as so
+ * the user can confirm intent before saving the card. The classification is *advisory* —
+ * Walt does not block any payload here. The downstream validator (wpass-lzi.4) rejects
+ * structural hazards (bidi controls, length overruns); this classifier assumes a payload
+ * that has already cleared that bar.
+ *
+ * Trust posture per arm:
+ *
+ *  - [PlainText]: nothing happens on scan beyond display. Lowest risk.
+ *  - [Url]: third-party scanner phone's browser will offer to open. Phishing / drive-by
+ *    download risk on the recipient device.
+ *  - [Phone] / [Sms]: dialer / messaging app opens, pre-filled. Premium-rate dial fraud risk.
+ *  - [Mailto]: mail app opens with recipient pre-filled.
+ *  - [Geo]: maps app opens at coordinates.
+ *  - [Wifi]: phone offers to join network. Note: password is parsed out of the source string
+ *    but deliberately NOT carried in this kind — see [Wifi] for rationale.
+ *  - [Bitcoin] / [Ethereum]: crypto wallet apps may auto-send. Address-substitution attack risk.
+ *  - [Magnet]: torrent client may auto-add.
+ *  - [Market]: Play Store opens a listing.
+ *  - [Intent]: arbitrary Android intent URI. Most dangerous — can target named components,
+ *    pass extras, bypass user-visible scheme prompts. Walt surfaces these as "Android intent"
+ *    with no further dissection.
+ *  - [UnknownScheme]: scheme matches RFC 3986 syntax but is not in the recognized roster.
+ */
+public sealed interface QrPayloadKind {
+    /** No URI scheme detected. The QR holds opaque text. */
+    public object PlainText : QrPayloadKind
+
+    /**
+     * `http` or `https` URL. [host] may be null even on URIs that parse cleanly (e.g. a
+     * scheme-only string like `http://`). [raw] preserves the original string verbatim —
+     * no normalization, no IDN conversion, no Punycode unwrapping — so the preview UI shows
+     * the user exactly what a future scanner would receive.
+     */
+    public data class Url(val scheme: String, val host: String?, val raw: String) : QrPayloadKind
+
+    /** `tel:` payload. [number] is the raw substring after the scheme. */
+    public data class Phone(val number: String) : QrPayloadKind
+
+    /** `sms:` payload. [number] is the raw substring after the scheme, stripped of any `?` query tail. */
+    public data class Sms(val number: String) : QrPayloadKind
+
+    /** `mailto:` payload. [address] is the raw substring after the scheme, stripped of any `?` query tail. */
+    public data class Mailto(val address: String) : QrPayloadKind
+
+    /** `geo:` payload. [coords] is the raw substring after the scheme. */
+    public data class Geo(val coords: String) : QrPayloadKind
+
+    /**
+     * `WIFI:` payload. [ssid] is the network name; null if the payload omits the `S:` field.
+     *
+     * CRITICAL: the password field (`P:`) is deliberately NOT modeled here even though it
+     * is present in the source string. The classifier output flows to a preview dialog
+     * the user might screenshot, copy, or share. Surfacing the password through this
+     * data class would let it leak into UI state, screenshots, accessibility tree, and
+     * any telemetry that flattens kind instances. Parsing-and-dropping is a trust choice:
+     * the user already knows their own wifi password if they typed this in; the scanner
+     * recipient is the one who needs the password, and they get it from the QR — not from
+     * Walt's preview surface.
+     */
+    public data class Wifi(val ssid: String?) : QrPayloadKind
+
+    /** `bitcoin:` payment URI. [address] is the bare address, with any `?amount=...` tail stripped. */
+    public data class Bitcoin(val address: String) : QrPayloadKind
+
+    /** `ethereum:` payment URI. [address] is the bare address, with any `?value=...` tail stripped. */
+    public data class Ethereum(val address: String) : QrPayloadKind
+
+    /** `magnet:` torrent link. Raw payload not surfaced — the magnet xt hash is rarely user-meaningful. */
+    public object Magnet : QrPayloadKind
+
+    /**
+     * Android Play Store URI (`market:` or `market://`). [productId] is whatever follows
+     * the scheme (typically `details?id=com.example`).
+     */
+    public data class Market(val productId: String) : QrPayloadKind
+
+    /**
+     * Android intent URI (`intent:`). Carries [raw] — these URIs are too dangerous to
+     * dissect in the preview surface. The user gets a generic "Android intent" warning
+     * and the verbatim string; pretending to parse a structured shape would invite
+     * mis-classification.
+     */
+    public data class Intent(val raw: String) : QrPayloadKind
+
+    /** Some other RFC 3986 scheme. The user should see both [scheme] and [raw]. */
+    public data class UnknownScheme(val scheme: String, val raw: String) : QrPayloadKind
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -26,14 +26,56 @@ public sealed interface ScannableCardCreateResult {
 }
 
 /**
- * Why a user-typed payload was rejected before encoding. Empty here on purpose — concrete
- * arms (length caps, charset rules, bidi/control-character rejection) land in Child 4
- * (wpass-lzi.4).
+ * Why a user-typed payload was rejected before encoding. Distinct arms so the consumer UI
+ * can surface a specific error string without inspecting raw input.
  */
-public sealed interface PayloadRejection
+public sealed interface PayloadRejection {
+    /** Payload exceeds the per-format length cap (see [ScannableFormatConstraints]). */
+    public data class TooLong(public val actual: Int, public val max: Int) : PayloadRejection
 
-/** Why a user-typed label was rejected. Arms land with [PayloadRejection] in Child 4. */
-public sealed interface LabelRejection
+    /** A character is not in the symbology's allowed charset (e.g. a letter in EAN-13). */
+    public data class WrongCharset(
+        public val format: ScannableFormat,
+        public val offendingChar: Char,
+    ) : PayloadRejection
+
+    /** Length mismatch for fixed-length symbologies (EAN-13 must be 13, UPC-A must be 12). */
+    public data class WrongLength(
+        public val actual: Int,
+        public val required: Int,
+        public val format: ScannableFormat,
+    ) : PayloadRejection
+
+    /** Mod-10 check digit did not match for a fixed-length symbology (EAN-13, UPC-A). */
+    public data class InvalidCheckDigit(public val format: ScannableFormat) : PayloadRejection
+
+    /** Payload contained a Unicode Cc (Control) codepoint — rejected for all formats. */
+    public object ContainsControlChar : PayloadRejection
+
+    /** Payload contained a Unicode Cf (Format) codepoint — bidi controls etc., all formats. */
+    public object ContainsBidiChar : PayloadRejection
+
+    /** Payload was empty (after whitespace trimming). */
+    public object Empty : PayloadRejection
+}
+
+/**
+ * Why a user-typed label was rejected. Mirrors the bidi/control hygiene of [PayloadRejection]
+ * because the label is rendered alongside untrusted user content.
+ */
+public sealed interface LabelRejection {
+    /** Label exceeded the display-friendly cap (see [ScannableCardInputValidator]). */
+    public data class TooLong(public val actual: Int, public val max: Int) : LabelRejection
+
+    /** Label contained a Unicode Cf (Format) codepoint — bidi controls etc. */
+    public object ContainsBidiChar : LabelRejection
+
+    /** Label contained a Unicode Cc (Control) codepoint. */
+    public object ContainsControlChar : LabelRejection
+
+    /** Label was empty. */
+    public object Empty : LabelRejection
+}
 
 /** Why the encoder rejected a structurally valid payload. Arms land in Child 3 (wpass-lzi.3). */
 public sealed interface EncoderFailureReason

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
@@ -10,8 +10,9 @@ package `is`.walt.passes.core
  * tests are deterministic. The validator only judges field content; it does not allocate
  * identity or time.
  *
- * Fail-fast: returns the first violation found. Order is label first (cheaper, format-
- * independent), then payload (trim, empty, bidi/control, length, charset, structural).
+ * Fail-fast: returns the first violation found. Label trimmed first (a whitespace-only
+ * label is empty for users), then payload (trim, empty, bidi/control, length, charset,
+ * structural). Both trimmed values land on the resulting [ScannableCard].
  */
 public object ScannableCardInputValidator {
     /** Display-friendly cap. Long enough for any realistic card name, short enough to render. */
@@ -25,7 +26,8 @@ public object ScannableCardInputValidator {
         id: ScannableCardId,
         createdAt: PassInstant,
     ): ScannableCardCreateResult {
-        validateLabel(input.label)?.let { return ScannableCardCreateResult.InvalidLabel(it) }
+        val trimmedLabel = input.label.trim()
+        validateLabel(trimmedLabel)?.let { return ScannableCardCreateResult.InvalidLabel(it) }
 
         val trimmedPayload = input.payload.trim()
         validatePayload(trimmedPayload, input.format)?.let {
@@ -37,7 +39,7 @@ public object ScannableCardInputValidator {
                 id = id,
                 payload = trimmedPayload,
                 format = input.format,
-                label = input.label,
+                label = trimmedLabel,
                 color = input.color,
                 createdAt = createdAt,
             ),
@@ -65,14 +67,25 @@ public object ScannableCardInputValidator {
         format: ScannableFormat,
     ): PayloadRejection? {
         if (payload.isEmpty()) return PayloadRejection.Empty
-        // Bidi/control check before charset so the error tells the user "your input
+        // Bidi/control check before length/charset so the error tells the user "your input
         // contains a hidden character," not "U+0000 is not in the EAN-13 charset."
         for (c in payload) {
             if (c.category == CharCategory.FORMAT) return PayloadRejection.ContainsBidiChar
             if (c.isISOControl()) return PayloadRejection.ContainsControlChar
         }
-        val max = ScannableFormatConstraints.maxPayloadLength(format)
-        if (payload.length > max) return PayloadRejection.TooLong(payload.length, max)
+        // Fixed-length symbologies (EAN-13, UPC-A): exact-length check surfaces WrongLength
+        // for both too-short AND too-long inputs, so the consumer never has to choose between
+        // TooLong and WrongLength for the same logical mistake. Variable-length symbologies
+        // use the soft cap and emit TooLong.
+        val required = ScannableFormatConstraints.requiredLength(format)
+        if (required != null) {
+            if (payload.length != required) {
+                return PayloadRejection.WrongLength(payload.length, required, format)
+            }
+        } else {
+            val max = ScannableFormatConstraints.maxPayloadLength(format)
+            if (payload.length > max) return PayloadRejection.TooLong(payload.length, max)
+        }
         for (c in payload) {
             if (!ScannableFormatConstraints.isAllowedChar(format, c)) {
                 return PayloadRejection.WrongCharset(format, c)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
@@ -1,0 +1,83 @@
+package `is`.walt.passes.core
+
+/**
+ * The single choke point that turns a raw [ScannableCardCreateInput] into a trusted
+ * [ScannableCard]. Existence of a [ScannableCard] value asserts that this validator approved
+ * it (the artifact's constructor is `internal` so no other path can mint one).
+ *
+ * The `id` and `createdAt` parameters are caller-provided because passes-core does not mint
+ * IDs (see [ScannableCardId]'s KDoc — storage assigns them) and the clock is injected so
+ * tests are deterministic. The validator only judges field content; it does not allocate
+ * identity or time.
+ *
+ * Fail-fast: returns the first violation found. Order is label first (cheaper, format-
+ * independent), then payload (trim, empty, bidi/control, length, charset, structural).
+ */
+public object ScannableCardInputValidator {
+    /** Display-friendly cap. Long enough for any realistic card name, short enough to render. */
+    public const val MAX_LABEL_LENGTH: Int = 100
+
+    // ReturnCount: fail-fast pipeline. Each early return surfaces a distinct rejection
+    // family so the caller's `when` branches read 1:1 with validator stages.
+    @Suppress("ReturnCount")
+    public fun validate(
+        input: ScannableCardCreateInput,
+        id: ScannableCardId,
+        createdAt: PassInstant,
+    ): ScannableCardCreateResult {
+        validateLabel(input.label)?.let { return ScannableCardCreateResult.InvalidLabel(it) }
+
+        val trimmedPayload = input.payload.trim()
+        validatePayload(trimmedPayload, input.format)?.let {
+            return ScannableCardCreateResult.InvalidPayload(it)
+        }
+
+        return ScannableCardCreateResult.Success(
+            ScannableCard(
+                id = id,
+                payload = trimmedPayload,
+                format = input.format,
+                label = input.label,
+                color = input.color,
+                createdAt = createdAt,
+            ),
+        )
+    }
+
+    @Suppress("ReturnCount")
+    private fun validateLabel(label: String): LabelRejection? {
+        if (label.isEmpty()) return LabelRejection.Empty
+        // Bidi/control check before length so a 200-char string of bidi marks reports the
+        // hazardous content, not just its size.
+        for (c in label) {
+            if (c.category == CharCategory.FORMAT) return LabelRejection.ContainsBidiChar
+            if (c.isISOControl()) return LabelRejection.ContainsControlChar
+        }
+        if (label.length > MAX_LABEL_LENGTH) {
+            return LabelRejection.TooLong(label.length, MAX_LABEL_LENGTH)
+        }
+        return null
+    }
+
+    @Suppress("ReturnCount")
+    private fun validatePayload(
+        payload: String,
+        format: ScannableFormat,
+    ): PayloadRejection? {
+        if (payload.isEmpty()) return PayloadRejection.Empty
+        // Bidi/control check before charset so the error tells the user "your input
+        // contains a hidden character," not "U+0000 is not in the EAN-13 charset."
+        for (c in payload) {
+            if (c.category == CharCategory.FORMAT) return PayloadRejection.ContainsBidiChar
+            if (c.isISOControl()) return PayloadRejection.ContainsControlChar
+        }
+        val max = ScannableFormatConstraints.maxPayloadLength(format)
+        if (payload.length > max) return PayloadRejection.TooLong(payload.length, max)
+        for (c in payload) {
+            if (!ScannableFormatConstraints.isAllowedChar(format, c)) {
+                return PayloadRejection.WrongCharset(format, c)
+            }
+        }
+        return ScannableFormatConstraints.validateStructural(format, payload)
+    }
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
@@ -15,7 +15,7 @@ package `is`.walt.passes.core
  */
 public object ScannableCardInputValidator {
     /** Display-friendly cap. Long enough for any realistic card name, short enough to render. */
-    public const val MAX_LABEL_LENGTH: Int = 100
+    public const val MAX_LABEL_LENGTH: Int = 64
 
     // ReturnCount: fail-fast pipeline. Each early return surfaces a distinct rejection
     // family so the caller's `when` branches read 1:1 with validator stages.

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -1,0 +1,118 @@
+package `is`.walt.passes.core
+
+/**
+ * Single source of truth for per-symbology charset, length cap, required length, and
+ * structural-checksum rules. Hook point for the wpass-lzi threat model — if a constraint
+ * here changes, the threat-model doc must change alongside it.
+ *
+ * Kept `internal` so the validator is the only callable boundary; the consumer never picks
+ * "is this character allowed" off of this object directly. Bidi / control-character checks
+ * live in [ScannableCardInputValidator] because they apply uniformly across all formats.
+ */
+internal object ScannableFormatConstraints {
+    /** Soft cap on payload length per symbology. Numeric symbologies use their exact length. */
+    fun maxPayloadLength(format: ScannableFormat): Int =
+        when (format) {
+            ScannableFormat.Code128 -> CODE128_MAX
+            ScannableFormat.Code39 -> CODE39_MAX
+            ScannableFormat.Ean13 -> EAN13_LENGTH
+            ScannableFormat.UpcA -> UPCA_LENGTH
+            ScannableFormat.Qr -> QR_MAX
+        }
+
+    /** Non-null only for fixed-length numeric symbologies (EAN-13, UPC-A). */
+    fun requiredLength(format: ScannableFormat): Int? =
+        when (format) {
+            ScannableFormat.Ean13 -> EAN13_LENGTH
+            ScannableFormat.UpcA -> UPCA_LENGTH
+            else -> null
+        }
+
+    /**
+     * True if [char] is in the symbology's allowed charset. Bidi / control characters are
+     * rejected by the validator before this is consulted, so the per-format set need only
+     * describe the visible alphabet.
+     */
+    fun isAllowedChar(
+        format: ScannableFormat,
+        char: Char,
+    ): Boolean =
+        when (format) {
+            // Code128 subsets A/B/C between them cover printable ASCII; bytes outside that
+            // range are rejected here (the upstream control-char check catches NUL etc first,
+            // so this guard only fires on extended-Unicode input like "é").
+            ScannableFormat.Code128 -> char.code in PRINTABLE_ASCII_MIN..PRINTABLE_ASCII_MAX
+            ScannableFormat.Code39 -> char in CODE39_ALLOWED
+            ScannableFormat.Ean13, ScannableFormat.UpcA -> char in '0'..'9'
+            ScannableFormat.Qr -> true
+        }
+
+    /**
+     * Structural validation for fixed-length symbologies. Returns the rejection arm to surface
+     * (length mismatch wins over check-digit mismatch), or null when the payload structurally
+     * conforms.
+     */
+    fun validateStructural(
+        format: ScannableFormat,
+        payload: String,
+    ): PayloadRejection? =
+        when (format) {
+            ScannableFormat.Ean13 -> validateEan13(payload)
+            ScannableFormat.UpcA -> validateUpcA(payload)
+            ScannableFormat.Code128, ScannableFormat.Code39, ScannableFormat.Qr -> null
+        }
+
+    private fun validateEan13(payload: String): PayloadRejection? {
+        if (payload.length != EAN13_LENGTH) {
+            return PayloadRejection.WrongLength(payload.length, EAN13_LENGTH, ScannableFormat.Ean13)
+        }
+        // EAN-13: rightmost digit is the check digit. Weights from right (excluding check
+        // digit) alternate 1, 3, 1, 3 ...; sum mod 10, then (10 - sum mod 10) mod 10.
+        val digits = payload.map { it.digitToInt() }
+        val expected = ean13CheckDigit(digits.dropLast(1))
+        return if (expected == digits.last()) null else PayloadRejection.InvalidCheckDigit(ScannableFormat.Ean13)
+    }
+
+    private fun validateUpcA(payload: String): PayloadRejection? {
+        if (payload.length != UPCA_LENGTH) {
+            return PayloadRejection.WrongLength(payload.length, UPCA_LENGTH, ScannableFormat.UpcA)
+        }
+        // UPC-A: weights from left (excluding check digit) alternate 3, 1, 3, 1 ...; equivalent
+        // to EAN-13 with a leading implicit zero, but expressed directly here for clarity.
+        val digits = payload.map { it.digitToInt() }
+        val expected = upcACheckDigit(digits.dropLast(1))
+        return if (expected == digits.last()) null else PayloadRejection.InvalidCheckDigit(ScannableFormat.UpcA)
+    }
+
+    private fun ean13CheckDigit(twelveDigits: List<Int>): Int {
+        var sum = 0
+        // Index from the right: position 0 = weight 1, position 1 = weight 3, alternating.
+        for ((indexFromRight, digit) in twelveDigits.asReversed().withIndex()) {
+            sum += digit * if (indexFromRight % 2 == 0) 1 else 3
+        }
+        return (10 - sum % 10) % 10
+    }
+
+    private fun upcACheckDigit(elevenDigits: List<Int>): Int {
+        var sum = 0
+        for ((indexFromLeft, digit) in elevenDigits.withIndex()) {
+            sum += digit * if (indexFromLeft % 2 == 0) 3 else 1
+        }
+        return (10 - sum % 10) % 10
+    }
+
+    private const val CODE128_MAX = 80
+    private const val CODE39_MAX = 80
+    private const val EAN13_LENGTH = 13
+    private const val UPCA_LENGTH = 12
+    private const val QR_MAX = 2000
+    private const val PRINTABLE_ASCII_MIN = 0x20
+    private const val PRINTABLE_ASCII_MAX = 0x7E
+
+    private val CODE39_ALLOWED: Set<Char> =
+        buildSet {
+            addAll(('A'..'Z').toSet())
+            addAll(('0'..'9').toSet())
+            addAll(setOf(' ', '-', '.', '$', '/', '+', '%'))
+        }
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -62,10 +62,9 @@ internal object ScannableFormatConstraints {
             ScannableFormat.Code128, ScannableFormat.Code39, ScannableFormat.Qr -> null
         }
 
+    // Length already enforced by the validator via [requiredLength]; structural check assumes
+    // a correctly-sized payload and only verifies the check digit.
     private fun validateEan13(payload: String): PayloadRejection? {
-        if (payload.length != EAN13_LENGTH) {
-            return PayloadRejection.WrongLength(payload.length, EAN13_LENGTH, ScannableFormat.Ean13)
-        }
         // EAN-13: rightmost digit is the check digit. Weights from right (excluding check
         // digit) alternate 1, 3, 1, 3 ...; sum mod 10, then (10 - sum mod 10) mod 10.
         val digits = payload.map { it.digitToInt() }
@@ -74,9 +73,6 @@ internal object ScannableFormatConstraints {
     }
 
     private fun validateUpcA(payload: String): PayloadRejection? {
-        if (payload.length != UPCA_LENGTH) {
-            return PayloadRejection.WrongLength(payload.length, UPCA_LENGTH, ScannableFormat.UpcA)
-        }
         // UPC-A: weights from left (excluding check digit) alternate 3, 1, 3, 1 ...; equivalent
         // to EAN-13 with a leading implicit zero, but expressed directly here for clarity.
         val digits = payload.map { it.digitToInt() }
@@ -111,8 +107,8 @@ internal object ScannableFormatConstraints {
 
     private val CODE39_ALLOWED: Set<Char> =
         buildSet {
-            addAll(('A'..'Z').toSet())
-            addAll(('0'..'9').toSet())
-            addAll(setOf(' ', '-', '.', '$', '/', '+', '%'))
+            addAll('A'..'Z')
+            addAll('0'..'9')
+            addAll(listOf(' ', '-', '.', '$', '/', '+', '%'))
         }
 }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/QrPayloadClassifierTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/QrPayloadClassifierTest.kt
@@ -1,0 +1,257 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavior lock for [QrPayloadClassifier]. Every arm of [QrPayloadKind] is covered, plus
+ * the security-sensitive edge cases:
+ *
+ *  - bare numeric strings are PlainText (not Phone)
+ *  - WIFI passwords are never carried into the kind
+ *  - Punycode / RTL hostnames are passed through verbatim (no IDN conversion in core)
+ *  - upstream-hostile chars (whitespace, control codes) are not silently fixed up
+ */
+class QrPayloadClassifierTest {
+    @Test
+    fun emptyStringIsPlainText() {
+        assertThat(QrPayloadClassifier.classify("")).isEqualTo(QrPayloadKind.PlainText)
+    }
+
+    @Test
+    fun bareNumericStringIsPlainTextNotPhone() {
+        // Regression: a 10-digit member number must not be classified as a tel: URI just
+        // because its glyphs are dial-able. The scheme regex requires a leading ALPHA and
+        // a trailing `:`, so this is locked by construction; the test pins the property.
+        assertThat(QrPayloadClassifier.classify("1234567890")).isEqualTo(QrPayloadKind.PlainText)
+    }
+
+    @Test
+    fun arbitraryTextWithoutSchemeIsPlainText() {
+        assertThat(QrPayloadClassifier.classify("hello world")).isEqualTo(QrPayloadKind.PlainText)
+    }
+
+    @Test
+    fun newlineSeparatedTextIsPlainText() {
+        // "line1\nline2" has no leading scheme (no `:` follows an ALPHA-led prefix before
+        // the newline), so this short-circuits at the scheme regex and lands in PlainText.
+        // Documented behavior: classifier does NOT split multi-line payloads.
+        assertThat(QrPayloadClassifier.classify("line1\nline2")).isEqualTo(QrPayloadKind.PlainText)
+    }
+
+    @Test
+    fun httpsUrlExposesScheme_HostAndRaw() {
+        val raw = "https://walt.is/example"
+        val kind = QrPayloadClassifier.classify(raw)
+        assertThat(kind).isEqualTo(QrPayloadKind.Url(scheme = "https", host = "walt.is", raw = raw))
+    }
+
+    @Test
+    fun httpUrlExposesScheme_HostAndRaw() {
+        val raw = "http://example.com/path?q=1"
+        val kind = QrPayloadClassifier.classify(raw)
+        assertThat(kind).isEqualTo(QrPayloadKind.Url(scheme = "http", host = "example.com", raw = raw))
+    }
+
+    @Test
+    fun httpsUrlWithUserInfoUsesAuthorityHost() {
+        val raw = "https://user:pass@host.example/"
+        val kind = QrPayloadClassifier.classify(raw) as QrPayloadKind.Url
+        assertThat(kind.host).isEqualTo("host.example")
+        assertThat(kind.raw).isEqualTo(raw)
+    }
+
+    @Test
+    fun httpsUrlWithMixedScriptHostnameClassifiesWithoutCrash() {
+        // U+0440 CYRILLIC SMALL LETTER ER, U+03B3 GREEK SMALL LETTER GAMMA inside an
+        // otherwise Latin-looking hostname. Classifier must NOT homoglyph-detect or
+        // normalize; that's the preview UI's job to surface visibly.
+        //
+        // JDK's java.net.URI considers non-ASCII characters illegal in the host portion of
+        // an absolute hierarchical URI: the parse succeeds but `host` comes back as null.
+        // Walt's classifier surfaces what the JDK gives us; downstream UI uses [raw] (which
+        // contains the original glyphs) to render what the user actually typed. The trust
+        // claim is preserved: the user sees their string verbatim, not a sanitized version.
+        val raw = "https://паγpal.com/"
+        val kind = QrPayloadClassifier.classify(raw)
+        assertThat(kind).isInstanceOf(QrPayloadKind.Url::class.java)
+        val url = kind as QrPayloadKind.Url
+        assertThat(url.scheme).isEqualTo("https")
+        assertThat(url.raw).isEqualTo(raw)
+    }
+
+    @Test
+    fun punycodeHostnameIsLeftVerbatim() {
+        val raw = "https://xn--80ak6aa92e.com/"
+        val kind = QrPayloadClassifier.classify(raw) as QrPayloadKind.Url
+        assertThat(kind.host).isEqualTo("xn--80ak6aa92e.com")
+        assertThat(kind.raw).isEqualTo(raw)
+    }
+
+    @Test
+    fun trailingWhitespaceIsNotSilentlyFixed() {
+        // Upstream validator rejects whitespace; if it slipped through, the raw payload
+        // must survive verbatim into the preview so the user sees what would be encoded.
+        val raw = "https://attacker.example/  "
+        val kind = QrPayloadClassifier.classify(raw)
+        // URI parsing may or may not accept the trailing whitespace depending on JDK;
+        // either way, raw must be preserved if Url is returned.
+        if (kind is QrPayloadKind.Url) {
+            assertThat(kind.raw).isEqualTo(raw)
+        } else {
+            assertThat(kind).isInstanceOf(QrPayloadKind.UnknownScheme::class.java)
+            assertThat((kind as QrPayloadKind.UnknownScheme).raw).isEqualTo(raw)
+        }
+    }
+
+    @Test
+    fun telUriIsPhone() {
+        assertThat(QrPayloadClassifier.classify("tel:+15551234567"))
+            .isEqualTo(QrPayloadKind.Phone("+15551234567"))
+    }
+
+    @Test
+    fun smsUriStripsQueryTail() {
+        assertThat(QrPayloadClassifier.classify("sms:+15551234567?body=hi"))
+            .isEqualTo(QrPayloadKind.Sms("+15551234567"))
+    }
+
+    @Test
+    fun mailtoUriStripsQueryTail() {
+        assertThat(QrPayloadClassifier.classify("mailto:a@b.com?subject=hello"))
+            .isEqualTo(QrPayloadKind.Mailto("a@b.com"))
+    }
+
+    @Test
+    fun geoUriExposesCoords() {
+        assertThat(QrPayloadClassifier.classify("geo:37.7749,-122.4194"))
+            .isEqualTo(QrPayloadKind.Geo("37.7749,-122.4194"))
+    }
+
+    @Test
+    fun wifiUriExposesSsidButNeverPassword() {
+        val payload = "WIFI:T:WPA;S:my-network;P:hunter2;;"
+        val kind = QrPayloadClassifier.classify(payload) as QrPayloadKind.Wifi
+        assertThat(kind.ssid).isEqualTo("my-network")
+        // Belt-and-suspenders: no field on the result type carries the password substring.
+        // The Wifi data class has exactly one property (ssid); this assertion locks the
+        // shape against a future "let's add a password field for convenience" PR.
+        assertThat(kind.toString()).doesNotContain("hunter2")
+    }
+
+    @Test
+    fun wifiUriWithoutSsidReturnsNullSsid() {
+        val payload = "WIFI:T:nopass;;"
+        assertThat(QrPayloadClassifier.classify(payload)).isEqualTo(QrPayloadKind.Wifi(ssid = null))
+    }
+
+    @Test
+    fun wifiUriWithEscapedSemicolonInSsidUnescapes() {
+        // SSID is `weird;name`. Escaped `\;` should produce a literal `;` and not terminate
+        // the field.
+        val payload = """WIFI:S:weird\;name;T:WPA;P:secret;;"""
+        val kind = QrPayloadClassifier.classify(payload) as QrPayloadKind.Wifi
+        assertThat(kind.ssid).isEqualTo("weird;name")
+        assertThat(kind.toString()).doesNotContain("secret")
+    }
+
+    @Test
+    fun bitcoinUriStripsAmountTail() {
+        assertThat(QrPayloadClassifier.classify("bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa?amount=0.5"))
+            .isEqualTo(QrPayloadKind.Bitcoin("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"))
+    }
+
+    @Test
+    fun ethereumUriStripsValueTail() {
+        assertThat(QrPayloadClassifier.classify("ethereum:0xabc?value=1"))
+            .isEqualTo(QrPayloadKind.Ethereum("0xabc"))
+    }
+
+    @Test
+    fun magnetUriClassifies() {
+        assertThat(QrPayloadClassifier.classify("magnet:?xt=urn:btih:abc"))
+            .isEqualTo(QrPayloadKind.Magnet)
+    }
+
+    @Test
+    fun marketUriWithAuthoritySliceExposesProductId() {
+        assertThat(QrPayloadClassifier.classify("market://details?id=com.example.app"))
+            .isEqualTo(QrPayloadKind.Market("details?id=com.example.app"))
+    }
+
+    @Test
+    fun marketUriWithoutAuthoritySliceExposesProductId() {
+        assertThat(QrPayloadClassifier.classify("market:details?id=com.example.app"))
+            .isEqualTo(QrPayloadKind.Market("details?id=com.example.app"))
+    }
+
+    @Test
+    fun intentUriKeepsRawString() {
+        val raw = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
+        assertThat(QrPayloadClassifier.classify(raw)).isEqualTo(QrPayloadKind.Intent(raw))
+    }
+
+    @Test
+    fun uppercaseSchemeIsNormalizedBeforeDispatch() {
+        // Schemes are case-insensitive per RFC 3986. The kind dispatches on lowercase,
+        // and the Bitcoin arm carries the address verbatim from after the scheme.
+        val payload = "BITCOIN:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+        assertThat(QrPayloadClassifier.classify(payload))
+            .isEqualTo(QrPayloadKind.Bitcoin("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"))
+    }
+
+    @Test
+    fun unrecognizedSchemeReturnsUnknownScheme() {
+        val raw = "foo://bar"
+        assertThat(QrPayloadClassifier.classify(raw))
+            .isEqualTo(QrPayloadKind.UnknownScheme(scheme = "foo", raw = raw))
+    }
+
+    @Test
+    fun unknownSchemeNormalizesToLowercase() {
+        val raw = "FOO://bar"
+        assertThat(QrPayloadClassifier.classify(raw))
+            .isEqualTo(QrPayloadKind.UnknownScheme(scheme = "foo", raw = raw))
+    }
+
+    @Test
+    fun allKindArmsAreReachableViaWhen() {
+        // Drift detection: removing an arm breaks compilation in [branchName] before it
+        // breaks any downstream `when`. Mirrors PublicApiSurfaceTest conventions.
+        val kinds: List<QrPayloadKind> =
+            listOf(
+                QrPayloadKind.PlainText,
+                QrPayloadKind.Url(scheme = "https", host = "x", raw = "https://x"),
+                QrPayloadKind.Phone("1"),
+                QrPayloadKind.Sms("1"),
+                QrPayloadKind.Mailto("a@b"),
+                QrPayloadKind.Geo("0,0"),
+                QrPayloadKind.Wifi(ssid = null),
+                QrPayloadKind.Bitcoin("a"),
+                QrPayloadKind.Ethereum("0x"),
+                QrPayloadKind.Magnet,
+                QrPayloadKind.Market("x"),
+                QrPayloadKind.Intent("intent://x"),
+                QrPayloadKind.UnknownScheme("foo", "foo:x"),
+            )
+        val branches = kinds.map(::branchName).toSet()
+        assertThat(branches).hasSize(kinds.size)
+    }
+
+    private fun branchName(k: QrPayloadKind): String =
+        when (k) {
+            QrPayloadKind.PlainText -> "plain"
+            is QrPayloadKind.Url -> "url"
+            is QrPayloadKind.Phone -> "phone"
+            is QrPayloadKind.Sms -> "sms"
+            is QrPayloadKind.Mailto -> "mailto"
+            is QrPayloadKind.Geo -> "geo"
+            is QrPayloadKind.Wifi -> "wifi"
+            is QrPayloadKind.Bitcoin -> "btc"
+            is QrPayloadKind.Ethereum -> "eth"
+            QrPayloadKind.Magnet -> "magnet"
+            is QrPayloadKind.Market -> "market"
+            is QrPayloadKind.Intent -> "intent"
+            is QrPayloadKind.UnknownScheme -> "unknown"
+        }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/QrPayloadClassifierTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/QrPayloadClassifierTest.kt
@@ -111,6 +111,15 @@ class QrPayloadClassifierTest {
     }
 
     @Test
+    fun telUriStripsQueryTail() {
+        // Mirrors the sms/mailto/bitcoin behavior so the preview dialog renders a clean
+        // dialable number rather than `+155?foo`. `tel:` per RFC 3966 uses `;` for params,
+        // not `?`, but consistency with the other "phone-like" arms wins over RFC purity.
+        assertThat(QrPayloadClassifier.classify("tel:+15551234567?foo=bar"))
+            .isEqualTo(QrPayloadKind.Phone("+15551234567"))
+    }
+
+    @Test
     fun smsUriStripsQueryTail() {
         assertThat(QrPayloadClassifier.classify("sms:+15551234567?body=hi"))
             .isEqualTo(QrPayloadKind.Sms("+15551234567"))
@@ -153,6 +162,19 @@ class QrPayloadClassifierTest {
         val kind = QrPayloadClassifier.classify(payload) as QrPayloadKind.Wifi
         assertThat(kind.ssid).isEqualTo("weird;name")
         assertThat(kind.toString()).doesNotContain("secret")
+    }
+
+    @Test
+    fun wifiUriWithFakeSsidKeyInsideEscapedPasswordDoesNotSpoof() {
+        // Field-boundary detection must honor escapes: the `\;` inside the password value
+        // here is NOT a real field separator, so the `S:` substring following it is NOT a
+        // real SSID-field key. The validator must read the real `S:realnet` field, not the
+        // decoy `S:secret` substring sitting inside the password's literal text.
+        val payload = """WIFI:T:WPA;P:my\;S:secret;S:realnet;;"""
+        val kind = QrPayloadClassifier.classify(payload) as QrPayloadKind.Wifi
+        assertThat(kind.ssid).isEqualTo("realnet")
+        // And the password substring still never surfaces, escape parsing aside.
+        assertThat(kind.toString()).doesNotContain("my")
     }
 
     @Test

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -185,13 +185,34 @@ class ScannableCardInputValidatorTest {
 
     @Test
     fun upcAShortLengthRejected() {
-        // 11 digits — below the UPC-A length cap so it passes the TooLong gate and
-        // surfaces the structural WrongLength rejection instead.
         val rejection = expectPayloadRejection("12345678901", ScannableFormat.UpcA)
         assertThat(rejection).isInstanceOf(PayloadRejection.WrongLength::class.java)
         rejection as PayloadRejection.WrongLength
         assertThat(rejection.actual).isEqualTo(11)
         assertThat(rejection.required).isEqualTo(12)
+    }
+
+    @Test
+    fun upcALongLengthRejectedAsWrongLength() {
+        // Fixed-length symbology: a 13-digit input must surface WrongLength (NOT TooLong),
+        // so the consumer has a single arm to render for "wrong digit count" regardless of
+        // whether the user typed too few or too many.
+        val rejection = expectPayloadRejection("1234567890128", ScannableFormat.UpcA)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongLength::class.java)
+        rejection as PayloadRejection.WrongLength
+        assertThat(rejection.actual).isEqualTo(13)
+        assertThat(rejection.required).isEqualTo(12)
+        assertThat(rejection.format).isEqualTo(ScannableFormat.UpcA)
+    }
+
+    @Test
+    fun ean13LongLengthRejectedAsWrongLength() {
+        val rejection = expectPayloadRejection("12345678901234", ScannableFormat.Ean13)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongLength::class.java)
+        rejection as PayloadRejection.WrongLength
+        assertThat(rejection.actual).isEqualTo(14)
+        assertThat(rejection.required).isEqualTo(13)
+        assertThat(rejection.format).isEqualTo(ScannableFormat.Ean13)
     }
 
     @Test
@@ -240,6 +261,13 @@ class ScannableCardInputValidatorTest {
         assertThat(result).isInstanceOf(ScannableCardCreateResult.Success::class.java)
     }
 
+    @Test
+    fun whitespaceOnlyLabelIsEmpty() {
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "   ")
+        val invalid = result as ScannableCardCreateResult.InvalidLabel
+        assertThat(invalid.reason).isEqualTo(LabelRejection.Empty)
+    }
+
     // ---- trim semantics on success path ----
 
     @Test
@@ -248,6 +276,14 @@ class ScannableCardInputValidatorTest {
         val success = result as ScannableCardCreateResult.Success
         assertThat(success.card.payload).isEqualTo("hello")
         assertThat(success.card.payload).doesNotContain(" ")
+    }
+
+    @Test
+    fun successCardCarriesTrimmedLabelNotRaw() {
+        val result =
+            validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "  My Card  ")
+        val success = result as ScannableCardCreateResult.Success
+        assertThat(success.card.label).isEqualTo("My Card")
     }
 
     @Test

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -1,0 +1,302 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavior lock for [ScannableCardInputValidator]. Pins per-format charset, length, bidi /
+ * control rejection, and EAN-13 / UPC-A check-digit rules. Companion to the surface lock in
+ * [ScannableCardSurfaceTest], which covers the shape of the result type.
+ */
+class ScannableCardInputValidatorTest {
+    private val id = ScannableCardId("test")
+    private val now = PassInstant(epochMillis = 1_800_000_000_000L)
+
+    // ---- per-format success ----
+
+    @Test
+    fun code128HappyPath() {
+        val result = validate("ABC123 xyz", ScannableFormat.Code128)
+        assertSuccessWithPayload(result, "ABC123 xyz")
+    }
+
+    @Test
+    fun code39HappyPath() {
+        val result = validate("ABC-123 +%/.$", ScannableFormat.Code39)
+        assertSuccessWithPayload(result, "ABC-123 +%/.$")
+    }
+
+    @Test
+    fun ean13HappyPathWithValidCheckDigit() {
+        val result = validate("1234567890120", ScannableFormat.Ean13)
+        assertSuccessWithPayload(result, "1234567890120")
+    }
+
+    @Test
+    fun upcAHappyPathWithValidCheckDigit() {
+        val result = validate("123456789012", ScannableFormat.UpcA)
+        assertSuccessWithPayload(result, "123456789012")
+    }
+
+    @Test
+    fun qrHappyPathAcceptsUtf8() {
+        val result = validate("https://example.org/é/👍", ScannableFormat.Qr)
+        assertSuccessWithPayload(result, "https://example.org/é/👍")
+    }
+
+    // ---- length caps ----
+
+    @Test
+    fun code128TooLong() {
+        val payload = "A".repeat(81)
+        val rejection = expectPayloadRejection(payload, ScannableFormat.Code128)
+        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+        rejection as PayloadRejection.TooLong
+        assertThat(rejection.actual).isEqualTo(81)
+        assertThat(rejection.max).isEqualTo(80)
+    }
+
+    @Test
+    fun code39TooLong() {
+        val rejection = expectPayloadRejection("A".repeat(81), ScannableFormat.Code39)
+        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+    }
+
+    @Test
+    fun qrTooLong() {
+        val rejection = expectPayloadRejection("x".repeat(2001), ScannableFormat.Qr)
+        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+    }
+
+    // ---- charset violations ----
+
+    @Test
+    fun code128RejectsNonAsciiBecauseOfCharset() {
+        val rejection = expectPayloadRejection("ABCé", ScannableFormat.Code128)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongCharset::class.java)
+        rejection as PayloadRejection.WrongCharset
+        assertThat(rejection.format).isEqualTo(ScannableFormat.Code128)
+        assertThat(rejection.offendingChar).isEqualTo('é')
+    }
+
+    @Test
+    fun code39RejectsLowercaseLetters() {
+        val rejection = expectPayloadRejection("abc", ScannableFormat.Code39)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongCharset::class.java)
+    }
+
+    @Test
+    fun ean13RejectsLetters() {
+        val rejection = expectPayloadRejection("12345678A0120", ScannableFormat.Ean13)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongCharset::class.java)
+    }
+
+    @Test
+    fun upcARejectsLetters() {
+        val rejection = expectPayloadRejection("12345A789012", ScannableFormat.UpcA)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongCharset::class.java)
+    }
+
+    // ---- bidi / control rejection across all formats ----
+
+    @Test
+    fun code128BidiCharRejected() {
+        val rejection = expectPayloadRejection("AB‮C", ScannableFormat.Code128)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun code39BidiCharRejected() {
+        val rejection = expectPayloadRejection("AB‮C", ScannableFormat.Code39)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun ean13BidiCharRejected() {
+        val rejection = expectPayloadRejection("1234567‮890120", ScannableFormat.Ean13)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun upcABidiCharRejected() {
+        val rejection = expectPayloadRejection("12345‮789012", ScannableFormat.UpcA)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun qrBidiCharRejected() {
+        val rejection = expectPayloadRejection("hello‮world", ScannableFormat.Qr)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun nullByteRejectedAsControlChar() {
+        val rejection = expectPayloadRejection("AB\u0000C", ScannableFormat.Code128)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsControlChar)
+    }
+
+    @Test
+    fun qrNullByteRejectedAsControlChar() {
+        val rejection = expectPayloadRejection("hi\u0000there", ScannableFormat.Qr)
+        assertThat(rejection).isEqualTo(PayloadRejection.ContainsControlChar)
+    }
+
+    // ---- trim / empty ----
+
+    @Test
+    fun payloadIsTrimmedBeforeValidation() {
+        val result = validate("  ABC  ", ScannableFormat.Code128)
+        assertSuccessWithPayload(result, "ABC")
+    }
+
+    @Test
+    fun whitespaceOnlyPayloadIsEmpty() {
+        val rejection = expectPayloadRejection("   ", ScannableFormat.Code128)
+        assertThat(rejection).isEqualTo(PayloadRejection.Empty)
+    }
+
+    @Test
+    fun emptyPayloadRejected() {
+        val rejection = expectPayloadRejection("", ScannableFormat.Code128)
+        assertThat(rejection).isEqualTo(PayloadRejection.Empty)
+    }
+
+    // ---- EAN-13 structural ----
+
+    @Test
+    fun ean13WrongLengthRejected() {
+        val rejection = expectPayloadRejection("123456789012", ScannableFormat.Ean13)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongLength::class.java)
+        rejection as PayloadRejection.WrongLength
+        assertThat(rejection.actual).isEqualTo(12)
+        assertThat(rejection.required).isEqualTo(13)
+        assertThat(rejection.format).isEqualTo(ScannableFormat.Ean13)
+    }
+
+    @Test
+    fun ean13InvalidCheckDigitRejected() {
+        val rejection = expectPayloadRejection("1234567890121", ScannableFormat.Ean13)
+        assertThat(rejection).isInstanceOf(PayloadRejection.InvalidCheckDigit::class.java)
+        rejection as PayloadRejection.InvalidCheckDigit
+        assertThat(rejection.format).isEqualTo(ScannableFormat.Ean13)
+    }
+
+    // ---- UPC-A structural ----
+
+    @Test
+    fun upcAShortLengthRejected() {
+        // 11 digits — below the UPC-A length cap so it passes the TooLong gate and
+        // surfaces the structural WrongLength rejection instead.
+        val rejection = expectPayloadRejection("12345678901", ScannableFormat.UpcA)
+        assertThat(rejection).isInstanceOf(PayloadRejection.WrongLength::class.java)
+        rejection as PayloadRejection.WrongLength
+        assertThat(rejection.actual).isEqualTo(11)
+        assertThat(rejection.required).isEqualTo(12)
+    }
+
+    @Test
+    fun upcAInvalidCheckDigitRejected() {
+        val rejection = expectPayloadRejection("123456789013", ScannableFormat.UpcA)
+        assertThat(rejection).isInstanceOf(PayloadRejection.InvalidCheckDigit::class.java)
+    }
+
+    // ---- label ----
+
+    @Test
+    fun labelEmptyRejected() {
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "")
+        val invalid = result as ScannableCardCreateResult.InvalidLabel
+        assertThat(invalid.reason).isEqualTo(LabelRejection.Empty)
+    }
+
+    @Test
+    fun labelBidiCharRejected() {
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "Card‮")
+        val invalid = result as ScannableCardCreateResult.InvalidLabel
+        assertThat(invalid.reason).isEqualTo(LabelRejection.ContainsBidiChar)
+    }
+
+    @Test
+    fun labelControlCharRejected() {
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "Card\u0007")
+        val invalid = result as ScannableCardCreateResult.InvalidLabel
+        assertThat(invalid.reason).isEqualTo(LabelRejection.ContainsControlChar)
+    }
+
+    @Test
+    fun labelTooLongRejected() {
+        val long = "L".repeat(101)
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = long)
+        val invalid = result as ScannableCardCreateResult.InvalidLabel
+        assertThat(invalid.reason).isInstanceOf(LabelRejection.TooLong::class.java)
+        val reason = invalid.reason as LabelRejection.TooLong
+        assertThat(reason.actual).isEqualTo(101)
+        assertThat(reason.max).isEqualTo(100)
+    }
+
+    @Test
+    fun labelExactlyAtCapAccepted() {
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "L".repeat(100))
+        assertThat(result).isInstanceOf(ScannableCardCreateResult.Success::class.java)
+    }
+
+    // ---- trim semantics on success path ----
+
+    @Test
+    fun successCardCarriesTrimmedPayloadNotRaw() {
+        val result = validate("  hello  ", ScannableFormat.Code128)
+        val success = result as ScannableCardCreateResult.Success
+        assertThat(success.card.payload).isEqualTo("hello")
+        assertThat(success.card.payload).doesNotContain(" ")
+    }
+
+    @Test
+    fun successCardCarriesCallerIdAndTimestamp() {
+        val result = validate("ABC", ScannableFormat.Code128)
+        val success = result as ScannableCardCreateResult.Success
+        assertThat(success.card.id).isEqualTo(id)
+        assertThat(success.card.createdAt).isEqualTo(now)
+    }
+
+    // ---- helpers ----
+
+    private fun validate(
+        payload: String,
+        format: ScannableFormat,
+    ): ScannableCardCreateResult = validateInput(payload = payload, format = format, label = "Card")
+
+    private fun validateInput(
+        payload: String,
+        format: ScannableFormat,
+        label: String,
+    ): ScannableCardCreateResult =
+        ScannableCardInputValidator.validate(
+            input =
+                ScannableCardCreateInput(
+                    payload = payload,
+                    format = format,
+                    label = label,
+                    color = null,
+                ),
+            id = id,
+            createdAt = now,
+        )
+
+    private fun expectPayloadRejection(
+        payload: String,
+        format: ScannableFormat,
+    ): PayloadRejection {
+        val result = validate(payload, format)
+        assertThat(result).isInstanceOf(ScannableCardCreateResult.InvalidPayload::class.java)
+        return (result as ScannableCardCreateResult.InvalidPayload).reason
+    }
+
+    private fun assertSuccessWithPayload(
+        result: ScannableCardCreateResult,
+        expectedPayload: String,
+    ) {
+        assertThat(result).isInstanceOf(ScannableCardCreateResult.Success::class.java)
+        val success = result as ScannableCardCreateResult.Success
+        assertThat(success.card.payload).isEqualTo(expectedPayload)
+    }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -225,18 +225,18 @@ class ScannableCardInputValidatorTest {
 
     @Test
     fun labelTooLongRejected() {
-        val long = "L".repeat(101)
+        val long = "L".repeat(65)
         val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = long)
         val invalid = result as ScannableCardCreateResult.InvalidLabel
         assertThat(invalid.reason).isInstanceOf(LabelRejection.TooLong::class.java)
         val reason = invalid.reason as LabelRejection.TooLong
-        assertThat(reason.actual).isEqualTo(101)
-        assertThat(reason.max).isEqualTo(100)
+        assertThat(reason.actual).isEqualTo(65)
+        assertThat(reason.max).isEqualTo(64)
     }
 
     @Test
     fun labelExactlyAtCapAccepted() {
-        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "L".repeat(100))
+        val result = validateInput(payload = "ABC", format = ScannableFormat.Code128, label = "L".repeat(64))
         assertThat(result).isInstanceOf(ScannableCardCreateResult.Success::class.java)
     }
 


### PR DESCRIPTION
## Summary

Combines two siblings of the wpass-lzi epic that both land in `passes-core`, both are pure-JVM, and both fill sealed families that `wpass-lzi.2` left as empty placeholders.

- **wpass-lzi.4** — input validator and per-format constraints. Fills `PayloadRejection` / `LabelRejection` arms in `ScannableCardCreateResult`; adds `ScannableCardInputValidator` (fail-fast: label → trim → empty → bidi/control → length → charset → structural) and `ScannableFormatConstraints` (the single source of truth for length caps, charset rules, and EAN-13 / UPC-A check-digit validation). Validator signature is `validate(input, id, createdAt)` because passes-core does not mint IDs and the clock is intentionally injectable for deterministic tests.
- **wpass-lzi.5** — QR payload URI-scheme classifier. Adds `QrPayloadKind` (13 arms — `PlainText`, `Url`, `Phone`, `Sms`, `Mailto`, `Geo`, `Wifi`, `Bitcoin`, `Ethereum`, `Magnet`, `Market`, `Intent`, `UnknownScheme`) and `QrPayloadClassifier`. Pure logic feeding the create-time confirmation dialog in sibling `wpass-lzi.9`. Conservative posture: scheme normalized lowercase before dispatch, WIFI password is parsed-and-dropped so it never reaches the UI layer, mixed-script hostnames are preserved verbatim (no homoglyph normalization — that's the UI's job to surface).

Trust posture: both modules are inputs-hygiene seams that run *before* the encoder (`wpass-lzi.3`) and storage (`wpass-lzi.6`) ever see the data. Without them, a malicious payload could embed bidi-override chars that visually misrepresent the label, exceed scanner-realistic limits, or — for QR — encode an unsuspected URI that a third-party scanner auto-acts on.

### Decisions worth flagging for review

- **EAN-13 / UPC-A check digit**: validator rejects a wrong user-supplied check digit rather than auto-computing. Preserves the symbology's built-in typo-detection on the other data digits.
- **Label max length**: 64 chars. Tracks PKPASS `logoText` real-world length; the cap is a trust/sanity guard, not a layout choice (the tile UI ellipsis-truncates visually much earlier).
- **Payload length caps**: Code128 80, Code39 80, EAN13 13, UPCA 12, QR 2000. Tight enough to reject abuse, loose enough to never reject legitimate input.
- **WIFI password is parsed-and-dropped**: the classifier extracts only the SSID. Adding a code comment locking this property; the eventual UI dialog cannot accidentally surface a network password.

## Test plan

- [x] `:passes-core:check` green (236 tests: 30 new in `ScannableCardInputValidatorTest`, 27 new in `QrPayloadClassifierTest`, plus the pre-existing surface).
- [x] Detekt + ktlint clean.
- [ ] Manual review of validator decision table against the threat-model doc.
- [ ] Manual review of `QrPayloadKind.Wifi` arm to confirm no field carries the password (asserted in test, worth a human read).

Closes wpass-lzi.4, wpass-lzi.5.