### PR TITLE
passes-ui: expose FieldLinkScanner + LinkSpan as public API (wpass-a9b)

### DIFF
--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -117,15 +117,19 @@ carry the *verbatim* substring from the field — no normalization, no scheme
 injection — so a confirmation sheet built from a span shows the user exactly the
 string that will leave the device. The trust contract (bidi-spoofing rejection,
 RFC 3986 URL class, phone digit-count + adjacency hints, email shape) lives
-entirely inside [FieldLinkScanner.scan]; there is no constructor path that
-produces a [LinkSpan] without going through it.
+entirely inside [FieldLinkScanner.scan], and `LinkSpan`'s constructor is
+`internal`, so every span a consumer holds has been through that validation.
+`copy(...)` on a scanner-produced span still works for styling needs.
+
+`start` / `endExclusive` are UTF-16 char offsets into the field string passed to
+`scan` — the same units `Regex`, `String.substring`, and `AnnotatedString` use.
 
 ```kotlin
 public object FieldLinkScanner {
     public fun scan(fieldValue: String, source: SourceField): List<LinkSpan>
 }
 
-public data class LinkSpan(
+public data class LinkSpan internal constructor(
     public val start: Int,
     public val endExclusive: Int,
     public val intent: SecurityIntent,

--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -108,6 +108,30 @@ public fun PassBack(
 )
 ```
 
+## Back-field link scanner
+
+Public so consumers that render their own back-field layouts (no kernel `Surface`
+card, flat rows on a host-owned gradient, etc.) can route through the canonical
+detector instead of hand-rolling regex. The scanner returns spans whose intents
+carry the *verbatim* substring from the field — no normalization, no scheme
+injection — so a confirmation sheet built from a span shows the user exactly the
+string that will leave the device. The trust contract (bidi-spoofing rejection,
+RFC 3986 URL class, phone digit-count + adjacency hints, email shape) lives
+entirely inside [FieldLinkScanner.scan]; there is no constructor path that
+produces a [LinkSpan] without going through it.
+
+```kotlin
+public object FieldLinkScanner {
+    public fun scan(fieldValue: String, source: SourceField): List<LinkSpan>
+}
+
+public data class LinkSpan(
+    public val start: Int,
+    public val endExclusive: Int,
+    public val intent: SecurityIntent,
+)
+```
+
 ## Barcode
 
 ```kotlin

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/FieldLinkScanner.kt
@@ -40,8 +40,11 @@ package `is`.walt.passes.ui
  *
  * Public so consumers that render their own back-field layouts (e.g. walt-android's
  * flat-row PKPASS detail screen) can invoke the canonical scanner instead of
- * hand-rolling regex. The only ingress remains [scan]: there is no way to construct
- * a [LinkSpan] with an intent target that did not originate from a real match.
+ * hand-rolling regex. [LinkSpan]'s constructor is `internal`, so the only way a
+ * consumer obtains a span is through [scan] — every span they see has therefore
+ * passed the bidi-spoofing rejection, the URL/phone/email shape checks, and the
+ * containment rules below. `copy(...)` on a scanner-produced span still works for
+ * styling needs.
  */
 public object FieldLinkScanner {
 
@@ -177,13 +180,19 @@ public object FieldLinkScanner {
 }
 
 /**
- * One detected link in a back-field value. [start] and [endExclusive] are codepoint
- * offsets into the field string the consumer passed to [FieldLinkScanner.scan]; the
- * consumer should use them to style and route taps over that range. [intent] carries
- * the verbatim substring as its target — no normalization, no scheme injection — so a
- * confirmation sheet built from it shows the user exactly what will leave the device.
+ * One detected link in a back-field value. [start] and [endExclusive] are UTF-16
+ * char offsets (the units Kotlin's `Regex`, `String.substring`, and
+ * `AnnotatedString` all use) into the field string the consumer passed to
+ * [FieldLinkScanner.scan]; the consumer should use them to style and route taps
+ * over that range. [intent] carries the verbatim substring as its target — no
+ * normalization, no scheme injection — so a confirmation sheet built from it
+ * shows the user exactly what will leave the device.
+ *
+ * The constructor is `internal`: consumers can only obtain a `LinkSpan` from
+ * [FieldLinkScanner.scan], which guarantees the intent target survived the
+ * scanner's validation rules.
  */
-public data class LinkSpan(
+public data class LinkSpan internal constructor(
     public val start: Int,
     public val endExclusive: Int,
     public val intent: SecurityIntent,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/FieldLinkScanner.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/FieldLinkScanner.kt
@@ -1,10 +1,4 @@
-package `is`.walt.passes.ui.internal
-
-import `is`.walt.passes.ui.B3UrlIntent
-import `is`.walt.passes.ui.EmailIntent
-import `is`.walt.passes.ui.PhoneIntent
-import `is`.walt.passes.ui.SecurityIntent
-import `is`.walt.passes.ui.SourceField
+package `is`.walt.passes.ui
 
 /**
  * Detects URLs, phone numbers, and email addresses in pass back-field values. Returns
@@ -43,8 +37,13 @@ import `is`.walt.passes.ui.SourceField
  * codepoint. This is redundant for phone and email under the current regexes but
  * locks the property so a future regex relaxation does not silently re-open a
  * spoofing path.
+ *
+ * Public so consumers that render their own back-field layouts (e.g. walt-android's
+ * flat-row PKPASS detail screen) can invoke the canonical scanner instead of
+ * hand-rolling regex. The only ingress remains [scan]: there is no way to construct
+ * a [LinkSpan] with an intent target that did not originate from a real match.
  */
-internal object FieldLinkScanner {
+public object FieldLinkScanner {
 
     // Permissive on the boundary chars (whitespace + brackets + quotes), then the
     // post-filter (`containsRenderingHazard`) rejects matches containing Cf/Cc
@@ -64,7 +63,7 @@ internal object FieldLinkScanner {
     private val phoneRegex =
         Regex("""(?<!\d)(\+?\d[\d\s\-()]{6,}\d)(?!\d)""")
 
-    fun scan(fieldValue: String, source: SourceField): List<LinkSpan> {
+    public fun scan(fieldValue: String, source: SourceField): List<LinkSpan> {
         // Field-level rejection: if ANY part of this field contains a Unicode
         // formatting (Cf) or control (Cc) codepoint, surface NO tappable links from
         // it. Even a clean URL adjacent to a hostile one becomes non-tappable; the
@@ -177,8 +176,15 @@ internal object FieldLinkScanner {
     private val PHONE_PREFIX_HINTS = setOf('+', '(')
 }
 
-internal data class LinkSpan(
-    val start: Int,
-    val endExclusive: Int,
-    val intent: SecurityIntent,
+/**
+ * One detected link in a back-field value. [start] and [endExclusive] are codepoint
+ * offsets into the field string the consumer passed to [FieldLinkScanner.scan]; the
+ * consumer should use them to style and route taps over that range. [intent] carries
+ * the verbatim substring as its target — no normalization, no scheme injection — so a
+ * confirmation sheet built from it shows the user exactly what will leave the device.
+ */
+public data class LinkSpan(
+    public val start: Int,
+    public val endExclusive: Int,
+    public val intent: SecurityIntent,
 )

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassBack.kt
@@ -25,8 +25,6 @@ import `is`.walt.passes.core.PassField
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.lookupOrSelf
 import `is`.walt.passes.core.resolveLocalizedStrings
-import `is`.walt.passes.ui.internal.FieldLinkScanner
-import `is`.walt.passes.ui.internal.LinkSpan
 import `is`.walt.passes.ui.internal.LocalLocalizedStrings
 
 /**

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/FieldLinkScannerTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/FieldLinkScannerTest.kt
@@ -1,9 +1,5 @@
-package `is`.walt.passes.ui.internal
+package `is`.walt.passes.ui
 
-import `is`.walt.passes.ui.B3UrlIntent
-import `is`.walt.passes.ui.EmailIntent
-import `is`.walt.passes.ui.PhoneIntent
-import `is`.walt.passes.ui.SourceField
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import org.junit.Test


### PR DESCRIPTION
## Summary
- Promote `FieldLinkScanner` and `LinkSpan` from `is.walt.passes.ui.internal` to `is.walt.passes.ui` and mark them `public` so walt-android's flat-row PKPASS detail screen (wlt-b19) can route through the canonical detector instead of hand-rolling regex.
- Trust contract is unchanged: the only public ingress is `FieldLinkScanner.scan`, so consumers cannot construct a `LinkSpan` with an intent target that did not flow through the bidi-spoofing rejection, RFC 3986 URL class, phone digit/adjacency rules, and email shape check.
- Updated `passes-ui/COMPOSABLE_SIGNATURES.md` with a "Back-field link scanner" section advertising the new public surface.

## Test plan
- [x] `./gradlew :passes-ui:test :passes-ui:detekt`
- [x] `./gradlew :passes-ui:assembleDebug`