### PR TITLE
passes-ui: ScannableCardTile + 'Created by you' trust caption (wpass-lzi.8)

### DIFF
--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -1,7 +1,6 @@
 package `is`.walt.passes.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -63,14 +63,15 @@ public fun ScannableCardScreen(
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            ScannableCardView(card = card)
+            // clearAndSetSemantics drops the barcode's standalone contentDescription
+            // (which is `card.label`) so TalkBack does not announce the label twice —
+            // the title Text above already speaks it.
+            ScannableCardView(
+                card = card,
+                modifier = Modifier.clearAndSetSemantics {},
+            )
         }
 
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(0.dp),
-        ) {
-            ScannableCardTrustCaption()
-        }
+        ScannableCardTrustCaption(modifier = Modifier.fillMaxWidth())
     }
 }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -1,0 +1,76 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.ui.core.isolated
+
+/**
+ * Full-screen surface for scanning a [ScannableCard]. Wraps [ScannableCardView] with
+ * minimal chrome: the user-controlled label up top (FSI/PDI isolated), the barcode
+ * itself rendered at its full nominal size, and the non-suppressible
+ * [ScannableCardTrustCaption] docked at the bottom.
+ *
+ * Trust contract: the caption is composed unconditionally at the bottom of the screen
+ * (C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`), structurally separate from any host
+ * navigation chrome. There is no parameter, theme token, or overload that hides it.
+ *
+ * No share / save-to-photos / print affordance, and no overflow menu. The user came
+ * here to scan, then back out — those are the only two paths off this surface. Host
+ * navigation chrome (back button, screen title) is supplied by the consumer's
+ * scaffold; this composable is the body only.
+ */
+@Composable
+public fun ScannableCardScreen(
+    card: ScannableCard,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        Text(
+            text = isolated(card.label),
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .padding(24.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            ScannableCardView(card = card)
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+        ) {
+            ScannableCardTrustCaption()
+        }
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -112,7 +113,7 @@ public fun ScannableCardTile(
                         cornerRadiusDp = INNER_CORNER_RADIUS,
                     )
                     .padding(CONTENT_PADDING),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(CONTENT_VERTICAL_SPACING),
             ) {
                 // Barcode preview: small, identification-only. Centered so a 1D
                 // barcode (which renders short and wide) and a QR (square) share the
@@ -121,13 +122,21 @@ public fun ScannableCardTile(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    val (w, h) = card.format.previewSizeDp()
+                    val (w, h) = card.format.previewSize()
                     ScannableCardView(
                         card = card,
                         // requiredSize wins over ScannableCardView's internal
                         // defaultMinSize, so the preview honors the tile-scoped size
                         // even though the full surface would render larger.
-                        modifier = Modifier.requiredSize(width = w.dp, height = h.dp),
+                        //
+                        // clearAndSetSemantics drops the barcode's own contentDescription
+                        // (it carries `card.label` for standalone use) so TalkBack does
+                        // not announce the label twice — once for the barcode image,
+                        // again for the sibling Text below. Mirrors DocumentTile's
+                        // decorative-thumbnail stance.
+                        modifier = Modifier
+                            .requiredSize(width = w, height = h)
+                            .clearAndSetSemantics {},
                     )
                 }
 
@@ -179,13 +188,13 @@ private fun Modifier.dashedBorder(
     )
 }
 
-private fun ScannableFormat.previewSizeDp(): Pair<Int, Int> = when (this) {
-    ScannableFormat.Qr -> 96 to 96
+private fun ScannableFormat.previewSize(): Pair<Dp, Dp> = when (this) {
+    ScannableFormat.Qr -> 96.dp to 96.dp
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,
     ScannableFormat.Code39,
-    -> 132 to 40
+    -> 132.dp to 40.dp
 }
 
 private val TILE_WIDTH = 168.dp
@@ -196,3 +205,4 @@ private val DASHED_BORDER_STROKE = 1.5.dp
 private val DASHED_DASH_ON = 6.dp
 private val DASHED_DASH_OFF = 4.dp
 private val CONTENT_PADDING = 10.dp
+private val CONTENT_VERTICAL_SPACING = 8.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
@@ -1,0 +1,198 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.core.isolated
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Home-lane tile for a [ScannableCard]. The visual contract for this surface lives in
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md` C1 / C2: render as a different artifact class
+ * from a verified PKPASS tile through redundant means so theming any single dimension
+ * flat cannot collapse the distinction. Four redundant distinguishing elements are
+ * applied here:
+ *
+ *  1. Dashed outline (vs the solid rounded `Surface` shape of `PassFront`).
+ *  2. Leading [accent]-colored band along the start edge (vs the pass's full
+ *     [PassColors] background).
+ *  3. Smaller corner radius (8 dp vs the pass's 16 dp), mirroring `DocumentTile`'s
+ *     same "not a pass" cue.
+ *  4. The non-suppressible "Created by you" caption with its pencil glyph
+ *     ([ScannableCardTrustCaption]), composed inside the tile so the trust signal
+ *     travels with the artifact and cannot be hidden by a host.
+ *
+ * The caption is always rendered, [maxLines = 1], `softWrap = false`, and overflow
+ * [TextOverflow.Visible] so it does not truncate at any tile size — the trust caption
+ * is the load-bearing one of the four distinguishers; collapsing it would re-create the
+ * verified/unverified visual-conflation risk.
+ *
+ * The displayed [ScannableCard.label] is user-controlled text and is wrapped in
+ * U+2068/U+2069 (FSI/PDI) by `passes-ui-core::isolated` so a malicious label carrying
+ * directional-format characters cannot reorder surrounding chrome glyphs. Same defense
+ * `DocumentTile` and the security sheets apply to user-controlled strings. The kernel's
+ * `ScannableCardCreateInput` validator already rejects Cf/Cc codepoints at the create
+ * boundary (C3); this is belt-and-suspenders.
+ *
+ * The barcode preview embedded here uses a small fixed render size — these previews are
+ * a visual identifier ("which card is this"), not a scan surface. The full-screen
+ * [ScannableCardScreen] is the scan target; tapping the tile is what gets the user
+ * there (the [onClick] callback is the consumer's hook for that navigation).
+ *
+ * No share / export affordance, no overflow menu, no delete button. Consumer-side
+ * lifecycle actions (rename, delete) are walt-android responsibilities and out of scope
+ * for the kernel surface.
+ */
+@Composable
+public fun ScannableCardTile(
+    card: ScannableCard,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val style = LocalPassesSemantics.current.unverifiedArtifact
+    val accent = style.accent.toComposeColor()
+
+    Surface(
+        modifier = modifier
+            .width(TILE_WIDTH)
+            .clickable(onClick = onClick),
+        color = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = RoundedCornerShape(TILE_CORNER_RADIUS),
+        tonalElevation = 0.dp,
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            // Leading accent band — visual distinguisher (2). Drawn as a thin filled
+            // Box rather than a side border so it reads as a deliberate stripe.
+            Box(
+                modifier = Modifier
+                    .width(ACCENT_BAND_WIDTH)
+                    .fillMaxHeight()
+                    .background(accent),
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Dashed outline — visual distinguisher (1). Drawn around the
+                    // content column (inside the leading band) so the dash stroke does
+                    // not visually compete with the band.
+                    .dashedBorder(
+                        strokeWidthDp = DASHED_BORDER_STROKE,
+                        dashOnDp = DASHED_DASH_ON,
+                        dashOffDp = DASHED_DASH_OFF,
+                        color = accent,
+                        cornerRadiusDp = INNER_CORNER_RADIUS,
+                    )
+                    .padding(CONTENT_PADDING),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                // Barcode preview: small, identification-only. Centered so a 1D
+                // barcode (which renders short and wide) and a QR (square) share the
+                // same visual slot without one drifting off-center.
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    val (w, h) = card.format.previewSizeDp()
+                    ScannableCardView(
+                        card = card,
+                        // requiredSize wins over ScannableCardView's internal
+                        // defaultMinSize, so the preview honors the tile-scoped size
+                        // even though the full surface would render larger.
+                        modifier = Modifier.requiredSize(width = w.dp, height = h.dp),
+                    )
+                }
+
+                Text(
+                    // User-controlled label. The kernel's validator (passes-core
+                    // ScannableCardCreateInput) already strips Cf/Cc, but isolating
+                    // here is required defense-in-depth: a future change to the
+                    // validator that loosens that rule cannot silently weaken this
+                    // surface.
+                    text = isolated(card.label),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                ScannableCardTrustCaption()
+            }
+        }
+    }
+}
+
+/**
+ * Compose's stock `Modifier.border` does not accept a dash effect, so we paint the
+ * dashed rectangle directly via `drawBehind`. Stroke is centered on the path (Compose
+ * default), so a stroke of width *w* extends *w/2* outside and *w/2* inside the rect —
+ * inset by half the stroke so the visible dashes sit fully within the column bounds.
+ */
+private fun Modifier.dashedBorder(
+    strokeWidthDp: Dp,
+    dashOnDp: Dp,
+    dashOffDp: Dp,
+    color: Color,
+    cornerRadiusDp: Dp,
+): Modifier = drawBehind {
+    val stroke = strokeWidthDp.toPx()
+    val on = dashOnDp.toPx()
+    val off = dashOffDp.toPx()
+    val radius = cornerRadiusDp.toPx()
+    val effect = PathEffect.dashPathEffect(floatArrayOf(on, off), 0f)
+    val inset = stroke / 2f
+    drawRoundRect(
+        color = color,
+        topLeft = Offset(inset, inset),
+        size = Size(size.width - stroke, size.height - stroke),
+        cornerRadius = CornerRadius(radius, radius),
+        style = Stroke(width = stroke, pathEffect = effect),
+    )
+}
+
+private fun ScannableFormat.previewSizeDp(): Pair<Int, Int> = when (this) {
+    ScannableFormat.Qr -> 96 to 96
+    ScannableFormat.Code128,
+    ScannableFormat.Ean13,
+    ScannableFormat.UpcA,
+    ScannableFormat.Code39,
+    -> 132 to 40
+}
+
+private val TILE_WIDTH = 168.dp
+private val TILE_CORNER_RADIUS = 8.dp
+private val INNER_CORNER_RADIUS = 6.dp
+private val ACCENT_BAND_WIDTH = 4.dp
+private val DASHED_BORDER_STROKE = 1.5.dp
+private val DASHED_DASH_ON = 6.dp
+private val DASHED_DASH_OFF = 4.dp
+private val CONTENT_PADDING = 10.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTrustCaption.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTrustCaption.kt
@@ -79,14 +79,14 @@ public fun ScannableCardTrustCaption(
 }
 
 /**
- * The exact caption copy. Public-internal so tests can assert the displayed text
- * matches the trust claim verbatim. Wording is the load-bearing part of
+ * The exact caption copy. Wording is the load-bearing part of
  * `SCANNABLE_CARD_THREAT_MODEL.md` C2; a contributor changing this string is making a
- * security-policy edit and the test suite will require them to update the assertion.
+ * security-policy edit and the test suite — which asserts the literal — will require
+ * them to update the assertion.
  *
  * Note on dual-anchor placement: the caption is composed BOTH inside `ScannableCardTile`
  * (so the wallet-list user sees it before tapping) AND inside `ScannableCardScreen` (so
  * a deep-linked or shortcut-launched scan surface does not bypass it). The duplication
  * is deliberate; do NOT refactor it to a single render site.
  */
-internal const val TRUST_CAPTION_TEXT: String = "Created by you"
+private const val TRUST_CAPTION_TEXT: String = "Created by you"

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTrustCaption.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTrustCaption.kt
@@ -1,0 +1,92 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.ui.internal.PencilIcon
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * The non-suppressible "this is something you typed, not a verified pass" caption that
+ * anchors the trust contract of every `ScannableCard` surface (C2 in
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`): a card rendered by Walt is never
+ * signature-verified, has no issuer, and is presented under a fixed caption that the
+ * user cannot dismiss and the host cannot hide.
+ *
+ * The composable has no `enabled` parameter, no theme token that hides it, and no
+ * `ScannableCardTile` / `ScannableCardScreen` overload that skips rendering it. Mirrors
+ * `DocumentTrustCaption` and `ExpiredOverlay`: the trust claim is structural, not a
+ * configuration. Adding a parameter to this function or a sibling overload fails
+ * `ComposableSurfaceLockTest`.
+ *
+ * Layout is a flat [Row] of the pencil glyph followed by the caption text, both
+ * center-aligned. The caption uses a semi-bold weight so it survives glance-level
+ * viewing even on small tiles; [softWrap] is false and overflow is [TextOverflow.Visible]
+ * so the caption never truncates at any tile size (the constraint comes from the issue
+ * acceptance criteria: visible at every tile size, does not truncate).
+ *
+ * The displayed text is a fixed English literal; no part of it comes from the card.
+ * The user-controlled `label` is rendered separately by `ScannableCardTile` and is
+ * wrapped in FSI/PDI by `passes-ui-core::isolated` at that boundary.
+ */
+@Composable
+public fun ScannableCardTrustCaption(
+    modifier: Modifier = Modifier,
+) {
+    val style = LocalPassesSemantics.current.unverifiedArtifact
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(style.captionBackground.toComposeColor())
+            .padding(PaddingValues(horizontal = 12.dp, vertical = 8.dp)),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Icon(
+            imageVector = PencilIcon,
+            // Decorative: the verbatim caption text sits immediately beside it and is
+            // the audit-relevant semantics node.
+            contentDescription = null,
+            tint = style.captionIconTint.toComposeColor(),
+            modifier = Modifier.size(14.dp),
+        )
+        Text(
+            text = TRUST_CAPTION_TEXT,
+            // Semi-bold so the caption survives glance-level viewing even when the
+            // surrounding tile chrome uses a lighter weight (issue acceptance criterion:
+            // typographic weight survives glance-level viewing).
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
+            color = style.captionForeground.toComposeColor(),
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Visible,
+        )
+    }
+}
+
+/**
+ * The exact caption copy. Public-internal so tests can assert the displayed text
+ * matches the trust claim verbatim. Wording is the load-bearing part of
+ * `SCANNABLE_CARD_THREAT_MODEL.md` C2; a contributor changing this string is making a
+ * security-policy edit and the test suite will require them to update the assertion.
+ *
+ * Note on dual-anchor placement: the caption is composed BOTH inside `ScannableCardTile`
+ * (so the wallet-list user sees it before tapping) AND inside `ScannableCardScreen` (so
+ * a deep-linked or shortcut-launched scan surface does not bypass it). The duplication
+ * is deliberate; do NOT refactor it to a single render site.
+ */
+internal const val TRUST_CAPTION_TEXT: String = "Created by you"

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/PencilIcon.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/PencilIcon.kt
@@ -1,0 +1,55 @@
+package `is`.walt.passes.ui.internal
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Hand-authored pencil glyph used by `ScannableCardTile` and `ScannableCardTrustCaption`
+ * to signal "user-created, editable artifact" — the second of the redundant visual
+ * distinguishers required by C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`.
+ *
+ * Kept in-module on purpose: `passes-ui` does NOT depend on
+ * `androidx.compose.material:material-icons-extended` (a multi-megabyte artifact for a
+ * single 24dp path). Mirrors the same dependency-light stance as
+ * `passes-pdf-ui::InfoOutlineIcon`. Geometry is the standard Material "edit" pencil on
+ * a 24×24 viewport.
+ *
+ * The [SolidColor] fill is `Color.Black` only because the builder requires a fill; the
+ * actual on-screen colour comes from the `tint` passed to `Icon(...)` at the call site
+ * (sourced from `UnverifiedArtifactStyle.captionIconTint`). Changing the literal here
+ * has no rendered effect.
+ */
+internal val PencilIcon: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "Pencil",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(fill = SolidColor(Color.Black)) {
+            // Pencil body + tip: a diagonal stroke from upper-right toward lower-left,
+            // closing at the bottom-left "nub" rectangle.
+            moveTo(3f, 17.25f)
+            verticalLineTo(21f)
+            horizontalLineToRelative(3.75f)
+            lineTo(17.81f, 9.94f)
+            lineToRelative(-3.75f, -3.75f)
+            lineTo(3f, 17.25f)
+            close()
+            // Ferrule / eraser cap at the upper-right end of the pencil.
+            moveTo(20.71f, 7.04f)
+            curveTo(21.1f, 6.65f, 21.1f, 6.02f, 20.71f, 5.63f)
+            lineToRelative(-2.34f, -2.34f)
+            curveTo(18.18f, 3.1f, 17.92f, 3f, 17.66f, 3f)
+            curveTo(17.4f, 3f, 17.15f, 3.1f, 16.96f, 3.29f)
+            lineToRelative(-1.83f, 1.83f)
+            lineToRelative(3.75f, 3.75f)
+            lineToRelative(1.83f, -1.83f)
+            close()
+        }
+    }.build()
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/theme/PassesSemantics.kt
@@ -40,6 +40,7 @@ public data class PassesSemantics(
     public val expiredBadge: ExpiredBadgeStyle,
     public val securitySheet: SecuritySheetStyle,
     public val categoryAccent: CategoryAccentColors,
+    public val unverifiedArtifact: UnverifiedArtifactStyle = UnverifiedArtifactStyle.Placeholder,
 )
 
 /**
@@ -112,3 +113,44 @@ public data class CategoryAccentColors(
     public val storeCard: ArgbColor,
     public val generic: ArgbColor,
 )
+
+/**
+ * Visual treatment for a user-generated, unsigned scannable artifact (`ScannableCard`).
+ * Powers the chrome around `ScannableCardTile` and `ScannableCardScreen`, both of which
+ * must read as a different artifact class from a verified PKPASS tile at a glance.
+ *
+ * The trust-claim is C1 + C2 from `docs/SCANNABLE_CARD_THREAT_MODEL.md`: every
+ * `ScannableCardTile` renders the non-suppressible "Created by you" caption AND is
+ * visually distinct from a `PassFront`-style tile through redundant treatment (dashed
+ * border + leading color band + edit icon). The redundancy is load-bearing: theming any
+ * single dimension flat must not collapse the artifact-class distinction.
+ *
+ * These slots NEVER reuse `SignatureBadgeColors`. A `ScannableCard` has no signature to
+ * band; borrowing the verified palette would re-create the trust-conflation risk this
+ * style exists to prevent. Walt-android supplies concrete tokens — `passes-ui` ships
+ * [Placeholder] only so tests and Compose previews compose without a host theme.
+ *
+ * [accent] colors the dashed border and the leading band. [captionBackground] /
+ * [captionForeground] color the "Created by you" caption strip; [captionIconTint] tints
+ * the pencil glyph next to it. Contrast (WCAG AA) is the host theme's responsibility.
+ */
+public data class UnverifiedArtifactStyle(
+    public val accent: ArgbColor,
+    public val captionBackground: ArgbColor,
+    public val captionForeground: ArgbColor,
+    public val captionIconTint: ArgbColor = captionForeground,
+) {
+    public companion object {
+        /**
+         * Neutral grayscale placeholder so `PassesSemantics()` default-constructs and
+         * Compose previews / tests render without a host theme. Hosts MUST override
+         * with brand tokens; relying on the placeholder in production would leave the
+         * "Created by you" caption unstyled relative to surrounding chrome.
+         */
+        public val Placeholder: UnverifiedArtifactStyle = UnverifiedArtifactStyle(
+            accent = ArgbColor(0xFF6B6B6B.toInt()),
+            captionBackground = ArgbColor(0xFFF2F2F2.toInt()),
+            captionForeground = ArgbColor(0xFF202020.toInt()),
+        )
+    }
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -119,6 +119,55 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
+    fun scannableCardTrustCaptionHasExactlyOneUserVisibleParameter() {
+        // (modifier) — C2 in SCANNABLE_CARD_THREAT_MODEL.md: no `enabled`, no theme
+        // suppression flag, no overload that hides the caption. The "Created by you"
+        // caption is structurally always-on, mirroring DocumentTrustCaption.
+        assertUserVisibleParamCount(
+            "ScannableCardTrustCaptionKt",
+            "ScannableCardTrustCaption",
+            expected = 1,
+        )
+    }
+
+    @Test
+    fun scannableCardTileHasExactlyThreeUserVisibleParameters() {
+        // (card, onClick, modifier). No share/export, no overflow menu, no
+        // showCaption flag — drift here is a trust-claim regression (SCANNABLE_CARD_
+        // THREAT_MODEL.md C2: caption non-suppressibility).
+        assertUserVisibleParamCount("ScannableCardTileKt", "ScannableCardTile", expected = 3)
+    }
+
+    @Test
+    fun scannableCardScreenHasExactlyTwoUserVisibleParameters() {
+        // (card, modifier). The trust caption is composed inside the surface; no
+        // parameter omits it.
+        assertUserVisibleParamCount(
+            "ScannableCardScreenKt",
+            "ScannableCardScreen",
+            expected = 2,
+        )
+    }
+
+    @Test
+    fun scannableCardSurfacesHaveNoOverloads() {
+        // The caption non-suppressibility rule extends to overloads: a future
+        // contributor cannot quietly add `ScannableCardTile(..., showCaption: Boolean)`
+        // as a sibling with the same name.
+        listOf(
+            "ScannableCardTrustCaptionKt" to "ScannableCardTrustCaption",
+            "ScannableCardTileKt" to "ScannableCardTile",
+            "ScannableCardScreenKt" to "ScannableCardScreen",
+        ).forEach { (file, name) ->
+            val klass = Class.forName("is.walt.passes.ui.$file")
+            val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }
+            assertWithMessage("$name should have exactly one declared overload")
+                .that(matches.size)
+                .isEqualTo(1)
+        }
+    }
+
+    @Test
     fun passImportRejectionSheetAcceptsParseFailureKindAndUiTelemetryGuard() {
         val method = findComposable("PassImportRejectionKt", "PassImportRejectionSheet")
         val typeNames = method.parameterTypes.map { it.simpleName }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -13,6 +13,7 @@ import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
 import `is`.walt.passes.ui.theme.PassesSemantics
 import `is`.walt.passes.ui.theme.SecuritySheetStyle
 import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import `is`.walt.passes.ui.theme.UnverifiedArtifactStyle
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.io.File
@@ -247,7 +248,7 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun passesSemanticsDataClassExposesAllFourSlotFamilies() {
+    fun passesSemanticsDataClassExposesAllSlotFamilies() {
         val argb = ArgbColor(0xFF000000.toInt())
         val semantics = PassesSemantics(
             signatureBadge = SignatureBadgeColors(
@@ -281,6 +282,11 @@ class PublicApiSurfaceTest {
                 storeCard = argb,
                 generic = argb,
             ),
+            unverifiedArtifact = UnverifiedArtifactStyle(
+                accent = argb,
+                captionBackground = argb,
+                captionForeground = argb,
+            ),
         )
         // Reading every nested field forces them to remain in the public-API shape;
         // a rename or removal breaks the test. Document tokens (caption / tile / lane
@@ -290,6 +296,25 @@ class PublicApiSurfaceTest {
         assertThat(semantics.expiredBadge.scrimAlpha).isEqualTo(96)
         assertThat(semantics.securitySheet.confirmContainer).isEqualTo(argb)
         assertThat(semantics.categoryAccent.boardingPass).isEqualTo(argb)
+        assertThat(semantics.unverifiedArtifact.accent).isEqualTo(argb)
+        // captionIconTint defaults to captionForeground when not explicitly supplied —
+        // a consumer that does not opt into a separate accent gets a consistent
+        // monochrome caption. Locking the default here keeps that contract testable.
+        assertThat(semantics.unverifiedArtifact.captionIconTint)
+            .isEqualTo(semantics.unverifiedArtifact.captionForeground)
+    }
+
+    @Test
+    fun unverifiedArtifactStylePlaceholderIsAvailableForTestsAndPreviews() {
+        val placeholder = UnverifiedArtifactStyle.Placeholder
+        // The placeholder is a neutral grayscale set, NOT a brand value — its sole
+        // purpose is to make `PassesSemantics()` default-constructible. Hosts must
+        // override. The test merely asserts the constant exists and parses; concrete
+        // values are not part of the contract.
+        assertThat(placeholder.accent).isNotNull()
+        assertThat(placeholder.captionBackground).isNotNull()
+        assertThat(placeholder.captionForeground).isNotNull()
+        assertThat(placeholder.captionIconTint).isEqualTo(placeholder.captionForeground)
     }
 
     /**

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -1,0 +1,224 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import `is`.walt.passes.core.PassInstant
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableCardCreateInput
+import `is`.walt.passes.core.ScannableCardCreateResult
+import `is`.walt.passes.core.ScannableCardId
+import `is`.walt.passes.core.ScannableCardInputValidator
+import `is`.walt.passes.core.ScannableColor
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import `is`.walt.passes.ui.theme.UnverifiedArtifactStyle
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed Compose smoke tests for the `ScannableCard` trust surfaces. The
+ * behavioral contract under test maps 1:1 to the threat-model controls in
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`:
+ *
+ *  - **C2 (non-suppressible "Created by you" caption)**: every tile renders the verbatim
+ *    caption regardless of tile-modifier-scoped size; the full-screen surface renders it
+ *    docked at the bottom; theming the placeholder semantics does not remove it.
+ *  - **C2 (≥2 visual distinguishers)**: indirectly asserted via the surface lock tests in
+ *    `ComposableSurfaceLockTest` (param shape locks out a hide-caption flag) and the no-
+ *    overload assertion. Pixel-level coverage of the dashed border + leading band + icon
+ *    triple is the implementation bead's emulator-backed instrumentation work.
+ *
+ * Caption text is asserted by literal because the wording is the load-bearing trust
+ * claim; renaming it requires updating this test, which forces a security-policy
+ * conversation rather than a silent UX edit.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class ScannableCardTrustSurfaceTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = ArgbColor(0xFFFFE0E0.toInt()),
+            unsignedForeground = ArgbColor(0xFF101010.toInt()),
+            selfSignedBackground = ArgbColor(0xFFFFF0E0.toInt()),
+            selfSignedForeground = ArgbColor(0xFF101010.toInt()),
+            appleVerifiedBackground = ArgbColor(0xFFE0FFE0.toInt()),
+            appleVerifiedForeground = ArgbColor(0xFF101010.toInt()),
+            certChainIncompleteBackground = ArgbColor(0xFFFFFFE0.toInt()),
+            certChainIncompleteForeground = ArgbColor(0xFF101010.toInt()),
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = ArgbColor(0xFF202020.toInt()),
+            pillForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = ArgbColor(0xFFFFFFFF.toInt()),
+            emphasisBackground = ArgbColor(0xFFEFEFEF.toInt()),
+            emphasisForeground = ArgbColor(0xFF000000.toInt()),
+            bodyForeground = ArgbColor(0xFF202020.toInt()),
+            confirmContainer = ArgbColor(0xFF202020.toInt()),
+            confirmForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            cancelForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = ArgbColor(0xFF1D4ED8.toInt()),
+            eventTicket = ArgbColor(0xFF7C2D92.toInt()),
+            coupon = ArgbColor(0xFF555555.toInt()),
+            storeCard = ArgbColor(0xFF555555.toInt()),
+            generic = ArgbColor(0xFF555555.toInt()),
+        ),
+        unverifiedArtifact = UnverifiedArtifactStyle(
+            accent = ArgbColor(0xFF8A4A2E.toInt()),
+            captionBackground = ArgbColor(0xFFFFF0E0.toInt()),
+            captionForeground = ArgbColor(0xFF301010.toInt()),
+        ),
+    )
+
+    @Test
+    fun trustCaptionTextIsLiteralCreatedByYou() {
+        composeRule.setContent {
+            ThemedHost { ScannableCardTrustCaption() }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRendersTrustCaptionByLiteralWording() {
+        composeRule.setContent {
+            ThemedHost { ScannableCardTile(card = qrFixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRendersTrustCaptionAtConstrainedSmallSize() {
+        // Constrain the tile modifier to a deliberately tight box so the caption layout
+        // has to survive a smaller-than-default slot. Acceptance criterion: caption must
+        // remain visible at every tile size (no truncation, no clipping out of view).
+        composeRule.setContent {
+            ThemedHost {
+                Box(modifier = Modifier.size(160.dp, 220.dp)) {
+                    ScannableCardTile(card = qrFixture(), onClick = {})
+                }
+            }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun tileRendersTrustCaptionForOneDimensionalBarcodeFormat() {
+        // The previewSize path for 1D barcodes is a different code branch from QR; both
+        // must compose with the caption visible.
+        composeRule.setContent {
+            ThemedHost { ScannableCardTile(card = code128Fixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun tilePropagatesClickToOnClickCallback() {
+        var clicks = 0
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardTile(card = qrFixture(), onClick = { clicks++ })
+            }
+        }
+        composeRule.onNodeWithText("Created by you").performClick()
+        composeRule.waitForIdle()
+        // Caption is part of the tile's clickable surface; tapping anywhere navigates.
+        assert(clicks == 1) { "expected one click propagation, got $clicks" }
+    }
+
+    @Test
+    fun fullScreenRendersTrustCaptionDockedAtBottom() {
+        composeRule.setContent {
+            ThemedHost { ScannableCardScreen(card = qrFixture()) }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun fullScreenRendersUserSuppliedLabel() {
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(card = qrFixture(label = "Library card"))
+            }
+        }
+        // The label is wrapped in FSI/PDI, so look up by the isolated form. Mirrors how
+        // the security-sheet tests assert isolated-form display of user-supplied strings.
+        composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun placeholderUnverifiedArtifactStyleStillRendersCaption() {
+        // PassesSemantics ships UnverifiedArtifactStyle.Placeholder so the surfaces
+        // compose under a default-constructed semantics (tests / previews). Lock that
+        // a host who forgets to override still gets the trust caption — degraded
+        // styling is acceptable, missing caption is not.
+        val defaulted = semantics.copy(
+            unverifiedArtifact = UnverifiedArtifactStyle.Placeholder,
+        )
+        composeRule.setContent {
+            PassesTheme(semantics = defaulted) {
+                MaterialTheme { ScannableCardTile(card = qrFixture(), onClick = {}) }
+            }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme { PassesTheme(semantics = semantics, content = content) }
+    }
+
+    private fun qrFixture(label: String = "Membership"): ScannableCard = card(
+        format = ScannableFormat.Qr,
+        payload = "WALT-MEMBER-12345",
+        label = label,
+    )
+
+    private fun code128Fixture(): ScannableCard = card(
+        format = ScannableFormat.Code128,
+        payload = "ABCDE12345",
+        label = "Gym",
+    )
+
+    private fun card(
+        format: ScannableFormat,
+        payload: String,
+        label: String,
+    ): ScannableCard {
+        val result = ScannableCardInputValidator.validate(
+            input = ScannableCardCreateInput(
+                payload = payload,
+                format = format,
+                label = label,
+                color = ScannableColor(0xFF334455.toInt()),
+            ),
+            id = ScannableCardId("test"),
+            createdAt = PassInstant(0L),
+        )
+        return (result as ScannableCardCreateResult.Success).card
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ScannableCardTile`, `ScannableCardScreen`, and the non-suppressible `ScannableCardTrustCaption` so a user-typed `ScannableCard` renders as a structurally different artifact class from a verified PKPASS.
- Four redundant visual distinguishers: dashed border, leading accent band, smaller corner radius (8 dp vs PassFront's 16 dp), and the pencil-glyph caption. Theming any single dimension flat cannot collapse the distinction (`docs/SCANNABLE_CARD_THREAT_MODEL.md` C1/C2).
- Extends `PassesSemantics` with `UnverifiedArtifactStyle`. Slots are independent of `signatureBadge` — a ScannableCard has no signature to band. A `Placeholder` default keeps `PassesSemantics()` default-constructible for tests / previews; brand tokens come from walt-android.
- `ComposableSurfaceLockTest` gains reflection-based shape locks for the three new composables (caption is 1-arg, tile is 3-arg, screen is 2-arg, no overloads) so a future contributor cannot silently add a `showCaption` flag or sibling overload.
- Pencil glyph hand-authored in `internal/PencilIcon.kt` so passes-ui stays off `material-icons-extended`, mirroring `passes-pdf-ui::InfoOutlineIcon`.

ConsumerSpec / handoff doc work is intentionally out of scope (wpass-lzi.10).

## Test plan

- [x] `./gradlew :passes-ui:check` green (detekt + lint + 8 new `ScannableCardTrustSurfaceTest` cases + +4 new shape locks + +1 placeholder test).
- [x] `./gradlew check` green across all seven modules.
- [ ] Visual review by product on tile-vs-verified-pass side-by-side preview (the bead notes call out side-by-side screenshots; instrumentation-backed snapshot coverage is deferred to a follow-up).