### PR TITLE
passes-ui: wire UiTelemetryGuard into BarcodeCreateConfirmSheet (wpass-rnv)

### DIFF
--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -206,16 +206,17 @@ sheet AND calls `onConfirm`; dismissal closes WITHOUT firing `onConfirm`.
  * gate unconditional; [requiresCreateConfirmation] lets callers branch when they
  * want to skip the composable entirely.
  *
- * NOTE: this surface ships WITHOUT a `telemetry: UiTelemetryGuard` parameter -
- * deliberate deferral, tracked under wpass-rnv. The other security sheets emit
- * `onSecuritySheetShown` / `Confirmed` / `Dismissed`; the create-time gate is
- * invisible to that dashboard until that bead lands. ComposableSurfaceLockTest
- * pins the three-param shape so re-adding a guard is a deliberate edit, not a
- * silent drift.
+ * Fires `telemetry.onBarcodeCreateGateShown` on first composition (per non-PlainText
+ * payload kind), `onBarcodeCreateGateConfirmed` on confirm tap, and
+ * `onBarcodeCreateGateDismissed` on cancel tap or any sheet dismissal. The kind
+ * dimension is the coarse [BarcodeCreateKind] family of the underlying payload; the
+ * user-typed string never crosses the boundary, matching the PII discipline pinned
+ * by `PublicApiSurfaceTest`.
  */
 @Composable
 public fun BarcodeCreateConfirmSheet(
     payloadKind: QrPayloadKind,
+    telemetry: UiTelemetryGuard,
     onConfirm: () -> Unit,
     onCancel: () -> Unit,
 )

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -196,9 +196,7 @@ private fun BarcodeCreateActions(
         horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End),
     ) {
         // Confirm is the low-emphasis text button - inverted from B3Url so a
-        // stray dismissal lands on Cancel, not on a silent persist. The
-        // divergence is pinned by ComposableSurfaceLockTest's three-param lock
-        // on this composable; resyncing the two surfaces will fail that lock.
+        // stray dismissal lands on Cancel, not on a silent persist.
         TextButton(
             onClick = onConfirm,
             modifier = Modifier.testTag(BarcodeCreateConfirmTestTags.Confirm),

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -59,15 +59,18 @@ import `is`.walt.passes.ui.theme.toComposeColor
  * directional context surrounding the sheet chrome; the upstream validator
  * (wpass-lzi.4) already rejects Cf/Cc characters in the payload itself.
  *
- * NOTE: this surface ships WITHOUT a `telemetry: UiTelemetryGuard` parameter -
- * deferred to wpass-rnv. The other security sheets emit show / confirm / dismiss
- * events, so the create-time gate is invisible to walt-android's dismissal-rate
- * dashboard until that bead lands.
+ * Emits [UiTelemetryGuard.onBarcodeCreateGateShown] on first composition for each
+ * non-PlainText payload kind, [onBarcodeCreateGateConfirmed] on confirm tap, and
+ * [onBarcodeCreateGateDismissed] on cancel tap or sheet dismissal. The
+ * [BarcodeCreateKind] dimension is the coarse family of the underlying
+ * [QrPayloadKind] - the user-typed string itself never crosses the boundary,
+ * matching the PII discipline pinned by `PublicApiSurfaceTest`.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 public fun BarcodeCreateConfirmSheet(
     payloadKind: QrPayloadKind,
+    telemetry: UiTelemetryGuard,
     onConfirm: () -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -76,6 +79,8 @@ public fun BarcodeCreateConfirmSheet(
     val sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val emphasis = LocalPassesSemantics.current.securitySheet
     val cancelFocus = remember { FocusRequester() }
+    val kind = barcodeCreateKindOf(payloadKind)
+    LaunchedEffect(kind) { telemetry.onBarcodeCreateGateShown(kind) }
     // Cancel-default focus: the prominent action wins keyboard / d-pad focus on
     // open so muscle memory pointed at the primary slot lands on Cancel. The
     // LaunchedEffect fires after composition, so the requester is attached by
@@ -84,7 +89,10 @@ public fun BarcodeCreateConfirmSheet(
     LaunchedEffect(payloadKind) { cancelFocus.requestFocus() }
 
     ModalBottomSheet(
-        onDismissRequest = onCancel,
+        onDismissRequest = {
+            telemetry.onBarcodeCreateGateDismissed(kind)
+            onCancel()
+        },
         sheetState = sheetState,
         containerColor = emphasis.sheetBackground.toComposeColor(),
     ) {
@@ -98,11 +106,41 @@ public fun BarcodeCreateConfirmSheet(
             BarcodeCreateActions(
                 emphasis = emphasis,
                 cancelFocus = cancelFocus,
-                onConfirm = onConfirm,
-                onCancel = onCancel,
+                onConfirm = {
+                    telemetry.onBarcodeCreateGateConfirmed(kind)
+                    onConfirm()
+                },
+                onCancel = {
+                    telemetry.onBarcodeCreateGateDismissed(kind)
+                    onCancel()
+                },
             )
         }
     }
+}
+
+/**
+ * Maps a [QrPayloadKind] to its coarse [BarcodeCreateKind] family for telemetry.
+ * [QrPayloadKind.PlainText] is unreachable here - the caller short-circuits before
+ * any telemetry-bearing path - but the `when` enumerates it so adding a new arm in
+ * `passes-core` surfaces as a missing-branch compile error rather than a silent
+ * fallthrough to the wrong family.
+ */
+@Suppress("CyclomaticComplexMethod")
+private fun barcodeCreateKindOf(payloadKind: QrPayloadKind): BarcodeCreateKind = when (payloadKind) {
+    is QrPayloadKind.PlainText -> error("PlainText payloads short-circuit the gate before telemetry fires")
+    is QrPayloadKind.Url -> BarcodeCreateKind.Url
+    is QrPayloadKind.Phone -> BarcodeCreateKind.Phone
+    is QrPayloadKind.Sms -> BarcodeCreateKind.Sms
+    is QrPayloadKind.Mailto -> BarcodeCreateKind.Mailto
+    is QrPayloadKind.Geo -> BarcodeCreateKind.Geo
+    is QrPayloadKind.Wifi -> BarcodeCreateKind.Wifi
+    is QrPayloadKind.Bitcoin -> BarcodeCreateKind.Bitcoin
+    is QrPayloadKind.Ethereum -> BarcodeCreateKind.Ethereum
+    QrPayloadKind.Magnet -> BarcodeCreateKind.Magnet
+    is QrPayloadKind.Market -> BarcodeCreateKind.Market
+    is QrPayloadKind.Intent -> BarcodeCreateKind.Intent
+    is QrPayloadKind.UnknownScheme -> BarcodeCreateKind.UnknownScheme
 }
 
 @Composable

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetPreviews.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetPreviews.kt
@@ -54,6 +54,7 @@ private fun PreviewBarcodeCreateConfirm_Url() {
                 host = "example.com",
                 raw = "https://example.com/login",
             ),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -66,6 +67,7 @@ private fun PreviewBarcodeCreateConfirm_Phone() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -78,6 +80,7 @@ private fun PreviewBarcodeCreateConfirm_Sms() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Sms("+44 7700 900000"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -90,6 +93,7 @@ private fun PreviewBarcodeCreateConfirm_Mailto() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -102,6 +106,7 @@ private fun PreviewBarcodeCreateConfirm_Geo() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Geo("51.5074,-0.1278"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -114,6 +119,7 @@ private fun PreviewBarcodeCreateConfirm_Wifi() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Wifi(ssid = "MyNetwork"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -126,6 +132,7 @@ private fun PreviewBarcodeCreateConfirm_WifiUnnamed() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Wifi(ssid = null),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -138,6 +145,7 @@ private fun PreviewBarcodeCreateConfirm_Bitcoin() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Bitcoin("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -150,6 +158,7 @@ private fun PreviewBarcodeCreateConfirm_Ethereum() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Ethereum("0x71C7656EC7ab88b098defB751B7401B5f6d8976F"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -162,6 +171,7 @@ private fun PreviewBarcodeCreateConfirm_Magnet() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Magnet,
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -174,6 +184,7 @@ private fun PreviewBarcodeCreateConfirm_Market() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Market("details?id=com.example.app"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -186,6 +197,7 @@ private fun PreviewBarcodeCreateConfirm_Intent() {
     PreviewHost {
         BarcodeCreateConfirmSheet(
             payloadKind = QrPayloadKind.Intent("intent://example#Intent;scheme=https;end"),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )
@@ -201,6 +213,7 @@ private fun PreviewBarcodeCreateConfirm_Unknown() {
                 scheme = "myapp",
                 raw = "myapp://action?id=1",
             ),
+            telemetry = NoopUiTelemetryGuard,
             onConfirm = {},
             onCancel = {},
         )

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/UiTelemetryGuard.kt
@@ -97,6 +97,34 @@ public interface UiTelemetryGuard {
      * a duplicate-with-narrower-shape would only invite drift.
      */
     public fun onImportRejected(kind: ParseFailureKind)
+
+    /**
+     * The create-time QR URI-scheme confirmation gate ([BarcodeCreateConfirmSheet]) was
+     * shown to the user. Fires only on actual composition; the [QrPayloadKind.PlainText]
+     * short-circuit never produces this event.
+     *
+     * Modeled as a sibling method family rather than a fourth arm on
+     * [onSecuritySheetShown] because the existing arms take a [PassType], which is
+     * PKPASS-specific and has no `ScannableCard` member. The create gate guards an
+     * unverified, user-typed artifact; conflating it with verified-pass back-field
+     * intent gates would muddy both the trust UX and the dashboards that consume
+     * these events.
+     */
+    public fun onBarcodeCreateGateShown(kind: BarcodeCreateKind)
+
+    /**
+     * The user confirmed the create-time gate. The consumer's persist call to
+     * `BarcodeCardRepository.upsert` is the next thing constructed after this event.
+     */
+    public fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind)
+
+    /**
+     * The user dismissed the create-time gate without confirming - either by tapping
+     * Cancel (the focus-default action) or by dismissing the sheet. A sustained rise,
+     * especially scoped to [BarcodeCreateKind.Intent] or [BarcodeCreateKind.UnknownScheme],
+     * is a useful UX or social-engineering signal.
+     */
+    public fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind)
 }
 
 /**
@@ -120,6 +148,29 @@ public enum class SecurityIntentKind {
     Url,
     Phone,
     Email,
+}
+
+/**
+ * Coarse family of the QR payload classified by [QrPayloadKind] at the moment the
+ * create-time gate ([BarcodeCreateConfirmSheet]) is shown. Mirrors the source
+ * sealed-interface arms but flattens to enum-only at the telemetry boundary so the
+ * user-typed payload string (host, address, raw URI, SSID) never crosses into the
+ * host. [QrPayloadKind.PlainText] has no representative here: the gate short-circuits
+ * for plain text and no event fires.
+ */
+public enum class BarcodeCreateKind {
+    Url,
+    Phone,
+    Sms,
+    Mailto,
+    Geo,
+    Wifi,
+    Bitcoin,
+    Ethereum,
+    Magnet,
+    Market,
+    Intent,
+    UnknownScheme,
 }
 
 /**
@@ -150,4 +201,7 @@ public object NoopUiTelemetryGuard : UiTelemetryGuard {
     override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand): Unit = Unit
     override fun onImportDismissed(type: PassType, signatureBand: SignatureBand): Unit = Unit
     override fun onImportRejected(kind: ParseFailureKind): Unit = Unit
+    override fun onBarcodeCreateGateShown(kind: BarcodeCreateKind): Unit = Unit
+    override fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind): Unit = Unit
+    override fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind): Unit = Unit
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ParseFailureKind
+import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.QrPayloadKind
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
@@ -56,6 +58,7 @@ class BarcodeCreateConfirmSheetTest {
                         host = "example.com",
                         raw = "https://example.com/login",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -73,6 +76,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Url(scheme = "http", host = null, raw = "http://"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -87,6 +91,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -102,6 +107,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Sms("+44 7700 900000"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -117,6 +123,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -132,6 +139,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Geo("51.5074,-0.1278"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -149,6 +157,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Wifi(ssid = "MyNetwork"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -166,6 +175,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Wifi(ssid = null),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -187,6 +197,7 @@ class BarcodeCreateConfirmSheetTest {
                     payloadKind = QrPayloadKind.Bitcoin(
                         "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -208,6 +219,7 @@ class BarcodeCreateConfirmSheetTest {
                     payloadKind = QrPayloadKind.Ethereum(
                         "0x71C7656EC7ab88b098defB751B7401B5f6d8976F",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -227,6 +239,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Magnet,
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -243,6 +256,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Market("details?id=com.example.app"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -262,6 +276,7 @@ class BarcodeCreateConfirmSheetTest {
                     payloadKind = QrPayloadKind.Intent(
                         "intent://example#Intent;scheme=https;end",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -285,6 +300,7 @@ class BarcodeCreateConfirmSheetTest {
                         scheme = "myapp",
                         raw = "myapp://action?id=1",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -303,6 +319,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.PlainText,
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -337,6 +354,7 @@ class BarcodeCreateConfirmSheetTest {
                     payloadKind = QrPayloadKind.Bitcoin(
                         "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = {},
                     onCancel = {},
                 )
@@ -361,6 +379,7 @@ class BarcodeCreateConfirmSheetTest {
                     payloadKind = QrPayloadKind.Bitcoin(
                         "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
                     ),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = { confirmed++ },
                     onCancel = { cancelled++ },
                 )
@@ -379,6 +398,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Phone("+44 7700 900000"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = { confirmed++ },
                     onCancel = { cancelled++ },
                 )
@@ -398,6 +418,7 @@ class BarcodeCreateConfirmSheetTest {
             ThemedHost {
                 BarcodeCreateConfirmSheet(
                     payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+                    telemetry = NoopUiTelemetryGuard,
                     onConfirm = { confirmed++ },
                     onCancel = { cancelled++ },
                 )
@@ -409,9 +430,121 @@ class BarcodeCreateConfirmSheetTest {
         assertThat(cancelled).isEqualTo(1)
     }
 
+    @Test
+    fun openingTheSheetFiresShownExactlyOnceWithMappedKind() {
+        val recorder = RecordingGuard()
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Bitcoin(
+                        "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+                    ),
+                    telemetry = recorder,
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        assertThat(recorder.events).containsExactly("shown:Bitcoin")
+    }
+
+    @Test
+    fun plainTextNeverFiresShown() {
+        // The gate short-circuits for PlainText; no telemetry event should escape.
+        val recorder = RecordingGuard()
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.PlainText,
+                    telemetry = recorder,
+                    onConfirm = {},
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        assertThat(recorder.events).isEmpty()
+    }
+
+    @Test
+    fun confirmTapFiresConfirmedEventBeforeCallback() {
+        val recorder = RecordingGuard()
+        var confirmEventIndexAtCallback = -1
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Url(
+                        scheme = "https",
+                        host = "example.com",
+                        raw = "https://example.com",
+                    ),
+                    telemetry = recorder,
+                    onConfirm = { confirmEventIndexAtCallback = recorder.events.size - 1 },
+                    onCancel = {},
+                )
+            }
+        }
+        composeRule.onNodeWithTag(BarcodeCreateConfirmTestTags.Confirm).performClick()
+        composeRule.waitForIdle()
+        assertThat(recorder.events).containsExactly(
+            "shown:Url",
+            "confirm:Url",
+        ).inOrder()
+        // The confirm event must precede the host's persist callback so the
+        // dashboard captures the user's choice even if the persist throws.
+        assertThat(confirmEventIndexAtCallback).isEqualTo(1)
+    }
+
+    @Test
+    fun cancelTapFiresDismissedEventBeforeCallback() {
+        val recorder = RecordingGuard()
+        var cancelEventIndexAtCallback = -1
+        composeRule.setContent {
+            ThemedHost {
+                BarcodeCreateConfirmSheet(
+                    payloadKind = QrPayloadKind.Mailto("alice@example.com"),
+                    telemetry = recorder,
+                    onConfirm = {},
+                    onCancel = { cancelEventIndexAtCallback = recorder.events.size - 1 },
+                )
+            }
+        }
+        composeRule.onNodeWithTag(BarcodeCreateConfirmTestTags.Cancel).performClick()
+        composeRule.waitForIdle()
+        assertThat(recorder.events).containsExactly(
+            "shown:Mailto",
+            "dismiss:Mailto",
+        ).inOrder()
+        assertThat(cancelEventIndexAtCallback).isEqualTo(1)
+    }
+
     @Composable
     private fun ThemedHost(content: @Composable () -> Unit) {
         MaterialTheme { PassesTheme(semantics = semantics, content = content) }
+    }
+
+    private class RecordingGuard : UiTelemetryGuard {
+        val events: MutableList<String> = mutableListOf()
+        override fun onPassRendered(type: PassType, signatureBand: SignatureBand): Unit = Unit
+        override fun onPassBackOpened(type: PassType): Unit = Unit
+        override fun onSecuritySheetShown(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+        override fun onSecuritySheetConfirmed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+        override fun onSecuritySheetDismissed(intentKind: SecurityIntentKind, type: PassType): Unit = Unit
+        override fun onImageDecodeRejected(reason: ImageDecodeRejection): Unit = Unit
+        override fun onImportConfirmShown(type: PassType, signatureBand: SignatureBand): Unit = Unit
+        override fun onImportConfirmed(type: PassType, signatureBand: SignatureBand): Unit = Unit
+        override fun onImportDismissed(type: PassType, signatureBand: SignatureBand): Unit = Unit
+        override fun onImportRejected(kind: ParseFailureKind): Unit = Unit
+        override fun onBarcodeCreateGateShown(kind: BarcodeCreateKind) {
+            events += "shown:${kind.name}"
+        }
+        override fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind) {
+            events += "confirm:${kind.name}"
+        }
+        override fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind) {
+            events += "dismiss:${kind.name}"
+        }
     }
 
     private val semantics = PassesSemantics(

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -94,20 +94,25 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
-    fun barcodeCreateConfirmSheetHasExactlyThreeUserVisibleParameters() {
-        // (payloadKind, onConfirm, onCancel). The gate is structurally minimal:
-        // no skipConfirmation flag, no per-arm copy override. The shape will
-        // legitimately grow to 4 when wpass-rnv lands the deliberately-deferred
-        // UiTelemetryGuard wiring; at that point bump this expectation to 4 and
-        // document the new event semantics in COMPOSABLE_SIGNATURES.md. Adding a
-        // fourth parameter for any other reason (a "skipConfirmation" / per-arm
-        // silence flag) would weaken the wpass-lzi.9 trust posture and is what
-        // this lock exists to prevent.
+    fun barcodeCreateConfirmSheetHasExactlyFourUserVisibleParameters() {
+        // (payloadKind, telemetry, onConfirm, onCancel). Adding any further parameter
+        // (a "skipConfirmation" / per-arm silence flag, an override for the kind
+        // dimension) would weaken the wpass-lzi.9 trust posture and is what this
+        // lock exists to prevent.
         assertUserVisibleParamCount(
             "BarcodeCreateConfirmSheetKt",
             "BarcodeCreateConfirmSheet",
-            expected = 3,
+            expected = 4,
         )
+    }
+
+    @Test
+    fun barcodeCreateConfirmSheetAcceptsUiTelemetryGuard() {
+        val method = findComposable("BarcodeCreateConfirmSheetKt", "BarcodeCreateConfirmSheet")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("BarcodeCreateConfirmSheet must declare a UiTelemetryGuard parameter")
+            .that(typeNames)
+            .contains("UiTelemetryGuard")
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassImportConfirmBackPressTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassImportConfirmBackPressTest.kt
@@ -161,5 +161,14 @@ class PassImportConfirmBackPressTest {
         override fun onImportRejected(kind: ParseFailureKind) {
             events += "import-rejected:${kind.name}"
         }
+        override fun onBarcodeCreateGateShown(kind: BarcodeCreateKind) {
+            events += "barcode-shown:${kind.name}"
+        }
+        override fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind) {
+            events += "barcode-confirm:${kind.name}"
+        }
+        override fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind) {
+            events += "barcode-dismiss:${kind.name}"
+        }
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -206,6 +206,18 @@ class PublicApiSurfaceTest {
             override fun onImportRejected(kind: ParseFailureKind) {
                 recorded += "import-rejected:${kind.name}"
             }
+
+            override fun onBarcodeCreateGateShown(kind: BarcodeCreateKind) {
+                recorded += "barcode-shown:${kind.name}"
+            }
+
+            override fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind) {
+                recorded += "barcode-confirm:${kind.name}"
+            }
+
+            override fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind) {
+                recorded += "barcode-dismiss:${kind.name}"
+            }
         }
         guard.onPassRendered(PassType.BoardingPass, SignatureBand.AppleVerified)
         guard.onPassBackOpened(PassType.EventTicket)
@@ -217,6 +229,9 @@ class PublicApiSurfaceTest {
         guard.onImportConfirmed(PassType.Generic, SignatureBand.SelfSigned)
         guard.onImportDismissed(PassType.BoardingPass, SignatureBand.Untrusted)
         guard.onImportRejected(ParseFailureKind.Tampered)
+        guard.onBarcodeCreateGateShown(BarcodeCreateKind.Url)
+        guard.onBarcodeCreateGateConfirmed(BarcodeCreateKind.Wifi)
+        guard.onBarcodeCreateGateDismissed(BarcodeCreateKind.Intent)
 
         assertThat(recorded).containsExactly(
             "rendered:BoardingPass:AppleVerified",
@@ -229,6 +244,9 @@ class PublicApiSurfaceTest {
             "import-confirm:Generic:SelfSigned",
             "import-dismiss:BoardingPass:Untrusted",
             "import-rejected:Tampered",
+            "barcode-shown:Url",
+            "barcode-confirm:Wifi",
+            "barcode-dismiss:Intent",
         ).inOrder()
     }
 
@@ -245,6 +263,30 @@ class PublicApiSurfaceTest {
         guard.onImportConfirmed(PassType.BoardingPass, SignatureBand.AppleVerified)
         guard.onImportDismissed(PassType.BoardingPass, SignatureBand.Incomplete)
         guard.onImportRejected(ParseFailureKind.Malformed)
+        guard.onBarcodeCreateGateShown(BarcodeCreateKind.Url)
+        guard.onBarcodeCreateGateConfirmed(BarcodeCreateKind.Url)
+        guard.onBarcodeCreateGateDismissed(BarcodeCreateKind.Url)
+    }
+
+    @Test
+    fun barcodeCreateKindCoversNonPlainTextArmsOfQrPayloadKind() {
+        // PlainText is intentionally omitted: BarcodeCreateConfirmSheet short-circuits
+        // before any telemetry fires for it. The remaining 12 arms mirror QrPayloadKind
+        // 1:1 - adding a new arm in passes-core should force a new arm here.
+        assertThat(BarcodeCreateKind.entries.map { it.name }).containsExactly(
+            "Url",
+            "Phone",
+            "Sms",
+            "Mailto",
+            "Geo",
+            "Wifi",
+            "Bitcoin",
+            "Ethereum",
+            "Magnet",
+            "Market",
+            "Intent",
+            "UnknownScheme",
+        ).inOrder()
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -574,4 +574,13 @@ private class RecordingGuard : UiTelemetryGuard {
     override fun onImportRejected(kind: ParseFailureKind) {
         events += "import-rejected:${kind.name}"
     }
+    override fun onBarcodeCreateGateShown(kind: BarcodeCreateKind) {
+        events += "barcode-shown:${kind.name}"
+    }
+    override fun onBarcodeCreateGateConfirmed(kind: BarcodeCreateKind) {
+        events += "barcode-confirm:${kind.name}"
+    }
+    override fun onBarcodeCreateGateDismissed(kind: BarcodeCreateKind) {
+        events += "barcode-dismiss:${kind.name}"
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a sibling `BarcodeCreateKind` enum + `onBarcodeCreateGate{Shown,Confirmed,Dismissed}` method family to `UiTelemetryGuard`, then wires `BarcodeCreateConfirmSheet` to fire them. Closes the wpass-lzi.9 follow-up: the create-time QR gate was previously invisible to walt-android's dismissal-rate dashboard.
- Sibling method family rather than a fourth arm on `SecurityIntentKind`: the existing methods take a `PassType`, which is PKPASS-only (no `ScannableCard` member), and the epic mandates a distinct artifact class end-to-end. `BarcodeCreateKind` mirrors `QrPayloadKind`'s non-PlainText arms 1:1; PlainText short-circuits the gate so no event ever fires for it.
- `ComposableSurfaceLockTest` bumps the BarcodeCreateConfirmSheet param count from 3 → 4 and grows a contains-`UiTelemetryGuard` assertion mirroring the other security sheets; `PublicApiSurfaceTest.uiTelemetryGuardEventsAreEnumsAndPrimitivesOnly`, the Noop-full-surface test, and a new `barcodeCreateKindCovers…` enum-arm test all extend to cover the new shape. `COMPOSABLE_SIGNATURES.md` updated.

## Test plan

- [x] `./gradlew :passes-ui:check` (compile, unit tests, lint, detekt)
- [ ] Visual regression: confirm previews render unchanged after Noop guard wired into BarcodeCreateConfirmSheetPreviews