### PR TITLE
passes-core+storage+ui: drop ScannableCard.color tearout (wpass-q5p)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -71,9 +71,10 @@ only when, all three of the following hold:
    by `WalletListTest`'s "no scannable-card row owns a signature dot" invariant.
 2. The row owns no coloured leading strip styled to read as a verified-pass
    band. The kernel surface uses the `unverifiedArtifact.accent` token (the
-   same neutral token the carousel tile's leading strip uses), NOT the user's
-   `card.color`. Routing user-chosen colour through this strip at list scale
-   would re-create the trust-conflation risk row 1 names.
+   same neutral token the carousel tile's leading strip uses). Per-card
+   user-chosen colour was removed from the kernel (`wpass-q5p`); routing it
+   through this strip at list scale would have re-created the trust-conflation
+   risk row 1 names.
 3. The detail surface (`ScannableCardScreen`) retains the bottom-docked
    non-suppressible `ScannableCardTrustCaption`. The trust caption shifts from
    list-row to detail-surface only; a user who taps a row to *use* the artifact
@@ -302,14 +303,13 @@ browser CSS / SVG parsers (named-color injection, `var(--…)` escapes). A
 naive "type a hex code" picker could allow inputs that round-trip as something
 unexpected.
 
-**Mitigation.** `ScannableCard.color: Int?` is an ARGB integer, not a string.
-The walt-android consumer's color picker UI may present hex input, but the
-boundary between consumer and kernel is a 32-bit integer with no parsing on
-the kernel side. The picker UI's own sanitization is a consumer concern, filed
-as `wlt-*`.
+**Mitigation.** The kernel no longer exposes a per-card user colour at all
+(`wpass-q5p` removed `ScannableCard.color` and `ScannableColor`). With no
+colour field on the artifact, the kernel has no colour parsing or storage
+surface to attack, and the consumer's create flow no longer presents a colour
+picker.
 
-**Status.** Out of scope for the kernel (no parsing surface); consumer-side
-filed separately.
+**Status.** Removed at the kernel; no parsing surface remains.
 
 ### 11. Future TOTP / HMAC-OATH secret leakage — Explicit non-feature
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ android.nonTransitiveRClass=true
 # Version stays on the SNAPSHOT track until ADR 0004's GitHub Packages cutover,
 # at which point tagged releases drop the suffix.
 walt.passes.group=is.walt
-walt.passes.version=0.1.0-SNAPSHOT
+walt.passes.version=0.2.0-SNAPSHOT

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCard.kt
@@ -19,7 +19,6 @@ public data class ScannableCard internal constructor(
     public val payload: String,
     public val format: ScannableFormat,
     public val label: String,
-    public val color: ScannableColor?,
     public val createdAt: PassInstant,
 )
 
@@ -30,14 +29,3 @@ public data class ScannableCard internal constructor(
  */
 @JvmInline
 public value class ScannableCardId(public val value: String)
-
-/**
- * 32-bit packed ARGB color (`0xAARRGGBB`) for the card's background tint. Distinct from
- * [ColorValue] (24-bit RGB for PKPASS color fields) — that one originates from a verified
- * archive and never carries alpha; this one is user-chosen and may want translucency.
- *
- * passes-core cannot depend on passes-ui-core's `ArgbColor` (would invert the module dep
- * direction). The consumer module provides a conversion extension when rendering.
- */
-@JvmInline
-public value class ScannableColor(public val argb: Int)

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateInput.kt
@@ -7,12 +7,9 @@ package `is`.walt.passes.core
  * or bidi/control-character hygiene yet, and anything of type [ScannableCard] has.
  *
  * Construction is deliberately permissive — the validator (Child 4) is the choke point.
- * `color = null` means "use the consumer-side default tint," not "no tint" — there is no
- * untinted render path; the consumer always applies a fallback.
  */
 public data class ScannableCardCreateInput(
     public val payload: String,
     public val format: ScannableFormat,
     public val label: String,
-    public val color: ScannableColor?,
 )

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
@@ -40,7 +40,6 @@ public object ScannableCardInputValidator {
                 payload = trimmedPayload,
                 format = input.format,
                 label = trimmedLabel,
-                color = input.color,
                 createdAt = createdAt,
             ),
         )

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -312,7 +312,6 @@ class ScannableCardInputValidatorTest {
                     payload = payload,
                     format = format,
                     label = label,
-                    color = null,
                 ),
             id = id,
             createdAt = now,

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
@@ -19,13 +19,11 @@ class ScannableCardSurfaceTest {
                 payload = "1234567890128",
                 format = ScannableFormat.Ean13,
                 label = "Grocery loyalty",
-                color = ScannableColor(argb = 0xFF1F4FA0.toInt()),
                 createdAt = PassInstant(epochMillis = 1_800_000_000_000L),
             )
 
         assertThat(card.id).isEqualTo(ScannableCardId("card-001"))
         assertThat(card.format).isEqualTo(ScannableFormat.Ean13)
-        assertThat(card.color?.argb).isEqualTo(0xFF1F4FA0.toInt())
         // Every ScannableFormat referenced so removal breaks compilation here.
         val allFormats =
             setOf(
@@ -47,19 +45,12 @@ class ScannableCardSurfaceTest {
     }
 
     @Test
-    fun scannableCardColorIsOptional() {
-        val card = sampleCard(color = null)
-        assertThat(card.color).isNull()
-    }
-
-    @Test
     fun scannableCardCreateInputAcceptsEdgeValues() {
         val empty =
             ScannableCardCreateInput(
                 payload = "",
                 format = ScannableFormat.Qr,
                 label = "",
-                color = null,
             )
         assertThat(empty.payload).isEmpty()
         assertThat(empty.label).isEmpty()
@@ -70,7 +61,6 @@ class ScannableCardSurfaceTest {
                 payload = "X".repeat(10_000),
                 format = ScannableFormat.Code128,
                 label = "Y".repeat(1_000),
-                color = ScannableColor(argb = 0),
             )
         assertThat(maxish.payload).hasLength(10_000)
     }
@@ -152,10 +142,9 @@ class ScannableCardSurfaceTest {
     }
 
     @Test
-    fun scannableCardIdAndColorAreValueClasses() {
+    fun scannableCardIdIsAValueClass() {
         // @JvmInline value classes equate by wrapped value, not reference.
         assertThat(ScannableCardId("x")).isEqualTo(ScannableCardId("x"))
-        assertThat(ScannableColor(0x11223344)).isEqualTo(ScannableColor(0x11223344))
     }
 
     // Walks superclasses and their declared interfaces. Skips interface-of-interface ancestors
@@ -172,13 +161,12 @@ class ScannableCardSurfaceTest {
         return out
     }
 
-    private fun sampleCard(color: ScannableColor? = ScannableColor(argb = 0)): ScannableCard =
+    private fun sampleCard(): ScannableCard =
         ScannableCard(
             id = ScannableCardId("card-fixed"),
             payload = "PAYLOAD",
             format = ScannableFormat.Code128,
             label = "label",
-            color = color,
             createdAt = PassInstant(epochMillis = 1_700_000_000_000L),
         )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -14,7 +14,7 @@ package `is`.walt.passes.storage
 public object Schema {
     public const val DATABASE_NAME: String = "walt_passes.db"
 
-    public const val VERSION: Int = 3
+    public const val VERSION: Int = 4
 
     public object Tables {
         public const val SCHEMA_META: String = "schema_meta"
@@ -35,12 +35,12 @@ public object Schema {
     }
 
     /**
-     * Statements that introduce the v3 scannable-cards table. Referenced from both [DDL]
-     * (for fresh installs) and [MIGRATIONS]`[2]` (for v2 -> v3 upgrades) so the two paths
-     * cannot drift. The fresh-vs-migrated parity guard in `SchemaMigrationTest` covers
-     * both v1 -> v2 and v2 -> v3 by walking every hop. `scannable_cards` lives in the
-     * same SQLCipher database as the existing tables, so
-     * [BackupRulesContract.REQUIRED_EXCLUDES] already covers it.
+     * Statements that introduced the v3 scannable-cards table. Kept verbatim so a v2 -> v3
+     * upgrade still produces the historical shape (including the now-dropped `color_argb`
+     * column); the v3 -> v4 migration then rewrites the table to the current shape. Fresh
+     * installs skip this entirely and go straight to [V4_SCANNABLE_CARD_TABLES]. The
+     * fresh-vs-migrated parity guard in `SchemaMigrationTest` verifies the two paths
+     * converge at v4.
      */
     private val V3_SCANNABLE_CARD_TABLES: List<String> = listOf(
         """
@@ -53,6 +53,56 @@ public object Schema {
             created_at_epoch_ms INTEGER NOT NULL
         )
         """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_scannable_cards_created_at " +
+            "ON scannable_cards(created_at_epoch_ms)",
+    )
+
+    /**
+     * Statements that introduce the v4 scannable-cards table — the v3 shape minus the
+     * `color_argb` column. Used by [DDL] for fresh installs at v4 and beyond. Existing
+     * v3 installs reach the same shape via the [V3_TO_V4_DROP_COLOR_COLUMN] table-rewrite
+     * migration. `scannable_cards` lives in the same SQLCipher database as the existing
+     * tables, so [BackupRulesContract.REQUIRED_EXCLUDES] already covers it.
+     */
+    private val V4_SCANNABLE_CARD_TABLES: List<String> = listOf(
+        """
+        CREATE TABLE IF NOT EXISTS scannable_cards (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            payload             TEXT    NOT NULL,
+            format              TEXT    NOT NULL,
+            label               TEXT    NOT NULL,
+            created_at_epoch_ms INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        "CREATE INDEX IF NOT EXISTS idx_scannable_cards_created_at " +
+            "ON scannable_cards(created_at_epoch_ms)",
+    )
+
+    /**
+     * v3 -> v4 migration. Drops the `color_argb` column from the scannable_cards table.
+     * Implemented as a table-rewrite (RENAME / CREATE / INSERT...SELECT / DROP) rather
+     * than `ALTER TABLE DROP COLUMN` so the migration works on every SQLCipher version
+     * the project ships on without depending on SQLite 3.35+ semantics. Row identity is
+     * preserved by re-using each row's explicit `id` in the INSERT; SQLite's
+     * AUTOINCREMENT bookkeeping in `sqlite_sequence` updates to max(id) on insert, so
+     * subsequent inserts do not collide with surviving rows.
+     */
+    private val V3_TO_V4_DROP_COLOR_COLUMN: List<String> = listOf(
+        "ALTER TABLE scannable_cards RENAME TO scannable_cards_v3",
+        """
+        CREATE TABLE scannable_cards (
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            payload             TEXT    NOT NULL,
+            format              TEXT    NOT NULL,
+            label               TEXT    NOT NULL,
+            created_at_epoch_ms INTEGER NOT NULL
+        )
+        """.trimIndent(),
+        """
+        INSERT INTO scannable_cards (id, payload, format, label, created_at_epoch_ms)
+            SELECT id, payload, format, label, created_at_epoch_ms FROM scannable_cards_v3
+        """.trimIndent(),
+        "DROP TABLE scannable_cards_v3",
         "CREATE INDEX IF NOT EXISTS idx_scannable_cards_created_at " +
             "ON scannable_cards(created_at_epoch_ms)",
     )
@@ -132,7 +182,7 @@ public object Schema {
             PRIMARY KEY (pass_id, locale_tag)
         )
         """.trimIndent(),
-    ) + V2_DOCUMENT_TABLES + V3_SCANNABLE_CARD_TABLES
+    ) + V2_DOCUMENT_TABLES + V4_SCANNABLE_CARD_TABLES
 
     /**
      * Schema migrations, keyed by `fromVersion`. Forward-only per ADR 0002. Each entry's
@@ -143,9 +193,17 @@ public object Schema {
      * v1 -> v2 introduces `documents` and `document_thumbnails` for PDF document support
      * (ADR 0005). The new tables live in the same SQLCipher database, so no XML / Auto
      * Backup change is needed: the file-level exclusion already covers them.
+     *
+     * v2 -> v3 introduces `scannable_cards` for user-generated scannable artifacts.
+     *
+     * v3 -> v4 drops the now-unused `color_argb` column from `scannable_cards`. The
+     * consumer no longer reads or writes the field (walt-android `wlt-z17`); the
+     * column was dormant user-private data on disk. Row identity is preserved; per-row
+     * colour bytes are lost, which is intentional — Walt already stopped reading them.
      */
     public val MIGRATIONS: Map<Int, List<String>> = mapOf(
         1 to V2_DOCUMENT_TABLES,
         2 to V3_SCANNABLE_CARD_TABLES,
+        3 to V3_TO_V4_DROP_COLOR_COLUMN,
     )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -36,11 +36,8 @@ public object Schema {
 
     /**
      * Statements that introduced the v3 scannable-cards table. Kept verbatim so a v2 -> v3
-     * upgrade still produces the historical shape (including the now-dropped `color_argb`
-     * column); the v3 -> v4 migration then rewrites the table to the current shape. Fresh
-     * installs skip this entirely and go straight to [V4_SCANNABLE_CARD_TABLES]. The
-     * fresh-vs-migrated parity guard in `SchemaMigrationTest` verifies the two paths
-     * converge at v4.
+     * upgrade still produces the historical shape; the v3 -> v4 migration then rewrites
+     * the table. Fresh installs skip this and go straight to [V4_SCANNABLE_CARD_TABLES].
      */
     private val V3_SCANNABLE_CARD_TABLES: List<String> = listOf(
         """
@@ -98,6 +95,8 @@ public object Schema {
             created_at_epoch_ms INTEGER NOT NULL
         )
         """.trimIndent(),
+        // Explicit column list intentional — SELECT * would pull color_argb and shift
+        // column order on the target table (label -> created_at_epoch_ms et al.).
         """
         INSERT INTO scannable_cards (id, payload, format, label, created_at_epoch_ms)
             SELECT id, payload, format, label, created_at_epoch_ms FROM scannable_cards_v3

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -197,7 +197,6 @@ public class SqlCipherPassRepository internal constructor(
                     payload = approved.payload,
                     format = approved.format,
                     label = approved.label,
-                    colorArgb = approved.color?.argb,
                     nowEpochMs = now,
                 ),
             )

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
@@ -34,7 +34,6 @@ internal data class ScannableCardInsertRequest(
     val payload: String,
     val format: ScannableFormat,
     val label: String,
-    val colorArgb: Int?,
     val nowEpochMs: Long,
 )
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
@@ -8,7 +8,6 @@ import `is`.walt.passes.core.ScannableCardCreateInput
 import `is`.walt.passes.core.ScannableCardCreateResult
 import `is`.walt.passes.core.ScannableCardId
 import `is`.walt.passes.core.ScannableCardInputValidator
-import `is`.walt.passes.core.ScannableColor
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.storage.MigrationFailureKind
 import `is`.walt.passes.storage.ScannableCardRecordId
@@ -61,7 +60,6 @@ internal class SqlCipherScannableCardStore(
                 put("payload", request.payload)
                 put("format", request.format.name)
                 put("label", request.label)
-                request.colorArgb?.let { put("color_argb", it) } ?: putNull("color_argb")
                 put("created_at_epoch_ms", request.nowEpochMs)
             }
             rowId = db.insertOrThrow(Schema.Tables.SCANNABLE_CARDS, null, cv)
@@ -96,7 +94,6 @@ internal class SqlCipherScannableCardStore(
         val payloadIdx = getColumnIndexOrThrow("payload")
         val formatIdx = getColumnIndexOrThrow("format")
         val labelIdx = getColumnIndexOrThrow("label")
-        val colorIdx = getColumnIndexOrThrow("color_argb")
         val createdIdx = getColumnIndexOrThrow("created_at_epoch_ms")
 
         val format = ScannableFormat.entries.firstOrNull { it.name == getString(formatIdx) }
@@ -107,7 +104,6 @@ internal class SqlCipherScannableCardStore(
         val rowId = getLong(idIdx)
         val payload = getString(payloadIdx)
         val label = getString(labelIdx)
-        val colorArgb = if (isNull(colorIdx)) null else getInt(colorIdx)
         val createdAtMs = getLong(createdIdx)
 
         val result = ScannableCardInputValidator.validate(
@@ -115,7 +111,6 @@ internal class SqlCipherScannableCardStore(
                 payload = payload,
                 format = format,
                 label = label,
-                color = colorArgb?.let(::ScannableColor),
             ),
             id = ScannableCardId(rowId.toString()),
             createdAt = PassInstant(createdAtMs),
@@ -134,6 +129,6 @@ internal class SqlCipherScannableCardStore(
 
     private companion object {
         const val ALL_COLUMNS: String =
-            "id, payload, format, label, color_argb, created_at_epoch_ms"
+            "id, payload, format, label, created_at_epoch_ms"
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -199,7 +199,8 @@ class PublicApiSurfaceTest {
         assertThat(Schema.Tables.SCANNABLE_CARDS).isEqualTo("scannable_cards")
         // schema_meta + passes + 3 pass-side indexes + pass_images + pass_locales
         // + documents + 1 document index + document_thumbnails
-        // + scannable_cards + 1 scannable-card index = 12 statements.
+        // + scannable_cards (v4 shape, no color_argb) + 1 scannable-card index
+        // = 12 statements.
         assertThat(Schema.DDL).hasSize(12)
         assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3)
     }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -188,8 +188,8 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun schemaDeclaresSevenTablesAndIsAtVersionThree() {
-        assertThat(Schema.VERSION).isEqualTo(3)
+    fun schemaDeclaresSevenTablesAndIsAtVersionFour() {
+        assertThat(Schema.VERSION).isEqualTo(4)
         assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
         assertThat(Schema.Tables.PASSES).isEqualTo("passes")
         assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
@@ -201,7 +201,7 @@ class PublicApiSurfaceTest {
         // + documents + 1 document index + document_thumbnails
         // + scannable_cards + 1 scannable-card index = 12 statements.
         assertThat(Schema.DDL).hasSize(12)
-        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2)
+        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3)
     }
 
     @Test

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -9,7 +9,6 @@ import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableCardCreateInput
 import `is`.walt.passes.core.ScannableCardId
 import `is`.walt.passes.core.ScannableCardInputValidator
-import `is`.walt.passes.core.ScannableColor
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.storage.internal.DeleteOutcome
@@ -75,7 +74,6 @@ class ScannableCardRepositoryTest {
                 payload = "5012345678900", // valid EAN-13 with check digit
                 format = ScannableFormat.Ean13,
                 label = "Grocery loyalty",
-                color = ScannableColor(0xFF112233.toInt()),
             ),
         )
 
@@ -85,7 +83,6 @@ class ScannableCardRepositoryTest {
         assertThat(rows[0].payload).isEqualTo("5012345678900")
         assertThat(rows[0].format).isEqualTo(ScannableFormat.Ean13)
         assertThat(rows[0].label).isEqualTo("Grocery loyalty")
-        assertThat(rows[0].color?.argb).isEqualTo(0xFF112233.toInt())
         assertThat(telemetry.events).containsExactly(
             "init:Tee",
             "card-created:Ean13",
@@ -103,7 +100,6 @@ class ScannableCardRepositoryTest {
                 payload = "abcdef", // bell character — Cc category
                 format = ScannableFormat.Code128,
                 label = "Test",
-                color = null,
             ),
         )
 
@@ -131,7 +127,6 @@ class ScannableCardRepositoryTest {
                 payload = "5012345678900",
                 format = ScannableFormat.Ean13,
                 label = "   ", // whitespace-only, trims to empty
-                color = null,
             ),
         )
 
@@ -156,7 +151,6 @@ class ScannableCardRepositoryTest {
                 payload = "HELLO WORLD",
                 format = ScannableFormat.Code128,
                 label = "x",
-                color = null,
             ),
         )
         check(create is StorageResult.Success)
@@ -201,7 +195,6 @@ class ScannableCardRepositoryTest {
                 payload = "5012345678900",
                 format = ScannableFormat.Ean13,
                 label = "Grocery",
-                color = ScannableColor(0x80AABBCC.toInt()),
             ),
         )
         check(create is StorageResult.Success)
@@ -213,7 +206,6 @@ class ScannableCardRepositoryTest {
         assertThat(card.payload).isEqualTo("5012345678900")
         assertThat(card.format).isEqualTo(ScannableFormat.Ean13)
         assertThat(card.label).isEqualTo("Grocery")
-        assertThat(card.color?.argb).isEqualTo(0x80AABBCC.toInt())
         // The kernel-visible id is the stringified row id minted by storage.
         assertThat(card.id.value).isEqualTo(id.value.toString())
     }
@@ -261,7 +253,6 @@ class ScannableCardRepositoryTest {
             val payload: String,
             val format: ScannableFormat,
             val label: String,
-            val colorArgb: Int?,
             val createdAtEpochMs: Long,
         )
 
@@ -287,7 +278,6 @@ class ScannableCardRepositoryTest {
                 payload = request.payload,
                 format = request.format,
                 label = request.label,
-                colorArgb = request.colorArgb,
                 createdAtEpochMs = request.nowEpochMs,
             )
             return ScannableCardInsertOutcome(id = ScannableCardRecordId(rowId))
@@ -306,7 +296,6 @@ class ScannableCardRepositoryTest {
                     payload = row.payload,
                     format = row.format,
                     label = row.label,
-                    color = row.colorArgb?.let(::ScannableColor),
                 ),
                 id = ScannableCardId(row.id.toString()),
                 createdAt = PassInstant(row.createdAtEpochMs),

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
@@ -81,7 +81,6 @@ class SchemaDdlTest {
                 "payload",
                 "format",
                 "label",
-                "color_argb",
                 "created_at_epoch_ms",
             )
         }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
@@ -44,14 +44,23 @@ class SchemaMigrationTest {
     }
 
     /**
-     * Applies the v2 schema (v1 + the v1 -> v2 hop). A v2 -> v3 test stands on top of
-     * this and asserts that the result equals the full v3 schema once the second hop
-     * lands.
+     * Applies the v2 schema (v1 + the v1 -> v2 hop).
      */
     private fun applyV2Ddl(conn: Connection) {
         applyV1Ddl(conn)
         conn.createStatement().use { stmt ->
             for (sql in Schema.MIGRATIONS.getValue(1)) stmt.execute(sql)
+        }
+    }
+
+    /**
+     * Applies the v3 schema (v1 + v1 -> v2 + v2 -> v3). The v3 shape still carries the
+     * `color_argb` column on `scannable_cards`; the v3 -> v4 migration drops it.
+     */
+    private fun applyV3Ddl(conn: Connection) {
+        applyV2Ddl(conn)
+        conn.createStatement().use { stmt ->
+            for (sql in Schema.MIGRATIONS.getValue(2)) stmt.execute(sql)
         }
     }
 
@@ -312,6 +321,190 @@ class SchemaMigrationTest {
                     stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.SCANNABLE_CARDS}")
                         .also { it.next() }.getInt(1),
                 ).isEqualTo(0)
+            }
+        }
+    }
+
+    @Test
+    fun migrationFromV3DropsColorArgbColumnFromScannableCards() {
+        openMemoryDb().use { conn ->
+            applyV3Ddl(conn)
+
+            for (sql in Schema.MIGRATIONS.getValue(3)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.SCANNABLE_CARDS})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).containsExactly(
+                "id",
+                "payload",
+                "format",
+                "label",
+                "created_at_epoch_ms",
+            )
+        }
+    }
+
+    @Test
+    fun migrationFromV3PreservesScannableCardRowsAndIdentities() {
+        openMemoryDb().use { conn ->
+            applyV3Ddl(conn)
+            // Two pre-migration v3 rows. Explicit ids assert row identity survives the
+            // table rewrite: the migration must INSERT...SELECT each existing id rather
+            // than letting AUTOINCREMENT reassign them.
+            insertV3ScannableCard(
+                conn,
+                id = 7L,
+                payload = "1234567890128",
+                format = "Ean13",
+                label = "Grocery",
+                colorArgb = 0xFF112233.toInt(),
+                createdAtMs = 1_700_000_000_000L,
+            )
+            insertV3ScannableCard(
+                conn,
+                id = 9L,
+                payload = "ZX-99",
+                format = "Code128",
+                label = "Cinema",
+                colorArgb = null,
+                createdAtMs = 1_700_000_010_000L,
+            )
+
+            for (sql in Schema.MIGRATIONS.getValue(3)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            assertThat(scannableCardRowsAfterMigration(conn)).containsExactly(
+                "7|1234567890128|Ean13|Grocery|1700000000000",
+                "9|ZX-99|Code128|Cinema|1700000010000",
+            ).inOrder()
+            // AUTOINCREMENT high-water mark survives: a fresh insert without an explicit
+            // id must mint id > 9, not collide with surviving rows.
+            assertThat(insertAfterMigrationAndReturnId(conn)).isGreaterThan(9L)
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun insertV3ScannableCard(
+        conn: Connection,
+        id: Long,
+        payload: String,
+        format: String,
+        label: String,
+        colorArgb: Int?,
+        createdAtMs: Long,
+    ) {
+        conn.prepareStatement(
+            "INSERT INTO ${Schema.Tables.SCANNABLE_CARDS}" +
+                "(id, payload, format, label, color_argb, created_at_epoch_ms) " +
+                "VALUES (?, ?, ?, ?, ?, ?)",
+        ).use { ps ->
+            ps.setLong(1, id)
+            ps.setString(2, payload)
+            ps.setString(3, format)
+            ps.setString(4, label)
+            if (colorArgb == null) ps.setNull(5, java.sql.Types.INTEGER) else ps.setInt(5, colorArgb)
+            ps.setLong(6, createdAtMs)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun scannableCardRowsAfterMigration(conn: Connection): List<String> {
+        val out = mutableListOf<String>()
+        conn.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT id, payload, format, label, created_at_epoch_ms " +
+                    "FROM ${Schema.Tables.SCANNABLE_CARDS} ORDER BY id",
+            )
+            while (rs.next()) {
+                out += listOf(
+                    rs.getLong("id").toString(),
+                    rs.getString("payload"),
+                    rs.getString("format"),
+                    rs.getString("label"),
+                    rs.getLong("created_at_epoch_ms").toString(),
+                ).joinToString("|")
+            }
+        }
+        return out
+    }
+
+    private fun insertAfterMigrationAndReturnId(conn: Connection): Long {
+        conn.prepareStatement(
+            "INSERT INTO ${Schema.Tables.SCANNABLE_CARDS}" +
+                "(payload, format, label, created_at_epoch_ms) VALUES (?, ?, ?, ?)",
+        ).use { ps ->
+            ps.setString(1, "AFTER")
+            ps.setString(2, "Code128")
+            ps.setString(3, "After")
+            ps.setLong(4, 1_700_000_020_000L)
+            ps.executeUpdate()
+        }
+        conn.createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT id FROM ${Schema.Tables.SCANNABLE_CARDS} WHERE payload = 'AFTER'",
+            )
+            rs.next()
+            return rs.getLong("id")
+        }
+    }
+
+    @Test
+    fun migrationFromV3KeepsTheScannableCardsCreatedAtIndex() {
+        openMemoryDb().use { conn ->
+            applyV3Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(3)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val indexes = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'",
+                )
+                while (rs.next()) indexes.add(rs.getString(1))
+            }
+            assertThat(indexes).contains("idx_scannable_cards_created_at")
+        }
+    }
+
+    @Test
+    fun preexistingV3PassesAndDocumentsSurviveMigrationToV4() {
+        openMemoryDb().use { conn ->
+            applyV3Ddl(conn)
+
+            // Sibling tables that the v3 -> v4 migration must leave untouched.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (1, 'BoardingPass', 'S1', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.DOCUMENTS}" +
+                    "(id, display_label, pdf_bytes, byte_count, page_count, imported_at_epoch_ms) " +
+                    "VALUES (1, 'doc.pdf', x'00', 1, 1, 1)",
+            ).use { it.executeUpdate() }
+
+            for (sql in Schema.MIGRATIONS.getValue(3)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            conn.createStatement().use { stmt ->
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.PASSES}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
+                assertThat(
+                    stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.DOCUMENTS}")
+                        .also { it.next() }.getInt(1),
+                ).isEqualTo(1)
             }
         }
     }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardRowTile.kt
@@ -51,9 +51,9 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *
  * ## Visual shape
  *
- * A flat row, label-led, with a leading neutral-tone accent strip (NOT the user's chosen
- * `card.color` — that would re-create the verified-band read at list scale). The format
- * appears as a short subtitle below the label. No tile, no thumbnail, no badge.
+ * A flat row, label-led, with a leading neutral-tone accent strip (per-card user colour
+ * was removed from the kernel — it would re-create the verified-band read at list scale).
+ * The format appears as a short subtitle below the label. No tile, no thumbnail, no badge.
  *
  * The leading strip is sourced from [LocalPassesSemantics] `unverifiedArtifact.accent`,
  * the same accent the carousel tile uses. Consumers wanting a richer leading affordance

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -19,7 +19,6 @@ import `is`.walt.passes.core.ScannableCardCreateInput
 import `is`.walt.passes.core.ScannableCardCreateResult
 import `is`.walt.passes.core.ScannableCardId
 import `is`.walt.passes.core.ScannableCardInputValidator
-import `is`.walt.passes.core.ScannableColor
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
@@ -331,7 +330,6 @@ class ScannableCardTrustSurfaceTest {
                 payload = payload,
                 format = format,
                 label = label,
-                color = ScannableColor(0xFF334455.toInt()),
             ),
             id = ScannableCardId("test"),
             createdAt = PassInstant(0L),


### PR DESCRIPTION
## Summary

Stage 2 of the chosen-colour tearout (`wpass-q5p`). After this lands:

- `ScannableCard.color` field removed.
- `ScannableCardCreateInput.color` field removed.
- `ScannableColor` value class deleted.
- `passes-storage` v3 -> v4 migration drops the `color_argb` column from `scannable_cards`.
- Kernel version bumped to `0.2.0-SNAPSHOT` (breaking public API).

## Coordinated with walt-android `wlt-z17`

Stage 1 ([walt-app/android#227](https://github.com/walt-app/android/pull/227)) landed first: walt-android no longer reads or writes `card.color` and passes `null` at the create boundary. With no consumer reading or writing the field, the kernel side could safely drop it.

Step 3 (walt-android version bump + cleanup) lands after this kernel PR via a follow-up bead.

## Public-API break

`ScannableCard` is `@ConsistentCopyVisibility data class internal constructor(...)`. Dropping `color: ScannableColor?` is breaking:

- `equals` / `hashCode` (one fewer component).
- `copy()` signature (`color` argument gone).
- Component functions (`componentN` indices shift).
- `ScannableCardCreateInput`'s shape changes the same way.

Version bumped accordingly.

## SQLCipher migration shape

v3 -> v4 is a table-rewrite migration (RENAME / CREATE / INSERT...SELECT / DROP / index recreate) rather than `ALTER TABLE DROP COLUMN`, so the migration works on every SQLCipher version the project ships on without depending on SQLite 3.35+ semantics. Row identity is preserved by re-using each row's explicit `id` in the INSERT; SQLite's AUTOINCREMENT bookkeeping in `sqlite_sequence` updates to max(id) on insert, so subsequent inserts do not collide with surviving rows. Per-row colour bytes are intentionally lost; Walt already stopped reading them in Stage 1.

Migration tests cover: column-set drop, row survival with explicit-id preservation, post-migration autoincrement high-water mark, scannable-cards index retention, and untouched sibling tables.

## Threat-model doc

`docs/SCANNABLE_CARD_THREAT_MODEL.md`:

- C2 mitigation reworded — the field is now gone at the kernel, not just unused.
- Section 10 ("colour picker as injection vector") updated to reflect the parsing surface no longer exists.

## Test plan

- [x] `./gradlew :passes-core:test :passes-storage:testDebugUnitTest :passes-ui:testDebugUnitTest`
- [x] `./gradlew test` (full JVM suite, all modules)
- [x] `./gradlew detekt`
- [x] `./gradlew :passes-storage:assembleDebug :passes-ui:assembleDebug`
- [ ] SQLCipher instrumentation round-trip (existing androidTest suite) on CI
- [ ] walt-android composite-build green after consumer-side version bump (follow-up bead)

## Cross-refs

- Stage 1 (consumer): walt-android `wlt-z17` / [walt-app/android#227](https://github.com/walt-app/android/pull/227) (merged 2026-05-19).
- Decision context: walt-android `wlt-5wz` (deferred-collapse rationale, 2026-05-19); kernel `ScannableCardRowTile.kt` KDoc on the verified-band read.
- Threat model: `docs/SCANNABLE_CARD_THREAT_MODEL.md` C1/C2, section 10.