### PR TITLE
passes-storage: add updateDocumentLabel API (wpass-hhq)

### DIFF
--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.flow.StateFlow
  * All trust-claim-bearing storage logic lives behind this interface: encryption-at-rest,
  * backup exclusion, irreversible deletion, decoded summary maintenance.
  */
+// TooManyFunctions: scales with the per-tier surface (pass, document, scannable-card).
+// Splitting would scatter the one-stop consumer contract walt-android binds against.
+@Suppress("TooManyFunctions")
 public interface PassRepository {
     /**
      * Hot list of pass summaries, sorted by `created_at_epoch_ms` descending. Backed by the
@@ -87,10 +90,30 @@ public interface PassRepository {
     ): StorageResult<DocumentRecordId>
 
     /**
+     * Updates the display label of an existing document row. Mirrors [insertDocument]'s
+     * label cap: rejects labels longer than [DocumentBounds.MAX_LABEL_CHARS] with
+     * [StorageError.DocumentRejected] carrying
+     * [DocumentStorageRejectedKind.LabelTooLongAtStorage], and no row is touched. The cap
+     * is checked before the row is loaded, so an over-long label against an unknown
+     * [id] surfaces as [StorageError.DocumentRejected], not
+     * [StorageError.IntegrityViolation]. Empty and blank labels are accepted, matching
+     * [insertDocument]'s behavior.
+     *
+     * Returns [StorageError.IntegrityViolation] if no row matches [id] (and the label
+     * passed the cap). On success, the row's `imported_at_epoch_ms` is unchanged
+     * (rename is not a re-import), so the row's position in [observeDocuments] is
+     * preserved.
+     */
+    public suspend fun updateDocumentLabel(
+        id: DocumentRecordId,
+        label: String,
+    ): StorageResult<Unit>
+
+    /**
      * Cold flow of document list-view rows, sorted by `imported_at_epoch_ms` descending.
-     * Emits the current snapshot on collect and re-emits when documents are inserted or
-     * deleted. The PDF and thumbnail blobs are NOT loaded by this flow; consumers fetch
-     * them with [loadDocumentBytes] / [loadDocumentThumbnail] on demand.
+     * Emits the current snapshot on collect and re-emits when documents are inserted,
+     * relabeled, or deleted. The PDF and thumbnail blobs are NOT loaded by this flow;
+     * consumers fetch them with [loadDocumentBytes] / [loadDocumentThumbnail] on demand.
      */
     public fun observeDocuments(): Flow<List<DocumentRow>>
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -152,6 +152,22 @@ public class SqlCipherPassRepository internal constructor(
         StorageResult.Success(outcome.id)
     }
 
+    override suspend fun updateDocumentLabel(
+        id: DocumentRecordId,
+        label: String,
+    ): StorageResult<Unit> = runIo {
+        if (label.length > DocumentBounds.MAX_LABEL_CHARS) {
+            return@runIo rejectDocument(DocumentStorageRejectedKind.LabelTooLongAtStorage)
+        }
+        val matched = writeMutex.withLock {
+            val ok = documentStore.updateLabel(id, label)
+            if (ok) _documents.value = documentStore.listRows()
+            ok
+        }
+        if (!matched) return@runIo failure(StorageError.IntegrityViolation(id))
+        StorageResult.Success(Unit)
+    }
+
     override fun observeDocuments(): Flow<List<DocumentRow>> = _documents.asStateFlow()
 
     override suspend fun createScannableCard(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -74,8 +74,11 @@ public interface StorageTelemetryGuard {
     public fun onDocumentImported(event: DocumentImportedEvent)
 
     /**
-     * A document insertion was rejected by the storage-side defense-in-depth check
-     * (ADR 0005 D7). Emitted before the row is created. The row never reaches disk.
+     * A document write was rejected by the storage-side defense-in-depth check
+     * (ADR 0005 D7). Fires for both [PassRepository.insertDocument] and
+     * [PassRepository.updateDocumentLabel]: aggregate counts blend the two paths.
+     * Emitted before any row is created or modified; storage state is unchanged on
+     * rejection.
      */
     public fun onDocumentRejected(kind: DocumentStorageRejectedKind)
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
@@ -13,6 +13,12 @@ internal interface DocumentStore {
     fun insert(request: DocumentInsertRequest): DocumentInsertOutcome
     fun loadBytes(id: DocumentRecordId): ByteArray?
     fun loadThumbnail(id: DocumentRecordId): ByteArray?
+
+    /**
+     * Single-column UPDATE on the documents row. Returns `true` if a row matched [id],
+     * `false` otherwise (caller maps to `IntegrityViolation`).
+     */
+    fun updateLabel(id: DocumentRecordId, label: String): Boolean
     fun delete(id: DocumentRecordId): DocumentDeleteOutcome?
 
     /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
@@ -73,6 +73,17 @@ internal class SqlCipherDocumentStore(
         }
     }
 
+    override fun updateLabel(id: DocumentRecordId, label: String): Boolean {
+        val cv = ContentValues().apply { put("display_label", label) }
+        val rows = db.update(
+            Schema.Tables.DOCUMENTS,
+            cv,
+            "id = ?",
+            arrayOf(id.value.toString()),
+        )
+        return rows > 0
+    }
+
     override fun loadBytes(id: DocumentRecordId): ByteArray? = db.rawQuery(
         "SELECT pdf_bytes FROM ${Schema.Tables.DOCUMENTS} WHERE id = ?",
         arrayOf(id.value.toString()),

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -223,6 +223,105 @@ class DocumentRepositoryTest {
     }
 
     @Test
+    fun updateLabelReplacesDisplayLabelAndPreservesPositionWithNoTelemetry() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val insert = repo.insertDocument(
+            label = "old.pdf",
+            pdfBytes = ByteArray(8),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        val result = repo.updateDocumentLabel(id, "new.pdf")
+        check(result is StorageResult.Success)
+
+        val rows = repo.observeDocuments().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].id).isEqualTo(id)
+        assertThat(rows[0].displayLabel).isEqualTo("new.pdf")
+        // Rename emits no telemetry: nothing follows the import event.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:8:1",
+        ).inOrder()
+    }
+
+    @Test
+    fun updateLabelOfUnknownIdReturnsIntegrityViolation() = runTest {
+        val telemetry = RecordingGuard()
+        val repo = repo(FakeDocumentStore(), telemetry)
+
+        val result = repo.updateDocumentLabel(DocumentRecordId(404L), "x")
+
+        check(result is StorageResult.Failure)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is DocumentRecordId)
+        assertThat(violation.recordId.value).isEqualTo(404L)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
+    fun updateLabelMaxLengthBoundaryIsAcceptedAndPlusOneIsRejected() = runTest {
+        val docs = FakeDocumentStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(docs, telemetry)
+
+        val insert = repo.insertDocument(
+            label = "seed",
+            pdfBytes = ByteArray(8),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        val okLabel = "a".repeat(DocumentBounds.MAX_LABEL_CHARS)
+        val ok = repo.updateDocumentLabel(id, okLabel)
+        check(ok is StorageResult.Success)
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo(okLabel)
+
+        val tooLong = "a".repeat(DocumentBounds.MAX_LABEL_CHARS + 1)
+        val rejected = repo.updateDocumentLabel(id, tooLong)
+        check(rejected is StorageResult.Failure)
+        val err = rejected.error as StorageError.DocumentRejected
+        assertThat(err.kind).isEqualTo(DocumentStorageRejectedKind.LabelTooLongAtStorage)
+        // Rejection emits exactly `doc-rejected`; no `failure:DocumentRejected:...`.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-imported:8:1",
+            "doc-rejected:LabelTooLongAtStorage",
+        ).inOrder()
+        // Stored label was not overwritten by the rejected update.
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo(okLabel)
+    }
+
+    @Test
+    fun updateLabelAcceptsEmptyAndBlankToMatchInsertDocument() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+        val insert = repo.insertDocument(
+            label = "seed",
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        check(repo.updateDocumentLabel(id, "") is StorageResult.Success)
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("")
+        check(repo.updateDocumentLabel(id, "   ") is StorageResult.Success)
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("   ")
+    }
+
+    @Test
     fun loadDocumentBytesAndThumbnailRoundTripUntouched() = runTest {
         val docs = FakeDocumentStore()
         val telemetry = RecordingGuard()
@@ -322,6 +421,12 @@ class DocumentRepositoryTest {
 
         override fun loadThumbnail(id: DocumentRecordId): ByteArray? =
             entries[id.value]?.thumbnailBytes?.copyOf()
+
+        override fun updateLabel(id: DocumentRecordId, label: String): Boolean {
+            val entry = entries[id.value] ?: return false
+            entries[id.value] = entry.copy(row = entry.row.copy(displayLabel = label))
+            return true
+        }
 
         override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? {
             val entry = entries.remove(id.value) ?: return null

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -326,6 +326,7 @@ class PassRepositoryContractTest {
             error("unused in pass-side tests")
         override fun loadBytes(id: DocumentRecordId): ByteArray? = null
         override fun loadThumbnail(id: DocumentRecordId): ByteArray? = null
+        override fun updateLabel(id: DocumentRecordId, label: String): Boolean = false
         override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? = null
         override fun close() { closeCount++ }
     }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -323,6 +323,7 @@ class ScannableCardRepositoryTest {
             error("unused in scannable-card tests")
         override fun loadBytes(id: DocumentRecordId): ByteArray? = null
         override fun loadThumbnail(id: DocumentRecordId): ByteArray? = null
+        override fun updateLabel(id: DocumentRecordId, label: String): Boolean = false
         override fun delete(id: DocumentRecordId): DocumentDeleteOutcome? = null
         override fun close() = Unit
     }


### PR DESCRIPTION
## Summary
- Adds `PassRepository.updateDocumentLabel(id, label): StorageResult<Unit>`. Companion bead for walt-android `wlt-4dn.1` (GH walt-app/walt-passes-android#75: allow renaming of passes).
- Mirrors `insertDocument`'s `MAX_LABEL_CHARS` cap (`LabelTooLongAtStorage`); accepts empty/blank labels to match. Rename is not a re-import, so `imported_at_epoch_ms` is unchanged and the row's position in `observeDocuments` is preserved.
- No telemetry on success. Rejections share the existing `onDocumentRejected` event with `insertDocument`; `StorageTelemetryGuard.onDocumentRejected` KDoc updated to document the conflation.

## Test plan
- [x] `./gradlew :passes-storage:testDebugUnitTest` — 4 new tests cover success-preserves-position-no-telemetry, unknown-id → IntegrityViolation, label cap boundary, empty/blank accepted.
- [x] `./gradlew :passes-storage:detekt :passes-storage:lintDebug` — clean.
- [ ] CI green.