### PR TITLE
passes-ui: create-time QR URI-scheme confirmation gate (wpass-lzi.9)

### DIFF
--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -190,6 +190,53 @@ The sheets fire `telemetry.onSecuritySheetShown` on first composition,
 `telemetry.onSecuritySheetDismissed` on any other dismissal. Confirming closes the
 sheet AND calls `onConfirm`; dismissal closes WITHOUT firing `onConfirm`.
 
+## Create-time URI confirmation gate (QR only)
+
+```kotlin
+/**
+ * Create-time URI-scheme confirmation gate for a QR `ScannableCard`. Shown by the
+ * consumer's create flow between input validation and persistence whenever the
+ * classified [QrPayloadKind] would auto-act on a future scanner phone. Cancel is
+ * the focused, filled action; Confirm is the lower-emphasis text button - inverted
+ * from B3UrlConfirmSheet by design. Payload renders verbatim, wrapped in FSI/PDI
+ * via `isolated()`; crypto addresses (Bitcoin / Ethereum) render in full with
+ * monospace + wrap so create-time transcription review can see every character.
+ *
+ * [QrPayloadKind.PlainText] short-circuits to no output, so callers can keep the
+ * gate unconditional; [requiresCreateConfirmation] lets callers branch when they
+ * want to skip the composable entirely.
+ *
+ * NOTE: this surface ships WITHOUT a `telemetry: UiTelemetryGuard` parameter -
+ * deliberate deferral, tracked under wpass-rnv. The other security sheets emit
+ * `onSecuritySheetShown` / `Confirmed` / `Dismissed`; the create-time gate is
+ * invisible to that dashboard until that bead lands. ComposableSurfaceLockTest
+ * pins the three-param shape so re-adding a guard is a deliberate edit, not a
+ * silent drift.
+ */
+@Composable
+public fun BarcodeCreateConfirmSheet(
+    payloadKind: QrPayloadKind,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+)
+
+/**
+ * Returns `false` only for [QrPayloadKind.PlainText]. Consumer create flows
+ * branch on this to persist a plain-text QR directly without invoking the gate.
+ */
+public fun QrPayloadKind.requiresCreateConfirmation(): Boolean
+
+/**
+ * Test tags for the two action buttons on `BarcodeCreateConfirmSheet`. Exposed
+ * so per-arm focus and click assertions can target the buttons structurally
+ * rather than by their localized labels.
+ */
+public object BarcodeCreateConfirmTestTags {
+    public const val Cancel: String
+    public const val Confirm: String
+}
+```
+
 ## Expired badge
 
 ```kotlin
@@ -250,3 +297,7 @@ security-policy edit, not a refactor:
    higher caps.
 5. The security confirmation sheets do not accept a "skip confirmation" parameter.
    The host's outbound `Intent` fires only on user confirm.
+6. `BarcodeCreateConfirmSheet` does not accept a `skipConfirmation`, per-arm
+   silence flag, or "auto-confirm safe arms" toggle. PlainText is the only arm
+   that short-circuits the gate, and that branch lives in the composable, not
+   in a caller-visible parameter.

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -1,0 +1,241 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.QrPayloadKind
+import `is`.walt.passes.ui.core.isolated
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Create-time URI-scheme confirmation gate for a QR `ScannableCard`. Mirrors the
+ * verbatim-rendering / FSI-PDI isolation / trust-styling-token posture of the
+ * back-field [B3UrlConfirmSheet], but inverts the button prominence: Cancel is the
+ * focused, filled action; Confirm is the lower-emphasis text button. The dialog
+ * runs between input validation and persistence so a payload classified by
+ * [QrPayloadKind] as auto-acting on a future scanner phone cannot land in the
+ * wallet without an explicit confirm tap.
+ *
+ * Triggered ONLY for the QR symbology - linear formats do not auto-act when
+ * scanned and skip this gate at the caller. [QrPayloadKind.PlainText] also skips:
+ * the composable short-circuits to no output so the caller's create flow can be a
+ * single unconditional `BarcodeCreateConfirmSheet` invocation.
+ *
+ * The trust claim that this gate enforces is "the user saw, in their own typed
+ * form, what a scanner phone would do" - the verbatim payload is the load-bearing
+ * surface. Wrapping it in [isolated] is defense in depth against any residual
+ * directional context surrounding the sheet chrome; the upstream validator
+ * (wpass-lzi.4) already rejects Cf/Cc characters in the payload itself.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+public fun BarcodeCreateConfirmSheet(
+    payloadKind: QrPayloadKind,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    if (payloadKind is QrPayloadKind.PlainText) return
+
+    val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val emphasis = LocalPassesSemantics.current.securitySheet
+    val cancelFocus = remember { FocusRequester() }
+    // Cancel-default focus: the prominent action wins keyboard / d-pad focus on
+    // open so muscle memory pointed at the primary slot lands on Cancel.
+    LaunchedEffect(payloadKind) { runCatching { cancelFocus.requestFocus() } }
+
+    ModalBottomSheet(
+        onDismissRequest = onCancel,
+        sheetState = sheetState,
+        containerColor = emphasis.sheetBackground.toComposeColor(),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(PaddingValues(horizontal = 24.dp, vertical = 16.dp)),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BarcodeCreateBody(payloadKind = payloadKind, emphasis = emphasis)
+            BarcodeCreateActions(
+                emphasis = emphasis,
+                cancelFocus = cancelFocus,
+                onConfirm = onConfirm,
+                onCancel = onCancel,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BarcodeCreateBody(
+    payloadKind: QrPayloadKind,
+    emphasis: SecuritySheetStyle,
+) {
+    val message = barcodeCreateMessage(payloadKind)
+    val verbatim = verbatimForKind(payloadKind)
+    Text(
+        text = stringResource(R.string.barcode_create_confirm_title),
+        style = MaterialTheme.typography.headlineSmall,
+        color = emphasis.bodyForeground.toComposeColor(),
+    )
+    Text(
+        text = message,
+        style = MaterialTheme.typography.bodyMedium,
+        color = emphasis.bodyForeground.toComposeColor(),
+    )
+    if (verbatim != null) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(emphasis.emphasisBackground.toComposeColor())
+                .padding(16.dp),
+        ) {
+            Text(
+                // User-controlled payload data, fenced in FSI/PDI so any
+                // directional context cannot reorder it against chrome.
+                text = isolated(verbatim),
+                style = MaterialTheme.typography.bodyLarge,
+                color = emphasis.emphasisForeground.toComposeColor(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BarcodeCreateActions(
+    emphasis: SecuritySheetStyle,
+    cancelFocus: FocusRequester,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
+    ) {
+        // Confirm is the low-emphasis text button - inverted from B3Url so a
+        // stray dismissal lands on Cancel, not on a silent persist.
+        TextButton(
+            onClick = onConfirm,
+            modifier = Modifier.testTag(BarcodeCreateConfirmTestTags.Confirm),
+            colors = ButtonDefaults.textButtonColors(
+                contentColor = emphasis.cancelForeground.toComposeColor(),
+            ),
+        ) {
+            Text(stringResource(R.string.barcode_create_confirm_confirm))
+        }
+        Button(
+            onClick = onCancel,
+            modifier = Modifier
+                .focusRequester(cancelFocus)
+                .testTag(BarcodeCreateConfirmTestTags.Cancel),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = emphasis.confirmContainer.toComposeColor(),
+                contentColor = emphasis.confirmForeground.toComposeColor(),
+            ),
+        ) {
+            Text(stringResource(R.string.barcode_create_confirm_cancel))
+        }
+    }
+}
+
+/**
+ * Whether [BarcodeCreateConfirmSheet] should be invoked for [QrPayloadKind]. Returns
+ * `false` only for [QrPayloadKind.PlainText]; callers branch on this to persist a
+ * plain-text QR directly without showing a no-op sheet.
+ */
+public fun QrPayloadKind.requiresCreateConfirmation(): Boolean =
+    this !is QrPayloadKind.PlainText
+
+/**
+ * Test tags for the two action buttons. Exposed so per-arm focus and click assertions
+ * in `BarcodeCreateConfirmSheetTest` (and any host smoke test) can target the buttons
+ * structurally rather than by their localized labels.
+ */
+public object BarcodeCreateConfirmTestTags {
+    public const val Cancel: String = "barcode-create-confirm:cancel"
+    public const val Confirm: String = "barcode-create-confirm:confirm"
+}
+
+/**
+ * Crypto-address mask: first 6 and last 6 characters, ellipsis in the middle. Below
+ * the 14-character threshold the address fits without truncation.
+ */
+internal fun maskAddress(address: String): String =
+    if (address.length <= 14) address else "${address.take(6)}...${address.takeLast(6)}"
+
+/**
+ * Per-arm dispatcher for the warning sentence shown above the verbatim payload.
+ * Cyclomatic complexity is load-bearing: every [QrPayloadKind] arm enumerated in
+ * one place forces adding a new arm in `passes-core` to surface here as a missing-
+ * branch compile error, rather than silently rendering an empty warning.
+ */
+@Composable
+@Suppress("CyclomaticComplexMethod")
+private fun barcodeCreateMessage(kind: QrPayloadKind): String = when (kind) {
+    is QrPayloadKind.PlainText -> ""
+    is QrPayloadKind.Url -> stringResource(R.string.barcode_create_confirm_url)
+    is QrPayloadKind.Phone -> stringResource(R.string.barcode_create_confirm_phone)
+    is QrPayloadKind.Sms -> stringResource(R.string.barcode_create_confirm_sms)
+    is QrPayloadKind.Mailto -> stringResource(R.string.barcode_create_confirm_mailto)
+    is QrPayloadKind.Geo -> stringResource(R.string.barcode_create_confirm_geo)
+    is QrPayloadKind.Wifi -> wifiMessage(kind.ssid)
+    is QrPayloadKind.Bitcoin -> stringResource(R.string.barcode_create_confirm_bitcoin)
+    is QrPayloadKind.Ethereum -> stringResource(R.string.barcode_create_confirm_ethereum)
+    QrPayloadKind.Magnet -> stringResource(R.string.barcode_create_confirm_magnet)
+    is QrPayloadKind.Market -> stringResource(R.string.barcode_create_confirm_market)
+    is QrPayloadKind.Intent -> stringResource(R.string.barcode_create_confirm_intent)
+    is QrPayloadKind.UnknownScheme -> stringResource(R.string.barcode_create_confirm_unknown)
+}
+
+@Composable
+private fun wifiMessage(ssid: String?): String =
+    if (ssid != null) stringResource(R.string.barcode_create_confirm_wifi)
+    else stringResource(R.string.barcode_create_confirm_wifi_unnamed)
+
+/**
+ * Per-arm dispatcher for the verbatim payload string rendered in the emphasis
+ * panel. Same load-bearing-complexity rationale as [barcodeCreateMessage].
+ */
+@Suppress("CyclomaticComplexMethod")
+internal fun verbatimForKind(kind: QrPayloadKind): String? = when (kind) {
+    is QrPayloadKind.PlainText -> null
+    is QrPayloadKind.Url -> kind.host ?: kind.raw
+    is QrPayloadKind.Phone -> kind.number
+    is QrPayloadKind.Sms -> kind.number
+    is QrPayloadKind.Mailto -> kind.address
+    is QrPayloadKind.Geo -> kind.coords
+    is QrPayloadKind.Wifi -> kind.ssid
+    is QrPayloadKind.Bitcoin -> maskAddress(kind.address)
+    is QrPayloadKind.Ethereum -> maskAddress(kind.address)
+    QrPayloadKind.Magnet -> null
+    is QrPayloadKind.Market -> kind.productId
+    is QrPayloadKind.Intent -> kind.raw
+    is QrPayloadKind.UnknownScheme -> kind.raw
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -58,6 +58,11 @@ import `is`.walt.passes.ui.theme.toComposeColor
  * hide them. Wrapping in [isolated] is defense in depth against any residual
  * directional context surrounding the sheet chrome; the upstream validator
  * (wpass-lzi.4) already rejects Cf/Cc characters in the payload itself.
+ *
+ * NOTE: this surface ships WITHOUT a `telemetry: UiTelemetryGuard` parameter -
+ * deferred to wpass-rnv. The other security sheets emit show / confirm / dismiss
+ * events, so the create-time gate is invisible to walt-android's dismissal-rate
+ * dashboard until that bead lands.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -136,7 +141,6 @@ private fun BarcodeCreateBody(
                 style = MaterialTheme.typography.bodyLarge,
                 color = emphasis.emphasisForeground.toComposeColor(),
                 fontFamily = if (isCryptoAddress) FontFamily.Monospace else null,
-                softWrap = true,
             )
         }
     }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.QrPayloadKind
 import `is`.walt.passes.ui.core.isolated
@@ -38,10 +39,11 @@ import `is`.walt.passes.ui.theme.toComposeColor
  * Create-time URI-scheme confirmation gate for a QR `ScannableCard`. Mirrors the
  * verbatim-rendering / FSI-PDI isolation / trust-styling-token posture of the
  * back-field [B3UrlConfirmSheet], but inverts the button prominence: Cancel is the
- * focused, filled action; Confirm is the lower-emphasis text button. The dialog
- * runs between input validation and persistence so a payload classified by
- * [QrPayloadKind] as auto-acting on a future scanner phone cannot land in the
- * wallet without an explicit confirm tap.
+ * focused, filled action; Confirm is the lower-emphasis text button. That divergence
+ * is pinned by `ComposableSurfaceLockTest`; a future neighbor refactor that resyncs
+ * the two will trip the lock. The dialog runs between input validation and
+ * persistence so a payload classified by [QrPayloadKind] as auto-acting on a future
+ * scanner phone cannot land in the wallet without an explicit confirm tap.
  *
  * Triggered ONLY for the QR symbology - linear formats do not auto-act when
  * scanned and skip this gate at the caller. [QrPayloadKind.PlainText] also skips:
@@ -50,7 +52,10 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *
  * The trust claim that this gate enforces is "the user saw, in their own typed
  * form, what a scanner phone would do" - the verbatim payload is the load-bearing
- * surface. Wrapping it in [isolated] is defense in depth against any residual
+ * surface. Crypto addresses are rendered in full (monospace + wrap) rather than
+ * masked: at create time the user is verifying their own transcription, and base58
+ * / hex typos accumulate in the middle of the string - exactly where a mask would
+ * hide them. Wrapping in [isolated] is defense in depth against any residual
  * directional context surrounding the sheet chrome; the upstream validator
  * (wpass-lzi.4) already rejects Cf/Cc characters in the payload itself.
  */
@@ -67,8 +72,11 @@ public fun BarcodeCreateConfirmSheet(
     val emphasis = LocalPassesSemantics.current.securitySheet
     val cancelFocus = remember { FocusRequester() }
     // Cancel-default focus: the prominent action wins keyboard / d-pad focus on
-    // open so muscle memory pointed at the primary slot lands on Cancel.
-    LaunchedEffect(payloadKind) { runCatching { cancelFocus.requestFocus() } }
+    // open so muscle memory pointed at the primary slot lands on Cancel. The
+    // LaunchedEffect fires after composition, so the requester is attached by
+    // the time requestFocus() runs; a throw here is a real regression worth
+    // surfacing, not swallowing.
+    LaunchedEffect(payloadKind) { cancelFocus.requestFocus() }
 
     ModalBottomSheet(
         onDismissRequest = onCancel,
@@ -110,6 +118,10 @@ private fun BarcodeCreateBody(
         color = emphasis.bodyForeground.toComposeColor(),
     )
     if (verbatim != null) {
+        // Crypto addresses get monospace + wrap so every character is
+        // distinguishable for create-time transcription review.
+        val isCryptoAddress = payloadKind is QrPayloadKind.Bitcoin ||
+            payloadKind is QrPayloadKind.Ethereum
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -123,6 +135,8 @@ private fun BarcodeCreateBody(
                 text = isolated(verbatim),
                 style = MaterialTheme.typography.bodyLarge,
                 color = emphasis.emphasisForeground.toComposeColor(),
+                fontFamily = if (isCryptoAddress) FontFamily.Monospace else null,
+                softWrap = true,
             )
         }
     }
@@ -140,7 +154,9 @@ private fun BarcodeCreateActions(
         horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
     ) {
         // Confirm is the low-emphasis text button - inverted from B3Url so a
-        // stray dismissal lands on Cancel, not on a silent persist.
+        // stray dismissal lands on Cancel, not on a silent persist. The
+        // divergence is pinned by ComposableSurfaceLockTest's three-param lock
+        // on this composable; resyncing the two surfaces will fail that lock.
         TextButton(
             onClick = onConfirm,
             modifier = Modifier.testTag(BarcodeCreateConfirmTestTags.Confirm),
@@ -184,13 +200,6 @@ public object BarcodeCreateConfirmTestTags {
 }
 
 /**
- * Crypto-address mask: first 6 and last 6 characters, ellipsis in the middle. Below
- * the 14-character threshold the address fits without truncation.
- */
-internal fun maskAddress(address: String): String =
-    if (address.length <= 14) address else "${address.take(6)}...${address.takeLast(6)}"
-
-/**
  * Per-arm dispatcher for the warning sentence shown above the verbatim payload.
  * Cyclomatic complexity is load-bearing: every [QrPayloadKind] arm enumerated in
  * one place forces adding a new arm in `passes-core` to surface here as a missing-
@@ -205,7 +214,9 @@ private fun barcodeCreateMessage(kind: QrPayloadKind): String = when (kind) {
     is QrPayloadKind.Sms -> stringResource(R.string.barcode_create_confirm_sms)
     is QrPayloadKind.Mailto -> stringResource(R.string.barcode_create_confirm_mailto)
     is QrPayloadKind.Geo -> stringResource(R.string.barcode_create_confirm_geo)
-    is QrPayloadKind.Wifi -> wifiMessage(kind.ssid)
+    is QrPayloadKind.Wifi ->
+        if (kind.ssid != null) stringResource(R.string.barcode_create_confirm_wifi)
+        else stringResource(R.string.barcode_create_confirm_wifi_unnamed)
     is QrPayloadKind.Bitcoin -> stringResource(R.string.barcode_create_confirm_bitcoin)
     is QrPayloadKind.Ethereum -> stringResource(R.string.barcode_create_confirm_ethereum)
     QrPayloadKind.Magnet -> stringResource(R.string.barcode_create_confirm_magnet)
@@ -213,11 +224,6 @@ private fun barcodeCreateMessage(kind: QrPayloadKind): String = when (kind) {
     is QrPayloadKind.Intent -> stringResource(R.string.barcode_create_confirm_intent)
     is QrPayloadKind.UnknownScheme -> stringResource(R.string.barcode_create_confirm_unknown)
 }
-
-@Composable
-private fun wifiMessage(ssid: String?): String =
-    if (ssid != null) stringResource(R.string.barcode_create_confirm_wifi)
-    else stringResource(R.string.barcode_create_confirm_wifi_unnamed)
 
 /**
  * Per-arm dispatcher for the verbatim payload string rendered in the emphasis
@@ -232,8 +238,8 @@ internal fun verbatimForKind(kind: QrPayloadKind): String? = when (kind) {
     is QrPayloadKind.Mailto -> kind.address
     is QrPayloadKind.Geo -> kind.coords
     is QrPayloadKind.Wifi -> kind.ssid
-    is QrPayloadKind.Bitcoin -> maskAddress(kind.address)
-    is QrPayloadKind.Ethereum -> maskAddress(kind.address)
+    is QrPayloadKind.Bitcoin -> kind.address
+    is QrPayloadKind.Ethereum -> kind.address
     QrPayloadKind.Magnet -> null
     is QrPayloadKind.Market -> kind.productId
     is QrPayloadKind.Intent -> kind.raw

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetPreviews.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetPreviews.kt
@@ -1,0 +1,208 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import `is`.walt.passes.core.QrPayloadKind
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+
+@Composable
+private fun PreviewHost(content: @Composable () -> Unit) {
+    val argb = ArgbColor(0xFF202020.toInt())
+    val white = ArgbColor(0xFFFFFFFF.toInt())
+    val panel = ArgbColor(0xFFEFEFEF.toInt())
+    val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = argb, unsignedForeground = white,
+            selfSignedBackground = argb, selfSignedForeground = white,
+            appleVerifiedBackground = argb, appleVerifiedForeground = white,
+            certChainIncompleteBackground = argb, certChainIncompleteForeground = white,
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = argb, pillForeground = white, scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = white,
+            emphasisBackground = panel,
+            emphasisForeground = argb,
+            bodyForeground = argb,
+            confirmContainer = argb,
+            confirmForeground = white,
+            cancelForeground = argb,
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = argb, eventTicket = argb,
+            coupon = argb, storeCard = argb, generic = argb,
+        ),
+    )
+    MaterialTheme { PassesTheme(semantics = semantics, content = content) }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Url() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Url(
+                scheme = "https",
+                host = "example.com",
+                raw = "https://example.com/login",
+            ),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Phone() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Sms() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Sms("+44 7700 900000"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Mailto() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Geo() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Geo("51.5074,-0.1278"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Wifi() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Wifi(ssid = "MyNetwork"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_WifiUnnamed() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Wifi(ssid = null),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Bitcoin() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Bitcoin("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Ethereum() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Ethereum("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Magnet() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Magnet,
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Market() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Market("details?id=com.example.app"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Intent() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.Intent("intent://example#Intent;scheme=https;end"),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewBarcodeCreateConfirm_Unknown() {
+    PreviewHost {
+        BarcodeCreateConfirmSheet(
+            payloadKind = QrPayloadKind.UnknownScheme(
+                scheme = "myapp",
+                raw = "myapp://action?id=1",
+            ),
+            onConfirm = {},
+            onCancel = {},
+        )
+    }
+}

--- a/passes-ui/src/main/res/values/strings.xml
+++ b/passes-ui/src/main/res/values/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Per-arm copy for BarcodeCreateConfirmSheet. The wording is the trust-claim load-bearing
+  surface: the user reads it to decide whether the payload they typed should be persisted.
+  Wrapping each arm in a string resource (rather than hardcoding) prepares the strings for
+  localization (GitHub #65 / wpass-pk5) without changing call sites.
+
+  Lint suppressions: this module does not declare app-level translatable defaults yet;
+  every string here is en-only until the localization bead lands.
+-->
+<resources>
+    <string name="barcode_create_confirm_title">Confirm what this QR will do</string>
+    <string name="barcode_create_confirm_confirm">Add card</string>
+    <string name="barcode_create_confirm_cancel">Cancel</string>
+
+    <string name="barcode_create_confirm_url">When scanned, this QR will open a website:</string>
+    <string name="barcode_create_confirm_phone">When scanned, this QR will dial:</string>
+    <string name="barcode_create_confirm_sms">When scanned, this QR will text:</string>
+    <string name="barcode_create_confirm_mailto">When scanned, this QR will email:</string>
+    <string name="barcode_create_confirm_geo">When scanned, this QR will show a location on a map:</string>
+    <string name="barcode_create_confirm_wifi">When scanned, this QR will offer to join Wi-Fi network:</string>
+    <string name="barcode_create_confirm_wifi_unnamed">When scanned, this QR will offer to join a Wi-Fi network.</string>
+    <string name="barcode_create_confirm_bitcoin">When scanned, this QR will prepare a Bitcoin payment to:</string>
+    <string name="barcode_create_confirm_ethereum">When scanned, this QR will prepare an Ethereum payment to:</string>
+    <string name="barcode_create_confirm_magnet">When scanned, this QR will start a torrent download.</string>
+    <string name="barcode_create_confirm_market">When scanned, this QR will open a Play Store listing:</string>
+    <string name="barcode_create_confirm_intent">When scanned, this QR can trigger an app action. This is uncommon for loyalty cards. Continue?</string>
+    <string name="barcode_create_confirm_unknown">When scanned, this QR uses a scheme Walt doesn\'t recognize. If you didn\'t expect this, cancel.</string>
+</resources>

--- a/passes-ui/src/main/res/values/strings.xml
+++ b/passes-ui/src/main/res/values/strings.xml
@@ -5,10 +5,12 @@
   Wrapping each arm in a string resource (rather than hardcoding) prepares the strings for
   localization (GitHub #65 / wpass-pk5) without changing call sites.
 
-  Lint suppressions: this module does not declare app-level translatable defaults yet;
-  every string here is en-only until the localization bead lands.
+  tools:locale="en" pins the source locale so downstream consumers (walt-android) do not
+  surface MissingTranslation lint warnings on non-en build variants while wpass-pk5 is
+  still pending. Remove this once translated values/ resource sets exist.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:locale="en">
     <string name="barcode_create_confirm_title">Confirm what this QR will do</string>
     <string name="barcode_create_confirm_confirm">Add card</string>
     <string name="barcode_create_confirm_cancel">Cancel</string>

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
@@ -1,0 +1,459 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.QrPayloadKind
+import `is`.walt.passes.ui.theme.ArgbColor
+import `is`.walt.passes.ui.theme.CategoryAccentColors
+import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
+import `is`.walt.passes.ui.theme.PassesSemantics
+import `is`.walt.passes.ui.theme.PassesTheme
+import `is`.walt.passes.ui.theme.SecuritySheetStyle
+import `is`.walt.passes.ui.theme.SignatureBadgeColors
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Behavioral lock for [BarcodeCreateConfirmSheet]. Each arm of [QrPayloadKind]
+ * asserts:
+ *
+ *  - The per-arm warning copy is the visible explanation (no silent confirm).
+ *  - The verbatim payload (where applicable) renders wrapped in U+2068...U+2069
+ *    (FSI/PDI) so a future directional context surrounding the sheet chrome
+ *    cannot reorder the load-bearing trust-claim string.
+ *
+ * Plus three structural assertions:
+ *
+ *  - [QrPayloadKind.PlainText] composes nothing (the gate is skipped).
+ *  - Cancel button is focused on open (cancel-default-action posture).
+ *  - Confirm and Cancel callbacks fire only on explicit tap, not on initial
+ *    composition.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class BarcodeCreateConfirmSheetTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun urlArmShowsWarningAndIsolatedHost() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Url(
+                        scheme = "https",
+                        host = "example.com",
+                        raw = "https://example.com/login",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will open a website:",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨example.com⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun urlArmFallsBackToRawWhenHostMissing() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Url(scheme = "http", host = null, raw = "http://"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("⁨http://⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun phoneArmShowsWarningAndIsolatedNumber() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("When scanned, this QR will dial:").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨+44 7700 900000⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun smsArmShowsWarningAndIsolatedNumber() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Sms("+44 7700 900000"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("When scanned, this QR will text:").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨+44 7700 900000⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun mailtoArmShowsWarningAndIsolatedAddress() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("When scanned, this QR will email:").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨alice@example.com⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun geoArmShowsWarningAndIsolatedCoords() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Geo("51.5074,-0.1278"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will show a location on a map:",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨51.5074,-0.1278⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun wifiArmWithSsidShowsWarningAndIsolatedSsid() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Wifi(ssid = "MyNetwork"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will offer to join Wi-Fi network:",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨MyNetwork⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun wifiArmWithoutSsidShowsGenericWarning() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Wifi(ssid = null),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will offer to join a Wi-Fi network.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun bitcoinArmShowsWarningAndMasksLongAddress() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Bitcoin(
+                        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will prepare a Bitcoin payment to:",
+        ).assertIsDisplayed()
+        // First 6 + ... + last 6 of the source address. Wrapped in FSI/PDI.
+        composeRule.onNodeWithText("⁨1A1zP1...DivfNa⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun ethereumArmShowsWarningAndMasksLongAddress() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Ethereum(
+                        "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will prepare an Ethereum payment to:",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨0x71C7...d8976F⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun magnetArmShowsWarningWithoutEmphasisPanel() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Magnet,
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will start a torrent download.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun marketArmShowsWarningAndIsolatedProductId() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Market("details?id=com.example.app"),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR will open a Play Store listing:",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨details?id=com.example.app⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun intentArmShowsExtraStrongWarningAndIsolatedRaw() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Intent(
+                        "intent://example#Intent;scheme=https;end",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR can trigger an app action. " +
+                "This is uncommon for loyalty cards. Continue?",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "⁨intent://example#Intent;scheme=https;end⁩",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun unknownSchemeArmShowsWarningAndIsolatedRaw() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.UnknownScheme(
+                        scheme = "myapp",
+                        raw = "myapp://action?id=1",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "When scanned, this QR uses a scheme Walt doesn't recognize. " +
+                "If you didn't expect this, cancel.",
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("⁨myapp://action?id=1⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun plainTextSkipsTheGateEntirely() {
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.PlainText,
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText("Confirm what this QR will do").assertDoesNotExist()
+    }
+
+    @Test
+    fun maskAddressLeavesShortAddressesUntouched() {
+        assertThat(maskAddress("short")).isEqualTo("short")
+        assertThat(maskAddress("14characters!!")).isEqualTo("14characters!!")
+    }
+
+    @Test
+    fun maskAddressShowsFirstAndLastSixWithEllipsis() {
+        assertThat(maskAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"))
+            .isEqualTo("1A1zP1...DivfNa")
+        assertThat(maskAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"))
+            .isEqualTo("0x71C7...d8976F")
+    }
+
+    @Test
+    fun requiresCreateConfirmationIsFalseOnlyForPlainText() {
+        assertThat(QrPayloadKind.PlainText.requiresCreateConfirmation()).isFalse()
+        assertThat(QrPayloadKind.Magnet.requiresCreateConfirmation()).isTrue()
+        assertThat(
+            QrPayloadKind.Url("https", "example.com", "https://example.com")
+                .requiresCreateConfirmation(),
+        ).isTrue()
+        assertThat(QrPayloadKind.Wifi(ssid = null).requiresCreateConfirmation()).isTrue()
+    }
+
+    @Test
+    fun cancelButtonExposesRequestFocusActionForDefaultFocus() {
+        // Robolectric's Compose host does not propagate window focus the way a
+        // real device does, so a literal `assertIsFocused()` is unreliable here;
+        // the contract this test locks is the structural one: the Cancel button
+        // is the focusable target, with RequestFocus exposed on its semantics
+        // node, so the in-source `LaunchedEffect { cancelFocus.requestFocus() }`
+        // has a real target to land on. The on-device focus behavior is the
+        // instrumentation bead's coverage.
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Bitcoin(
+                        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+                    ),
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(BarcodeCreateConfirmTestTags.Cancel)
+            .assert(
+                androidx.compose.ui.test.SemanticsMatcher.keyIsDefined(
+                    androidx.compose.ui.semantics.SemanticsActions.RequestFocus,
+                ),
+            )
+    }
+
+    @Test
+    fun openingTheSheetFiresNeitherCallback() {
+        var confirmed = 0
+        var cancelled = 0
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Bitcoin(
+                        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+                    ),
+                    onConfirm = { confirmed++ },
+                    onCancel = { cancelled++ },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        assertThat(confirmed).isEqualTo(0)
+        assertThat(cancelled).isEqualTo(0)
+    }
+
+    @Test
+    fun confirmTapInvokesOnConfirmExactlyOnce() {
+        var confirmed = 0
+        var cancelled = 0
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+                    onConfirm = { confirmed++ },
+                    onCancel = { cancelled++ },
+                )
+            }
+        }
+        composeRule.onNodeWithTag(BarcodeCreateConfirmTestTags.Confirm).performClick()
+        composeRule.waitForIdle()
+        assertThat(confirmed).isEqualTo(1)
+        assertThat(cancelled).isEqualTo(0)
+    }
+
+    @Test
+    fun cancelTapInvokesOnCancelExactlyOnce() {
+        var confirmed = 0
+        var cancelled = 0
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+                    onConfirm = { confirmed++ },
+                    onCancel = { cancelled++ },
+                )
+            }
+        }
+        composeRule.onNodeWithTag(BarcodeCreateConfirmTestTags.Cancel).performClick()
+        composeRule.waitForIdle()
+        assertThat(confirmed).isEqualTo(0)
+        assertThat(cancelled).isEqualTo(1)
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme { PassesTheme(semantics = semantics, content = content) }
+    }
+
+    private val semantics = PassesSemantics(
+        signatureBadge = SignatureBadgeColors(
+            unsignedBackground = ArgbColor(0xFFFFE0E0.toInt()),
+            unsignedForeground = ArgbColor(0xFF101010.toInt()),
+            selfSignedBackground = ArgbColor(0xFFFFF0E0.toInt()),
+            selfSignedForeground = ArgbColor(0xFF101010.toInt()),
+            appleVerifiedBackground = ArgbColor(0xFFE0FFE0.toInt()),
+            appleVerifiedForeground = ArgbColor(0xFF101010.toInt()),
+            certChainIncompleteBackground = ArgbColor(0xFFFFFFE0.toInt()),
+            certChainIncompleteForeground = ArgbColor(0xFF101010.toInt()),
+        ),
+        expiredBadge = ExpiredBadgeStyle(
+            pillBackground = ArgbColor(0xFF202020.toInt()),
+            pillForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            scrimAlpha = 96,
+        ),
+        securitySheet = SecuritySheetStyle(
+            sheetBackground = ArgbColor(0xFFFFFFFF.toInt()),
+            emphasisBackground = ArgbColor(0xFFEFEFEF.toInt()),
+            emphasisForeground = ArgbColor(0xFF000000.toInt()),
+            bodyForeground = ArgbColor(0xFF202020.toInt()),
+            confirmContainer = ArgbColor(0xFF202020.toInt()),
+            confirmForeground = ArgbColor(0xFFFFFFFF.toInt()),
+            cancelForeground = ArgbColor(0xFF202020.toInt()),
+        ),
+        categoryAccent = CategoryAccentColors(
+            boardingPass = ArgbColor(0xFF1D4ED8.toInt()),
+            eventTicket = ArgbColor(0xFF7C2D92.toInt()),
+            coupon = ArgbColor(0xFF555555.toInt()),
+            storeCard = ArgbColor(0xFF555555.toInt()),
+            generic = ArgbColor(0xFF555555.toInt()),
+        ),
+    )
+
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
@@ -177,7 +177,10 @@ class BarcodeCreateConfirmSheetTest {
     }
 
     @Test
-    fun bitcoinArmShowsWarningAndMasksLongAddress() {
+    fun bitcoinArmShowsWarningAndFullAddressVerbatim() {
+        // At create time the user is verifying their own typing. A masked middle
+        // would hide exactly where base58 transcription errors accumulate, so the
+        // full address renders in the emphasis panel.
         composeRule.setContent {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
@@ -192,12 +195,13 @@ class BarcodeCreateConfirmSheetTest {
         composeRule.onNodeWithText(
             "When scanned, this QR will prepare a Bitcoin payment to:",
         ).assertIsDisplayed()
-        // First 6 + ... + last 6 of the source address. Wrapped in FSI/PDI.
-        composeRule.onNodeWithText("⁨1A1zP1...DivfNa⁩").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "⁨1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa⁩",
+        ).assertIsDisplayed()
     }
 
     @Test
-    fun ethereumArmShowsWarningAndMasksLongAddress() {
+    fun ethereumArmShowsWarningAndFullAddressVerbatim() {
         composeRule.setContent {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
@@ -212,7 +216,9 @@ class BarcodeCreateConfirmSheetTest {
         composeRule.onNodeWithText(
             "When scanned, this QR will prepare an Ethereum payment to:",
         ).assertIsDisplayed()
-        composeRule.onNodeWithText("⁨0x71C7...d8976F⁩").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "⁨0x71C7656EC7ab88b098defB751B7401B5f6d8976F⁩",
+        ).assertIsDisplayed()
     }
 
     @Test
@@ -303,20 +309,6 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText("Confirm what this QR will do").assertDoesNotExist()
-    }
-
-    @Test
-    fun maskAddressLeavesShortAddressesUntouched() {
-        assertThat(maskAddress("short")).isEqualTo("short")
-        assertThat(maskAddress("14characters!!")).isEqualTo("14characters!!")
-    }
-
-    @Test
-    fun maskAddressShowsFirstAndLastSixWithEllipsis() {
-        assertThat(maskAddress("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"))
-            .isEqualTo("1A1zP1...DivfNa")
-        assertThat(maskAddress("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"))
-            .isEqualTo("0x71C7...d8976F")
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -94,6 +94,19 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
+    fun barcodeCreateConfirmSheetHasExactlyThreeUserVisibleParameters() {
+        // (payloadKind, onConfirm, onCancel). The gate is structurally minimal —
+        // no skipConfirmation flag, no per-arm copy override, no telemetry knob.
+        // Adding a fourth parameter would invite a way to silence the create-time
+        // URI preview warning (wpass-lzi.9 trust posture).
+        assertUserVisibleParamCount(
+            "BarcodeCreateConfirmSheetKt",
+            "BarcodeCreateConfirmSheet",
+            expected = 3,
+        )
+    }
+
+    @Test
     fun passImportConfirmHasExactlySevenUserVisibleParameters() {
         // (pass, signatureStatus, telemetry, onConfirm, onDismiss, modifier, locale).
         // No `enabled`, no `skipConfirmation`, no `showTrustCaption` — drift here is a

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -95,10 +95,14 @@ class ComposableSurfaceLockTest {
 
     @Test
     fun barcodeCreateConfirmSheetHasExactlyThreeUserVisibleParameters() {
-        // (payloadKind, onConfirm, onCancel). The gate is structurally minimal —
-        // no skipConfirmation flag, no per-arm copy override, no telemetry knob.
-        // Adding a fourth parameter would invite a way to silence the create-time
-        // URI preview warning (wpass-lzi.9 trust posture).
+        // (payloadKind, onConfirm, onCancel). The gate is structurally minimal:
+        // no skipConfirmation flag, no per-arm copy override. The shape will
+        // legitimately grow to 4 when wpass-rnv lands the deliberately-deferred
+        // UiTelemetryGuard wiring; at that point bump this expectation to 4 and
+        // document the new event semantics in COMPOSABLE_SIGNATURES.md. Adding a
+        // fourth parameter for any other reason (a "skipConfirmation" / per-arm
+        // silence flag) would weaken the wpass-lzi.9 trust posture and is what
+        // this lock exists to prevent.
         assertUserVisibleParamCount(
             "BarcodeCreateConfirmSheetKt",
             "BarcodeCreateConfirmSheet",


### PR DESCRIPTION
## Summary

- Adds `BarcodeCreateConfirmSheet`, the create-time mitigation for **C4** in the scannable-card threat model: when a typed QR payload classifies as auto-acting (URL, tel/sms, mailto, geo, wifi, crypto, market, intent, unknown scheme), the consumer's create flow opens this gate between input validation and persistence so the payload cannot land in the wallet without an explicit confirm.
- Cancel is the focused, filled action; Confirm is the lower-emphasis text button - the inverse of `B3UrlConfirmSheet`'s prominence. Verbatim payload is fenced in FSI/PDI via `isolated()`. Crypto addresses >14 chars use `1A1zP1...DivfNa` masking. `PlainText` short-circuits; `requiresCreateConfirmation()` lets callers branch.
- Per-arm copy lives in `strings.xml` so wpass-pk5 localization can pick it up. Previews live in a sibling `BarcodeCreateConfirmSheetPreviews.kt`. Param-count lock added to `ComposableSurfaceLockTest`.

## Test plan

- [x] `:passes-ui:check` green
- [x] Full repo `./gradlew check` green
- [x] Per-arm `BarcodeCreateConfirmSheetTest` covers all 13 `QrPayloadKind` arms (warning copy + isolated verbatim where applicable)
- [x] `PlainText` short-circuits to no output
- [x] `maskAddress` unit tests (boundary and long-address)
- [x] No-auto-confirm structural test (rendering does not invoke callbacks)
- [x] On-device focus behavior deferred to instrumentation bead (Robolectric does not propagate window focus reliably; structural `RequestFocus` semantics action is asserted on Cancel)

## Follow-ups

- wpass-lzi.10 (cross-repo handoff spec for walt-android consumer wiring) unblocked.