### PR TITLE
passes-ui: ScannableCardRowTile wallet-row register (wpass-pnb)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -55,6 +55,37 @@ The tile is also visually distinct from a verified-PKPASS tile by at least two
 of: border treatment, leading icon, color band, typography weight — picked for
 redundancy so theming a single dimension flat cannot collapse the distinction.
 
+**C1 / C2 — consumer-side concession (wallet-row register).** The kernel
+exposes a sibling composable `ScannableCardRowTile` (wpass-pnb; consumer epic
+wlt-6ub) for hosts that interleave scannable cards with passes / PDFs in a
+single homogeneous wallet list rather than in their own carousel lane. The row
+intentionally drops the carousel tile's four-distinguisher contract: there is
+no dashed outline, no smaller corner radius vs a `PassFront`-style tile, and no
+in-row "Created by you" caption. The concession is permitted strictly when, and
+only when, all three of the following hold:
+
+1. The row owns no signature dot or other verified-pass affordance. Pinned at
+   the kernel surface by `ComposableSurfaceLockTest.scannableCardRowTileHas
+   ExactlyThreeUserVisibleParameters` (count: 3 — `card`, `onClick`, `modifier`;
+   no `showSignatureBadge`, no `leadingIcon`) and at the consumer (walt-android)
+   by `WalletListTest`'s "no scannable-card row owns a signature dot" invariant.
+2. The row owns no coloured leading strip styled to read as a verified-pass
+   band. The kernel surface uses the `unverifiedArtifact.accent` token (the
+   same neutral token the carousel tile's leading strip uses), NOT the user's
+   `card.color`. Routing user-chosen colour through this strip at list scale
+   would re-create the trust-conflation risk row 1 names.
+3. The detail surface (`ScannableCardScreen`) retains the bottom-docked
+   non-suppressible `ScannableCardTrustCaption`. The trust caption shifts from
+   list-row to detail-surface only; a user who taps a row to *use* the artifact
+   still sees "Created by you" before the scan target renders.
+
+The trade is bounded. `ScannableCardTile` and its four-distinguisher contract
+remain the kernel's recommended surface for hosts that present scannable cards
+in their own lane; `ScannableCardRowTile` is the alternative for the
+homogeneous-list register and nothing else. A future consumer wanting a wallet
+list that also drops the detail-surface caption is amending this row, not
+filing a refactor.
+
 **C3. Input hygiene at the create boundary.** `passes-core` validates
 `ScannableCardCreateInput` for: per-format length caps (Code128 ~80 chars,
 EAN-13 / UPC-A fixed-length with checksum, QR per-version cap with a
@@ -108,6 +139,15 @@ existing PKPASS pipeline.
 C2 (non-suppressible "Created by you" caption with ≥2 visual distinguishing
 elements). The two combine: the user sees a different-shaped tile in a
 different-titled lane with a different caption.
+
+A bounded consumer-side concession permits a homogeneous wallet-row register
+(`ScannableCardRowTile`) when the row carries no signature dot, no
+verified-band-styled leading strip, and the detail surface retains the
+non-suppressible trust caption. Full conditions and rationale are recorded in
+the C1 / C2 concession subsection above. The trust caption shifts from
+list-row to detail-surface only; the artifact-class distinction at list scale
+is then carried by the absence of pass-only chrome (signature dot, verified
+band) rather than by the carousel tile's four redundant distinguishers.
 
 **Status.** Mitigated structurally. This is the load-bearing concern of the
 entire epic; every downstream child must trace back to this row.
@@ -356,8 +396,12 @@ threat row above.
 - **No payload-bytes telemetry.** The `ScannableCardTelemetryGuard` may
   surface format counts and create/delete event counts; payload contents and
   payload length distributions are PII and never leave the device.
-- **No bypass of the "Created by you" caption** through theming, layout, or
-  consumer-supplied composables. C2 forbids it.
+- **No bypass of the "Created by you" caption on the detail surface**
+  (`ScannableCardScreen`), through theming, layout, or consumer-supplied
+  composables. The list-row register (`ScannableCardRowTile`) shifts the
+  caption from list-row to detail surface under the bounded C1 / C2
+  concession above; the detail surface itself remains non-suppressible. C2
+  forbids any further bypass.
 
 ## How each control is tested
 
@@ -369,7 +413,7 @@ can trace back here.
 | Control | Pinned by                                  |
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
-| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot) |
+| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb` adds `scannableCardRowTileHasExactlyThreeUserVisibleParameters` to pin the wallet-row concession shape, and `rowTileDoesNotRenderTrustCaption` / `rowTileRendersFormatSubtitle` to pin the caption-shift contract |
 | C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests)             |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration), dependency-graph assertion in build      |

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
@@ -67,20 +67,19 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *   kernel validator already rejects Cf / Cc codepoints at the create boundary (C3);
  *   isolating again ensures a future relaxation of the validator cannot silently weaken
  *   this surface.
- * - The merged [contentDescription] reads as "{label}, barcode card" so screen-reader
- *   users hear the artifact-class distinction the list-row chrome drops.
+ * - The merged [contentDescription] inlines the format token so a TalkBack user hears
+ *   "{label}, {format}, barcode card". Setting [contentDescription] on a
+ *   `mergeDescendants` node replaces (not appends to) descendant `Text` contributions, so
+ *   the format-as-subtitle visible to sighted users would otherwise be silent to AT. The
+ *   `rowTileSemanticsExposeFormatToken` smoke test pins that this stays the case.
  * - No signature affordance is composed inside the row. The absence is structural; the
  *   surface-lock test (`scannableCardRowTileHasExactlyThreeUserVisibleParameters`) pins
  *   the parameter shape so a future contributor cannot add `showSignatureBadge` without
  *   amending the threat-model concession.
  *
- * ## Out of scope
- *
- * - No long-press / overflow callback. Lifecycle actions (rename, delete) are consumer
- *   responsibilities, same posture as [ScannableCardTile].
- * - No share / export affordance.
- * - No alternative size profile. The row's height floor is fixed so it co-aligns with
- *   sibling wallet rows in the consumer's list at the same DP.
+ * Lifecycle gestures (long-press, overflow, share) and alternative size profiles are
+ * consumer responsibilities, same posture as [ScannableCardTile]; the kernel surface
+ * stays minimal so the surface-lock test pins a tight shape.
  */
 @Composable
 public fun ScannableCardRowTile(
@@ -90,6 +89,7 @@ public fun ScannableCardRowTile(
 ) {
     val accent = LocalPassesSemantics.current.unverifiedArtifact.accent.toComposeColor()
     val labelText = isolated(card.label)
+    val formatToken = card.format.rowSubtitle()
 
     Row(
         modifier = modifier
@@ -97,7 +97,10 @@ public fun ScannableCardRowTile(
             .heightIn(min = ROW_HEIGHT)
             .clickable(onClick = onClick)
             .semantics(mergeDescendants = true) {
-                contentDescription = "$labelText, barcode card"
+                // Setting contentDescription on a merged node replaces descendant Text
+                // contributions, so the format subtitle below has to be inlined here or
+                // TalkBack loses it.
+                contentDescription = "$labelText, $formatToken, barcode card"
             },
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -118,7 +121,7 @@ public fun ScannableCardRowTile(
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = card.format.rowSubtitle(),
+                text = formatToken,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -133,7 +136,6 @@ private fun LeadingAccentStrip(color: Color) {
     Box(
         modifier = Modifier
             .width(ACCENT_STRIP_WIDTH)
-            .heightIn(min = ROW_HEIGHT)
             .fillMaxHeight()
             .background(color),
     )

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
@@ -1,0 +1,154 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.ScannableCard
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.core.isolated
+import `is`.walt.passes.ui.theme.LocalPassesSemantics
+import `is`.walt.passes.ui.theme.toComposeColor
+
+/**
+ * Wallet-row register for a [ScannableCard]. Sibling to [ScannableCardTile]; intended for
+ * consumers that interleave scannable cards with passes / PDFs in a single homogeneous
+ * list rather than presenting them in their own carousel lane. Parent kernel epic
+ * `wpass-hy2`; consumer epic `wlt-6ub` (walt-android wallet-list redesign).
+ *
+ * Where [ScannableCardTile] carries four redundant artifact-class distinguishers (dashed
+ * outline, leading accent band, smaller corner radius, non-suppressible "Created by you"
+ * caption) per `docs/SCANNABLE_CARD_THREAT_MODEL.md` C1 / C2, this register intentionally
+ * does not. The threat-model concession (recorded in that same doc) permits a homogeneous
+ * row when, and only when, all three of:
+ *
+ *  1. The row carries no signature dot.
+ *  2. The row carries no coloured leading band styled to read as a verified-pass band.
+ *  3. The detail surface ([ScannableCardScreen]) retains the bottom-docked
+ *     non-suppressible [ScannableCardTrustCaption].
+ *
+ * The trust caption shifts from list-row to detail-surface only. A user who taps the row
+ * to use the artifact still sees "Created by you" before scanning. This trade is explicit
+ * and bounded; it is not a generalised opt-out of C2.
+ *
+ * ## Visual shape
+ *
+ * A flat row, label-led, with a leading neutral-tone accent strip (NOT the user's chosen
+ * `card.color` — that would re-create the verified-band read at list scale). The format
+ * appears as a short subtitle below the label. No tile, no thumbnail, no badge.
+ *
+ * The leading strip is sourced from [LocalPassesSemantics] `unverifiedArtifact.accent`,
+ * the same accent the carousel tile uses. Consumers wanting a richer leading slot
+ * (format-icon glyph, format-tinted tile) layer that themselves in their own wrapper —
+ * the kernel surface stays minimal so the surface-lock test below can pin a tight shape.
+ *
+ * ## Trust-claim contract
+ *
+ * - User-supplied [ScannableCard.label] is wrapped in U+2068 / U+2069 (FSI / PDI) by
+ *   `passes-ui-core::isolated`, same defense-in-depth `ScannableCardTile` applies. The
+ *   kernel validator already rejects Cf / Cc codepoints at the create boundary (C3);
+ *   isolating again ensures a future relaxation of the validator cannot silently weaken
+ *   this surface.
+ * - The merged [contentDescription] reads as "{label}, barcode card" so screen-reader
+ *   users hear the artifact-class distinction the list-row chrome drops.
+ * - No signature affordance is composed inside the row. The absence is structural; the
+ *   surface-lock test (`scannableCardRowTileHasExactlyThreeUserVisibleParameters`) pins
+ *   the parameter shape so a future contributor cannot add `showSignatureBadge` without
+ *   amending the threat-model concession.
+ *
+ * ## Out of scope
+ *
+ * - No long-press / overflow callback. Lifecycle actions (rename, delete) are consumer
+ *   responsibilities, same posture as [ScannableCardTile].
+ * - No share / export affordance.
+ * - No alternative size profile. The row's height floor is fixed so it co-aligns with
+ *   sibling wallet rows in the consumer's list at the same DP.
+ */
+@Composable
+public fun ScannableCardRowTile(
+    card: ScannableCard,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accent = LocalPassesSemantics.current.unverifiedArtifact.accent.toComposeColor()
+    val labelText = isolated(card.label)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = ROW_HEIGHT)
+            .clickable(onClick = onClick)
+            .semantics(mergeDescendants = true) {
+                contentDescription = "$labelText, barcode card"
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LeadingAccentStrip(color = accent)
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = TEXT_LEADING_GAP, end = TEXT_TRAILING_PADDING),
+            verticalArrangement = Arrangement.spacedBy(TEXT_VERTICAL_GAP),
+        ) {
+            Text(
+                text = labelText,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = card.format.rowSubtitle(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LeadingAccentStrip(color: Color) {
+    Box(
+        modifier = Modifier
+            .width(ACCENT_STRIP_WIDTH)
+            .heightIn(min = ROW_HEIGHT)
+            .fillMaxHeight()
+            .background(color),
+    )
+}
+
+private fun ScannableFormat.rowSubtitle(): String = when (this) {
+    ScannableFormat.Code128 -> "Code 128"
+    ScannableFormat.Code39 -> "Code 39"
+    ScannableFormat.Ean13 -> "EAN-13"
+    ScannableFormat.UpcA -> "UPC-A"
+    ScannableFormat.Qr -> "QR"
+}
+
+private val ROW_HEIGHT = 64.dp
+private val ACCENT_STRIP_WIDTH = 4.dp
+private val TEXT_LEADING_GAP = 16.dp
+private val TEXT_TRAILING_PADDING = 16.dp
+private val TEXT_VERTICAL_GAP = 2.dp

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -172,14 +172,29 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
+    fun scannableCardRowTileHasExactlyThreeUserVisibleParameters() {
+        // (card, onClick, modifier). Wallet-row register sibling of ScannableCardTile.
+        // The row deliberately drops the carousel tile's caption per the threat-model
+        // concession in SCANNABLE_CARD_THREAT_MODEL.md C1 / C2; adding a 4th parameter
+        // (e.g. `showSignatureBadge`, `leadingIcon`, `onLongPress`) either re-opens the
+        // trust-conflation risk or expands the surface past what the concession permits.
+        // Review the concession before changing this number.
+        assertUserVisibleParamCount("ScannableCardRowTileKt", "ScannableCardRowTile", expected = 3)
+    }
+
+    @Test
     fun scannableCardSurfacesHaveNoOverloads() {
         // The caption non-suppressibility rule extends to overloads: a future
         // contributor cannot quietly add `ScannableCardTile(..., showCaption: Boolean)`
-        // as a sibling with the same name.
+        // as a sibling with the same name. `ScannableCardRowTile` is included even
+        // though it does not itself render the caption — the threat-model concession is
+        // a specific row shape (label + neutral leading strip + format subtitle) and an
+        // overload that adds richer chrome would dilute the shape this lock pins.
         listOf(
             "ScannableCardTrustCaptionKt" to "ScannableCardTrustCaption",
             "ScannableCardTileKt" to "ScannableCardTile",
             "ScannableCardScreenKt" to "ScannableCardScreen",
+            "ScannableCardRowTileKt" to "ScannableCardRowTile",
         ).forEach { (file, name) ->
             val klass = Class.forName("is.walt.passes.ui.$file")
             val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -187,6 +187,51 @@ class ScannableCardTrustSurfaceTest {
         composeRule.onNodeWithText("Created by you").assertIsDisplayed()
     }
 
+    @Test
+    fun rowTileDoesNotRenderTrustCaption() {
+        // The wallet-row register intentionally drops the carousel tile's "Created by
+        // you" caption per the SCANNABLE_CARD_THREAT_MODEL.md C1 / C2 concession. The
+        // detail surface (asserted separately by fullScreenRendersTrustCaptionDockedAtBottom)
+        // is where the trust caption surfaces for this register; missing it on the row
+        // is the load-bearing difference between the two siblings.
+        composeRule.setContent {
+            ThemedHost { ScannableCardRowTile(card = qrFixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("Created by you").assertDoesNotExist()
+    }
+
+    @Test
+    fun rowTileRendersIsolatedLabel() {
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardRowTile(card = qrFixture(label = "Library card"), onClick = {})
+            }
+        }
+        // FSI / PDI defense-in-depth on user-controlled label, same as ScannableCardTile.
+        composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun rowTileRendersFormatSubtitle() {
+        composeRule.setContent {
+            ThemedHost { ScannableCardRowTile(card = code128Fixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("Code 128").assertIsDisplayed()
+    }
+
+    @Test
+    fun rowTilePropagatesClickToOnClickCallback() {
+        var clicks = 0
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardRowTile(card = qrFixture(), onClick = { clicks++ })
+            }
+        }
+        composeRule.onNodeWithText("⁨Membership⁩").performClick()
+        composeRule.waitForIdle()
+        assert(clicks == 1) { "expected one click propagation, got $clicks" }
+    }
+
     @Composable
     private fun ThemedHost(content: @Composable () -> Unit) {
         MaterialTheme { PassesTheme(semantics = semantics, content = content) }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
@@ -230,6 +231,36 @@ class ScannableCardTrustSurfaceTest {
         composeRule.onNodeWithText("⁨Membership⁩").performClick()
         composeRule.waitForIdle()
         assert(clicks == 1) { "expected one click propagation, got $clicks" }
+    }
+
+    @Test
+    fun rowTileSemanticsExposeFormatToken() {
+        // The merged-descendants node sets contentDescription explicitly, which replaces
+        // (not appends to) descendant Text contributions for accessibility services. The
+        // format-as-subtitle is one of the two signals compensating for the dropped
+        // carousel-tile chrome under the C1 / C2 wallet-row concession; a TalkBack user
+        // who only hears "{label}, barcode card" loses half of that. The contentDescription
+        // must inline the format token so the AT-level distinction matches the visual one.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardRowTile(card = qrFixture(label = "Library card"), onClick = {})
+            }
+        }
+        composeRule
+            .onNodeWithContentDescription("⁨Library card⁩, QR, barcode card")
+            .assertExists()
+    }
+
+    @Test
+    fun rowTileSemanticsExposeFormatTokenForOneDimensionalFormat() {
+        // The QR path and the 1D path render different subtitle strings; both must reach
+        // the merged contentDescription so neither barcode family is silently AT-blind.
+        composeRule.setContent {
+            ThemedHost { ScannableCardRowTile(card = code128Fixture(), onClick = {}) }
+        }
+        composeRule
+            .onNodeWithContentDescription("⁨Gym⁩, Code 128, barcode card")
+            .assertExists()
     }
 
     @Composable


### PR DESCRIPTION
## Summary

Adds public sibling composable `ScannableCardRowTile(card, onClick, modifier)` to `passes-ui` for consumers that interleave scannable cards with passes / PDFs in a single homogeneous wallet list rather than presenting them in their own carousel lane. Parent kernel epic `wpass-hy2`; consumer epic `wlt-6ub` (walt-android wallet-list redesign).

The row deliberately drops the carousel tile's four-distinguisher contract under a bounded threat-model concession recorded in `docs/SCANNABLE_CARD_THREAT_MODEL.md` C1 / C2:

1. No signature dot or other verified-pass affordance (pinned by new `scannableCardRowTileHasExactlyThreeUserVisibleParameters` lock test).
2. No coloured leading strip styled to read as a verified-pass band — the strip uses `unverifiedArtifact.accent` (neutral kernel token), NOT `card.color`.
3. The detail surface (`ScannableCardScreen`) retains the non-suppressible bottom-docked `ScannableCardTrustCaption`.

The trust caption shifts from list-row to detail-surface only; a user who taps the row to *use* the artifact still sees "Created by you" before the scan target renders.

Two PR-review fixes also applied in commit 2:

- Format token inlined into the merged `contentDescription` so TalkBack users hear `"{label}, {format}, barcode card"` (a `mergeDescendants` node with explicit `contentDescription` replaces descendant `Text` contributions; without inlining, the format subtitle visible to sighted users was silent to AT). Pinned by `rowTileSemanticsExposeFormatToken` and `...ForOneDimensionalFormat`.
- Dropped redundant `heightIn(min = ROW_HEIGHT)` on the leading strip; the parent `Row` already enforces the floor.

## Test plan

- [x] `./gradlew check` passes (full multi-module: tests, lint, detekt)
- [x] New unit tests in `ScannableCardTrustSurfaceTest`: `rowTileDoesNotRenderTrustCaption`, `rowTileRendersIsolatedLabel`, `rowTileRendersFormatSubtitle`, `rowTilePropagatesClickToOnClickCallback`, `rowTileSemanticsExposeFormatToken`, `rowTileSemanticsExposeFormatTokenForOneDimensionalFormat`
- [x] Surface lock pinned by `scannableCardRowTileHasExactlyThreeUserVisibleParameters` and new entry in `scannableCardSurfacesHaveNoOverloads`
- [x] `SCANNABLE_CARD_THREAT_MODEL.md` C1 / C2 concession subsection added; threat-row 1 updated; non-features bullet narrowed to "on the detail surface"; C2 test-mapping row references the new lock test