### PR TITLE
passes-ui: ScannableCardRowTile leadingSlot parameter (wpass-2a2)

### DIFF
--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
@@ -56,9 +56,14 @@ import `is`.walt.passes.ui.theme.toComposeColor
  * appears as a short subtitle below the label. No tile, no thumbnail, no badge.
  *
  * The leading strip is sourced from [LocalPassesSemantics] `unverifiedArtifact.accent`,
- * the same accent the carousel tile uses. Consumers wanting a richer leading slot
- * (format-icon glyph, format-tinted tile) layer that themselves in their own wrapper —
- * the kernel surface stays minimal so the surface-lock test below can pin a tight shape.
+ * the same accent the carousel tile uses. Consumers wanting a richer leading affordance
+ * (format-icon glyph, format-tinted tile) pass a composable via [leadingSlot]; it sits
+ * between the accent strip and the label/format column, inside the row's
+ * `mergeDescendants` block. The kernel surface stays minimal; the slot is a visual hook
+ * only and is not a trust signal — anything composed inside it that exposes a non-null
+ * `contentDescription` will participate in the merged description Walt's accessibility
+ * contract already pins, so slot content should set `contentDescription = null` on its
+ * icons / images and rely on the kernel-built description.
  *
  * ## Trust-claim contract
  *
@@ -73,9 +78,10 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *   the format-as-subtitle visible to sighted users would otherwise be silent to AT. The
  *   `rowTileSemanticsExposeFormatToken` smoke test pins that this stays the case.
  * - No signature affordance is composed inside the row. The absence is structural; the
- *   surface-lock test (`scannableCardRowTileHasExactlyThreeUserVisibleParameters`) pins
+ *   surface-lock test (`scannableCardRowTileHasExactlyFourUserVisibleParameters`) pins
  *   the parameter shape so a future contributor cannot add `showSignatureBadge` without
- *   amending the threat-model concession.
+ *   amending the threat-model concession. [leadingSlot] is the only sanctioned
+ *   visual-hook parameter; a signature-bearing addition still belongs out of band.
  *
  * Lifecycle gestures (long-press, overflow, share) and alternative size profiles are
  * consumer responsibilities, same posture as [ScannableCardTile]; the kernel surface
@@ -86,6 +92,7 @@ public fun ScannableCardRowTile(
     card: ScannableCard,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    leadingSlot: @Composable () -> Unit = {},
 ) {
     val accent = LocalPassesSemantics.current.unverifiedArtifact.accent.toComposeColor()
     val labelText = isolated(card.label)
@@ -105,6 +112,7 @@ public fun ScannableCardRowTile(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         LeadingAccentStrip(color = accent)
+        leadingSlot()
         Column(
             modifier = Modifier
                 .weight(1f)

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -172,14 +172,15 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
-    fun scannableCardRowTileHasExactlyThreeUserVisibleParameters() {
-        // (card, onClick, modifier). Wallet-row register sibling of ScannableCardTile.
-        // The row deliberately drops the carousel tile's caption per the threat-model
-        // concession in SCANNABLE_CARD_THREAT_MODEL.md C1 / C2; adding a 4th parameter
-        // (e.g. `showSignatureBadge`, `leadingIcon`, `onLongPress`) either re-opens the
-        // trust-conflation risk or expands the surface past what the concession permits.
-        // Review the concession before changing this number.
-        assertUserVisibleParamCount("ScannableCardRowTileKt", "ScannableCardRowTile", expected = 3)
+    fun scannableCardRowTileHasExactlyFourUserVisibleParameters() {
+        // (card, onClick, modifier, leadingSlot). Wallet-row register sibling of
+        // ScannableCardTile. The row deliberately drops the carousel tile's caption per
+        // the threat-model concession in SCANNABLE_CARD_THREAT_MODEL.md C1 / C2;
+        // `leadingSlot` is a visual hook only (see wpass-2a2) and is not a trust signal —
+        // adding any further parameter (e.g. `showSignatureBadge`, `onLongPress`) either
+        // re-opens the trust-conflation risk or expands the surface past what the
+        // concession permits. Review the concession before changing this number.
+        assertUserVisibleParamCount("ScannableCardRowTileKt", "ScannableCardRowTile", expected = 4)
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -263,6 +263,46 @@ class ScannableCardTrustSurfaceTest {
             .assertExists()
     }
 
+    @Test
+    fun rowTileRendersLeadingSlot() {
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardRowTile(
+                    card = qrFixture(),
+                    onClick = {},
+                    leadingSlot = {
+                        androidx.compose.material3.Text(text = "GLYPH")
+                    },
+                )
+            }
+        }
+        composeRule.onNodeWithText("GLYPH").assertIsDisplayed()
+    }
+
+    @Test
+    fun rowTileLeadingSlotWithoutContentDescriptionDoesNotPolluteMergedSemantics() {
+        // The slot lives inside the row's mergeDescendants block. The kernel-built
+        // contentDescription on the merged node replaces (not appends to) descendant
+        // contributions, so a slot composable whose icons set contentDescription = null
+        // must leave the merged description exactly equal to the kernel-built string.
+        // Pinning this protects the wpass-2a2 surface claim that `leadingSlot` is a
+        // visual hook, not a trust signal.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardRowTile(
+                    card = qrFixture(label = "Library card"),
+                    onClick = {},
+                    leadingSlot = {
+                        Box(modifier = Modifier.size(24.dp))
+                    },
+                )
+            }
+        }
+        composeRule
+            .onNodeWithContentDescription("⁨Library card⁩, QR, barcode card")
+            .assertExists()
+    }
+
     @Composable
     private fun ThemedHost(content: @Composable () -> Unit) {
         MaterialTheme { PassesTheme(semantics = semantics, content = content) }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -3,6 +3,7 @@ package `is`.walt.passes.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
@@ -271,7 +272,7 @@ class ScannableCardTrustSurfaceTest {
                     card = qrFixture(),
                     onClick = {},
                     leadingSlot = {
-                        androidx.compose.material3.Text(text = "GLYPH")
+                        Text(text = "GLYPH")
                     },
                 )
             }


### PR DESCRIPTION
## Summary

- Adds `leadingSlot: @Composable () -> Unit = {}` to `ScannableCardRowTile`, positioned between the leading accent strip and the label/format `Column` (inside the row's `mergeDescendants` block).
- Lets walt-android (wlt-5wz) collapse its consumer-side `ScannableCardSummaryRow` reimplementation onto the kernel tile — same kernel-parameterises-divergence pattern as wpass-48v / wlt-owh.
- Trust contract unchanged: no signature dot, neutral accent strip retained, slot is a visual hook only. Slot content whose icons set `contentDescription = null` leaves the kernel-built merged description (`"{label}, {format}, barcode card"`) unchanged.
- Surface-lock test renamed `…HasExactlyThreeUserVisibleParameters` → `…HasExactlyFourUserVisibleParameters`; `leadingSlot` pinned as the only sanctioned addition; `showSignatureBadge` / `onLongPress` still forbidden.
- KDoc updated to document the slot and the renamed surface-lock test.

## Test plan

- [x] `:passes-ui:testDebugUnitTest` — 20/20 in ComposableSurfaceLockTest, 16/16 in ScannableCardTrustSurfaceTest (incl. new `rowTileRendersLeadingSlot` and `rowTileLeadingSlotWithoutContentDescriptionDoesNotPolluteMergedSemantics`)
- [x] `:passes-ui:detekt` clean
- [x] Default `{}` arg preserves existing call sites — verified by the unchanged behavioural row tests (`rowTileRendersFormatSubtitle`, `rowTileSemanticsExposeFormatToken`, `rowTileRendersIsolatedLabel`, `rowTilePropagatesClickToOnClickCallback`).

Closes wpass-2a2.