### PR TITLE
passes-storage: add updateScannableCard API to PassRepository (wpass-lay)

### DIFF
--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -152,6 +152,27 @@ public interface PassRepository {
     ): StorageResult<ScannableCardRecordId>
 
     /**
+     * Overwrites the payload / format / label of an existing scannable-card row. Re-runs
+     * the kernel `ScannableCardInputValidator` (the single insert-time choke point per
+     * [createScannableCard]'s KDoc) on the new [input] before the row is touched; a
+     * validation rejection bubbles up as [StorageError.ScannableCardRejected] with the
+     * typed reason preserved and shares the same `onScannableCardRejected` telemetry
+     * channel as [createScannableCard]. The row is not modified on rejection.
+     *
+     * Validation is checked before the row is loaded, so an invalid [input] against an
+     * unknown [id] surfaces as [StorageError.ScannableCardRejected], not
+     * [StorageError.IntegrityViolation], mirroring [updateDocumentLabel]'s precedence.
+     *
+     * Returns [StorageError.IntegrityViolation] if no row matches [id] and the input
+     * passed validation. On success the row's `created_at_epoch_ms` is unchanged (edit
+     * is not a re-insert), so the row's position in [observeScannableCards] is preserved.
+     */
+    public suspend fun updateScannableCard(
+        id: ScannableCardRecordId,
+        input: ScannableCardCreateInput,
+    ): StorageResult<Unit>
+
+    /**
      * Loads a stored [ScannableCard] by row id. Returns [StorageError.IntegrityViolation]
      * if no row matches.
      */
@@ -170,8 +191,8 @@ public interface PassRepository {
 
     /**
      * Cold flow of [ScannableCard] rows sorted by `created_at_epoch_ms` descending.
-     * Emits the current snapshot on collect and re-emits on insert / delete. Unlike the
-     * pass and document lanes, the full card materializes here — there are no large
+     * Emits the current snapshot on collect and re-emits on insert / update / delete.
+     * Unlike the pass and document lanes, the full card materializes here — there are no large
      * blob columns to defer, and the consumer's tile renderer needs the payload to
      * re-encode the barcode at render time.
      */

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -15,6 +15,7 @@ import `is`.walt.passes.storage.internal.DocumentStore
 import `is`.walt.passes.storage.internal.PassStore
 import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
 import `is`.walt.passes.storage.internal.ScannableCardStore
+import `is`.walt.passes.storage.internal.ScannableCardUpdateRequest
 import `is`.walt.passes.storage.internal.SqlCipherDatabaseFactory
 import `is`.walt.passes.storage.internal.SqlCipherDocumentStore
 import `is`.walt.passes.storage.internal.SqlCipherPassStore
@@ -221,6 +222,58 @@ public class SqlCipherPassRepository internal constructor(
         }
         telemetryGuard.onScannableCardCreated(approved.format)
         StorageResult.Success(outcome.id)
+    }
+
+    override suspend fun updateScannableCard(
+        id: ScannableCardRecordId,
+        input: ScannableCardCreateInput,
+    ): StorageResult<Unit> = runIo {
+        // Validator does not consume the id or timestamp for validation logic; storage
+        // preserves the existing row's created_at_epoch_ms at the SQL layer, so the
+        // placeholders below never reach disk.
+        val validation = ScannableCardInputValidator.validate(
+            input = input,
+            id = ScannableCardId(id.value.toString()),
+            createdAt = PassInstant(clock()),
+        )
+        val approved = when (validation) {
+            is ScannableCardCreateResult.Success -> validation.card
+            is ScannableCardCreateResult.InvalidLabel ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
+                )
+            is ScannableCardCreateResult.InvalidPayload ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
+                )
+            is ScannableCardCreateResult.UnsupportedFormat ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
+                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
+                )
+            is ScannableCardCreateResult.EncoderFailure ->
+                return@runIo rejectScannableCard(
+                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
+                )
+        }
+
+        val matched = writeMutex.withLock {
+            val ok = scannableCardStore.update(
+                id,
+                ScannableCardUpdateRequest(
+                    payload = approved.payload,
+                    format = approved.format,
+                    label = approved.label,
+                ),
+            )
+            if (ok) _scannableCards.value = scannableCardStore.listAll()
+            ok
+        }
+        if (!matched) return@runIo failure(StorageError.IntegrityViolation(id))
+        StorageResult.Success(Unit)
     }
 
     override suspend fun loadScannableCard(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -102,11 +102,13 @@ public interface StorageTelemetryGuard {
     public fun onScannableCardDeleted(format: ScannableFormat)
 
     /**
-     * A scannable-card insert was refused by the kernel validator. Emitted before any
-     * row is created. The structural [kind] is what flows through telemetry; the
-     * underlying kernel rejection reason is preserved on the typed
-     * [StorageError.ScannableCardRejected] for the consumer's error UI but is NOT
-     * carried here (it would re-link telemetry to user input — bidi-marker offsets,
+     * A scannable-card write was refused by the kernel validator. Fires for both
+     * [PassRepository.createScannableCard] and [PassRepository.updateScannableCard]:
+     * aggregate counts blend the two paths. Emitted before any row is created or
+     * modified; storage state is unchanged on rejection. The structural [kind] is what
+     * flows through telemetry; the underlying kernel rejection reason is preserved on
+     * the typed [StorageError.ScannableCardRejected] for the consumer's error UI but is
+     * NOT carried here (it would re-link telemetry to user input — bidi-marker offsets,
      * offending characters, etc.).
      */
     public fun onScannableCardRejected(kind: ScannableCardRejectedKind)

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/ScannableCardStore.kt
@@ -21,6 +21,13 @@ internal interface ScannableCardStore {
     fun listAll(): List<ScannableCard>
     fun loadById(id: ScannableCardRecordId): ScannableCard?
     fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome
+
+    /**
+     * Multi-column UPDATE on the scannable-cards row. Returns `true` if a row matched
+     * [id], `false` otherwise (caller maps to `IntegrityViolation`). `created_at_epoch_ms`
+     * is preserved so the row's position in `listAll()` does not move on update.
+     */
+    fun update(id: ScannableCardRecordId, request: ScannableCardUpdateRequest): Boolean
     fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome?
     fun close()
 }
@@ -35,6 +42,17 @@ internal data class ScannableCardInsertRequest(
     val format: ScannableFormat,
     val label: String,
     val nowEpochMs: Long,
+)
+
+/**
+ * Pre-validated request to overwrite a scannable card's mutable columns. Same payload
+ * shape as [ScannableCardInsertRequest] minus `nowEpochMs`: rename / re-edit is not a
+ * re-insert, so the row's `created_at_epoch_ms` is preserved.
+ */
+internal data class ScannableCardUpdateRequest(
+    val payload: String,
+    val format: ScannableFormat,
+    val label: String,
 )
 
 internal data class ScannableCardInsertOutcome(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherScannableCardStore.kt
@@ -70,6 +70,28 @@ internal class SqlCipherScannableCardStore(
         return ScannableCardInsertOutcome(id = ScannableCardRecordId(rowId))
     }
 
+    override fun update(id: ScannableCardRecordId, request: ScannableCardUpdateRequest): Boolean {
+        val rows: Int
+        db.beginTransaction()
+        try {
+            val cv = ContentValues().apply {
+                put("payload", request.payload)
+                put("format", request.format.name)
+                put("label", request.label)
+            }
+            rows = db.update(
+                Schema.Tables.SCANNABLE_CARDS,
+                cv,
+                "id = ?",
+                arrayOf(id.value.toString()),
+            )
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+        return rows > 0
+    }
+
     override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? {
         val card = loadById(id) ?: return null
         db.beginTransaction()

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -16,6 +16,7 @@ import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
 import `is`.walt.passes.storage.internal.ScannableCardStore
+import `is`.walt.passes.storage.internal.ScannableCardUpdateRequest
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -446,6 +447,8 @@ class DocumentRepositoryTest {
         override fun listAll(): List<ScannableCard> = emptyList()
         override fun loadById(id: ScannableCardRecordId): ScannableCard? = null
         override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome =
+            error("unused in document tests")
+        override fun update(id: ScannableCardRecordId, request: ScannableCardUpdateRequest): Boolean =
             error("unused in document tests")
         override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? = null
         override fun close() = Unit

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -29,6 +29,7 @@ import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
 import `is`.walt.passes.storage.internal.ScannableCardStore
+import `is`.walt.passes.storage.internal.ScannableCardUpdateRequest
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -339,6 +340,8 @@ class PassRepositoryContractTest {
         override fun listAll(): List<ScannableCard> = emptyList()
         override fun loadById(id: ScannableCardRecordId): ScannableCard? = null
         override fun insert(request: ScannableCardInsertRequest): ScannableCardInsertOutcome =
+            error("unused in pass-side tests")
+        override fun update(id: ScannableCardRecordId, request: ScannableCardUpdateRequest): Boolean =
             error("unused in pass-side tests")
         override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? = null
         override fun close() = Unit

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -21,6 +21,7 @@ import `is`.walt.passes.storage.internal.ScannableCardDeleteOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
 import `is`.walt.passes.storage.internal.ScannableCardStore
+import `is`.walt.passes.storage.internal.ScannableCardUpdateRequest
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -57,6 +58,13 @@ import org.robolectric.annotation.Config
  *     validator) and re-mints the [ScannableCardId] as the stringified row id.
  *  8. `close()` releases the scannable-card store along with the pass and document
  *     stores; the call is idempotent.
+ *  9. `updateScannableCard` re-runs the validator before any write, re-emits the
+ *     observe flow on success, emits no success telemetry, and shares the
+ *     `onScannableCardRejected` channel with `createScannableCard` on rejection.
+ * 10. `updateScannableCard` of an unknown id returns [StorageError.IntegrityViolation]
+ *     when the input passed validation; an invalid input against an unknown id
+ *     surfaces as [StorageError.ScannableCardRejected] (validation precedes the row
+ *     lookup, mirroring `updateDocumentLabel`).
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -186,6 +194,169 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
+    fun updateReplacesFieldsPreservesRowPositionAndEmitsNoSuccessTelemetry() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val seed = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "old",
+            ),
+        )
+        check(seed is StorageResult.Success)
+        val id = seed.value
+
+        val result = repo.updateScannableCard(
+            id,
+            ScannableCardCreateInput(
+                payload = "HELLO WORLD",
+                format = ScannableFormat.Code128,
+                label = "new",
+            ),
+        )
+
+        check(result is StorageResult.Success)
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].id.value).isEqualTo(id.value.toString())
+        assertThat(rows[0].payload).isEqualTo("HELLO WORLD")
+        assertThat(rows[0].format).isEqualTo(ScannableFormat.Code128)
+        assertThat(rows[0].label).isEqualTo("new")
+        // Update emits no telemetry: nothing follows the original card-created event.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Ean13",
+        ).inOrder()
+    }
+
+    @Test
+    fun updateOfUnknownIdWithValidInputReturnsIntegrityViolation() = runTest {
+        val telemetry = RecordingGuard()
+        val repo = repo(FakeScannableCardStore(), telemetry)
+
+        val result = repo.updateScannableCard(
+            ScannableCardRecordId(404L),
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "Grocery",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val violation = result.error as StorageError.IntegrityViolation
+        check(violation.recordId is ScannableCardRecordId)
+        assertThat(violation.recordId.value).isEqualTo(404L)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
+    fun updateWithControlCharInPayloadIsRejectedAndStoredRowIsUnchanged() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val seed = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "seed",
+            ),
+        )
+        check(seed is StorageResult.Success)
+
+        val result = repo.updateScannableCard(
+            seed.value,
+            ScannableCardCreateInput(
+                payload = "abcdef", // bell character — Cc category
+                format = ScannableFormat.Code128,
+                label = "new",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        check(rejected.reason is ScannableCardRejectionReason.InvalidPayload)
+        // Same telemetry channel as createScannableCard rejections; no `failure:...`.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Ean13",
+            "card-rejected:PayloadInvalid",
+        ).inOrder()
+        // Stored row was not overwritten by the rejected update.
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].payload).isEqualTo("5012345678900")
+        assertThat(rows[0].label).isEqualTo("seed")
+    }
+
+    @Test
+    fun updateWithEmptyLabelIsRejectedWithTypedReason() = runTest {
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val seed = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "seed",
+            ),
+        )
+        check(seed is StorageResult.Success)
+
+        val result = repo.updateScannableCard(
+            seed.value,
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "   ", // whitespace-only, trims to empty
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        check(rejected.reason is ScannableCardRejectionReason.InvalidLabel)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Ean13",
+            "card-rejected:LabelInvalid",
+        ).inOrder()
+    }
+
+    @Test
+    fun updateOfUnknownIdWithInvalidInputPrefersRejectionOverIntegrityViolation() = runTest {
+        // Validation runs before the row is loaded; an invalid input against an unknown
+        // id surfaces as ScannableCardRejected, mirroring updateDocumentLabel's
+        // label-cap-before-load precedence.
+        val telemetry = RecordingGuard()
+        val repo = repo(FakeScannableCardStore(), telemetry)
+
+        val result = repo.updateScannableCard(
+            ScannableCardRecordId(999L),
+            ScannableCardCreateInput(
+                payload = "abcdef", // bell character — Cc category
+                format = ScannableFormat.Code128,
+                label = "x",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        check(rejected.reason is ScannableCardRejectionReason.InvalidPayload)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:PayloadInvalid",
+        ).inOrder()
+    }
+
+    @Test
     fun loadRoundTripsStoredFields() = runTest {
         val cards = FakeScannableCardStore()
         val repo = repo(cards, RecordingGuard())
@@ -281,6 +452,17 @@ class ScannableCardRepositoryTest {
                 createdAtEpochMs = request.nowEpochMs,
             )
             return ScannableCardInsertOutcome(id = ScannableCardRecordId(rowId))
+        }
+
+        override fun update(id: ScannableCardRecordId, request: ScannableCardUpdateRequest): Boolean {
+            val row = rows[id.value] ?: return false
+            // createdAtEpochMs is preserved so the row's position in listAll() is unchanged.
+            rows[id.value] = row.copy(
+                payload = request.payload,
+                format = request.format,
+                label = request.label,
+            )
+            return true
         }
 
         override fun delete(id: ScannableCardRecordId): ScannableCardDeleteOutcome? {


### PR DESCRIPTION
## Summary

- Adds `PassRepository.updateScannableCard(id, input)` so walt-android can mutate the payload / format / label of a stored scannable card without re-creating the row. Companion to walt-android `wlt-4dn.2` and partially GitHub #100 (edit created codes); sibling to the just-shipped `updateDocumentLabel` (#109).
- Re-runs `ScannableCardInputValidator` (the single insert-time choke point per `createScannableCard`'s KDoc) before any UPDATE. Rejection arms route through the existing `rejectScannableCard` helper, so they share the `onScannableCardRejected` telemetry channel and the typed `StorageError.ScannableCardRejected` reason with `createScannableCard`. Validation runs before the row is loaded, so an invalid input against an unknown id surfaces as `ScannableCardRejected` rather than `IntegrityViolation` (mirrors `updateDocumentLabel`'s label-cap-before-load precedence).
- Single UPDATE on `payload` / `format` / `label` under `writeMutex`; `created_at_epoch_ms` is preserved at the SQL layer so the row's position in `observeScannableCards` does not move. No telemetry on success. KDoc on `StorageTelemetryGuard.onScannableCardRejected` updated to document that the channel now blends `createScannableCard` and `updateScannableCard`.

## Test plan

- [x] `:passes-storage:testDebugUnitTest` — adds 5 new cases on `ScannableCardRepositoryTest`: success (preserves row position, no success telemetry), unknown-id-with-valid-input → `IntegrityViolation`, control-char-payload rejection (stored row unchanged), empty-label rejection, and unknown-id-with-invalid-input → `ScannableCardRejected` (validation-before-lookup precedence).
- [x] `:passes-storage:detekt`
- [x] `:passes-storage:lintDebug`
- [ ] Instrumentation round-trip lives on the SQLCipher side and is exercised by the existing scannable-card androidTest suite when wired up downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)