### PR TITLE
passes-storage + passes-ui: ScannableCard persistence and rendering (wpass-lzi.6, .7)

### DIFF
--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.storage
 
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableFormat
 
 /**
  * Telemetry sink for instrumentation tests. The on-device tests verify storage behavior,
@@ -23,4 +24,7 @@ internal object NoOpStorageTelemetryGuard : StorageTelemetryGuard {
     override fun onDocumentImported(event: DocumentImportedEvent) = Unit
     override fun onDocumentRejected(kind: DocumentStorageRejectedKind) = Unit
     override fun onDocumentDeleted(event: DocumentDeletedEvent) = Unit
+    override fun onScannableCardCreated(format: ScannableFormat) = Unit
+    override fun onScannableCardDeleted(format: ScannableFormat) = Unit
+    override fun onScannableCardRejected(kind: ScannableCardRejectedKind) = Unit
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -117,18 +117,12 @@ public interface PassRepository {
     public suspend fun deleteDocument(id: DocumentRecordId): StorageResult<Unit>
 
     /**
-     * Mints a [ScannableCard] from raw [input], persists it, and returns the assigned
-     * [ScannableCardRecordId]. The kernel validator
-     * (`ScannableCardInputValidator.validate`) is the single choke point that decides
-     * whether the input passes: a validation rejection bubbles up as
-     * [StorageError.ScannableCardRejected] with the typed kernel reason preserved, never
-     * as a generic infra failure. The row never reaches disk in that case.
-     *
-     * Storage owns the id and timestamp: the [ScannableCardId][`is`.walt.passes.core.ScannableCardId]
-     * the consumer observes on the materialized [ScannableCard] is the stringified row
-     * id, and `createdAt` is taken from the repository's injected clock at insert time.
-     * The kernel does not mint these (see KDoc on `ScannableCardId`); centralizing here
-     * keeps multiple consumer call sites from inventing their own id schemes.
+     * Mints a [ScannableCard] from raw [input] and persists it. Storage owns the id and
+     * `createdAt` timestamp; the consumer-visible [`ScannableCardId`][`is`.walt.passes.core.ScannableCardId]
+     * is the stringified row id. The kernel's `ScannableCardInputValidator` is the
+     * single insert-time choke point: a validation rejection bubbles up as
+     * [StorageError.ScannableCardRejected] with the typed reason preserved, never as a
+     * generic infra failure, and the row never reaches disk.
      */
     public suspend fun createScannableCard(
         input: ScannableCardCreateInput,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -3,6 +3,8 @@ package `is`.walt.passes.storage
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableCardCreateInput
 import `is`.walt.passes.core.SignatureStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -115,6 +117,50 @@ public interface PassRepository {
     public suspend fun deleteDocument(id: DocumentRecordId): StorageResult<Unit>
 
     /**
+     * Mints a [ScannableCard] from raw [input], persists it, and returns the assigned
+     * [ScannableCardRecordId]. The kernel validator
+     * (`ScannableCardInputValidator.validate`) is the single choke point that decides
+     * whether the input passes: a validation rejection bubbles up as
+     * [StorageError.ScannableCardRejected] with the typed kernel reason preserved, never
+     * as a generic infra failure. The row never reaches disk in that case.
+     *
+     * Storage owns the id and timestamp: the [ScannableCardId][`is`.walt.passes.core.ScannableCardId]
+     * the consumer observes on the materialized [ScannableCard] is the stringified row
+     * id, and `createdAt` is taken from the repository's injected clock at insert time.
+     * The kernel does not mint these (see KDoc on `ScannableCardId`); centralizing here
+     * keeps multiple consumer call sites from inventing their own id schemes.
+     */
+    public suspend fun createScannableCard(
+        input: ScannableCardCreateInput,
+    ): StorageResult<ScannableCardRecordId>
+
+    /**
+     * Loads a stored [ScannableCard] by row id. Returns [StorageError.IntegrityViolation]
+     * if no row matches.
+     */
+    public suspend fun loadScannableCard(
+        id: ScannableCardRecordId,
+    ): StorageResult<ScannableCard>
+
+    /**
+     * Irreversible delete (ADR 0002 D6). Mirrors [delete] for passes: removes the row
+     * in one transaction, updates the [observeScannableCards] flow, then emits
+     * `onScannableCardDeleted`. No undo, no soft-delete, no VACUUM.
+     */
+    public suspend fun deleteScannableCard(
+        id: ScannableCardRecordId,
+    ): StorageResult<Unit>
+
+    /**
+     * Cold flow of [ScannableCard] rows sorted by `created_at_epoch_ms` descending.
+     * Emits the current snapshot on collect and re-emits on insert / delete. Unlike the
+     * pass and document lanes, the full card materializes here — there are no large
+     * blob columns to defer, and the consumer's tile renderer needs the payload to
+     * re-encode the barcode at render time.
+     */
+    public fun observeScannableCards(): Flow<List<ScannableCard>>
+
+    /**
      * Releases the underlying database connection. Idempotent: calling [close] more than
      * once is a no-op, and method calls after [close] return [StorageError.DatabaseLocked]
      * rather than throwing. Intended for consumer paths where the repository's lifetime is
@@ -184,3 +230,12 @@ public value class PassRecordId(public override val value: Long) : RecordId
  */
 @JvmInline
 public value class DocumentRecordId(public override val value: Long) : RecordId
+
+/**
+ * Auto-incremented primary-key surrogate for a row in the `scannable_cards` table.
+ * Distinct from [`is`.walt.passes.core.ScannableCardId] (which is the kernel's opaque
+ * string identifier exposed on [ScannableCard]) so that a row id cannot be silently
+ * substituted for any other [RecordId] arm at compile time.
+ */
+@JvmInline
+public value class ScannableCardRecordId(public override val value: Long) : RecordId

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -14,7 +14,7 @@ package `is`.walt.passes.storage
 public object Schema {
     public const val DATABASE_NAME: String = "walt_passes.db"
 
-    public const val VERSION: Int = 2
+    public const val VERSION: Int = 3
 
     public object Tables {
         public const val SCHEMA_META: String = "schema_meta"
@@ -23,6 +23,7 @@ public object Schema {
         public const val PASS_LOCALES: String = "pass_locales"
         public const val DOCUMENTS: String = "documents"
         public const val DOCUMENT_THUMBNAILS: String = "document_thumbnails"
+        public const val SCANNABLE_CARDS: String = "scannable_cards"
     }
 
     public object MetaKeys {
@@ -39,6 +40,28 @@ public object Schema {
      * never drift. A `SchemaParityTest` asserts that a fresh-install DB and a
      * v1-then-migrated DB land at the same `sqlite_master` shape.
      */
+    /**
+     * Statements that introduce the v3 scannable-cards table. Referenced from both [DDL]
+     * (for fresh installs) and [MIGRATIONS]`[2]` (for v2 -> v3 upgrades) so the two paths
+     * cannot drift. `scannable_cards` lives in the same SQLCipher database as the existing
+     * tables, so [BackupRulesContract.REQUIRED_EXCLUDES] already covers it; no new entry is
+     * required there.
+     */
+    private val V3_SCANNABLE_CARD_TABLES: List<String> = listOf(
+        """
+        CREATE TABLE IF NOT EXISTS scannable_cards (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            payload             TEXT    NOT NULL,
+            format              TEXT    NOT NULL,
+            label               TEXT    NOT NULL,
+            color_argb          INTEGER,
+            created_at_epoch_ms INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_scannable_cards_created_at " +
+            "ON scannable_cards(created_at_epoch_ms)",
+    )
+
     private val V2_DOCUMENT_TABLES: List<String> = listOf(
         """
         CREATE TABLE IF NOT EXISTS documents (
@@ -109,7 +132,7 @@ public object Schema {
             PRIMARY KEY (pass_id, locale_tag)
         )
         """.trimIndent(),
-    ) + V2_DOCUMENT_TABLES
+    ) + V2_DOCUMENT_TABLES + V3_SCANNABLE_CARD_TABLES
 
     /**
      * Schema migrations, keyed by `fromVersion`. Forward-only per ADR 0002. Each entry's
@@ -123,5 +146,6 @@ public object Schema {
      */
     public val MIGRATIONS: Map<Int, List<String>> = mapOf(
         1 to V2_DOCUMENT_TABLES,
+        2 to V3_SCANNABLE_CARD_TABLES,
     )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -35,17 +35,12 @@ public object Schema {
     }
 
     /**
-     * Statements that introduce the v2 document tables. Referenced from both [DDL] (for
-     * fresh installs) and [MIGRATIONS]`[1]` (for v1 -> v2 upgrades) so the two paths can
-     * never drift. A `SchemaParityTest` asserts that a fresh-install DB and a
-     * v1-then-migrated DB land at the same `sqlite_master` shape.
-     */
-    /**
      * Statements that introduce the v3 scannable-cards table. Referenced from both [DDL]
      * (for fresh installs) and [MIGRATIONS]`[2]` (for v2 -> v3 upgrades) so the two paths
-     * cannot drift. `scannable_cards` lives in the same SQLCipher database as the existing
-     * tables, so [BackupRulesContract.REQUIRED_EXCLUDES] already covers it; no new entry is
-     * required there.
+     * cannot drift. The fresh-vs-migrated parity guard in `SchemaMigrationTest` covers
+     * both v1 -> v2 and v2 -> v3 by walking every hop. `scannable_cards` lives in the
+     * same SQLCipher database as the existing tables, so
+     * [BackupRulesContract.REQUIRED_EXCLUDES] already covers it.
      */
     private val V3_SCANNABLE_CARD_TABLES: List<String> = listOf(
         """
@@ -62,6 +57,11 @@ public object Schema {
             "ON scannable_cards(created_at_epoch_ms)",
     )
 
+    /**
+     * Statements that introduce the v2 document tables. Referenced from both [DDL] (for
+     * fresh installs) and [MIGRATIONS]`[1]` (for v1 -> v2 upgrades) so the two paths
+     * cannot drift.
+     */
     private val V2_DOCUMENT_TABLES: List<String> = listOf(
         """
         CREATE TABLE IF NOT EXISTS documents (

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -157,15 +157,12 @@ public class SqlCipherPassRepository internal constructor(
     override suspend fun createScannableCard(
         input: ScannableCardCreateInput,
     ): StorageResult<ScannableCardRecordId> = runIo {
-        val now = clock()
-        // The kernel validator does not use the id for validation (it only embeds it on
-        // the resulting Success arm); pass a placeholder. Storage mints the real id
-        // post-insert, and the subsequent listAll() rehydrates the StateFlow with rows
-        // whose ScannableCardId is the stringified row id.
+        // Validator does not use the id for validation; storage mints the real one
+        // post-insert and listAll() rehydrates the StateFlow with the stringified row id.
         val validation = ScannableCardInputValidator.validate(
             input = input,
             id = ScannableCardId(""),
-            createdAt = PassInstant(now),
+            createdAt = PassInstant(clock()),
         )
         val approved = when (validation) {
             is ScannableCardCreateResult.Success -> validation.card
@@ -179,17 +176,22 @@ public class SqlCipherPassRepository internal constructor(
                     ScannableCardRejectionReason.InvalidPayload(validation.reason),
                     telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
                 )
-            is ScannableCardCreateResult.UnsupportedFormat,
+            is ScannableCardCreateResult.UnsupportedFormat ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
+                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
+                )
             is ScannableCardCreateResult.EncoderFailure ->
-                // The pure validator never produces these arms (encoding is a separate
-                // step that runs at render time, not at create time). The branch exists
-                // only so this when stays exhaustive against the kernel's full result
-                // family — adding a new arm in passes-core forces a deliberate decision
-                // here rather than a silent fallthrough.
-                return@runIo failure(StorageError.Unknown(UnknownStorageFailureKind.Other))
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
+                )
         }
 
         val outcome = writeMutex.withLock {
+            // O(N) per insert: listAll() re-runs the validator on every row. Acceptable
+            // because wallets hold O(10s) of cards; revisit if profiles flag it.
+            val now = clock()
             val o = scannableCardStore.insert(
                 ScannableCardInsertRequest(
                     payload = approved.payload,
@@ -292,10 +294,7 @@ public class SqlCipherPassRepository internal constructor(
 
     /**
      * Single emission point for a scannable-card validator rejection. Same discipline
-     * as [rejectDocument]: emits `onScannableCardRejected(kind)` and returns the typed
-     * [StorageError.ScannableCardRejected] arm without going through [failure]. A
-     * validator rejection is not a generic storage failure, so
-     * [StorageTelemetryGuard.onStorageFailure] does NOT also fire.
+     * as [rejectDocument]: skip [failure] so `onStorageFailure` does not double-fire.
      */
     private fun <T> rejectScannableCard(
         reason: ScannableCardRejectionReason,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -2,14 +2,23 @@ package `is`.walt.passes.storage
 
 import android.content.Context
 import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableCardCreateInput
+import `is`.walt.passes.core.ScannableCardCreateResult
+import `is`.walt.passes.core.ScannableCardId
+import `is`.walt.passes.core.ScannableCardInputValidator
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.toKind
 import `is`.walt.passes.storage.internal.DocumentInsertRequest
 import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
+import `is`.walt.passes.storage.internal.ScannableCardStore
 import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
 import `is`.walt.passes.storage.internal.SqlCipherDocumentStore
 import `is`.walt.passes.storage.internal.SqlCipherPassStore
+import `is`.walt.passes.storage.internal.SqlCipherScannableCardStore
 import `is`.walt.passes.storage.internal.toFailureKind
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -28,9 +37,19 @@ import java.util.concurrent.atomic.AtomicBoolean
  * live here so they can be exercised against an in-memory fake [PassStore]. The constructor
  * is internal; [create] is the only construction path.
  */
+// LongParameterList: the constructor carries one store per persistence tier (pass,
+// document, scannable-card) plus the cross-cutting telemetry / dispatcher / clock /
+// key-backing seams; collapsing them into a holder type would obscure the fan-out the
+// `create()` factory has to wire up.
+// TooManyFunctions: scales linearly with the number of tier-specific surface methods on
+// PassRepository; the class is one coherent SQLCipher entry point per the repo contract
+// (see PassRepository KDoc), and splitting it would scatter the shared write-mutex and
+// closed-flag invariants.
+@Suppress("LongParameterList", "TooManyFunctions")
 public class SqlCipherPassRepository internal constructor(
     private val store: PassStore,
     private val documentStore: DocumentStore,
+    private val scannableCardStore: ScannableCardStore,
     private val telemetryGuard: StorageTelemetryGuard,
     private val ioDispatcher: CoroutineDispatcher,
     private val clock: () -> Long,
@@ -45,6 +64,9 @@ public class SqlCipherPassRepository internal constructor(
 
     private val _documents: MutableStateFlow<List<DocumentRow>> =
         MutableStateFlow(documentStore.listRows())
+
+    private val _scannableCards: MutableStateFlow<List<ScannableCard>> =
+        MutableStateFlow(scannableCardStore.listAll())
 
     init {
         telemetryGuard.onKeyProviderInitialized(keyBacking)
@@ -132,6 +154,82 @@ public class SqlCipherPassRepository internal constructor(
 
     override fun observeDocuments(): Flow<List<DocumentRow>> = _documents.asStateFlow()
 
+    override suspend fun createScannableCard(
+        input: ScannableCardCreateInput,
+    ): StorageResult<ScannableCardRecordId> = runIo {
+        val now = clock()
+        // The kernel validator does not use the id for validation (it only embeds it on
+        // the resulting Success arm); pass a placeholder. Storage mints the real id
+        // post-insert, and the subsequent listAll() rehydrates the StateFlow with rows
+        // whose ScannableCardId is the stringified row id.
+        val validation = ScannableCardInputValidator.validate(
+            input = input,
+            id = ScannableCardId(""),
+            createdAt = PassInstant(now),
+        )
+        val approved = when (validation) {
+            is ScannableCardCreateResult.Success -> validation.card
+            is ScannableCardCreateResult.InvalidLabel ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
+                )
+            is ScannableCardCreateResult.InvalidPayload ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
+                )
+            is ScannableCardCreateResult.UnsupportedFormat,
+            is ScannableCardCreateResult.EncoderFailure ->
+                // The pure validator never produces these arms (encoding is a separate
+                // step that runs at render time, not at create time). The branch exists
+                // only so this when stays exhaustive against the kernel's full result
+                // family — adding a new arm in passes-core forces a deliberate decision
+                // here rather than a silent fallthrough.
+                return@runIo failure(StorageError.Unknown(UnknownStorageFailureKind.Other))
+        }
+
+        val outcome = writeMutex.withLock {
+            val o = scannableCardStore.insert(
+                ScannableCardInsertRequest(
+                    payload = approved.payload,
+                    format = approved.format,
+                    label = approved.label,
+                    colorArgb = approved.color?.argb,
+                    nowEpochMs = now,
+                ),
+            )
+            _scannableCards.value = scannableCardStore.listAll()
+            o
+        }
+        telemetryGuard.onScannableCardCreated(approved.format)
+        StorageResult.Success(outcome.id)
+    }
+
+    override suspend fun loadScannableCard(
+        id: ScannableCardRecordId,
+    ): StorageResult<ScannableCard> = runIo {
+        val card = scannableCardStore.loadById(id)
+            ?: return@runIo failure(StorageError.IntegrityViolation(id))
+        StorageResult.Success(card)
+    }
+
+    override suspend fun deleteScannableCard(
+        id: ScannableCardRecordId,
+    ): StorageResult<Unit> = runIo {
+        val deleted = writeMutex.withLock {
+            val outcome = scannableCardStore.delete(id) ?: return@withLock null
+            _scannableCards.value = _scannableCards.value.filterNot { it.id.value == id.value.toString() }
+            outcome
+        } ?: return@runIo failure(StorageError.IntegrityViolation(id))
+
+        telemetryGuard.onScannableCardDeleted(deleted.format)
+        StorageResult.Success(Unit)
+    }
+
+    override fun observeScannableCards(): Flow<List<ScannableCard>> =
+        _scannableCards.asStateFlow()
+
     override suspend fun loadDocumentBytes(id: DocumentRecordId): StorageResult<ByteArray> = runIo {
         val bytes = documentStore.loadBytes(id)
             ?: return@runIo failure(StorageError.IntegrityViolation(id))
@@ -157,6 +255,7 @@ public class SqlCipherPassRepository internal constructor(
 
     override fun close() {
         if (closed.compareAndSet(false, true)) {
+            scannableCardStore.close()
             documentStore.close()
             store.close()
         }
@@ -189,6 +288,21 @@ public class SqlCipherPassRepository internal constructor(
     private fun <T> rejectDocument(kind: DocumentStorageRejectedKind): StorageResult<T> {
         telemetryGuard.onDocumentRejected(kind)
         return StorageResult.Failure(StorageError.DocumentRejected(kind))
+    }
+
+    /**
+     * Single emission point for a scannable-card validator rejection. Same discipline
+     * as [rejectDocument]: emits `onScannableCardRejected(kind)` and returns the typed
+     * [StorageError.ScannableCardRejected] arm without going through [failure]. A
+     * validator rejection is not a generic storage failure, so
+     * [StorageTelemetryGuard.onStorageFailure] does NOT also fire.
+     */
+    private fun <T> rejectScannableCard(
+        reason: ScannableCardRejectionReason,
+        telemetryKind: ScannableCardRejectedKind,
+    ): StorageResult<T> {
+        telemetryGuard.onScannableCardRejected(telemetryKind)
+        return StorageResult.Failure(StorageError.ScannableCardRejected(reason))
     }
 
     /**
@@ -272,9 +386,11 @@ public class SqlCipherPassRepository internal constructor(
             }
             val store = SqlCipherPassStore(opened.db, opened.keyHandle, telemetryGuard)
             val documentStore = SqlCipherDocumentStore(opened.db)
+            val scannableCardStore = SqlCipherScannableCardStore(opened.db, telemetryGuard)
             val repo = SqlCipherPassRepository(
                 store = store,
                 documentStore = documentStore,
+                scannableCardStore = scannableCardStore,
                 telemetryGuard = telemetryGuard,
                 ioDispatcher = ioDispatcher,
                 clock = clock,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -93,11 +93,6 @@ public sealed interface StorageError {
 }
 
 /**
- * Stable telemetry-friendly enumeration of the open-ended failure space. New arms here
- * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
- * routing telemetry through enums rather than free-form strings.
- */
-/**
  * Why a [PassRepository.createScannableCard] call was refused. The first two arms
  * mirror what `ScannableCardInputValidator` produces today (structural payload and
  * label checks). The latter two cover the kernel result family's remaining arms; the
@@ -115,6 +110,11 @@ public sealed interface ScannableCardRejectionReason {
     public data class EncoderFailure(public val reason: EncoderFailureReason) : ScannableCardRejectionReason
 }
 
+/**
+ * Stable telemetry-friendly enumeration of the open-ended failure space. New arms here
+ * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
+ * routing telemetry through enums rather than free-form strings.
+ */
 public enum class UnknownStorageFailureKind {
     DiskFull,
     PermissionDenied,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -1,5 +1,8 @@
 package `is`.walt.passes.storage
 
+import `is`.walt.passes.core.LabelRejection
+import `is`.walt.passes.core.PayloadRejection
+
 /**
  * The result type for every [PassRepository] call. Mirrors the `Result<T> over exceptions`
  * convention from CLAUDE.md and gives the consumer a typed partition of the failure space:
@@ -60,6 +63,16 @@ public sealed interface StorageError {
     ) : StorageError
 
     /**
+     * A scannable-card insert was rejected by the kernel validator
+     * (`ScannableCardInputValidator`). Carries the typed kernel rejection so the
+     * consumer's error UI can localize a specific message without re-running
+     * validation. The row never reaches disk.
+     */
+    public data class ScannableCardRejected(
+        public val reason: ScannableCardRejectionReason,
+    ) : StorageError
+
+    /**
      * The schema version on disk is newer than this build of `passes-storage` understands.
      * This happens when a user downgrades the wallet app. The DB is read-only-protected
      * until a forward-compatible build runs again.
@@ -82,6 +95,19 @@ public sealed interface StorageError {
  * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
  * routing telemetry through enums rather than free-form strings.
  */
+/**
+ * Why a [PassRepository.createScannableCard] call was refused by the kernel validator.
+ * Mirrors the two structural arms `ScannableCardInputValidator` can surface; the
+ * encoder-failure and unsupported-format arms of `ScannableCardCreateResult` are NOT
+ * surfaced here because the validator on its own never produces them (encoding happens
+ * downstream at render time).
+ */
+public sealed interface ScannableCardRejectionReason {
+    public data class InvalidLabel(public val reason: LabelRejection) : ScannableCardRejectionReason
+
+    public data class InvalidPayload(public val reason: PayloadRejection) : ScannableCardRejectionReason
+}
+
 public enum class UnknownStorageFailureKind {
     DiskFull,
     PermissionDenied,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -1,7 +1,9 @@
 package `is`.walt.passes.storage
 
+import `is`.walt.passes.core.EncoderFailureReason
 import `is`.walt.passes.core.LabelRejection
 import `is`.walt.passes.core.PayloadRejection
+import `is`.walt.passes.core.ScannableFormat
 
 /**
  * The result type for every [PassRepository] call. Mirrors the `Result<T> over exceptions`
@@ -96,16 +98,21 @@ public sealed interface StorageError {
  * routing telemetry through enums rather than free-form strings.
  */
 /**
- * Why a [PassRepository.createScannableCard] call was refused by the kernel validator.
- * Mirrors the two structural arms `ScannableCardInputValidator` can surface; the
- * encoder-failure and unsupported-format arms of `ScannableCardCreateResult` are NOT
- * surfaced here because the validator on its own never produces them (encoding happens
- * downstream at render time).
+ * Why a [PassRepository.createScannableCard] call was refused. The first two arms
+ * mirror what `ScannableCardInputValidator` produces today (structural payload and
+ * label checks). The latter two cover the kernel result family's remaining arms; the
+ * validator does not produce them in the current build, but typing them here keeps
+ * the defensive path loud rather than collapsing them into [StorageError.Unknown] on
+ * the day the kernel does start surfacing one.
  */
 public sealed interface ScannableCardRejectionReason {
     public data class InvalidLabel(public val reason: LabelRejection) : ScannableCardRejectionReason
 
     public data class InvalidPayload(public val reason: PayloadRejection) : ScannableCardRejectionReason
+
+    public data class UnsupportedFormat(public val format: ScannableFormat) : ScannableCardRejectionReason
+
+    public data class EncoderFailure(public val reason: EncoderFailureReason) : ScannableCardRejectionReason
 }
 
 public enum class UnknownStorageFailureKind {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.storage
 
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.SignatureStatusKind as CoreSignatureStatusKind
 
 /**
@@ -20,6 +21,10 @@ public typealias SignatureStatusKind = CoreSignatureStatusKind
  * shape of these methods, not by documentation. Reviewers MUST treat any future addition
  * of a free-form parameter as a security-policy change.
  */
+// ComplexInterface: the surface intentionally carries every storage-side telemetry
+// event in one place — that cohesion is the trust claim. Splitting would fragment the
+// no-PII-in-telemetry guarantee across multiple bindings.
+@Suppress("ComplexInterface")
 public interface StorageTelemetryGuard {
     /**
      * Emitted once per database open after the key provider is initialized. Reports the
@@ -79,6 +84,39 @@ public interface StorageTelemetryGuard {
      * document StateFlow is updated. Carries the byte count of the deleted PDF only.
      */
     public fun onDocumentDeleted(event: DocumentDeletedEvent)
+
+    /**
+     * A user-generated scannable card row was inserted. Carries the format only — the
+     * payload, label, and color are user-typed free-form and are intentionally NOT part
+     * of the event. The same no-PII discipline as `onPassUpserted` applies.
+     */
+    public fun onScannableCardCreated(format: ScannableFormat)
+
+    /**
+     * A scannable card row was deleted. Emitted after the transaction commits and after
+     * the observe flow is updated. Carries the format only.
+     */
+    public fun onScannableCardDeleted(format: ScannableFormat)
+
+    /**
+     * A scannable-card insert was refused by the kernel validator. Emitted before any
+     * row is created. The structural [kind] is what flows through telemetry; the
+     * underlying kernel rejection reason is preserved on the typed
+     * [StorageError.ScannableCardRejected] for the consumer's error UI but is NOT
+     * carried here (it would re-link telemetry to user input — bidi-marker offsets,
+     * offending characters, etc.).
+     */
+    public fun onScannableCardRejected(kind: ScannableCardRejectedKind)
+}
+
+/**
+ * Why a scannable-card insert was refused, projected to a stable telemetry vocabulary.
+ * Two arms only — the kernel's richer rejection reasons (offending char, length, check
+ * digit, etc.) carry information derived from user input and stay off telemetry.
+ */
+public enum class ScannableCardRejectedKind {
+    LabelInvalid,
+    PayloadInvalid,
 }
 
 /**
@@ -126,6 +164,7 @@ public enum class StorageFailureKind {
     Unsupported,
     Unknown,
     DocumentRejected,
+    ScannableCardRejected,
 }
 
 public enum class MigrationFailureKind {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -117,6 +117,8 @@ public interface StorageTelemetryGuard {
 public enum class ScannableCardRejectedKind {
     LabelInvalid,
     PayloadInvalid,
+    FormatUnsupported,
+    EncoderFailed,
 }
 
 /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -31,4 +31,5 @@ internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
     is StorageError.Unsupported -> StorageFailureKind.Unsupported
     is StorageError.Unknown -> StorageFailureKind.Unknown
     is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
+    is StorageError.ScannableCardRejected -> StorageFailureKind.ScannableCardRejected
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
@@ -1,0 +1,47 @@
+package `is`.walt.passes.storage.internal
+
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.storage.ScannableCardRecordId
+
+/**
+ * Internal persistence boundary for the `scannable_cards` table. Same shape as
+ * [PassStore] and [DocumentStore]: blocking, synchronous, called by the repository
+ * inside an IO dispatcher. A fake impl in `ScannableCardRepositoryTest` exercises the
+ * repo-layer plumbing without an Android runtime.
+ *
+ * Materialization of a [ScannableCard] is delegated to the kernel validator on load —
+ * passes-core's `ScannableCard` constructor is module-internal, and the validator is
+ * the only public mint path. Re-running validation on every load also acts as
+ * defense-in-depth against on-disk tampering: if a row's bytes were altered to violate
+ * the format's charset / length rules, the row is dropped via
+ * `onMigrationRowDropped(Other)` rather than surfacing as a fake-trusted artifact.
+ */
+internal interface ScannableCardStore {
+    fun listAll(): List<ScannableCard>
+    fun loadById(id: ScannableCardRecordId): ScannableCard?
+    fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome
+    fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome?
+    fun close()
+}
+
+/**
+ * Pre-validated request to persist a scannable card. The repository runs the kernel
+ * validator first and feeds the trimmed payload and label into this request; the
+ * store does NOT re-run validation on insert.
+ */
+internal data class ScannableCardInsertRequest(
+    val payload: String,
+    val format: ScannableFormat,
+    val label: String,
+    val colorArgb: Int?,
+    val nowEpochMs: Long,
+)
+
+internal data class ScannableCardInsertOutcome(
+    val id: ScannableCardRecordId,
+)
+
+internal data class ScannableCardDeleteOutcome(
+    val format: ScannableFormat,
+)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
@@ -1,0 +1,139 @@
+package `is`.walt.passes.storage.internal
+
+import android.content.ContentValues
+import android.database.Cursor
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableCardCreateInput
+import `is`.walt.passes.core.ScannableCardCreateResult
+import `is`.walt.passes.core.ScannableCardId
+import `is`.walt.passes.core.ScannableCardInputValidator
+import `is`.walt.passes.core.ScannableColor
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.storage.MigrationFailureKind
+import `is`.walt.passes.storage.ScannableCardRecordId
+import `is`.walt.passes.storage.Schema
+import `is`.walt.passes.storage.StorageTelemetryGuard
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+
+/**
+ * SQLCipher-backed [ScannableCardStore]. Shares the database handle with
+ * [SqlCipherPassStore] and [SqlCipherDocumentStore]; the storage repository owns the
+ * single handle for the process. Rows surface as fully-materialized [ScannableCard]
+ * values — there are no large blob columns to defer, and the consumer's tile renderer
+ * needs the payload to re-encode the barcode at render time.
+ *
+ * Rows whose `format` column does not decode to a known [ScannableFormat] arm, or
+ * whose stored fields no longer pass [ScannableCardInputValidator] (defense-in-depth
+ * against on-disk tampering), are dropped via
+ * [StorageTelemetryGuard.onMigrationRowDropped] and silently omitted from the list.
+ */
+internal class SqlCipherScannableCardStore(
+    private val db: SQLiteDatabase,
+    private val telemetryGuard: StorageTelemetryGuard,
+) : ScannableCardStore {
+
+    override fun listAll(): List<ScannableCard> {
+        val out = ArrayList<ScannableCard>()
+        db.rawQuery(
+            "SELECT $ALL_COLUMNS FROM ${Schema.Tables.SCANNABLE_CARDS} " +
+                "ORDER BY created_at_epoch_ms DESC, id DESC",
+            emptyArray(),
+        ).use { c ->
+            while (c.moveToNext()) {
+                val card = c.toCardOrNull() ?: continue
+                out += card
+            }
+        }
+        return out
+    }
+
+    override fun loadById(id: ScannableCardRecordId): ScannableCard? = db.rawQuery(
+        "SELECT $ALL_COLUMNS FROM ${Schema.Tables.SCANNABLE_CARDS} WHERE id = ?",
+        arrayOf(id.value.toString()),
+    ).use { c -> if (!c.moveToNext()) null else c.toCardOrNull() }
+
+    override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome {
+        val rowId: Long
+        db.beginTransaction()
+        try {
+            val cv = ContentValues().apply {
+                put("payload", request.payload)
+                put("format", request.format.name)
+                put("label", request.label)
+                request.colorArgb?.let { put("color_argb", it) } ?: putNull("color_argb")
+                put("created_at_epoch_ms", request.nowEpochMs)
+            }
+            rowId = db.insertOrThrow(Schema.Tables.SCANNABLE_CARDS, null, cv)
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return ScannableCardInsertOutcome(id = ScannableCardRecordId(rowId))
+    }
+
+    override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? {
+        val card = loadById(id) ?: return null
+        db.beginTransaction()
+        try {
+            db.delete(Schema.Tables.SCANNABLE_CARDS, "id = ?", arrayOf(id.value.toString()))
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return ScannableCardDeleteOutcome(format = card.format)
+    }
+
+    /**
+     * No-op: the SQLCipher handle is owned by [SqlCipherPassStore] for the process
+     * lifetime. The interface contract exists so a future store that owns its own
+     * resource has an obvious release point.
+     */
+    override fun close() = Unit
+
+    private fun Cursor.toCardOrNull(): ScannableCard? {
+        val idIdx = getColumnIndexOrThrow("id")
+        val payloadIdx = getColumnIndexOrThrow("payload")
+        val formatIdx = getColumnIndexOrThrow("format")
+        val labelIdx = getColumnIndexOrThrow("label")
+        val colorIdx = getColumnIndexOrThrow("color_argb")
+        val createdIdx = getColumnIndexOrThrow("created_at_epoch_ms")
+
+        val format = ScannableFormat.entries.firstOrNull { it.name == getString(formatIdx) }
+            ?: run {
+                telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
+                return null
+            }
+        val rowId = getLong(idIdx)
+        val payload = getString(payloadIdx)
+        val label = getString(labelIdx)
+        val colorArgb = if (isNull(colorIdx)) null else getInt(colorIdx)
+        val createdAtMs = getLong(createdIdx)
+
+        val result = ScannableCardInputValidator.validate(
+            input = ScannableCardCreateInput(
+                payload = payload,
+                format = format,
+                label = label,
+                color = colorArgb?.let(::ScannableColor),
+            ),
+            id = ScannableCardId(rowId.toString()),
+            createdAt = PassInstant(createdAtMs),
+        )
+        return when (result) {
+            is ScannableCardCreateResult.Success -> result.card
+            is ScannableCardCreateResult.InvalidLabel,
+            is ScannableCardCreateResult.InvalidPayload,
+            is ScannableCardCreateResult.UnsupportedFormat,
+            is ScannableCardCreateResult.EncoderFailure -> {
+                telemetryGuard.onMigrationRowDropped(MigrationFailureKind.Other)
+                null
+            }
+        }
+    }
+
+    private companion object {
+        const val ALL_COLUMNS: String =
+            "id, payload, format, label, color_argb, created_at_epoch_ms"
+    }
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -3,6 +3,8 @@ package `is`.walt.passes.storage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.storage.internal.DeleteOutcome
 import `is`.walt.passes.storage.internal.DocumentDeleteOutcome
@@ -10,6 +12,10 @@ import `is`.walt.passes.storage.internal.DocumentInsertOutcome
 import `is`.walt.passes.storage.internal.DocumentInsertRequest
 import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
+import `is`.walt.passes.storage.internal.ScannableCardStore
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -264,6 +270,7 @@ class DocumentRepositoryTest {
         SqlCipherPassRepository(
             store = NoOpPassStore,
             documentStore = docs,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -327,6 +334,18 @@ class DocumentRepositoryTest {
     /**
      * Pass-side store stub: the document tests do not exercise pass-side code paths.
      */
+    /**
+     * Scannable-card store stub: the document tests do not exercise scannable-card paths.
+     */
+    private object NoOpScannableCardStore : ScannableCardStore {
+        override fun listAll(): List<ScannableCard> = emptyList()
+        override fun loadById(id: ScannableCardRecordId): ScannableCard? = null
+        override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome =
+            error("unused in document tests")
+        override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? = null
+        override fun close() = Unit
+    }
+
     private object NoOpPassStore : PassStore {
         override fun listSummaries(): List<PassSummary> = emptyList()
         override fun loadById(id: PassRecordId): StoredPass? = null
@@ -370,5 +389,8 @@ class DocumentRepositoryTest {
         override fun onDocumentDeleted(event: DocumentDeletedEvent) {
             events += "doc-deleted:${event.byteCount}"
         }
+        override fun onScannableCardCreated(format: ScannableFormat) = Unit
+        override fun onScannableCardDeleted(format: ScannableFormat) = Unit
+        override fun onScannableCardRejected(kind: ScannableCardRejectedKind) = Unit
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -16,6 +16,8 @@ import `is`.walt.passes.core.PassFields
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.storage.internal.DeleteOutcome
 import `is`.walt.passes.storage.internal.DocumentDeleteOutcome
@@ -23,6 +25,10 @@ import `is`.walt.passes.storage.internal.DocumentInsertOutcome
 import `is`.walt.passes.storage.internal.DocumentInsertRequest
 import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
+import `is`.walt.passes.storage.internal.ScannableCardStore
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -59,6 +65,7 @@ class PassRepositoryContractTest {
         val repo = SqlCipherPassRepository(
             store = store,
             documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -75,6 +82,7 @@ class PassRepositoryContractTest {
         val repo = SqlCipherPassRepository(
             store = store,
             documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -99,6 +107,7 @@ class PassRepositoryContractTest {
         val repo = SqlCipherPassRepository(
             store = store,
             documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1_000L },
@@ -125,6 +134,7 @@ class PassRepositoryContractTest {
         val repo = SqlCipherPassRepository(
             store = store,
             documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1L },
@@ -148,6 +158,7 @@ class PassRepositoryContractTest {
         val repo = SqlCipherPassRepository(
             store = store,
             documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
             telemetryGuard = telemetry,
             ioDispatcher = UnconfinedTestDispatcher(),
             clock = { 1L },
@@ -292,6 +303,15 @@ class PassRepositoryContractTest {
         override fun onDocumentDeleted(event: DocumentDeletedEvent) {
             events += "doc-deleted:${event.byteCount}"
         }
+        override fun onScannableCardCreated(format: ScannableFormat) {
+            events += "card-created:${format.name}"
+        }
+        override fun onScannableCardDeleted(format: ScannableFormat) {
+            events += "card-deleted:${format.name}"
+        }
+        override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
+            events += "card-rejected:${kind.name}"
+        }
     }
 
     /**
@@ -308,6 +328,19 @@ class PassRepositoryContractTest {
         override fun loadThumbnail(id: DocumentRecordId): ByteArray? = null
         override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? = null
         override fun close() { closeCount++ }
+    }
+
+    /**
+     * Scannable-card sibling of [NoOpDocumentStore]. Pass-side contract tests do not
+     * exercise scannable-card paths; reaching in here is an error.
+     */
+    private object NoOpScannableCardStore : ScannableCardStore {
+        override fun listAll(): List<ScannableCard> = emptyList()
+        override fun loadById(id: ScannableCardRecordId): ScannableCard? = null
+        override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome =
+            error("unused in pass-side tests")
+        override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? = null
+        override fun close() = Unit
     }
 
     private companion object {

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -1,6 +1,9 @@
 package `is`.walt.passes.storage
 
+import `is`.walt.passes.core.LabelRejection
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.PayloadRejection
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.SignatureStatus
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -34,9 +37,13 @@ class PublicApiSurfaceTest {
             StorageError.DatabaseLocked,
             StorageError.IntegrityViolation(PassRecordId(1L)),
             StorageError.IntegrityViolation(DocumentRecordId(2L)),
+            StorageError.IntegrityViolation(ScannableCardRecordId(3L)),
             StorageError.Unsupported(onDiskSchemaVersion = 99),
             StorageError.Unknown(UnknownStorageFailureKind.DiskFull),
             StorageError.DocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage),
+            StorageError.ScannableCardRejected(
+                ScannableCardRejectionReason.InvalidLabel(LabelRejection.Empty),
+            ),
         )
         val labels = errors.map { error ->
             when (error) {
@@ -46,10 +53,17 @@ class PublicApiSurfaceTest {
                 is StorageError.IntegrityViolation -> when (val id = error.recordId) {
                     is PassRecordId -> "integrity-pass:${id.value}"
                     is DocumentRecordId -> "integrity-doc:${id.value}"
+                    is ScannableCardRecordId -> "integrity-card:${id.value}"
                 }
                 is StorageError.Unsupported -> "unsupported:${error.onDiskSchemaVersion}"
                 is StorageError.Unknown -> "unknown:${error.kind.name}"
                 is StorageError.DocumentRejected -> "doc-rejected:${error.kind.name}"
+                is StorageError.ScannableCardRejected -> when (val r = error.reason) {
+                    is ScannableCardRejectionReason.InvalidLabel ->
+                        "card-rejected:label:${r.reason::class.simpleName}"
+                    is ScannableCardRejectionReason.InvalidPayload ->
+                        "card-rejected:payload:${r.reason::class.simpleName}"
+                }
             }
         }
         assertThat(labels).containsExactly(
@@ -58,9 +72,11 @@ class PublicApiSurfaceTest {
             "db-locked",
             "integrity-pass:1",
             "integrity-doc:2",
+            "integrity-card:3",
             "unsupported:99",
             "unknown:DiskFull",
             "doc-rejected:OversizedAtStorage",
+            "card-rejected:label:Empty",
         ).inOrder()
     }
 
@@ -124,6 +140,9 @@ class PublicApiSurfaceTest {
             StorageError.Unsupported(0),
             StorageError.Unknown(UnknownStorageFailureKind.Other),
             StorageError.DocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage),
+            StorageError.ScannableCardRejected(
+                ScannableCardRejectionReason.InvalidPayload(PayloadRejection.Empty),
+            ),
         )
         val kinds = errors.map { error ->
             when (error) {
@@ -134,6 +153,7 @@ class PublicApiSurfaceTest {
                 is StorageError.Unsupported -> StorageFailureKind.Unsupported
                 is StorageError.Unknown -> StorageFailureKind.Unknown
                 is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
+                is StorageError.ScannableCardRejected -> StorageFailureKind.ScannableCardRejected
             }
         }
         assertThat(kinds.toSet()).containsExactlyElementsIn(StorageFailureKind.entries)
@@ -141,32 +161,39 @@ class PublicApiSurfaceTest {
 
     @Test
     fun recordIdSealedArmsAreExhaustive() {
-        // Pinning the sealed surface: adding a third RecordId variant requires updating
+        // Pinning the sealed surface: adding a RecordId variant requires updating
         // every consumer that pattern-matches on it (StorageError.IntegrityViolation
         // routing in tests, telemetry projections, etc.).
-        val ids: List<RecordId> = listOf(PassRecordId(1L), DocumentRecordId(2L))
+        val ids: List<RecordId> = listOf(
+            PassRecordId(1L),
+            DocumentRecordId(2L),
+            ScannableCardRecordId(3L),
+        )
         val labels = ids.map { id ->
             when (id) {
                 is PassRecordId -> "pass:${id.value}"
                 is DocumentRecordId -> "doc:${id.value}"
+                is ScannableCardRecordId -> "card:${id.value}"
             }
         }
-        assertThat(labels).containsExactly("pass:1", "doc:2").inOrder()
+        assertThat(labels).containsExactly("pass:1", "doc:2", "card:3").inOrder()
     }
 
     @Test
-    fun schemaDeclaresSixTablesAndIsAtVersionTwo() {
-        assertThat(Schema.VERSION).isEqualTo(2)
+    fun schemaDeclaresSevenTablesAndIsAtVersionThree() {
+        assertThat(Schema.VERSION).isEqualTo(3)
         assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
         assertThat(Schema.Tables.PASSES).isEqualTo("passes")
         assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
         assertThat(Schema.Tables.PASS_LOCALES).isEqualTo("pass_locales")
         assertThat(Schema.Tables.DOCUMENTS).isEqualTo("documents")
         assertThat(Schema.Tables.DOCUMENT_THUMBNAILS).isEqualTo("document_thumbnails")
+        assertThat(Schema.Tables.SCANNABLE_CARDS).isEqualTo("scannable_cards")
         // schema_meta + passes + 3 pass-side indexes + pass_images + pass_locales
-        // + documents + 1 document index + document_thumbnails = 10 statements.
-        assertThat(Schema.DDL).hasSize(10)
-        assertThat(Schema.MIGRATIONS.keys).containsExactly(1)
+        // + documents + 1 document index + document_thumbnails
+        // + scannable_cards + 1 scannable-card index = 12 statements.
+        assertThat(Schema.DDL).hasSize(12)
+        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2)
     }
 
     @Test
@@ -353,6 +380,18 @@ class PublicApiSurfaceTest {
             override fun onDocumentDeleted(event: DocumentDeletedEvent) {
                 recorded += "doc-deleted:${event.byteCount}"
             }
+
+            override fun onScannableCardCreated(format: ScannableFormat) {
+                recorded += "card-created:${format.name}"
+            }
+
+            override fun onScannableCardDeleted(format: ScannableFormat) {
+                recorded += "card-deleted:${format.name}"
+            }
+
+            override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
+                recorded += "card-rejected:${kind.name}"
+            }
         }
         guard.onKeyProviderInitialized(KeyBacking.StrongBox)
         guard.onPassUpserted(PassType.BoardingPass, SignatureStatusKind.AppleVerified, false)
@@ -362,6 +401,9 @@ class PublicApiSurfaceTest {
         guard.onDocumentImported(DocumentImportedEvent(byteCount = 1024L, pageCount = 3))
         guard.onDocumentRejected(DocumentStorageRejectedKind.OversizedAtStorage)
         guard.onDocumentDeleted(DocumentDeletedEvent(byteCount = 2048L))
+        guard.onScannableCardCreated(ScannableFormat.Qr)
+        guard.onScannableCardDeleted(ScannableFormat.Code128)
+        guard.onScannableCardRejected(ScannableCardRejectedKind.PayloadInvalid)
 
         assertThat(recorded).containsExactly(
             "init:StrongBox",
@@ -372,7 +414,36 @@ class PublicApiSurfaceTest {
             "doc-imported:1024:3",
             "doc-rejected:OversizedAtStorage",
             "doc-deleted:2048",
+            "card-created:Qr",
+            "card-deleted:Code128",
+            "card-rejected:PayloadInvalid",
         ).inOrder()
+    }
+
+    @Test
+    fun scannableCardRejectedKindCoversTheTwoStructuralArms() {
+        // Two arms only — the kernel validator's richer rejection reasons carry user
+        // input (offending characters, lengths, check-digit detail), and routing them
+        // through telemetry would defeat the no-PII-in-telemetry contract.
+        assertThat(ScannableCardRejectedKind.entries.map { it.name }).containsExactly(
+            "LabelInvalid",
+            "PayloadInvalid",
+        ).inOrder()
+    }
+
+    @Test
+    fun scannableCardRejectionReasonArmsAreReachableViaWhen() {
+        val reasons: List<ScannableCardRejectionReason> = listOf(
+            ScannableCardRejectionReason.InvalidLabel(LabelRejection.Empty),
+            ScannableCardRejectionReason.InvalidPayload(PayloadRejection.Empty),
+        )
+        val labels = reasons.map { reason ->
+            when (reason) {
+                is ScannableCardRejectionReason.InvalidLabel -> "label:${reason.reason::class.simpleName}"
+                is ScannableCardRejectionReason.InvalidPayload -> "payload:${reason.reason::class.simpleName}"
+            }
+        }
+        assertThat(labels).containsExactly("label:Empty", "payload:Empty").inOrder()
     }
 
     @Test

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.storage
 
+import `is`.walt.passes.core.EncoderFailureReason
 import `is`.walt.passes.core.LabelRejection
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.PayloadRejection
@@ -29,6 +30,9 @@ class PublicApiSurfaceTest {
         assertThat(branch).isEqualTo("success:7")
     }
 
+    // CyclomaticComplexMethod: scales 1:1 with the StorageError + nested RecordId +
+    // ScannableCardRejectionReason arms by design; complexity is the test's job here.
+    @Suppress("CyclomaticComplexMethod")
     @Test
     fun storageErrorArmsAreReachableViaWhen() {
         val errors: List<StorageError> = listOf(
@@ -63,6 +67,10 @@ class PublicApiSurfaceTest {
                         "card-rejected:label:${r.reason::class.simpleName}"
                     is ScannableCardRejectionReason.InvalidPayload ->
                         "card-rejected:payload:${r.reason::class.simpleName}"
+                    is ScannableCardRejectionReason.UnsupportedFormat ->
+                        "card-rejected:fmt:${r.format.name}"
+                    is ScannableCardRejectionReason.EncoderFailure ->
+                        "card-rejected:enc:${r.reason::class.simpleName}"
                 }
             }
         }
@@ -421,13 +429,16 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun scannableCardRejectedKindCoversTheTwoStructuralArms() {
-        // Two arms only — the kernel validator's richer rejection reasons carry user
-        // input (offending characters, lengths, check-digit detail), and routing them
-        // through telemetry would defeat the no-PII-in-telemetry contract.
+    fun scannableCardRejectedKindCoversAllFourArms() {
+        // The first two arms are what the validator produces today; the latter two
+        // carry the kernel's UnsupportedFormat / EncoderFailure result arms through
+        // the typed channel so they cannot collapse into Unknown(Other) when the
+        // validator changes.
         assertThat(ScannableCardRejectedKind.entries.map { it.name }).containsExactly(
             "LabelInvalid",
             "PayloadInvalid",
+            "FormatUnsupported",
+            "EncoderFailed",
         ).inOrder()
     }
 
@@ -436,14 +447,23 @@ class PublicApiSurfaceTest {
         val reasons: List<ScannableCardRejectionReason> = listOf(
             ScannableCardRejectionReason.InvalidLabel(LabelRejection.Empty),
             ScannableCardRejectionReason.InvalidPayload(PayloadRejection.Empty),
+            ScannableCardRejectionReason.UnsupportedFormat(ScannableFormat.Qr),
+            ScannableCardRejectionReason.EncoderFailure(EncoderFailureReason.PayloadTooDense),
         )
         val labels = reasons.map { reason ->
             when (reason) {
                 is ScannableCardRejectionReason.InvalidLabel -> "label:${reason.reason::class.simpleName}"
                 is ScannableCardRejectionReason.InvalidPayload -> "payload:${reason.reason::class.simpleName}"
+                is ScannableCardRejectionReason.UnsupportedFormat -> "fmt:${reason.format.name}"
+                is ScannableCardRejectionReason.EncoderFailure -> "enc:${reason.reason::class.simpleName}"
             }
         }
-        assertThat(labels).containsExactly("label:Empty", "payload:Empty").inOrder()
+        assertThat(labels).containsExactly(
+            "label:Empty",
+            "payload:Empty",
+            "fmt:Qr",
+            "enc:PayloadTooDense",
+        ).inOrder()
     }
 
     @Test

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -1,0 +1,372 @@
+package `is`.walt.passes.storage
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableCardCreateInput
+import `is`.walt.passes.core.ScannableCardId
+import `is`.walt.passes.core.ScannableCardInputValidator
+import `is`.walt.passes.core.ScannableColor
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.core.SignatureStatus
+import `is`.walt.passes.storage.internal.DeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentDeleteOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertOutcome
+import `is`.walt.passes.storage.internal.DocumentInsertRequest
+import `is`.walt.passes.storage.internal.DocumentStore
+import `is`.walt.passes.storage.internal.PassStore
+import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
+import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
+import `is`.walt.passes.storage.internal.ScannableCardStore
+import `is`.walt.passes.storage.internal.UpsertOutcome
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed verification of the scannable-card side of [PassRepository].
+ * Exercises the create -> observe -> delete cycle plus the validator rejection paths
+ * against an in-memory fake [ScannableCardStore]. The SQLCipher round-trip lives in
+ * the instrumentation suite.
+ *
+ * Properties locked here:
+ *
+ *  1. A valid `createScannableCard` call inserts the row, the observe flow reflects
+ *     it, and `onScannableCardCreated(format)` fires AFTER the flow updates.
+ *  2. A validator-rejected payload (control character) surfaces as
+ *     [StorageError.ScannableCardRejected] with the typed kernel reason, emits
+ *     `onScannableCardRejected(PayloadInvalid)`, and the row never reaches disk.
+ *  3. A validator-rejected label (empty after trim) surfaces as
+ *     [StorageError.ScannableCardRejected] with the typed kernel reason and emits
+ *     `onScannableCardRejected(LabelInvalid)`.
+ *  4. A scannable-card validator rejection does NOT also emit
+ *     `onStorageFailure(ScannableCardRejected,...)` — rejection and infra failure are
+ *     distinct telemetry channels, mirroring the document-side discipline.
+ *  5. `deleteScannableCard` removes the row from the observe flow and emits
+ *     `onScannableCardDeleted(format)` afterward.
+ *  6. `deleteScannableCard` of an unknown id returns [StorageError.IntegrityViolation]
+ *     carrying a [ScannableCardRecordId] and emits `onStorageFailure` only.
+ *  7. `loadScannableCard` round-trips the stored fields exactly (trimmed by the
+ *     validator) and re-mints the [ScannableCardId] as the stringified row id.
+ *  8. `close()` releases the scannable-card store along with the pass and document
+ *     stores; the call is idempotent.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class ScannableCardRepositoryTest {
+
+    @Test
+    fun createInsertsRowUpdatesObserveFlowAndEmitsCreatedTelemetryAfter() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900", // valid EAN-13 with check digit
+                format = ScannableFormat.Ean13,
+                label = "Grocery loyalty",
+                color = ScannableColor(0xFF112233.toInt()),
+            ),
+        )
+
+        check(result is StorageResult.Success)
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].payload).isEqualTo("5012345678900")
+        assertThat(rows[0].format).isEqualTo(ScannableFormat.Ean13)
+        assertThat(rows[0].label).isEqualTo("Grocery loyalty")
+        assertThat(rows[0].color?.argb).isEqualTo(0xFF112233.toInt())
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Ean13",
+        ).inOrder()
+    }
+
+    @Test
+    fun createWithControlCharInPayloadIsRejectedWithTypedReason() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "abcdef", // bell character — Cc category
+                format = ScannableFormat.Code128,
+                label = "Test",
+                color = null,
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        check(rejected.reason is ScannableCardRejectionReason.InvalidPayload)
+        // The rejection emits exactly `card-rejected`; it does NOT also emit
+        // `failure:ScannableCardRejected:...`. A validator rejection is not a generic
+        // storage failure (mirrors the doc-side rejectDocument discipline).
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:PayloadInvalid",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
+    fun createWithEmptyLabelIsRejectedWithTypedReason() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "   ", // whitespace-only, trims to empty
+                color = null,
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        check(rejected.reason is ScannableCardRejectionReason.InvalidLabel)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:LabelInvalid",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
+    fun deleteRemovesRowFromObserveFlowAndEmitsDeletedTelemetryAfter() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val create = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "HELLO WORLD",
+                format = ScannableFormat.Code128,
+                label = "x",
+                color = null,
+            ),
+        )
+        check(create is StorageResult.Success)
+        val id = create.value
+
+        val deleteResult = repo.deleteScannableCard(id)
+        check(deleteResult is StorageResult.Success)
+
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Code128",
+            "card-deleted:Code128",
+        ).inOrder()
+    }
+
+    @Test
+    fun deleteOfUnknownIdReturnsIntegrityViolationAndEmitsFailureNotDeleted() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.deleteScannableCard(ScannableCardRecordId(404L))
+
+        check(result is StorageResult.Failure)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is ScannableCardRecordId)
+        assertThat(violation.recordId.value).isEqualTo(404L)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
+    fun loadRoundTripsStoredFields() = runTest {
+        val cards = FakeScannableCardStore()
+        val repo = repo(cards, RecordingGuard())
+
+        val create = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "Grocery",
+                color = ScannableColor(0x80AABBCC.toInt()),
+            ),
+        )
+        check(create is StorageResult.Success)
+        val id = create.value
+
+        val loaded = repo.loadScannableCard(id)
+        check(loaded is StorageResult.Success)
+        val card = loaded.value
+        assertThat(card.payload).isEqualTo("5012345678900")
+        assertThat(card.format).isEqualTo(ScannableFormat.Ean13)
+        assertThat(card.label).isEqualTo("Grocery")
+        assertThat(card.color?.argb).isEqualTo(0x80AABBCC.toInt())
+        // The kernel-visible id is the stringified row id minted by storage.
+        assertThat(card.id.value).isEqualTo(id.value.toString())
+    }
+
+    @Test
+    fun loadOfUnknownIdReturnsIntegrityViolation() = runTest {
+        val repo = repo(FakeScannableCardStore(), RecordingGuard())
+        val result = repo.loadScannableCard(ScannableCardRecordId(999L))
+        check(result is StorageResult.Failure)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is ScannableCardRecordId)
+    }
+
+    @Test
+    fun closeReleasesScannableCardStoreAlongWithPassAndDocumentStores() = runTest {
+        val cards = FakeScannableCardStore()
+        val repo = repo(cards, RecordingGuard())
+        repo.close()
+        repo.close() // idempotent
+        assertThat(cards.closeCount).isEqualTo(1)
+    }
+
+    private fun repo(cards: FakeScannableCardStore, telemetry: StorageTelemetryGuard): SqlCipherPassRepository =
+        SqlCipherPassRepository(
+            store = NoOpPassStore,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = cards,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1_000L },
+            keyBacking = KeyBacking.Tee,
+        )
+
+    /**
+     * In-memory scannable-card store. Mirrors the SQL contract: rows sorted by
+     * `created_at_epoch_ms DESC, id DESC`. The kernel validator runs at insert time
+     * (orchestrated by the repository), so this fake takes pre-validated inputs and
+     * round-trips them through the same `ScannableCardInputValidator` path the
+     * production SqlCipher impl uses on load, to keep the trimmed-label / trimmed-payload
+     * invariant honest in tests.
+     */
+    private class FakeScannableCardStore : ScannableCardStore {
+        private data class Row(
+            val id: Long,
+            val payload: String,
+            val format: ScannableFormat,
+            val label: String,
+            val colorArgb: Int?,
+            val createdAtEpochMs: Long,
+        )
+
+        private val rows: LinkedHashMap<Long, Row> = LinkedHashMap()
+        private var nextId: Long = 0L
+        var closeCount: Int = 0
+            private set
+
+        override fun listAll(): List<ScannableCard> =
+            rows.values
+                .sortedWith(
+                    compareByDescending<Row> { it.createdAtEpochMs }.thenByDescending { it.id },
+                )
+                .mapNotNull(::toCardOrNull)
+
+        override fun loadById(id: ScannableCardRecordId): ScannableCard? =
+            rows[id.value]?.let(::toCardOrNull)
+
+        override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome {
+            val rowId = ++nextId
+            rows[rowId] = Row(
+                id = rowId,
+                payload = request.payload,
+                format = request.format,
+                label = request.label,
+                colorArgb = request.colorArgb,
+                createdAtEpochMs = request.nowEpochMs,
+            )
+            return ScannableCardInsertOutcome(id = ScannableCardRecordId(rowId))
+        }
+
+        override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? {
+            val row = rows.remove(id.value) ?: return null
+            return ScannableCardDeleteOutcome(format = row.format)
+        }
+
+        override fun close() { closeCount++ }
+
+        private fun toCardOrNull(row: Row): ScannableCard? {
+            val result = ScannableCardInputValidator.validate(
+                input = ScannableCardCreateInput(
+                    payload = row.payload,
+                    format = row.format,
+                    label = row.label,
+                    color = row.colorArgb?.let(::ScannableColor),
+                ),
+                id = ScannableCardId(row.id.toString()),
+                createdAt = PassInstant(row.createdAtEpochMs),
+            )
+            return (result as? `is`.walt.passes.core.ScannableCardCreateResult.Success)?.card
+        }
+    }
+
+    private object NoOpPassStore : PassStore {
+        override fun listSummaries(): List<PassSummary> = emptyList()
+        override fun loadById(id: PassRecordId): StoredPass? = null
+        override fun summaryById(id: PassRecordId): PassSummary? = null
+        override fun upsert(
+            pass: Pass,
+            signatureStatus: SignatureStatus,
+            nowEpochMs: Long,
+        ): UpsertOutcome = error("unused in scannable-card tests")
+        override fun delete(id: PassRecordId): DeleteOutcome? = null
+        override fun close() = Unit
+    }
+
+    private object NoOpDocumentStore : DocumentStore {
+        override fun listRows(): List<DocumentRow> = emptyList()
+        override fun insert(request: DocumentInsertRequest): DocumentInsertOutcome =
+            error("unused in scannable-card tests")
+        override fun loadBytes(id: DocumentRecordId): ByteArray? = null
+        override fun loadThumbnail(id: DocumentRecordId): ByteArray? = null
+        override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? = null
+        override fun close() = Unit
+    }
+
+    private class RecordingGuard : StorageTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+        override fun onKeyProviderInitialized(backing: KeyBacking) {
+            events += "init:${backing.name}"
+        }
+        override fun onPassUpserted(
+            type: PassType,
+            signatureStatus: SignatureStatusKind,
+            wasReplacement: Boolean,
+        ) = Unit
+        override fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind) = Unit
+        override fun onMigrationRowDropped(kind: MigrationFailureKind) = Unit
+        override fun onStorageFailure(
+            kind: StorageFailureKind,
+            unknownKind: UnknownStorageFailureKind?,
+        ) {
+            events += "failure:${kind.name}:${unknownKind?.name ?: "n/a"}"
+        }
+        override fun onDocumentImported(event: DocumentImportedEvent) = Unit
+        override fun onDocumentRejected(kind: DocumentStorageRejectedKind) = Unit
+        override fun onDocumentDeleted(event: DocumentDeletedEvent) = Unit
+        override fun onScannableCardCreated(format: ScannableFormat) {
+            events += "card-created:${format.name}"
+        }
+        override fun onScannableCardDeleted(format: ScannableFormat) {
+            events += "card-deleted:${format.name}"
+        }
+        override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
+            events += "card-rejected:${kind.name}"
+        }
+    }
+}

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
@@ -29,7 +29,7 @@ class SchemaDdlTest {
     }
 
     @Test
-    fun ddlExecutesCleanlyAndCreatesTheSixDocumentedTables() {
+    fun ddlExecutesCleanlyAndCreatesTheSevenDocumentedTables() {
         applyDdl().use { conn ->
             val tables = mutableSetOf<String>()
             conn.createStatement().use { stmt ->
@@ -43,12 +43,13 @@ class SchemaDdlTest {
                 Schema.Tables.PASS_LOCALES,
                 Schema.Tables.DOCUMENTS,
                 Schema.Tables.DOCUMENT_THUMBNAILS,
+                Schema.Tables.SCANNABLE_CARDS,
             )
         }
     }
 
     @Test
-    fun ddlCreatesTheFourDocumentedIndexes() {
+    fun ddlCreatesTheFiveDocumentedIndexes() {
         applyDdl().use { conn ->
             val indexes = mutableSetOf<String>()
             conn.createStatement().use { stmt ->
@@ -62,6 +63,26 @@ class SchemaDdlTest {
                 "idx_passes_expiration",
                 "idx_passes_identity",
                 "idx_documents_imported_at",
+                "idx_scannable_cards_created_at",
+            )
+        }
+    }
+
+    @Test
+    fun scannableCardsTableHasTheExpectedColumns() {
+        applyDdl().use { conn ->
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.SCANNABLE_CARDS})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).containsExactly(
+                "id",
+                "payload",
+                "format",
+                "label",
+                "color_argb",
+                "created_at_epoch_ms",
             )
         }
     }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
@@ -43,6 +43,18 @@ class SchemaMigrationTest {
         }
     }
 
+    /**
+     * Applies the v2 schema (v1 + the v1 -> v2 hop). A v2 -> v3 test stands on top of
+     * this and asserts that the result equals the full v3 schema once the second hop
+     * lands.
+     */
+    private fun applyV2Ddl(conn: Connection) {
+        applyV1Ddl(conn)
+        conn.createStatement().use { stmt ->
+            for (sql in Schema.MIGRATIONS.getValue(1)) stmt.execute(sql)
+        }
+    }
+
     @Test
     fun migrationFromV1IntroducesDocumentsAndDocumentThumbnailsTables() {
         openMemoryDb().use { conn ->
@@ -151,12 +163,14 @@ class SchemaMigrationTest {
     }
 
     @Test
-    fun freshInstallAndV1ToV2MigrationLandAtTheSameSchema() {
-        // DDL drift guard: Schema.DDL (fresh install) and the v1 -> v2 migration must
-        // produce the same `sqlite_master` rows for tables and indexes. A future
-        // refactor that touches one path and misses the other would silently produce
-        // divergent shapes between fresh installs and migrated installs; this test
-        // surfaces the divergence at JVM-test time.
+    fun freshInstallAndFullMigrationChainLandAtTheSameSchema() {
+        // DDL drift guard: Schema.DDL (fresh install) and the full v1 -> current
+        // migration chain must produce the same `sqlite_master` rows for tables and
+        // indexes. A future refactor that touches one path and misses the other would
+        // silently produce divergent shapes between fresh installs and migrated
+        // installs; this test surfaces the divergence at JVM-test time. Generalized
+        // over all hops so a future Schema.VERSION bump does not need a new parity
+        // test entry.
         val freshShape = openMemoryDb().use { conn ->
             conn.createStatement().use { stmt ->
                 for (sql in Schema.DDL) stmt.execute(sql)
@@ -165,12 +179,18 @@ class SchemaMigrationTest {
         }
         val migratedShape = openMemoryDb().use { conn ->
             applyV1Ddl(conn)
-            for (sql in Schema.MIGRATIONS.getValue(1)) {
-                conn.createStatement().use { it.execute(sql) }
-            }
+            applyFullMigrationChain(conn)
             schemaShape(conn)
         }
         assertThat(migratedShape).isEqualTo(freshShape)
+    }
+
+    private fun applyFullMigrationChain(conn: Connection) {
+        for (from in 1 until Schema.VERSION) {
+            for (sql in Schema.MIGRATIONS.getValue(from)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+        }
     }
 
     private fun schemaShape(conn: Connection): Set<String> {
@@ -194,6 +214,106 @@ class SchemaMigrationTest {
             }
         }
         return out
+    }
+
+    @Test
+    fun migrationFromV2IntroducesScannableCardsTable() {
+        openMemoryDb().use { conn ->
+            applyV2Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(2)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val tables = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("SELECT name FROM sqlite_master WHERE type='table'")
+                while (rs.next()) tables.add(rs.getString(1))
+            }
+            assertThat(tables).contains(Schema.Tables.SCANNABLE_CARDS)
+        }
+    }
+
+    @Test
+    fun migrationFromV2AddsTheScannableCardsCreatedAtIndex() {
+        openMemoryDb().use { conn ->
+            applyV2Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(2)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val indexes = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+                )
+                while (rs.next()) indexes.add(rs.getString(1))
+            }
+            assertThat(indexes).contains("idx_scannable_cards_created_at")
+        }
+    }
+
+    @Test
+    fun scannableCardsTableAfterMigrationHasTheExpectedColumns() {
+        openMemoryDb().use { conn ->
+            applyV2Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(2)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.SCANNABLE_CARDS})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).containsExactly(
+                "id",
+                "payload",
+                "format",
+                "label",
+                "color_argb",
+                "created_at_epoch_ms",
+            )
+        }
+    }
+
+    @Test
+    fun preexistingV2DataSurvivesMigrationToV3() {
+        openMemoryDb().use { conn ->
+            applyV2Ddl(conn)
+
+            // Pre-migration: a v2 pass row and a v2 document row.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (1, 'BoardingPass', 'S1', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.DOCUMENTS}" +
+                    "(id, display_label, pdf_bytes, byte_count, page_count, imported_at_epoch_ms) " +
+                    "VALUES (1, 'doc.pdf', x'00', 1, 1, 1)",
+            ).use { it.executeUpdate() }
+
+            for (sql in Schema.MIGRATIONS.getValue(2)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            conn.createStatement().use { stmt ->
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.PASSES}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.DOCUMENTS}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.SCANNABLE_CARDS}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(0)
+            }
+        }
     }
 
     @Test

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.BarcodeEncoder
 import `is`.walt.passes.core.BarcodeMatrix
@@ -19,32 +21,16 @@ import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableFormat
 
 /**
- * Renders [card]'s barcode by feeding `(payload, format)` through
- * [BarcodeEncoder.encode] and painting the resulting [BarcodeMatrix] as a 1-bit
- * bitmap. Enforces a minimum on-screen size so the barcode is reliably scannable at
- * gate distance: 240 dp x 240 dp for the QR symbology; 320 dp x 96 dp for the four
- * 1D symbologies (Code128, EAN-13, UPC-A, Code39). Same sizing scheme as the existing
- * [BarcodeView] (which renders verified-pass PKPASS barcodes), so the kernel's two
- * barcode-rendering surfaces stay visually consistent at gate.
+ * Renders [card]'s barcode through [BarcodeEncoder] as a 1-bit-per-module bitmap.
+ * Minimum on-screen sizes mirror [BarcodeView] so the two barcode surfaces are
+ * consistent at gate distance: 240 dp square for QR, 320 dp x 96 dp for the four
+ * 1D symbologies. Painted with `FilterQuality.None` so the per-module upscale stays
+ * nearest-neighbor and module edges remain sharp.
  *
- * Encoder failures (rare; the kernel validator already gated the input at create
- * time) render as an empty placeholder of the same minimum size rather than throwing,
- * so a corrupted or otherwise-unencodable row does not crash the surface that
- * surrounds it. The placeholder is silent intentionally: the consumer's tile chrome
- * (issue wpass-lzi.8) is the surface that explains the artifact class to the user
- * and renders the "Created by you" trust caption; this composable is the bare-bones
- * scanner-facing matrix and nothing else.
- *
- * Card chrome — background tint from [ScannableCard.color], label rendering, the
- * "Created by you" trust caption — is intentionally NOT in this composable. Those
- * belong on the surrounding tile (wpass-lzi.8) so this surface can be reused as the
- * full-screen scan view without dragging tile chrome along.
- *
- * `[BitmapPainter]` is constructed with `filterQuality = FilterQuality.None` so the
- * Compose scaler does not introduce bilinear blur between modules. Sharp module
- * edges are essential for scanner reliability at gate distance; the per-module
- * upscale from the source bitmap to the final dp size happens at draw time via
- * nearest-neighbor.
+ * Encoder failures render as a same-sized [Spacer] with a TalkBack-readable
+ * `contentDescription` rather than throwing. Card chrome (background tint, label,
+ * "Created by you" trust caption) belongs on the surrounding tile (wpass-lzi.8) so
+ * this surface can be reused as the full-screen scan view unchanged.
  */
 @Composable
 public fun ScannableCardView(
@@ -73,23 +59,18 @@ public fun ScannableCardView(
             ),
         )
     } else {
-        // Encoder-failure placeholder. Same dimensions as the barcode so the surrounding
-        // layout does not shift between the success and failure paths.
+        // Same dimensions as the barcode so layout does not shift between paths.
+        // TalkBack signal so a user with vision support gets *something* — silent
+        // blank rectangles are the worst a11y failure mode.
         Spacer(
-            modifier = modifier.defaultMinSize(
-                minWidth = minWidthDp.dp,
-                minHeight = minHeightDp.dp,
-            ),
+            modifier = modifier
+                .defaultMinSize(minWidth = minWidthDp.dp, minHeight = minHeightDp.dp)
+                .semantics { contentDescription = "Barcode failed to render" },
         )
     }
 }
 
-/**
- * Minimum on-screen size per symbology, in dp. The QR symbology lays out as a square;
- * the 1D symbologies prefer a wide rectangle so the bars have enough horizontal
- * resolution to scan reliably without the user having to tilt the phone. Values
- * mirror the existing [BarcodeView] for consistency at gate.
- */
+/** Per-symbology min on-screen size in dp. Mirrors [BarcodeView] for gate consistency. */
 private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
     ScannableFormat.Qr -> 240 to 240
     ScannableFormat.Code128,
@@ -100,13 +81,8 @@ private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
 }
 
 /**
- * Paints a [BarcodeMatrix] into a 1-bit-per-module ARGB_8888 bitmap. The bitmap is
- * matrix-sized, not screen-sized — Compose scales it to the final dp container via
- * `BitmapPainter(filterQuality = None)`, which is nearest-neighbor and so preserves
- * sharp module edges.
- *
- * Two passes over the matrix would be wasteful; the loop materializes the whole
- * `pixels` IntArray in one sweep and hands it to `Bitmap.createBitmap` in one call.
+ * Paints a [BarcodeMatrix] into a matrix-sized ARGB_8888 bitmap. Compose scales to
+ * the final dp container nearest-neighbor via `BitmapPainter(filterQuality = None)`.
  */
 private fun BarcodeMatrix.toMonochromeBitmap(): Bitmap {
     val pixels = IntArray(width * height)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -1,0 +1,120 @@
+package `is`.walt.passes.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.BarcodeEncoder
+import `is`.walt.passes.core.BarcodeMatrix
+import `is`.walt.passes.core.EncodeResult
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
+
+/**
+ * Renders [card]'s barcode by feeding `(payload, format)` through
+ * [BarcodeEncoder.encode] and painting the resulting [BarcodeMatrix] as a 1-bit
+ * bitmap. Enforces a minimum on-screen size so the barcode is reliably scannable at
+ * gate distance: 240 dp x 240 dp for the QR symbology; 320 dp x 96 dp for the four
+ * 1D symbologies (Code128, EAN-13, UPC-A, Code39). Same sizing scheme as the existing
+ * [BarcodeView] (which renders verified-pass PKPASS barcodes), so the kernel's two
+ * barcode-rendering surfaces stay visually consistent at gate.
+ *
+ * Encoder failures (rare; the kernel validator already gated the input at create
+ * time) render as an empty placeholder of the same minimum size rather than throwing,
+ * so a corrupted or otherwise-unencodable row does not crash the surface that
+ * surrounds it. The placeholder is silent intentionally: the consumer's tile chrome
+ * (issue wpass-lzi.8) is the surface that explains the artifact class to the user
+ * and renders the "Created by you" trust caption; this composable is the bare-bones
+ * scanner-facing matrix and nothing else.
+ *
+ * Card chrome — background tint from [ScannableCard.color], label rendering, the
+ * "Created by you" trust caption — is intentionally NOT in this composable. Those
+ * belong on the surrounding tile (wpass-lzi.8) so this surface can be reused as the
+ * full-screen scan view without dragging tile chrome along.
+ *
+ * `[BitmapPainter]` is constructed with `filterQuality = FilterQuality.None` so the
+ * Compose scaler does not introduce bilinear blur between modules. Sharp module
+ * edges are essential for scanner reliability at gate distance; the per-module
+ * upscale from the source bitmap to the final dp size happens at draw time via
+ * nearest-neighbor.
+ */
+@Composable
+public fun ScannableCardView(
+    card: ScannableCard,
+    modifier: Modifier = Modifier,
+) {
+    val (minWidthDp, minHeightDp) = card.format.minRenderSizeDp()
+
+    val bitmap = remember(card.payload, card.format) {
+        when (val result = BarcodeEncoder.encode(card.payload, card.format)) {
+            is EncodeResult.Success -> result.matrix.toMonochromeBitmap()
+            is EncodeResult.Failure -> null
+        }
+    }
+
+    if (bitmap != null) {
+        Image(
+            painter = BitmapPainter(
+                image = bitmap.asImageBitmap(),
+                filterQuality = FilterQuality.None,
+            ),
+            contentDescription = card.label,
+            modifier = modifier.defaultMinSize(
+                minWidth = minWidthDp.dp,
+                minHeight = minHeightDp.dp,
+            ),
+        )
+    } else {
+        // Encoder-failure placeholder. Same dimensions as the barcode so the surrounding
+        // layout does not shift between the success and failure paths.
+        Spacer(
+            modifier = modifier.defaultMinSize(
+                minWidth = minWidthDp.dp,
+                minHeight = minHeightDp.dp,
+            ),
+        )
+    }
+}
+
+/**
+ * Minimum on-screen size per symbology, in dp. The QR symbology lays out as a square;
+ * the 1D symbologies prefer a wide rectangle so the bars have enough horizontal
+ * resolution to scan reliably without the user having to tilt the phone. Values
+ * mirror the existing [BarcodeView] for consistency at gate.
+ */
+private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
+    ScannableFormat.Qr -> 240 to 240
+    ScannableFormat.Code128,
+    ScannableFormat.Ean13,
+    ScannableFormat.UpcA,
+    ScannableFormat.Code39,
+    -> 320 to 96
+}
+
+/**
+ * Paints a [BarcodeMatrix] into a 1-bit-per-module ARGB_8888 bitmap. The bitmap is
+ * matrix-sized, not screen-sized — Compose scales it to the final dp container via
+ * `BitmapPainter(filterQuality = None)`, which is nearest-neighbor and so preserves
+ * sharp module edges.
+ *
+ * Two passes over the matrix would be wasteful; the loop materializes the whole
+ * `pixels` IntArray in one sweep and hands it to `Bitmap.createBitmap` in one call.
+ */
+private fun BarcodeMatrix.toMonochromeBitmap(): Bitmap {
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        val rowOffset = y * width
+        for (x in 0 until width) {
+            pixels[rowOffset + x] = if (isSet(x, y)) AndroidColor.BLACK else AndroidColor.WHITE
+        }
+    }
+    return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -6,6 +6,7 @@ import `is`.walt.passes.core.PassColors
 import `is`.walt.passes.core.PassFields
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
 import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
@@ -374,6 +375,25 @@ class PublicApiSurfaceTest {
             break
         }
         return found
+    }
+
+    @Test
+    fun scannableFormatArmsAreReachableViaWhen() {
+        // ScannableCardView.minRenderSizeDp() carries a per-symbology min-size table.
+        // Adding a new arm to ScannableFormat in passes-core would silently fall through
+        // the existing 1D branch without this exhaustive when forcing a UI-side decision.
+        val sizes = ScannableFormat.entries.map { format ->
+            when (format) {
+                ScannableFormat.Qr -> "qr"
+                ScannableFormat.Code128 -> "code128"
+                ScannableFormat.Ean13 -> "ean13"
+                ScannableFormat.UpcA -> "upca"
+                ScannableFormat.Code39 -> "code39"
+            }
+        }
+        assertThat(sizes.toSet()).containsExactlyElementsIn(
+            ScannableFormat.entries.map { it.name.lowercase() },
+        )
     }
 
     private fun passFixture(


### PR DESCRIPTION
## Summary

Two children of the [ScannableCard generator epic](#66) bundled into one PR — the storage tier and the bare matrix-rendering composable. Neither child blocks the other and both feed the same downstream tile (wpass-lzi.8), so reviewing them together saves a context switch.

### Storage (wpass-lzi.6)

- Schema v3 introduces a dedicated `scannable_cards` table inside the existing `walt_passes.db` SQLCipher file. The file-level Auto Backup exclusion in `BackupRulesContract.REQUIRED_EXCLUDES` already covers the new table; no XML change needed.
- `PassRepository` gains `createScannableCard` / `loadScannableCard` / `deleteScannableCard` / `observeScannableCards`. The repo orchestrates the kernel validator (`ScannableCardInputValidator`) at insert time and surfaces validator rejections through a new typed `StorageError.ScannableCardRejected` arm that preserves the kernel's `LabelRejection` / `PayloadRejection` reasons for the consumer's error UI.
- `StorageTelemetryGuard` adds three structural-only events (`onScannableCardCreated`, `onScannableCardDeleted`, `onScannableCardRejected`) — the rejection event carries only the `LabelInvalid` / `PayloadInvalid` bucket, never the offending payload or character (the no-PII-in-telemetry discipline).
- `SqlCipherScannableCardStore` hydrates every load through the validator a second time — defense-in-depth against on-disk tampering, since passes-core's `ScannableCard` internal constructor makes the validator the only legitimate public mint path.
- Sibling `ScannableCardRecordId` arm on the sealed `RecordId` interface keeps `IntegrityViolation` honest at the type level.
- Irreversible delete follows the same posture as `delete(passId)` and `deleteDocument(id)` — single-transaction row drop, StateFlow update, telemetry, no soft-delete, no VACUUM (ADR 0002 D6).

### UI (wpass-lzi.7)

- `ScannableCardView(card, modifier)` encodes the card via `BarcodeEncoder`, paints the resulting `BarcodeMatrix` as a 1-bit-per-module ARGB_8888 bitmap, and renders it with `BitmapPainter(filterQuality = FilterQuality.None)` so the per-module nearest-neighbor upscale preserves sharp edges at gate.
- Per-symbology minimum size table mirrors the existing `BarcodeView`: 240dp square for QR; 320x96dp for the four 1D symbologies. Encoder failures render as a same-sized `Spacer` placeholder rather than throwing.
- Card chrome — background tint, "Created by you" trust caption — is deliberately NOT here; that's the tile composable's job (wpass-lzi.8). Keeping this surface bare lets it be reused as the full-screen scan view without dragging tile chrome along.

## Naming

The epic notes record the BarcodeCard → ScannableCard rename decided in wpass-lzi.1 (`Children .2-.10 should rename references at claim time`). This PR uses `ScannableCard` / `ScannableCardView` / `ScannableCardRecordId` etc. throughout; the bd issue titles still say BarcodeCard because they predate the rename.

## Out of scope (intentionally deferred)

- **`update(card)`**: the issue lists update among CRUD methods, but `PassRepository` does not have an update method either (passes use `upsert` against the identity tuple, and `ScannableCard` has no identity tuple — the row id is the only identity). For users wanting to change a card's payload or label, delete + create is the natural flow. File-back if a real workflow needs it.
- **Instrumentation test for SQLCipher round-trip on the new table.** The `DocumentStore` pattern is to verify the contract at the Robolectric layer with a fake store; the SQLCipher integration is covered transitively by `CipherCompatReopenTest` (same SQLCipher handle, same DDL path).

## Test plan

- [x] `:passes-core:check` green
- [x] `:passes-storage:check` green (94 unit tests pass including the new `ScannableCardRepositoryTest` and the v2→v3 `SchemaMigrationTest` hops)
- [x] `:passes-ui:check` green (passes-ui `PublicApiSurfaceTest` extended with `ScannableFormat` exhaustive lock)
- [ ] `:passes-storage:connectedDebugAndroidTest` on a managed device (smoke against real SQLCipher) — reviewer's call whether to run