### PR TITLE
passes-core: replace HexFormat with API 28-safe hex decoder (wpass-g00)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ManifestVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ManifestVerifier.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.security.MessageDigest
-import java.util.HexFormat
 
 /**
  * Verifies the SHA-1 hash chain a PKPASS archive declares in `manifest.json`. Pure
@@ -133,12 +132,26 @@ private fun findExtraEntry(
  * Decodes a 40-character SHA-1 hex string to its 20 raw bytes, accepting any case
  * mix. Returns `null` (not an exception) so the caller can map to
  * [ManifestFailure.InvalidHashFormat] without a try/catch at every call site.
- * [HexFormat.parseHex] accepts both cases; the explicit length check is here because
- * `parseHex` accepts any even length and we require exactly SHA-1.
+ *
+ * Implemented as a manual nibble loop rather than `java.util.HexFormat` because the
+ * latter was added to AOSP at API 34 and D8 does not desugar it; on API 28–33 a
+ * file-scope `HexFormat.of()` triggers `NoClassDefFoundError` in `<clinit>` the
+ * first time any function in this file is called (wpass-g00).
  */
 private fun decodeSha1Hex(hex: String): ByteArray? {
     if (hex.length != SHA1_HEX_LENGTH) return null
-    return runCatching { HEX.parseHex(hex) }.getOrNull()
+    val out = ByteArray(SHA1_HEX_LENGTH / 2)
+    var ok = true
+    for (i in 0 until SHA1_HEX_LENGTH step 2) {
+        val hi = Character.digit(hex[i], 16)
+        val lo = Character.digit(hex[i + 1], 16)
+        if (hi < 0 || lo < 0) {
+            ok = false
+            break
+        }
+        out[i / 2] = (hi shl 4 or lo).toByte()
+    }
+    return if (ok) out else null
 }
 
 private sealed interface ManifestParse {
@@ -149,4 +162,3 @@ private sealed interface ManifestParse {
 
 private const val SHA1_ALGORITHM = "SHA-1"
 private const val SHA1_HEX_LENGTH = 40
-private val HEX: HexFormat = HexFormat.of()


### PR DESCRIPTION
## Summary

- `java.util.HexFormat` was added to AOSP at API 34 and D8 does not desugar it. The file-scope `private val HEX: HexFormat = HexFormat.of()` in `ManifestVerifier.kt` therefore threw `NoClassDefFoundError` in `<clinit>` the first time *any* top-level function in the file was called on API 28-33, crashing every signed PKPASS import on Android 9-13 under walt-android's `minSdk=28`. Caught by walt-android's `SignedPkpassImportSmokeTest` on the API 30 emulator job (walt-app/android#224).
- Replace `HexFormat.parseHex` with a manual `Character.digit` nibble loop. The length precondition, `null`-on-failure contract, and case-insensitivity behavior are all preserved.
- Closes wpass-g00.

## Test plan

- [x] `./gradlew :passes-core:test` — all `ManifestVerifierTest` cases pass, including `hexParsingAcceptsMixedCase`, `hexParsingRejectsNonHexCharacter`, `hexParsingRejectsWrongLengthShort`, `hexParsingRejectsWrongLengthLong`, and `selfReferentialEntryWinsOverInvalidHashFormat`.
- [x] `./gradlew :passes-core:detekt` — clean.
- [ ] walt-android `SignedPkpassImportSmokeTest` on the API 30 emulator passes once this lands and walt-android picks up the new commit.