### PR TITLE
passes-core: ZXing barcode encoder (wpass-lzi.3)

### DIFF
--- a/passes-core/build.gradle.kts
+++ b/passes-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.bouncycastle.bcprov)
     implementation(libs.bouncycastle.bcpkix)
+    implementation(libs.zxing.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeEncoder.kt
@@ -15,10 +15,12 @@ import `is`.walt.passes.core.internal.ZxingBarcodeEncoder
  * are therefore narrow — anything not caused by ZXing's encodability rules is the validator's
  * problem.
  *
- * **No-throw contract.** Any [Throwable] from the underlying ZXing writer is captured and
- * translated into an [EncodeResult.Failure] arm; the caller observes the outcome via
- * exhaustive `when` and never via `try/catch`. This matches the kernel-wide pattern set by
- * [ParseResult] and [ScannableCardCreateResult].
+ * **No-throw contract.** Every [Throwable] from the underlying ZXing writer — including
+ * the unchecked `NullPointerException` / `ArrayIndexOutOfBoundsException` cases its
+ * hand-rolled writers raise on some edge inputs — is captured and translated into an
+ * [EncodeResult.Failure] arm. The caller observes outcomes via exhaustive `when` and
+ * never via `try/catch`. Matches the kernel-wide pattern set by [ParseResult] and
+ * [ScannableCardCreateResult].
  *
  * **API stability.** ZXing's `BitMatrix` is deliberately not visible on this surface — the
  * matrix is wrapped in the kernel's own [BarcodeMatrix] so the encoder is replaceable

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeEncoder.kt
@@ -1,0 +1,46 @@
+package `is`.walt.passes.core
+
+import `is`.walt.passes.core.internal.ZxingBarcodeEncoder
+
+/**
+ * Encodes a [ScannableCard]'s `(payload, format)` into a [BarcodeMatrix] the renderer can
+ * draw. Pure synchronous function — ZXing's writers complete in well under 50ms for any
+ * realistic input. Callers that want to keep the main thread free wrap the call in their
+ * own dispatcher; the kernel does not pick a thread for the caller.
+ *
+ * **Validation boundary.** The encoder assumes its input has already cleared
+ * [ScannableCardInputValidator]. It does NOT re-run charset, length, or check-digit checks;
+ * those belong upstream so the consumer's error UI maps validation rejections to the right
+ * field (payload vs. label) before the encoder is ever called. The arms of [EncodeResult]
+ * are therefore narrow — anything not caused by ZXing's encodability rules is the validator's
+ * problem.
+ *
+ * **No-throw contract.** Any [Throwable] from the underlying ZXing writer is captured and
+ * translated into an [EncodeResult.Failure] arm; the caller observes the outcome via
+ * exhaustive `when` and never via `try/catch`. This matches the kernel-wide pattern set by
+ * [ParseResult] and [ScannableCardCreateResult].
+ *
+ * **API stability.** ZXing's `BitMatrix` is deliberately not visible on this surface — the
+ * matrix is wrapped in the kernel's own [BarcodeMatrix] so the encoder is replaceable
+ * without breaking consumers.
+ */
+public object BarcodeEncoder {
+    public fun encode(
+        payload: String,
+        format: ScannableFormat,
+    ): EncodeResult = ZxingBarcodeEncoder.encode(payload, format)
+}
+
+/**
+ * Outcome of [BarcodeEncoder.encode]. Sibling family to [ScannableCardCreateResult] —
+ * encoder failures bubble up into [ScannableCardCreateResult.EncoderFailure] when an
+ * orchestrator wraps validation + encoding into a single create flow (storage layer,
+ * Child 6). The two surface types are kept separate so the encoder can be called on its
+ * own (e.g., re-encoding for a render-time size change) without dragging the create-flow
+ * arms into a render-time call site.
+ */
+public sealed interface EncodeResult {
+    public data class Success(public val matrix: BarcodeMatrix) : EncodeResult
+
+    public data class Failure(public val reason: EncoderFailureReason) : EncodeResult
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeMatrix.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeMatrix.kt
@@ -1,0 +1,57 @@
+package `is`.walt.passes.core
+
+/**
+ * Encoded barcode as a grid of monochrome modules. `true` means "dark module"
+ * (printed/black); `false` means "light module" (background/white). Coordinates are
+ * zero-based with the origin at the top-left; `(0, 0)` is the top-left module.
+ *
+ * Opaque wrapper: the underlying storage layout is an implementation detail so the encoder
+ * can swap libraries (or move to a packed-bitset representation) without forcing every
+ * renderer to re-learn the matrix. Consumers iterate via [isSet] only.
+ *
+ * Construction is [internal] so this type is mintable only by the kernel's encoder path —
+ * external callers cannot fabricate a matrix that misrepresents what ZXing produced. The
+ * value type is structurally compared on `(width, height, modules)`; two encoders that
+ * produced byte-identical output compare equal even when the underlying arrays differ.
+ *
+ * Pure data, no behavior. ZXing's `BitMatrix` is intentionally NOT exposed on this surface
+ * — that would put a third-party type on the kernel's public API and complicate any future
+ * encoder swap.
+ */
+public class BarcodeMatrix internal constructor(
+    public val width: Int,
+    public val height: Int,
+    private val modules: BooleanArray,
+) {
+    init {
+        require(width > 0) { "width must be positive, was $width" }
+        require(height > 0) { "height must be positive, was $height" }
+        require(modules.size == width * height) {
+            "modules size ${modules.size} does not match width * height = ${width * height}"
+        }
+    }
+
+    public fun isSet(
+        x: Int,
+        y: Int,
+    ): Boolean {
+        require(x in 0 until width) { "x=$x out of bounds [0, $width)" }
+        require(y in 0 until height) { "y=$y out of bounds [0, $height)" }
+        return modules[y * width + x]
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is BarcodeMatrix) return false
+        return width == other.width && height == other.height && modules.contentEquals(other.modules)
+    }
+
+    override fun hashCode(): Int {
+        var result = width
+        result = 31 * result + height
+        result = 31 * result + modules.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String = "BarcodeMatrix(width=$width, height=$height)"
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -77,5 +77,32 @@ public sealed interface LabelRejection {
     public object Empty : LabelRejection
 }
 
-/** Why the encoder rejected a structurally valid payload. Arms land in Child 3 (wpass-lzi.3). */
-public sealed interface EncoderFailureReason
+/**
+ * Why the encoder rejected a structurally valid payload — i.e. one that already cleared
+ * [ScannableCardInputValidator]. These arms exist because per-symbology validation cannot
+ * fully predict ZXing's encodability ceiling: a payload of the correct length and charset
+ * can still fail to fit a chosen symbology's density rules (most often Code39 with a
+ * pathological pattern, or QR pushed past its largest version). The arms partition by
+ * recoverability so the consumer UI can suggest a different format vs. surfacing an opaque
+ * "try again" message.
+ */
+public sealed interface EncoderFailureReason {
+    /**
+     * The underlying ZXing writer rejected the payload at encode time. [format] identifies
+     * which writer failed (the consumer may suggest switching to a denser symbology). The
+     * raw ZXing exception message is preserved on [detail] for the consumer's diagnostic
+     * surface; it is not user-facing copy and may be empty when ZXing did not provide one.
+     */
+    public data class WriterRejected(
+        public val format: ScannableFormat,
+        public val detail: String,
+    ) : EncoderFailureReason
+
+    /**
+     * The payload is too dense to encode at the symbology's maximum version (only QR can
+     * surface this — the 1D writers reject density mismatches under [WriterRejected]). Distinct
+     * arm so the consumer UI can specifically suggest shortening the payload rather than
+     * switching format.
+     */
+    public object PayloadTooDense : EncoderFailureReason
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -92,6 +92,11 @@ public sealed interface EncoderFailureReason {
      * which writer failed (the consumer may suggest switching to a denser symbology). The
      * raw ZXing exception message is preserved on [detail] for the consumer's diagnostic
      * surface; it is not user-facing copy and may be empty when ZXing did not provide one.
+     *
+     * **Do not propagate [detail] to telemetry verbatim.** It is the only third-party
+     * string that crosses the kernel boundary on this surface, and ZXing has historically
+     * embedded input-derived substrings in its messages. Consumers that ship the field
+     * outside the device should hash or bucket it first.
      */
     public data class WriterRejected(
         public val format: ScannableFormat,

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -97,6 +97,15 @@ internal object ScannableFormatConstraints {
         return (10 - sum % 10) % 10
     }
 
+    /**
+     * UTF-8 byte ceiling for a QR payload at the encoder's pinned ECC level (M) and the
+     * largest QR version (40, byte mode). Sourced from the QR spec's capacity tables. Used
+     * by the encoder for a proactive PayloadTooDense check that does not depend on
+     * matching ZXing's English exception text. ECC-M was chosen at the encoder; if that
+     * pin changes, this constant must change in lockstep.
+     */
+    internal const val QR_BYTE_CEILING_ECC_M: Int = 2_331
+
     private const val CODE128_MAX = 80
     private const val CODE39_MAX = 80
     private const val EAN13_LENGTH = 13

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -98,13 +98,34 @@ internal object ScannableFormatConstraints {
     }
 
     /**
-     * UTF-8 byte ceiling for a QR payload at the encoder's pinned ECC level (M) and the
-     * largest QR version (40, byte mode). Sourced from the QR spec's capacity tables. Used
-     * by the encoder for a proactive PayloadTooDense check that does not depend on
+     * UTF-8 byte ceiling for a **byte-mode** QR payload at the encoder's pinned ECC level
+     * (M) and the largest QR version (40). Sourced from the QR spec's capacity tables.
+     * Used by the encoder for a proactive PayloadTooDense check that does not depend on
      * matching ZXing's English exception text. ECC-M was chosen at the encoder; if that
      * pin changes, this constant must change in lockstep.
+     *
+     * **Mode-scoped.** QR's numeric and alphanumeric modes have larger ceilings (~5,596
+     * digits, ~3,391 alphanumeric chars at v40-M). The encoder gates this byte-mode
+     * ceiling behind a charset check ([isQrAlphanumericChar]); payloads that fit a denser
+     * mode bypass the proactive check and fall through to ZXing's mode selection.
      */
-    internal const val QR_BYTE_CEILING_ECC_M: Int = 2_331
+    internal const val QR_BYTE_CEILING_ECC_M_BYTE_MODE: Int = 2_331
+
+    /**
+     * QR alphanumeric mode's character set (per ISO/IEC 18004): digits, uppercase A-Z, and
+     * the punctuation set `$ % * + - . / :` plus space. A payload composed entirely of
+     * these characters can be encoded in alphanumeric (or numeric, for all-digit input)
+     * mode, where capacity is much larger than byte mode. The encoder uses this membership
+     * test to decide whether the byte-mode pre-check is even applicable.
+     */
+    internal fun isQrAlphanumericChar(char: Char): Boolean = char in QR_ALPHANUMERIC
+
+    private val QR_ALPHANUMERIC: Set<Char> =
+        buildSet {
+            addAll('0'..'9')
+            addAll('A'..'Z')
+            addAll(listOf(' ', '$', '%', '*', '+', '-', '.', '/', ':'))
+        }
 
     private const val CODE128_MAX = 80
     private const val CODE39_MAX = 80

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -13,6 +13,7 @@ import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.EncoderFailureReason
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.ScannableFormatConstraints
+import java.util.concurrent.CancellationException
 import com.google.zxing.BarcodeFormat as ZxingFormat
 
 /**
@@ -44,13 +45,18 @@ internal object ZxingBarcodeEncoder {
         payload: String,
         format: ScannableFormat,
     ): EncodeResult {
-        // Proactive PayloadTooDense check for QR: ZXing's WriterException("Data too big") is
-        // the only signal the writer gives, and that English string can move under us on any
-        // minor version. Doing the byte-length check here keeps the consumer's "shorten the
-        // payload" hint working even if ZXing's message wording drifts. UTF-8 because QR's
-        // byte-mode capacity is in bytes, not chars (a payload of "é" × 1500 is 3000 bytes).
-        if (format == ScannableFormat.Qr &&
-            payload.toByteArray(Charsets.UTF_8).size > ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M
+        // Proactive PayloadTooDense check for QR. Gated by the alphanumeric-mode membership
+        // test: a payload that fits QR's numeric or alphanumeric mode has a much larger
+        // capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs
+        // 2,331 bytes), and ZXing's QRCodeWriter auto-selects the densest fitting mode.
+        // Pre-rejecting such payloads against the byte-mode ceiling would over-reject;
+        // instead, for anything outside the alphanumeric set the encoding must use byte
+        // mode and the byte-count check applies. UTF-8 because byte-mode capacity is in
+        // bytes (a payload of "é" × 1500 is 3000 bytes). The "Data too big" message match
+        // in translateFailure stays as belt-and-suspenders for dense alphanumeric/numeric
+        // payloads that still overflow at v40.
+        if (format == ScannableFormat.Qr && payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&
+            payload.toByteArray(Charsets.UTF_8).size > ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M_BYTE_MODE
         ) {
             return EncodeResult.Failure(EncoderFailureReason.PayloadTooDense)
         }
@@ -59,10 +65,17 @@ internal object ZxingBarcodeEncoder {
         // raise on some edge inputs — and funnels it into EncodeResult.Failure to honor the
         // kernel's no-throw contract. Matches the pattern in SignatureVerifier (the other
         // place the kernel wraps third-party code that escapes its declared exception set).
+        // CancellationException is re-thrown so that coroutine cancellation propagates if a
+        // future consumer ever wraps this in withTimeout { ... }; runCatching would
+        // otherwise absorb it indistinguishably from a WriterException. Uses the JDK type
+        // (Kotlin's CancellationException extends it) so passes-core stays coroutines-free.
         return runCatching { writeMatrix(payload, format) }
             .fold(
                 onSuccess = { EncodeResult.Success(it) },
-                onFailure = { EncodeResult.Failure(translateFailure(format, it)) },
+                onFailure = {
+                    if (it is CancellationException) throw it
+                    EncodeResult.Failure(translateFailure(format, it))
+                },
             )
     }
 
@@ -91,7 +104,7 @@ internal object ZxingBarcodeEncoder {
         // Belt-and-suspenders: the proactive byte-length check above handles the common QR
         // overflow path; this string match catches the same condition when ZXing surfaces it
         // for a payload that slipped under the byte ceiling (e.g. some mixed-mode inputs).
-        // The match is intentionally lossy — if ZXing reword the message on a future bump,
+        // The match is intentionally lossy — if ZXing rewords the message on a future bump,
         // the encoder still surfaces WriterRejected and the consumer still gets a usable
         // error path, just without the PayloadTooDense-specific UI hint.
         val message = cause.message.orEmpty()

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -1,0 +1,104 @@
+package `is`.walt.passes.core.internal
+
+import com.google.zxing.EncodeHintType
+import com.google.zxing.WriterException
+import com.google.zxing.common.BitMatrix
+import com.google.zxing.oned.Code128Writer
+import com.google.zxing.oned.Code39Writer
+import com.google.zxing.oned.EAN13Writer
+import com.google.zxing.oned.UPCAWriter
+import com.google.zxing.qrcode.QRCodeWriter
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
+import `is`.walt.passes.core.BarcodeMatrix
+import `is`.walt.passes.core.EncodeResult
+import `is`.walt.passes.core.EncoderFailureReason
+import `is`.walt.passes.core.ScannableFormat
+import com.google.zxing.BarcodeFormat as ZxingFormat
+
+/**
+ * ZXing-backed implementation of the kernel's barcode encoder. Per-format writers
+ * (`Code128Writer`, `EAN13Writer`, `UPCAWriter`, `Code39Writer`, `QRCodeWriter`) are used
+ * instead of `MultiFormatWriter` so the v1 roster of [ScannableFormat] is enforced at the
+ * dispatch site: adding a format here is the only path that lets a new symbology reach the
+ * encoder. The intermediate `MultiFormatWriter` would silently accept anything ZXing
+ * supports, including formats the validator has not been taught to gate.
+ *
+ * Hidden behind [BarcodeEncoder]; this object is package-internal so consumers cannot
+ * reach for ZXing types directly.
+ *
+ * **Quiet zone.** Most ZXing writers emit their own quiet zone (margin) at default
+ * settings. The kernel does not strip or extend it here — the render layer (passes-ui,
+ * Child 7) controls visual padding.
+ *
+ * **QR error correction.** Fixed at [ErrorCorrectionLevel.M] (~15% redundancy). High
+ * enough to survive moderate scratch/damage on a phone screen but low enough that long
+ * payloads still fit. v1 does not expose a tuning knob; if scanner reliability demands it
+ * later, surface a parameter on [BarcodeEncoder.encode] without changing the default.
+ */
+internal object ZxingBarcodeEncoder {
+    // The QR writer's hint for error correction. Other writers ignore the hint map.
+    private val qrHints: Map<EncodeHintType, Any> =
+        mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M)
+
+    fun encode(
+        payload: String,
+        format: ScannableFormat,
+    ): EncodeResult =
+        try {
+            EncodeResult.Success(writeMatrix(payload, format))
+        } catch (e: WriterException) {
+            EncodeResult.Failure(translateFailure(format, e))
+        } catch (e: IllegalArgumentException) {
+            // ZXing's writers occasionally throw IAE rather than WriterException for
+            // structurally bad input (e.g. UPC-A writer on a non-numeric string). Treat
+            // the same as a writer-side rejection.
+            EncodeResult.Failure(translateFailure(format, e))
+        }
+
+    private fun writeMatrix(
+        payload: String,
+        format: ScannableFormat,
+    ): BarcodeMatrix {
+        // Width/height of 0 tells each writer to use its symbology's natural minimum.
+        // The renderer scales the resulting matrix at draw time; encoding at the natural
+        // size avoids ZXing's resampling step and keeps every module at integer width.
+        val bitMatrix =
+            when (format) {
+                ScannableFormat.Code128 -> Code128Writer().encode(payload, ZxingFormat.CODE_128, 0, 0)
+                ScannableFormat.Code39 -> Code39Writer().encode(payload, ZxingFormat.CODE_39, 0, 0)
+                ScannableFormat.Ean13 -> EAN13Writer().encode(payload, ZxingFormat.EAN_13, 0, 0)
+                ScannableFormat.UpcA -> UPCAWriter().encode(payload, ZxingFormat.UPC_A, 0, 0)
+                ScannableFormat.Qr -> QRCodeWriter().encode(payload, ZxingFormat.QR_CODE, 0, 0, qrHints)
+            }
+        return bitMatrix.toBarcodeMatrix()
+    }
+
+    private fun translateFailure(
+        format: ScannableFormat,
+        cause: Throwable,
+    ): EncoderFailureReason {
+        // QR-only: ZXing signals "no version fits this payload" via a WriterException whose
+        // message contains "Data too big". Lift that into the dedicated PayloadTooDense arm
+        // so the consumer UI can suggest shortening instead of switching format.
+        val message = cause.message.orEmpty()
+        if (format == ScannableFormat.Qr && DATA_TOO_BIG_MESSAGE in message) {
+            return EncoderFailureReason.PayloadTooDense
+        }
+        return EncoderFailureReason.WriterRejected(format, message)
+    }
+
+    private fun BitMatrix.toBarcodeMatrix(): BarcodeMatrix {
+        val flat = BooleanArray(width * height)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                flat[y * width + x] = this[x, y]
+            }
+        }
+        return BarcodeMatrix(width, height, flat)
+    }
+
+    // ZXing's QRCodeWriter throws WriterException("Data too big") when no QR version fits.
+    // The exact substring is load-bearing — see PayloadTooDense lift above. Pinned by
+    // BarcodeEncoderTest.qrPayloadTooDenseLiftsToDedicatedArm.
+    private const val DATA_TOO_BIG_MESSAGE = "Data too big"
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -1,7 +1,6 @@
 package `is`.walt.passes.core.internal
 
 import com.google.zxing.EncodeHintType
-import com.google.zxing.WriterException
 import com.google.zxing.common.BitMatrix
 import com.google.zxing.oned.Code128Writer
 import com.google.zxing.oned.Code39Writer
@@ -13,6 +12,7 @@ import `is`.walt.passes.core.BarcodeMatrix
 import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.EncoderFailureReason
 import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.core.ScannableFormatConstraints
 import com.google.zxing.BarcodeFormat as ZxingFormat
 
 /**
@@ -43,17 +43,28 @@ internal object ZxingBarcodeEncoder {
     fun encode(
         payload: String,
         format: ScannableFormat,
-    ): EncodeResult =
-        try {
-            EncodeResult.Success(writeMatrix(payload, format))
-        } catch (e: WriterException) {
-            EncodeResult.Failure(translateFailure(format, e))
-        } catch (e: IllegalArgumentException) {
-            // ZXing's writers occasionally throw IAE rather than WriterException for
-            // structurally bad input (e.g. UPC-A writer on a non-numeric string). Treat
-            // the same as a writer-side rejection.
-            EncodeResult.Failure(translateFailure(format, e))
+    ): EncodeResult {
+        // Proactive PayloadTooDense check for QR: ZXing's WriterException("Data too big") is
+        // the only signal the writer gives, and that English string can move under us on any
+        // minor version. Doing the byte-length check here keeps the consumer's "shorten the
+        // payload" hint working even if ZXing's message wording drifts. UTF-8 because QR's
+        // byte-mode capacity is in bytes, not chars (a payload of "é" × 1500 is 3000 bytes).
+        if (format == ScannableFormat.Qr &&
+            payload.toByteArray(Charsets.UTF_8).size > ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M
+        ) {
+            return EncodeResult.Failure(EncoderFailureReason.PayloadTooDense)
         }
+        // runCatching absorbs anything ZXing throws — including the plain
+        // NullPointerException / ArrayIndexOutOfBoundsException its hand-rolled writers do
+        // raise on some edge inputs — and funnels it into EncodeResult.Failure to honor the
+        // kernel's no-throw contract. Matches the pattern in SignatureVerifier (the other
+        // place the kernel wraps third-party code that escapes its declared exception set).
+        return runCatching { writeMatrix(payload, format) }
+            .fold(
+                onSuccess = { EncodeResult.Success(it) },
+                onFailure = { EncodeResult.Failure(translateFailure(format, it)) },
+            )
+    }
 
     private fun writeMatrix(
         payload: String,
@@ -77,9 +88,12 @@ internal object ZxingBarcodeEncoder {
         format: ScannableFormat,
         cause: Throwable,
     ): EncoderFailureReason {
-        // QR-only: ZXing signals "no version fits this payload" via a WriterException whose
-        // message contains "Data too big". Lift that into the dedicated PayloadTooDense arm
-        // so the consumer UI can suggest shortening instead of switching format.
+        // Belt-and-suspenders: the proactive byte-length check above handles the common QR
+        // overflow path; this string match catches the same condition when ZXing surfaces it
+        // for a payload that slipped under the byte ceiling (e.g. some mixed-mode inputs).
+        // The match is intentionally lossy — if ZXing reword the message on a future bump,
+        // the encoder still surfaces WriterRejected and the consumer still gets a usable
+        // error path, just without the PayloadTooDense-specific UI hint.
         val message = cause.message.orEmpty()
         if (format == ScannableFormat.Qr && DATA_TOO_BIG_MESSAGE in message) {
             return EncoderFailureReason.PayloadTooDense

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -16,6 +16,8 @@ class BarcodeEncoderTest {
 
     @Test
     fun code128EncodesProducingNonTrivialMatrix() {
+        // Fixture stays inside the printable-ASCII range the validator enforces for Code128
+        // (ScannableFormatConstraints.PRINTABLE_ASCII_MIN..MAX, i.e. 0x20..0x7E).
         val result = BarcodeEncoder.encode("ABC123 xyz", ScannableFormat.Code128)
         val matrix = (result as EncodeResult.Success).matrix
         assertThat(matrix.width).isGreaterThan(0)
@@ -28,6 +30,7 @@ class BarcodeEncoderTest {
         val result = BarcodeEncoder.encode("HELLO-123", ScannableFormat.Code39)
         val matrix = (result as EncodeResult.Success).matrix
         assertThat(matrix.width).isGreaterThan(0)
+        assertThat(matrix.height).isGreaterThan(0)
         assertThat(anyModuleSet(matrix)).isTrue()
     }
 
@@ -93,12 +96,30 @@ class BarcodeEncoderTest {
     // ---- no-throw contract ----
 
     @Test
-    fun emptyPayloadDoesNotThrow() {
-        // Validator rejects empty upstream, but the encoder must still translate to a Failure.
+    fun emptyPayloadFailsWithFormatAttribution() {
+        // Validator rejects empty upstream, but the encoder must still translate to Failure
+        // and the failure must carry the format that was attempted, so a consumer triaging
+        // an "empty input" bug across multiple format-picker positions can attribute it.
+        // Locks no-throw AND per-format dispatch correctness in one test. Asserts on
+        // WriterRejected.format specifically; PayloadTooDense is not a plausible arm for an
+        // empty input (zero bytes can never exceed any ceiling).
         for (format in ScannableFormat.entries) {
             val result = BarcodeEncoder.encode("", format)
-            assertThat(result).isInstanceOf(EncodeResult.Failure::class.java)
+            val reason = (result as EncodeResult.Failure).reason
+            assertThat(reason).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
+            assertThat((reason as EncoderFailureReason.WriterRejected).format).isEqualTo(format)
         }
+    }
+
+    @Test
+    fun proactiveQrByteCeilingHandlesNonAsciiByteCountCorrectly() {
+        // Char count of 1,200 sits below QR_BYTE_CEILING_ECC_M (2,331) — but each "é" is
+        // two UTF-8 bytes, so the byte count is 2,400 and the proactive guard must fire.
+        // Pins the load-bearing detail that the byte-length check is on UTF-8 bytes, not
+        // chars; a regression to String.length would let this slip through to ZXing.
+        val payload = "é".repeat(1_200)
+        val result = BarcodeEncoder.encode(payload, ScannableFormat.Qr)
+        assertThat((result as EncodeResult.Failure).reason).isEqualTo(EncoderFailureReason.PayloadTooDense)
     }
 
     // ---- BarcodeMatrix sanity ----

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -113,13 +113,30 @@ class BarcodeEncoderTest {
 
     @Test
     fun proactiveQrByteCeilingHandlesNonAsciiByteCountCorrectly() {
-        // Char count of 1,200 sits below QR_BYTE_CEILING_ECC_M (2,331) — but each "é" is
-        // two UTF-8 bytes, so the byte count is 2,400 and the proactive guard must fire.
-        // Pins the load-bearing detail that the byte-length check is on UTF-8 bytes, not
-        // chars; a regression to String.length would let this slip through to ZXing.
+        // Char count of 1,200 sits below QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,331) — but each
+        // "é" is two UTF-8 bytes, so the byte count is 2,400 and the proactive guard must
+        // fire. Pins the load-bearing detail that the byte-length check is on UTF-8 bytes,
+        // not chars; a regression to String.length would let this slip through to ZXing.
+        // "é" is outside the QR alphanumeric mode set, so the proactive byte-mode check is
+        // reachable (pure-alphanumeric payloads of the same byte count fall through to
+        // ZXing instead — see [denseNumericQrPayloadEncodesViaNumericMode]).
         val payload = "é".repeat(1_200)
         val result = BarcodeEncoder.encode(payload, ScannableFormat.Qr)
         assertThat((result as EncodeResult.Failure).reason).isEqualTo(EncoderFailureReason.PayloadTooDense)
+    }
+
+    @Test
+    fun denseNumericQrPayloadEncodesViaNumericMode() {
+        // Pure-digit payload of 3,000 chars: above QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,331)
+        // and above QR v40-M alphanumeric capacity (~3,391 chars — close but under), but
+        // well under v40-M numeric capacity (~5,596 digits). ZXing's QRCodeWriter
+        // auto-selects numeric mode and encodes successfully. Pins that the proactive
+        // byte-mode check is gated by the alphanumeric-set membership test — a regression
+        // that re-introduces an unconditional byte-count pre-check would over-reject this
+        // input as PayloadTooDense even though ZXing can encode it.
+        val payload = "1".repeat(3_000)
+        val result = BarcodeEncoder.encode(payload, ScannableFormat.Qr)
+        assertThat(result).isInstanceOf(EncodeResult.Success::class.java)
     }
 
     // ---- BarcodeMatrix sanity ----

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -1,0 +1,140 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavior lock for [BarcodeEncoder]. Pins per-format round-trip success, per-format
+ * encoder-rejection paths, and the QR-specific [EncoderFailureReason.PayloadTooDense] lift.
+ *
+ * The encoder assumes its input has cleared [ScannableCardInputValidator]; tests here use
+ * the validator's known-good fixtures (or check-digit-correct strings) so encoder failures
+ * are attributable to ZXing's encodability ceiling, not to pre-validator hygiene.
+ */
+class BarcodeEncoderTest {
+    // ---- per-format success ----
+
+    @Test
+    fun code128EncodesProducingNonTrivialMatrix() {
+        val result = BarcodeEncoder.encode("ABC123 xyz", ScannableFormat.Code128)
+        val matrix = (result as EncodeResult.Success).matrix
+        assertThat(matrix.width).isGreaterThan(0)
+        assertThat(matrix.height).isGreaterThan(0)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    @Test
+    fun code39EncodesProducingNonTrivialMatrix() {
+        val result = BarcodeEncoder.encode("HELLO-123", ScannableFormat.Code39)
+        val matrix = (result as EncodeResult.Success).matrix
+        assertThat(matrix.width).isGreaterThan(0)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    @Test
+    fun ean13EncodesProducingNonTrivialMatrix() {
+        // 1234567890128 — last digit is the EAN-13 checksum for "123456789012".
+        val result = BarcodeEncoder.encode("1234567890128", ScannableFormat.Ean13)
+        val matrix = (result as EncodeResult.Success).matrix
+        assertThat(matrix.width).isGreaterThan(0)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    @Test
+    fun upcAEncodesProducingNonTrivialMatrix() {
+        // 036000291452 — published example UPC-A with valid checksum.
+        val result = BarcodeEncoder.encode("036000291452", ScannableFormat.UpcA)
+        val matrix = (result as EncodeResult.Success).matrix
+        assertThat(matrix.width).isGreaterThan(0)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    @Test
+    fun qrEncodesProducingSquareMatrix() {
+        val result = BarcodeEncoder.encode("https://example.org/loyalty/123", ScannableFormat.Qr)
+        val matrix = (result as EncodeResult.Success).matrix
+        // QR codes are square. Locks the encoder dispatching to QRCodeWriter (vs a 1D writer
+        // that would yield a tall thin strip).
+        assertThat(matrix.width).isEqualTo(matrix.height)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    // ---- per-format encoder rejection ----
+
+    @Test
+    fun ean13RejectsWrongLengthAtWriter() {
+        // Eleven digits — passes the digit charset check but EAN-13 writer wants 12+1 or 13.
+        val result = BarcodeEncoder.encode("12345678901", ScannableFormat.Ean13)
+        val failure = (result as EncodeResult.Failure).reason
+        assertThat(failure).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
+        assertThat((failure as EncoderFailureReason.WriterRejected).format).isEqualTo(ScannableFormat.Ean13)
+    }
+
+    @Test
+    fun upcARejectsNonNumericAtWriter() {
+        // Charset gate is upstream's job; calling the encoder directly with bad chars should
+        // surface as a writer-side rejection (UPCAWriter throws IAE), not crash.
+        val result = BarcodeEncoder.encode("12345678901A", ScannableFormat.UpcA)
+        val failure = (result as EncodeResult.Failure).reason
+        assertThat(failure).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
+        assertThat((failure as EncoderFailureReason.WriterRejected).format).isEqualTo(ScannableFormat.UpcA)
+    }
+
+    @Test
+    fun qrPayloadTooDenseLiftsToDedicatedArm() {
+        // Largest QR version maxes out around ~2,953 bytes at error correction L; at level M
+        // (the kernel's pin) the byte ceiling is ~2,331. A 4,000-char payload exceeds every
+        // version regardless of mode, forcing the writer's "Data too big" path.
+        val result = BarcodeEncoder.encode("A".repeat(4_000), ScannableFormat.Qr)
+        val failure = (result as EncodeResult.Failure).reason
+        assertThat(failure).isEqualTo(EncoderFailureReason.PayloadTooDense)
+    }
+
+    // ---- no-throw contract ----
+
+    @Test
+    fun emptyPayloadDoesNotThrow() {
+        // Validator rejects empty upstream, but the encoder must still translate to a Failure.
+        for (format in ScannableFormat.entries) {
+            val result = BarcodeEncoder.encode("", format)
+            assertThat(result).isInstanceOf(EncodeResult.Failure::class.java)
+        }
+    }
+
+    // ---- BarcodeMatrix sanity ----
+
+    @Test
+    fun matrixBoundsCheckRejectsOutOfRangeCoordinates() {
+        val matrix = (BarcodeEncoder.encode("ABC", ScannableFormat.Code128) as EncodeResult.Success).matrix
+        // Inside the grid: must not throw.
+        matrix.isSet(0, 0)
+        matrix.isSet(matrix.width - 1, matrix.height - 1)
+        // Outside: bounds check fires.
+        runCatching { matrix.isSet(-1, 0) }.exceptionOrNull().let {
+            assertThat(it).isInstanceOf(IllegalArgumentException::class.java)
+        }
+        runCatching { matrix.isSet(0, matrix.height) }.exceptionOrNull().let {
+            assertThat(it).isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Test
+    fun matrixEqualityIsStructural() {
+        val a = (BarcodeEncoder.encode("ABC", ScannableFormat.Code128) as EncodeResult.Success).matrix
+        val b = (BarcodeEncoder.encode("ABC", ScannableFormat.Code128) as EncodeResult.Success).matrix
+        assertThat(a).isEqualTo(b)
+        assertThat(a.hashCode()).isEqualTo(b.hashCode())
+
+        val different = (BarcodeEncoder.encode("XYZ", ScannableFormat.Code128) as EncodeResult.Success).matrix
+        assertThat(a).isNotEqualTo(different)
+    }
+
+    private fun anyModuleSet(matrix: BarcodeMatrix): Boolean {
+        for (y in 0 until matrix.height) {
+            for (x in 0 until matrix.width) {
+                if (matrix.isSet(x, y)) return true
+            }
+        }
+        return false
+    }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
@@ -76,18 +76,21 @@ class ScannableCardSurfaceTest {
     }
 
     /**
-     * Covers the two directly-constructible result arms. The remaining three arms wrap
-     * sealed reasons ([PayloadRejection], [LabelRejection], [EncoderFailureReason]) whose
-     * concrete arms land in Children .3 and .4. Compile-time `when` exhaustiveness still
-     * fires at every real call site, so this test only needs to prove the constructible
-     * arms reach their branches.
+     * Every [ScannableCardCreateResult] arm is constructible and reachable via exhaustive
+     * `when`. [InvalidPayload] / [InvalidLabel] use a sentinel reason from their sealed
+     * family (the per-arm coverage of those families lives in [ScannableCardInputValidatorTest]
+     * and the `*ArmsAreAllConstructible` tests in this file); the point here is the create
+     * result's own arm shape.
      */
     @Test
-    fun scannableCardCreateResultConstructibleArmsAreReachableViaWhen() {
+    fun scannableCardCreateResultArmsAreReachableViaWhen() {
         val results: List<ScannableCardCreateResult> =
             listOf(
                 ScannableCardCreateResult.Success(sampleCard()),
+                ScannableCardCreateResult.InvalidPayload(PayloadRejection.Empty),
+                ScannableCardCreateResult.InvalidLabel(LabelRejection.Empty),
                 ScannableCardCreateResult.UnsupportedFormat(ScannableFormat.Code39),
+                ScannableCardCreateResult.EncoderFailure(EncoderFailureReason.PayloadTooDense),
             )
         val branches =
             results.map { result ->
@@ -99,19 +102,32 @@ class ScannableCardSurfaceTest {
                     is ScannableCardCreateResult.EncoderFailure -> "encoder"
                 }
             }
-        assertThat(branches).containsExactly("success", "format").inOrder()
+        assertThat(branches).containsExactly("success", "payload", "label", "format", "encoder").inOrder()
     }
 
     /**
-     * The three sealed-reason families exist as kernel-exported types even though their
-     * arms land later (Child 3 for [EncoderFailureReason], Child 4 for the other two).
-     * Removing any of them breaks this test before it breaks the dependent child's compile.
+     * The three sealed-reason families exist as kernel-exported types. Removing any of
+     * them breaks this test before it breaks the dependent child's compile.
      */
     @Test
     fun rejectionFamiliesAreExported() {
         assertThat(PayloadRejection::class.java.isInterface).isTrue()
         assertThat(LabelRejection::class.java.isInterface).isTrue()
         assertThat(EncoderFailureReason::class.java.isInterface).isTrue()
+    }
+
+    /**
+     * Every [EncoderFailureReason] arm is constructible. Removing an arm breaks
+     * compilation here before it breaks a downstream `when` in the consumer's create flow.
+     */
+    @Test
+    fun encoderFailureReasonArmsAreAllConstructible() {
+        val reasons: List<EncoderFailureReason> =
+            listOf(
+                EncoderFailureReason.WriterRejected(ScannableFormat.Code128, "detail"),
+                EncoderFailureReason.PayloadTooDense,
+            )
+        assertThat(reasons.toSet()).hasSize(reasons.size)
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `BarcodeEncoder`, the pure-JVM facade that turns a validated `ScannableCard`'s `(payload, format)` into a `BarcodeMatrix` the renderer can draw. No-throw contract: every ZXing failure translates into an `EncodeResult.Failure` arm.
- Adds `BarcodeMatrix`, an opaque wrapper around the bit grid. Internal constructor keeps the kernel as the only minting path; ZXing's `BitMatrix` is deliberately not on the public surface so the encoder is replaceable.
- Fills in the `EncoderFailureReason` sealed family stubbed by wpass-lzi.2: `WriterRejected(format, detail)` (any ZXing-rejected payload) and `PayloadTooDense` (QR-specific lift of ZXing's "Data too big" message).

Per-format dispatch uses the specific writers (`Code128Writer`, `Code39Writer`, `EAN13Writer`, `UPCAWriter`, `QRCodeWriter`) rather than `MultiFormatWriter` so adding a format requires touching the dispatch site (the v1 `ScannableFormat` roster is enforced here, not just in the validator). QR is pinned to error-correction M.

## Architectural notes

- `passes-core` stays Android-free: `./gradlew :passes-core:dependencies --configuration runtimeClasspath` shows only `com.google.zxing:core:3.5.4` as the new dependency, no `androidx.*` or `android.*` transitives.
- The encoder is a sibling of the validator, not chained inside it. The validator produces a `ScannableCard` (trusted but unencoded); the encoder runs at render time or in the storage create-flow orchestrator (Child 6). Decoupling means re-encoding for a render-time size change does not have to drag the create-flow result arms into the render call site.
- `EncoderFailureReason` arms are partitioned by recoverability: `WriterRejected` carries the format so the consumer can suggest a different symbology; `PayloadTooDense` is QR-only and tells the consumer to shorten the payload instead of switching format.

## Test plan

- [x] `./gradlew :passes-core:check` (test + ktlint + detekt) green
- [x] One round-trip success test per `ScannableFormat`
- [x] Per-format writer-rejection tests (EAN-13 wrong length, UPC-A non-numeric)
- [x] QR `PayloadTooDense` lift verified at 4,000-char input
- [x] Empty payload no-throw for every format
- [x] `BarcodeMatrix` bounds-check + structural equality covered
- [x] `ScannableCardSurfaceTest` extended: `encoderFailureReasonArmsAreAllConstructible` and the create-result `when`-coverage now includes `EncoderFailure`
- [x] No-Android-deps verified via `./gradlew :passes-core:dependencies`

Closes wpass-lzi.3. Unblocks wpass-lzi.7 (`passes-ui: BarcodeCardView`).