### PR TITLE
passes-ui: ScannableCardView opt-in payload caption (GH #102)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -195,13 +195,19 @@ defense-in-depth, mirroring `B3UrlConfirmSheet` and the
 ### 4. Bidi / control-character spoofing in payload preview — Spoofing
 
 **What.** During create-time URI preview (C4), the dialog renders the raw
-`payload` so the user can see what they typed. The same bidi/control-char
-attack applies to that display.
+`payload` so the user can see what they typed. The detail surface
+(`ScannableCardScreen`) also renders the payload as a human-readable caption
+below the barcode (GH #102 — fallback for when a point-of-sale scanner cannot
+read the code; opt-in via `ScannableCardView.showPayloadCaption`). The same
+bidi/control-char attack applies to both displays.
 
 **Mitigation.** C3: `passes-core` rejects payloads containing Cf/Cc codepoints
-*before* any preview is shown. The dialog never receives a payload that could
-spoof its surrounding chrome. The fallback "looks URI-shaped but unrecognized
-scheme" path goes through the same validator.
+*before* any preview is shown or any caption is rendered. Neither the dialog
+nor the detail-surface caption ever receives a payload that could spoof its
+surrounding chrome. The fallback "looks URI-shaped but unrecognized scheme"
+path goes through the same validator. The UI layer additionally wraps the
+caption in FSI (U+2068) / PDI (U+2069) isolates as defense-in-depth, mirroring
+the label-isolation discipline in threat #3.
 
 **Status.** Mitigated.
 

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -63,12 +62,16 @@ public fun ScannableCardScreen(
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            // clearAndSetSemantics drops the barcode's standalone contentDescription
-            // (which is `card.label`) so TalkBack does not announce the label twice —
-            // the title Text above already speaks it.
+            // showPayloadCaption=true: the human-readable fallback for a failed POS
+            // scanner (GH #102). Only the detail surface opts in — tile / row
+            // registers are too small. ScannableCardView internally drops the
+            // image's contentDescription when the caption is on (the title Text
+            // above already speaks the label and the caption is what TalkBack
+            // needs to announce); no clearAndSetSemantics here, since that would
+            // zap the caption from a11y as well.
             ScannableCardView(
                 card = card,
-                modifier = Modifier.clearAndSetSemantics {},
+                showPayloadCaption = true,
             )
         }
 

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -62,13 +62,8 @@ public fun ScannableCardScreen(
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            // showPayloadCaption=true: the human-readable fallback for a failed POS
-            // scanner (GH #102). Only the detail surface opts in — tile / row
-            // registers are too small. ScannableCardView internally drops the
-            // image's contentDescription when the caption is on (the title Text
-            // above already speaks the label and the caption is what TalkBack
-            // needs to announce); no clearAndSetSemantics here, since that would
-            // zap the caption from a11y as well.
+            // POS-scan fallback for GH #102; only the detail surface is large
+            // enough. A11y rationale lives on ScannableCardView.
             ScannableCardView(
                 card = card,
                 showPayloadCaption = true,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -3,10 +3,16 @@ package `is`.walt.passes.ui
 import android.graphics.Bitmap
 import android.graphics.Color as AndroidColor
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
@@ -14,12 +20,15 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.BarcodeEncoder
 import `is`.walt.passes.core.BarcodeMatrix
 import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.core.isolated
 
 /**
  * Renders [card]'s barcode through [BarcodeEncoder] as a 1-bit-per-module bitmap.
@@ -41,14 +50,21 @@ import `is`.walt.passes.core.ScannableFormat
  * `contentDescription` rather than throwing. Card chrome (background tint, label,
  * "Created by you" trust caption) belongs on the surrounding tile (wpass-lzi.8) so
  * this surface can be reused as the full-screen scan view unchanged.
+ *
+ * When [showPayloadCaption] is true the encoded payload is rendered as a monospace,
+ * user-selectable caption beneath the barcode — fallback for when a point-of-sale
+ * scanner cannot read the code (GH issue #102). The caption is FSI/PDI isolated as
+ * defense-in-depth on top of the create-boundary Cf/Cc rejection (C3 in
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`). Default false; only [ScannableCardScreen]
+ * opts in. The tile / row registers keep it off because their identification-sized
+ * preview leaves no room for a legible caption.
  */
 @Composable
 public fun ScannableCardView(
     card: ScannableCard,
     modifier: Modifier = Modifier,
+    showPayloadCaption: Boolean = false,
 ) {
-    val (minWidthDp, minHeightDp) = card.format.minRenderSizeDp()
-
     val bitmap = remember(card.payload, card.format) {
         when (val result = BarcodeEncoder.encode(card.payload, card.format)) {
             is EncodeResult.Success -> result.matrix.toMonochromeBitmap()
@@ -56,13 +72,48 @@ public fun ScannableCardView(
         }
     }
 
+    if (!showPayloadCaption) {
+        BarcodeImage(card, bitmap, imageDescription = card.label, modifier = modifier)
+    } else {
+        Column(
+            modifier = modifier,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CAPTION_GAP),
+        ) {
+            // When the caption is on, the image's contentDescription is dropped
+            // (caller chrome — the screen title — already speaks the label, and the
+            // payload caption below is the announce-worthy text). Avoids the
+            // triple-announce a clearAndSetSemantics applied at the wrapping
+            // modifier would also block but at the cost of zapping the caption.
+            BarcodeImage(card, bitmap, imageDescription = null, modifier = Modifier)
+            SelectionContainer {
+                Text(
+                    text = isolated(card.payload),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BarcodeImage(
+    card: ScannableCard,
+    bitmap: Bitmap?,
+    imageDescription: String?,
+    modifier: Modifier,
+) {
+    val (minWidthDp, minHeightDp) = card.format.minRenderSizeDp()
     if (bitmap != null) {
         Image(
             painter = BitmapPainter(
                 image = bitmap.asImageBitmap(),
                 filterQuality = FilterQuality.None,
             ),
-            contentDescription = card.label,
+            contentDescription = imageDescription,
             contentScale = card.format.contentScale(),
             modifier = modifier.defaultMinSize(
                 minWidth = minWidthDp.dp,
@@ -115,3 +166,5 @@ private fun BarcodeMatrix.toMonochromeBitmap(): Bitmap {
     }
     return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
 }
+
+private val CAPTION_GAP = 12.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -73,7 +73,7 @@ public fun ScannableCardView(
     }
 
     if (!showPayloadCaption) {
-        BarcodeImage(card, bitmap, imageDescription = card.label, modifier = modifier)
+        BarcodeImage(card.format, bitmap, imageDescription = card.label, modifier = modifier)
     } else {
         Column(
             modifier = modifier,
@@ -82,10 +82,11 @@ public fun ScannableCardView(
         ) {
             // When the caption is on, the image's contentDescription is dropped
             // (caller chrome — the screen title — already speaks the label, and the
-            // payload caption below is the announce-worthy text). Avoids the
-            // triple-announce a clearAndSetSemantics applied at the wrapping
-            // modifier would also block but at the cost of zapping the caption.
-            BarcodeImage(card, bitmap, imageDescription = null, modifier = Modifier)
+            // payload caption below is the announce-worthy text). A
+            // clearAndSetSemantics wrapper would also dedupe but would zap the
+            // caption from a11y, which is the opposite of what the POS-fallback
+            // case needs.
+            BarcodeImage(card.format, bitmap, imageDescription = null, modifier = Modifier)
             SelectionContainer {
                 Text(
                     text = isolated(card.payload),
@@ -101,12 +102,12 @@ public fun ScannableCardView(
 
 @Composable
 private fun BarcodeImage(
-    card: ScannableCard,
+    format: ScannableFormat,
     bitmap: Bitmap?,
     imageDescription: String?,
     modifier: Modifier,
 ) {
-    val (minWidthDp, minHeightDp) = card.format.minRenderSizeDp()
+    val (minWidthDp, minHeightDp) = format.minRenderSizeDp()
     if (bitmap != null) {
         Image(
             painter = BitmapPainter(
@@ -114,7 +115,7 @@ private fun BarcodeImage(
                 filterQuality = FilterQuality.None,
             ),
             contentDescription = imageDescription,
-            contentScale = card.format.contentScale(),
+            contentScale = format.contentScale(),
             modifier = modifier.defaultMinSize(
                 minWidth = minWidthDp.dp,
                 minHeight = minHeightDp.dp,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -80,12 +80,9 @@ public fun ScannableCardView(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(CAPTION_GAP),
         ) {
-            // When the caption is on, the image's contentDescription is dropped
-            // (caller chrome — the screen title — already speaks the label, and the
-            // payload caption below is the announce-worthy text). A
-            // clearAndSetSemantics wrapper would also dedupe but would zap the
-            // caption from a11y, which is the opposite of what the POS-fallback
-            // case needs.
+            // Drop the image's contentDescription so TalkBack reads the caption,
+            // not the duplicate label. clearAndSetSemantics would dedupe too but
+            // would zap the caption.
             BarcodeImage(card.format, bitmap, imageDescription = null, modifier = Modifier)
             SelectionContainer {
                 Text(

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -20,6 +20,8 @@ import `is`.walt.passes.core.ScannableCardCreateResult
 import `is`.walt.passes.core.ScannableCardId
 import `is`.walt.passes.core.ScannableCardInputValidator
 import `is`.walt.passes.core.ScannableFormat
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
 import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
@@ -317,6 +319,23 @@ class ScannableCardTrustSurfaceTest {
     }
 
     @Test
+    fun fullScreenRendersPayloadCaptionEvenWhenEncoderFails() {
+        // GH #102's whole point is that the user can fall back to reading the
+        // number aloud when the *scanner* fails. The kernel-internal mirror of
+        // that is: when the *encoder* fails (the validator-bypassed defensive
+        // path inside ScannableCardView), the caption must still render — a user
+        // with an unrenderable barcode can still read their payload. An 11-digit
+        // EAN-13 trips ZxingBarcodeEncoder (see BarcodeEncoderTest's
+        // ean13RejectsWrongLengthAtWriter) but is rejected upstream by the
+        // validator; construct the card via the internal constructor so the
+        // encoder-failure UI path is exercised end-to-end.
+        composeRule.setContent {
+            ThemedHost { ScannableCardScreen(card = encoderRejectedEan13Fixture()) }
+        }
+        composeRule.onNodeWithText("⁨12345678901⁩").assertIsDisplayed()
+    }
+
+    @Test
     fun rowTileDoesNotRenderPayloadCaption() {
         // The wallet-row register is the smallest surface of the three; same
         // default-off rationale as the carousel tile.
@@ -382,5 +401,27 @@ class ScannableCardTrustSurfaceTest {
             createdAt = PassInstant(0L),
         )
         return (result as ScannableCardCreateResult.Success).card
+    }
+
+    /**
+     * Bypasses [ScannableCardInputValidator] so the test can hand
+     * [ScannableCardView] a payload that ZXing's writer rejects. The validator
+     * exists precisely to prevent this state in production, so the only way to
+     * reach the encoder-failure UI branch from a unit test is to invoke the
+     * type's internal constructor directly via kotlin-reflect. Limit usage to
+     * tests that need to assert behaviour of that defensive path.
+     */
+    private fun encoderRejectedEan13Fixture(): ScannableCard {
+        val ctor = requireNotNull(ScannableCard::class.primaryConstructor) {
+            "ScannableCard has no primary constructor"
+        }
+        ctor.isAccessible = true
+        return ctor.call(
+            ScannableCardId("test"),
+            "12345678901",
+            ScannableFormat.Ean13,
+            "Library card",
+            PassInstant(0L),
+        )
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -410,18 +410,30 @@ class ScannableCardTrustSurfaceTest {
      * reach the encoder-failure UI branch from a unit test is to invoke the
      * type's internal constructor directly via kotlin-reflect. Limit usage to
      * tests that need to assert behaviour of that defensive path.
+     *
+     * Bound by parameter name via `callBy` rather than positional `call`: a
+     * future add / remove / reorder of a primary-constructor parameter surfaces
+     * as a clear missing-key failure at test time, not a same-typed-field swap
+     * that quietly tests the wrong assertion.
      */
     private fun encoderRejectedEan13Fixture(): ScannableCard {
         val ctor = requireNotNull(ScannableCard::class.primaryConstructor) {
             "ScannableCard has no primary constructor"
         }
         ctor.isAccessible = true
-        return ctor.call(
-            ScannableCardId("test"),
-            "12345678901",
-            ScannableFormat.Ean13,
-            "Library card",
-            PassInstant(0L),
+        val args = mapOf(
+            "id" to ScannableCardId("test"),
+            "payload" to "12345678901",
+            "format" to ScannableFormat.Ean13,
+            "label" to "Library card",
+            "createdAt" to PassInstant(0L),
         )
+        val byName = ctor.parameters.associateBy { it.name }
+        val missing = args.keys - byName.keys
+        require(missing.isEmpty()) {
+            "ScannableCard primary constructor drifted; unknown params: $missing. " +
+                "Update encoderRejectedEan13Fixture before changing the data class."
+        }
+        return ctor.callBy(args.mapKeys { (name, _) -> byName.getValue(name) })
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -280,6 +280,53 @@ class ScannableCardTrustSurfaceTest {
     }
 
     @Test
+    fun fullScreenRendersPayloadCaptionVerbatim() {
+        // GH #102: the encoded payload is displayed below the barcode as a
+        // human-readable fallback for a failed POS scanner. The caption is FSI/PDI
+        // isolated as defense-in-depth on the create-boundary Cf/Cc rejection (C3
+        // in SCANNABLE_CARD_THREAT_MODEL.md); assert the isolated form so a
+        // regression that dropped the bidi fence would fail this test.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(card = qrFixture(label = "Library card"))
+            }
+        }
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun fullScreenRendersPayloadCaptionForOneDimensionalFormat() {
+        // Both encoder paths (QR and 1D) must reach the caption — the POS-scanner
+        // fallback case is more common for 1D loyalty cards than for QR.
+        composeRule.setContent {
+            ThemedHost { ScannableCardScreen(card = code128Fixture()) }
+        }
+        composeRule.onNodeWithText("⁨ABCDE12345⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun tileDoesNotRenderPayloadCaption() {
+        // The carousel tile is identification-only; rendering the payload below
+        // its small preview would crowd the chrome and is not the surface the
+        // GH #102 fallback targets. Default-off behaviour pinned here so the
+        // caption stays scoped to the detail surface.
+        composeRule.setContent {
+            ThemedHost { ScannableCardTile(card = qrFixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertDoesNotExist()
+    }
+
+    @Test
+    fun rowTileDoesNotRenderPayloadCaption() {
+        // The wallet-row register is the smallest surface of the three; same
+        // default-off rationale as the carousel tile.
+        composeRule.setContent {
+            ThemedHost { ScannableCardRowTile(card = qrFixture(), onClick = {}) }
+        }
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertDoesNotExist()
+    }
+
+    @Test
     fun rowTileLeadingSlotWithoutContentDescriptionDoesNotPolluteMergedSemantics() {
         // The slot lives inside the row's mergeDescendants block. The kernel-built
         // contentDescription on the merged node replaces (not appends to) descendant


### PR DESCRIPTION
Closes #102.

## Summary

When the POS scanner cannot read the code, the user needs a human-readable fallback they can read aloud or paste. Adds `showPayloadCaption: Boolean = false` to `ScannableCardView`; when on, the encoded payload renders below the barcode as a monospace, user-selectable caption (`SelectionContainer` so long-press-to-copy works). FSI/PDI isolated as defense-in-depth on the create-boundary Cf/Cc rejection.

`ScannableCardScreen` is the only opt-in site. `ScannableCardTile` (carousel) and `ScannableCardRowTile` (wallet list) keep the default off — both are identification-only previews where a legible caption would not fit.

## Accessibility

When the caption is on, the inner image's `contentDescription` is dropped so TalkBack does not double-announce the label. The screen title already speaks `card.label`; the new caption is the announce-worthy text. Replaces the previous `clearAndSetSemantics {}` wrapper on `ScannableCardScreen`, which would have zapped the caption from a11y if left in place.

## Trust posture

`docs/SCANNABLE_CARD_THREAT_MODEL.md` row 4 (bidi / control-character spoofing in payload preview) is extended to acknowledge the detail-surface caption as a second display surface for the same already-mitigated threat. Same C3 mitigation: payloads with Cf/Cc codepoints are rejected at the create boundary, and the UI layer wraps the verbatim payload in FSI/PDI as defense-in-depth.

`ScannableCardView` is not in `ComposableSurfaceLockTest` (the lock pins `ScannableCardScreen`, `ScannableCardTile`, `ScannableCardRowTile`, `ScannableCardTrustCaption`, none of which gain a parameter here). No lock bump needed.

## Test plan

- [x] `./gradlew :passes-ui:testDebugUnitTest` — 20/20 ScannableCardTrustSurfaceTest (16 prior + 4 new: full-screen verbatim render for QR + 1D, default-off on tile + row)
- [x] `./gradlew :passes-ui:detekt` clean
- [x] `./gradlew assembleDebug detekt` across all seven modules clean
- [ ] Visual smoke on device: open a Code128 ScannableCard from the home lane, confirm the payload renders below the barcode in the full-screen scan view and is long-press-copyable

## Beads

Closes wpass-3hr.