### PR TITLE
passes-pdf: clear bitmap to white before PdfRenderer.render (#92)

### DIFF
--- a/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfRendererServiceInstrumentedTest.kt
+++ b/passes-pdf/src/androidTest/kotlin/is/walt/passes/pdf/android/PdfRendererServiceInstrumentedTest.kt
@@ -52,4 +52,14 @@ class PdfRendererServiceInstrumentedTest {
     fun elevenPagePdfRejectsAtProbe() {
         // bind, probe 11-page PDF, expect ProbeResult.Rejected(TooManyPages).
     }
+
+    @Test
+    @Ignore("Pending fixture set + on-device CI wiring (wpass-5v9 follow-up)")
+    fun pageBackgroundRasterisesWhiteNotTransparent() {
+        // bind, send a PDF whose page draws only a small centred glyph on the implicit
+        // white background, render(0, 800, 1200), reconstruct ARGB_8888 bitmap from
+        // SharedMemory, assert corner pixels == Color.WHITE (not transparent / not
+        // ColorScheme.background). Regression for GitHub #92: QR codes were invisible
+        // in dark mode because the renderer left the page background transparent.
+    }
 }

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -3,6 +3,7 @@ package `is`.walt.passes.pdf.android
 import android.app.Service
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.graphics.Matrix
 import android.graphics.pdf.PdfRenderer
 import android.os.IBinder
@@ -144,6 +145,11 @@ private fun rasterise(
 ): RenderResult.Ok {
     val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
     try {
+        // PdfRenderer.Page.render() draws PDF content on top of existing pixels without
+        // clearing them. Pages that rely on the implicit white page background otherwise
+        // rasterise as content-on-transparent and compose against the host's dark surface,
+        // hiding white-on-page artwork (GitHub #92: QR codes vanish in dark mode).
+        bitmap.eraseColor(Color.WHITE)
         val transform = matrixFor(sourceRect, p.width, p.height, widthPx, heightPx)
         p.render(bitmap, null, transform, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         val pageAspect = p.width.toFloat() / p.height.toFloat()


### PR DESCRIPTION
## Summary

- Fixes GitHub #92: QR codes in PDFs become invisible in dark mode.
- Root cause: `Bitmap.createBitmap(ARGB_8888)` starts transparent and `PdfRenderer.Page.render` draws PDF content on top of existing pixels without clearing them. Pages with implicit white backgrounds rasterised as content-on-transparent, then composited over the host's dark Material surface. The QR's black squares were unchanged but the white quiet-zone went transparent, leaving black-on-dark and unreadable.
- One-line fix in `PdfRendererService.rasterise`: `bitmap.eraseColor(Color.WHITE)` before `p.render(...)`. Matches Android's documented contract for `PdfRenderer.Page.render`.

Issue tracked as `wpass-wgk`.

## Trade-off

Forcing white loses the ability to render genuinely-transparent PDFs. For Walt's import surface (pass-like PDFs: boarding passes, tickets, receipts) this is the correct trade. If a transparent-background mode is ever needed it would be an adjacent parameter on `RenderSourceRect`; out of scope here.

## Test plan

- [x] `./gradlew :passes-pdf:check` green (lint + unit tests)
- [x] `./gradlew :passes-pdf:detekt` green
- [x] Added stub `pageBackgroundRasterisesWhiteNotTransparent` in `PdfRendererServiceInstrumentedTest`, `@Ignore`'d to match the existing pattern. Will run on-device once `wpass-5v9` fixture set + CI wiring lands.
- [ ] Manual verification: install on a device in dark mode, import a PDF containing a QR (the issue reporter's repro), confirm QR is visible.

## Out of scope

GitHub #62 (dark mode resets on app restart) and #89 (follow system theme) were investigated alongside this issue. Both live entirely in walt-android (theme persistence, settings UI, `MainActivity` wiring) and have been handed off to that team.