### PR TITLE
passes-{storage,ui}: add user_label override and trust-caption rule (wpass-7xa)

### DIFF
--- a/docs/adr/0007-user-label-trust-caption.md
+++ b/docs/adr/0007-user-label-trust-caption.md
@@ -1,0 +1,312 @@
+# ADR 0007: user-label side-channel override and trust-caption rule for pkpass
+
+- Status: Accepted
+- Date: 2026-05-24
+- Tracks: `wpass-7xa` (this ADR + implementation), `wpass-osf` (rename-epic
+  parent), walt-android `wlt-4dn.3` / GitHub `walt-app/walt-passes-android#75`
+  (consumer-side rename UX). Sibling slices already shipped:
+  `wpass-hhq` (`updateDocumentLabel`, PR #109), `wpass-lay`
+  (`updateScannableCard`, PR #110).
+- Decision context: extends ADR 0002 D3 (the `passes` schema) and ADR 0003
+  (passes-ui theming surface). Trust-claim posture inherits from the repo
+  charter: every trust-claim-bearing behavior lives in this repository.
+
+## Context
+
+Walt-android wants a "rename pass" affordance: a user who has imported a
+Delta boarding pass should be able to label it "Mom's flight home" in the
+wallet list. PR #109 and #110 shipped the analogous capability for the two
+sibling artifact types (documents, scannable cards). pkpass is the
+highest-risk of the three because its title is part of the signed payload
+and therefore part of the trust bond.
+
+Today, a pkpass's visible identity on the front of the card and in lane
+tiles is the signed `pass.json` `organizationName` (after pass.strings
+substitution; see `PassFront.kt:102`). That string is what binds the user's
+mental model of *who issued this pass* to the cryptographically verified
+issuer identity. A naive "rename" feature that lets the user overwrite the
+displayed title would decouple displayed identity from signed identity in
+exactly the same shape as the #69 verifier-name swap incident: the screen
+says one thing, the cryptographically attested issuer is another, and there
+is no on-screen affordance to tell users which is which.
+
+The siblings did not have this problem. Documents (`updateDocumentLabel`)
+have no signed identity at all — the consumer supplies the label at import.
+Scannable cards (`updateScannableCard`) have no signature either; the
+payload is user-generated. pkpass is alone in carrying a PKCS#7-attested
+issuer identity that the rename feature must not silently hide.
+
+This ADR establishes the data model, repository API, surface contract, and
+in-repo enforcement mechanism for a pkpass user-label override that
+preserves the signed identity on every surface that presents the override.
+
+## Decisions
+
+### D1. user_label is a side-channel column on passes, never on the signed payload
+
+A new nullable `user_label TEXT` column is added to the `passes` table
+(ADR 0002 D3). `NULL` means "no override" and is the default for all
+existing and freshly imported rows.
+
+The override is stored alongside the row, not inside `pass_json`. The
+`pass_json` BLOB carries the parser's exact reconstruction of the signed
+PKPASS body (per ADR 0002 D3) and must remain bit-equivalent to what the
+signature attests. Putting `user_label` inside `pass_json` would corrupt
+that contract: a re-verification of the stored JSON against the original
+PKCS#7 signature would fail. Keeping it as a separate column makes the
+override obviously not-signed at the storage layer — a future contributor
+reading the schema sees that `user_label` and `pass_json` are distinct
+fields, and a future audit reading a row sees both side by side.
+
+Schema delta (v4 → v5):
+
+```sql
+ALTER TABLE passes ADD COLUMN user_label TEXT;
+```
+
+`NULL` default. No index: the column is not a query key (sort and filter
+continue against `type` / `expiration_epoch_ms` / `created_at_epoch_ms` per
+ADR 0002 D3); it is loaded with the row and rendered. Adding an index later
+is a non-breaking follow-on if a future feature surfaces it.
+
+Length cap: `MAX_USER_LABEL_CHARS = 100`, mirroring the existing
+`DocumentBounds.MAX_LABEL_CHARS` cap that `updateDocumentLabel` enforces.
+The cap exists at the repository boundary only; nothing upstream of the
+consumer-supplied label bounds it.
+
+### D2. PassRepository.updatePassUserLabel(id, label) replaces or clears
+
+```kotlin
+public suspend fun updatePassUserLabel(
+    id: PassRecordId,
+    label: String?,
+): StorageResult<Unit>
+```
+
+Semantics:
+
+- `label = null` clears the override (sets `user_label` to `NULL`).
+- A non-null `label` whose `.trim()` is empty is treated as a clear. This
+  is defense in depth against a "rename to all whitespace" UX bug that
+  would render an invisible primary identity and effectively hide the
+  pass. Walt-android's rename UI is expected to offer an explicit "clear"
+  button that passes `null`; the trim-blank-to-null rule means the
+  storage layer cannot end up in the all-spaces state even if a future
+  caller forgets the explicit-clear path.
+- A non-null `label` whose trimmed length exceeds `MAX_USER_LABEL_CHARS`
+  is rejected with `StorageError.PassRejected` carrying
+  `PassUpdateRejectedKind.LabelTooLong`. Mirrors `updateDocumentLabel`'s
+  cap-rejection shape. The cap is checked before the row is loaded, so
+  an over-long label against an unknown `id` surfaces as
+  `PassRejected`, not `IntegrityViolation`. Matches
+  `updateDocumentLabel`'s precedence rule.
+- Returns `StorageError.IntegrityViolation` if no row matches `id` and
+  the label passed the cap.
+- Whitespace at the leading and trailing edges is trimmed before
+  storage. Internal whitespace is preserved (a label like
+  `"Mom's    flight"` is legitimate user input; collapsing internal runs
+  is a UI concern, not a storage concern).
+
+### D3. updated_at_epoch_ms is NOT bumped by user_label changes
+
+`updated_at_epoch_ms` semantically tracks "the canonical pass payload
+changed" — i.e. the upsert re-import path in `PassRepository.upsert`. A
+user_label change does not touch `pass_json`, images, locales, or any
+signed field. It is metadata about the user's relationship to the pass,
+not a payload mutation.
+
+Precedent: `updateDocumentLabel` explicitly preserves
+`imported_at_epoch_ms` ("rename is not a re-import");
+`updateScannableCard` explicitly preserves `created_at_epoch_ms` ("edit
+is not a re-insert"). `updatePassUserLabel` matches that posture.
+
+Sort-order note: the `PassRepository.passes` `StateFlow` is sorted by
+`created_at_epoch_ms DESC`, not `updated_at_epoch_ms`, so a hypothetical
+bump would not change visible ordering. If a future feature needs a
+"recency of user attention" sort, that is a new column (e.g.
+`last_user_touch_epoch_ms`), not a re-purposing of `updated_at`.
+
+### D4. StoredPass and PassSummary surface user_label as a separate field
+
+Both data classes gain `userLabel: String?`. Callers (walt-android) read
+the field directly; the kernel does not blend it into `Pass`
+or `pass.organizationName`. Keeping the override on the storage-layer
+type, not on the `passes-core` `Pass` type, preserves the invariant that
+`Pass` carries only the parser's view of the signed payload.
+
+A consumer that ignores `userLabel` and renders `pass.organizationName`
+continues to work and continues to be trust-correct (it just doesn't
+display the user's rename). The override is opt-in at the consumer
+layer; the storage and parser layers are not aware of it.
+
+### D5. Trust-caption rule: signed organizationName MUST remain visible when user_label is set
+
+This is the load-bearing trust-claim decision of the ADR.
+
+> **Rule.** When a pkpass's `StoredPass.userLabel` is non-null, every UI
+> surface that presents that pass's primary visible identity MUST also
+> present the signed `organizationName` on the same surface, not behind
+> a tap-to-reveal, with a typographic treatment at least as legible as
+> a caption or eyebrow under the user label.
+
+Concrete shape on a pkpass tile:
+
+```
+┌──────────────────────────────────────┐
+│ Mom's flight home          [Verified]│   ← user_label (primary)
+│ Delta Air Lines                      │   ← signed organizationName (eyebrow)
+│ ... rest of pass body / fields ...   │
+└──────────────────────────────────────┘
+```
+
+Caption-anchor choice: `organizationName`, not `description`. PKPASS's
+`organizationName` is the spec-blessed issuer-identity string ("Display
+name of the organization that originated and signed the pass"). PKPASS's
+`description` is an accessibility-summary field ("Brief description of
+the pass, used by iOS accessibility technologies"). The trust bond a
+rename can decouple is "this pass identifies itself as issued by X"; the
+right anchor is the issuer identity, not the artifact-kind summary.
+Description remains available for accessibility surfaces (TalkBack /
+content descriptions), but is not the trust caption.
+
+Equality edge case: when `userLabel.trim()` equals the displayed
+`organizationName` (after `pass.strings` substitution) under
+case-insensitive ASCII comparison, the surface MAY suppress the eyebrow
+to avoid visually redundant identical lines. Storage still records what
+the user typed. The override is treated as "no-op for display purposes";
+the trust rule is satisfied trivially because the primary identity
+already IS the signed identity.
+
+### D6. The rule is enforced by a kernel-owned Composable, not by documentation
+
+`passes-ui` exposes a new public Composable:
+
+```kotlin
+@Composable
+public fun PassIdentityBlock(
+    pass: Pass,
+    userLabel: String?,
+    locale: PassLocale = PassLocale("en"),
+    modifier: Modifier = Modifier,
+)
+```
+
+This Composable is the canonical renderer of the D5 rule. Given a
+`Pass` (whose `organizationName` carries the signed issuer identity)
+and an optional `userLabel`, it renders:
+
+- when `userLabel` is `null`: the displayed `organizationName` alone, in
+  the same role as today's `PassFront` eyebrow at line 156-161.
+- when `userLabel` is non-null and not equal to the displayed
+  `organizationName`: the user label as the primary line and the
+  displayed `organizationName` as a sub-line (eyebrow), both rendered on
+  the same surface, both legible.
+- when `userLabel.trim()` equals the displayed `organizationName` (D5
+  equality edge case): the displayed `organizationName` alone.
+
+`PassFront` is updated to route its header eyebrow through
+`PassIdentityBlock` rather than rendering `displayOrganizationName`
+directly. `PassImportConfirm` is *not* updated; at import time
+`userLabel` does not exist yet, and the import-confirm surface always
+shows signed identity by construction (no override is possible until
+after the row is persisted).
+
+Walt-android's pkpass tile, pkpass lane row, and any future
+pkpass-surfacing chrome MUST call `PassIdentityBlock` rather than read
+`StoredPass.userLabel` and render it directly. Bypassing the Composable
+to surface `userLabel` as bare primary identity is a trust-claim
+violation, equivalent in shape to the #69 verifier-name swap.
+
+In-repo enforcement:
+
+- `PublicApiSurfaceTest` in `passes-ui` is extended to assert that
+  `PassIdentityBlock` exists and is `public`. This is the lock on the
+  surface contract: walt-android's tile code that compiles against this
+  module is wired to a symbol whose existence is tested here, so a
+  future refactor cannot quietly remove it.
+- A new test in `TrustClaimSurfaceTest` exercises `PassIdentityBlock`
+  with each of the four cases above and asserts that the signed
+  `organizationName` is on screen in all non-suppressed cases.
+
+Consumer-side enforcement is code review on walt-android (the rename
+PRs land in the same review cycle that touches the tile and lane
+surfaces); this ADR is the canonical reference the reviewer cites.
+
+### D7. Telemetry: a label-mutation event with no PII
+
+`StorageTelemetryGuard` gains:
+
+```kotlin
+public fun onUserLabelUpdated(
+    type: PassType,
+    hadPriorLabel: Boolean,
+    clearing: Boolean,
+)
+```
+
+Following the `passes-storage` discipline (ADR 0002 D8 + ADR 0002 D7):
+no `String` parameters, no `Pass` parameter, no `PassField` parameter.
+The event carries only the pass type, whether there was already an
+override, and whether the new write is a clear (`label == null` or
+trimmed to empty). The user's actual label text is never exposed
+through telemetry. Adding the label or any field of the pass to this
+event in the future is a security-policy change, not an API addition.
+
+A separate `passes-ui` telemetry event for "user-label override is
+being displayed" is *not* added. The trust-caption rule is enforced by
+the Composable's structure, not by a runtime event; counting how many
+overridden passes are on screen does not contribute to trust posture.
+
+## Consequences
+
+- The pkpass rename feature is unblocked behind a schema migration
+  (v4 → v5), a single new repository API, and a single new public
+  Composable. The trust-claim posture is preserved: the signed issuer
+  identity remains on every pkpass surface that surfaces a renamed
+  pass.
+- walt-android's `wlt-4dn.3` consumer-side work can land against a
+  fixed kernel contract: it adds a rename UI, calls
+  `updatePassUserLabel`, reads `StoredPass.userLabel`, and renders via
+  `PassIdentityBlock`. No parallel trust-claim-bearing logic on the
+  consumer side.
+- The audit narrative gains a worked example: "trust caption" is no
+  longer a phrase that lives only in the ADR for documents and
+  scannable cards; it is also the explicit rule for the artifact type
+  whose identity is *cryptographically attested*. This ADR is the
+  canonical reference when a future contributor asks "why can't we let
+  the user just type a new title?"
+- A schema-version-5 migration ships. The migration is a single
+  `ALTER TABLE`, mechanically the simplest in `Schema.MIGRATIONS` so
+  far. A row that fails the migration is impossible (no data is
+  transformed); `SchemaMigrationTest` gains a v4 → v5 walk-up assertion
+  that the column exists and defaults to `NULL`.
+- `Pass` (passes-core) is unchanged. The override never reaches
+  `passes-core`. The "pure Kotlin/JVM, signed-payload-only" character
+  of `passes-core` is preserved.
+
+## Open follow-ups
+
+- Implementation bead: schema v4 → v5 migration in `Schema.kt`,
+  `updatePassUserLabel` in `SqlCipherPassRepository`,
+  `PassRecordRow` / `PassSummary` / `StoredPass` field additions,
+  `StorageError.PassRejected` arm, `PassUpdateRejectedKind` enum,
+  `StorageTelemetryGuard.onUserLabelUpdated` event,
+  `PassRepositoryContractTest` coverage (set, clear, cap-reject,
+  trim-blank-to-null, integrity-violation, no `updated_at` bump),
+  `SchemaMigrationTest` v4 → v5 walk-up.
+- Implementation bead: `PassIdentityBlock` in `passes-ui`,
+  `PassFront.kt` re-wire to call it, `PublicApiSurfaceTest` lock
+  on the symbol, `TrustClaimSurfaceTest` cases for the four render
+  paths (null, override, override-equal-to-signed, longer label
+  wrapping).
+- walt-android `wlt-4dn.3`: rename UI + tile / lane surface
+  calls `PassIdentityBlock`. Reviewer cites this ADR for the trust
+  rule.
+- Accessibility surfaces: revisit whether `description` should drive a
+  `Modifier.semantics { contentDescription = ... }` on
+  `PassIdentityBlock` for TalkBack. This is a follow-on once the
+  rename surface lands; the trust rule itself does not depend on it.
+- Future "recency of user attention" sort, if walt-android product
+  surfaces want it: new column
+  (`last_user_touch_epoch_ms` or similar), separate ADR, not a
+  re-purposing of `updated_at_epoch_ms`.

--- a/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
+++ b/passes-storage/src/androidTest/kotlin/is/walt/passes/storage/NoOpStorageTelemetryGuard.kt
@@ -27,4 +27,10 @@ internal object NoOpStorageTelemetryGuard : StorageTelemetryGuard {
     override fun onScannableCardCreated(format: ScannableFormat) = Unit
     override fun onScannableCardDeleted(format: ScannableFormat) = Unit
     override fun onScannableCardRejected(kind: ScannableCardRejectedKind) = Unit
+    override fun onUserLabelUpdated(
+        type: PassType,
+        hadPriorLabel: Boolean,
+        clearing: Boolean,
+    ) = Unit
+    override fun onPassRejected(kind: PassUpdateRejectedKind) = Unit
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -61,6 +61,40 @@ public interface PassRepository {
     public suspend fun delete(id: PassRecordId): StorageResult<Unit>
 
     /**
+     * Sets or clears the user-supplied display label for a pkpass row (ADR 0007 D2). The
+     * override is stored alongside the signed `pass_json` blob, never inside it, so the
+     * `Pass` body remains bit-equivalent to what the PKCS#7 signature attests.
+     *
+     * Semantics:
+     *
+     * - `label = null` clears the override (writes SQL NULL to `user_label`).
+     * - A non-null `label` whose `.trim()` is empty is treated as a clear (defense in
+     *   depth against an "all whitespace" rename that would render an invisible primary
+     *   identity).
+     * - A non-null `label` is trimmed of leading and trailing whitespace before storage;
+     *   internal whitespace is preserved.
+     * - Rejects labels whose trimmed length exceeds [PassUserLabelBounds.MAX_USER_LABEL_CHARS]
+     *   with [StorageError.PassRejected] carrying [PassUpdateRejectedKind.LabelTooLong].
+     *   The cap is checked before the row is loaded, so an over-long label against an
+     *   unknown [id] surfaces as [StorageError.PassRejected], not
+     *   [StorageError.IntegrityViolation], mirroring [updateDocumentLabel]'s precedence.
+     *
+     * Returns [StorageError.IntegrityViolation] if no row matches [id] and the label
+     * passed the cap. On success the row's `updated_at_epoch_ms` is unchanged — rename
+     * is metadata, not a canonical-payload mutation (ADR 0007 D3), matching
+     * [updateDocumentLabel] and [updateScannableCard].
+     *
+     * Trust-caption rule: when this method has set a non-null label, every UI surface
+     * presenting that pass MUST also surface the signed `organizationName` (ADR 0007
+     * D5). The kernel-owned [is.walt.passes.ui.PassIdentityBlock] Composable is the
+     * canonical renderer.
+     */
+    public suspend fun updatePassUserLabel(
+        id: PassRecordId,
+        label: String?,
+    ): StorageResult<Unit>
+
+    /**
      * Insert a stored PDF document. Bytes and thumbnail bytes are written into the
      * `documents` and `document_thumbnails` tables in the same transaction; the assigned
      * row id is returned. The repository never decodes [pdfBytes] or [thumbnailBytes];
@@ -226,6 +260,13 @@ public data class PassSummary(
     public val signatureStatus: SignatureStatus,
     public val createdAt: PassInstant,
     public val updatedAt: PassInstant,
+    /**
+     * User-supplied display-label override (ADR 0007 D1). `null` means no override —
+     * surfaces present `organizationName` as today. When non-null, surfaces MUST
+     * present this value alongside the signed `organizationName` (ADR 0007 D5); the
+     * `is.walt.passes.ui.PassIdentityBlock` Composable is the canonical renderer.
+     */
+    public val userLabel: String? = null,
 )
 
 /**
@@ -240,7 +281,24 @@ public data class StoredPass(
     public val signatureStatus: SignatureStatus,
     public val createdAt: PassInstant,
     public val updatedAt: PassInstant,
+    /**
+     * User-supplied display-label override (ADR 0007 D1). See [PassSummary.userLabel].
+     */
+    public val userLabel: String? = null,
 )
+
+/**
+ * Defensive caps `passes-storage` enforces on the user-supplied pkpass display label.
+ * Mirrors [DocumentBounds.MAX_LABEL_CHARS]'s role for documents but lives separately so
+ * a future pass-side cap change cannot silently collide with a document-side cap.
+ *
+ * The cap exists only at this layer: nothing upstream of [PassRepository.updatePassUserLabel]
+ * bounds the consumer-supplied label, and the column is loaded with every row, so a
+ * multi-MB string would inflate every load and StateFlow emission.
+ */
+public object PassUserLabelBounds {
+    public const val MAX_USER_LABEL_CHARS: Int = 100
+}
 
 /**
  * Common surrogate-key surface shared by [PassRecordId] and [DocumentRecordId]. Carrying

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -14,7 +14,7 @@ package `is`.walt.passes.storage
 public object Schema {
     public const val DATABASE_NAME: String = "walt_passes.db"
 
-    public const val VERSION: Int = 4
+    public const val VERSION: Int = 5
 
     public object Tables {
         public const val SCHEMA_META: String = "schema_meta"
@@ -73,6 +73,16 @@ public object Schema {
         """.trimIndent(),
         "CREATE INDEX IF NOT EXISTS idx_scannable_cards_created_at " +
             "ON scannable_cards(created_at_epoch_ms)",
+    )
+
+    /**
+     * v4 -> v5 migration. Adds the nullable `user_label` column to the `passes` table for
+     * the side-channel rename override (ADR 0007 D1). NULL = no override; existing rows
+     * default to NULL so the post-migration shape preserves pre-migration display
+     * behavior. No data transformation; no row can fail the migration.
+     */
+    private val V4_TO_V5_ADD_USER_LABEL: List<String> = listOf(
+        "ALTER TABLE passes ADD COLUMN user_label TEXT",
     )
 
     /**
@@ -156,7 +166,8 @@ public object Schema {
             signature_status_kind TEXT    NOT NULL,
             pass_json             BLOB    NOT NULL,
             created_at_epoch_ms   INTEGER NOT NULL,
-            updated_at_epoch_ms   INTEGER NOT NULL
+            updated_at_epoch_ms   INTEGER NOT NULL,
+            user_label            TEXT
         )
         """.trimIndent(),
         "CREATE INDEX IF NOT EXISTS idx_passes_type ON passes(type)",
@@ -199,10 +210,15 @@ public object Schema {
      * consumer no longer reads or writes the field (walt-android `wlt-z17`); the
      * column was dormant user-private data on disk. Row identity is preserved; per-row
      * colour bytes are lost, which is intentional — Walt already stopped reading them.
+     *
+     * v4 -> v5 adds the nullable `user_label` column to `passes` for the side-channel
+     * rename override (ADR 0007). Pure additive change; existing rows default to NULL
+     * (no override) so display behavior is unchanged for pre-migration data.
      */
     public val MIGRATIONS: Map<Int, List<String>> = mapOf(
         1 to V2_DOCUMENT_TABLES,
         2 to V3_SCANNABLE_CARD_TABLES,
         3 to V3_TO_V4_DROP_COLOR_COLUMN,
+        4 to V4_TO_V5_ADD_USER_LABEL,
     )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -116,6 +116,38 @@ public class SqlCipherPassRepository internal constructor(
         StorageResult.Success(Unit)
     }
 
+    override suspend fun updatePassUserLabel(
+        id: PassRecordId,
+        label: String?,
+    ): StorageResult<Unit> = runIo {
+        // Normalize: trim, then collapse blank-after-trim to null (ADR 0007 D2). The
+        // trimmed value is what the cap is measured against and what reaches the store.
+        val trimmed = label?.trim()
+        val normalized = if (trimmed.isNullOrEmpty()) null else trimmed
+        val clearing = normalized == null
+
+        if (normalized != null && normalized.length > PassUserLabelBounds.MAX_USER_LABEL_CHARS) {
+            return@runIo rejectPass(PassUpdateRejectedKind.LabelTooLong)
+        }
+
+        val outcome = writeMutex.withLock {
+            val o = store.updateUserLabel(id, normalized) ?: return@withLock null
+            // Refresh the full ordered list rather than splicing: matches the other
+            // mutating paths and avoids assuming the in-memory list and the store agree
+            // on row presence (e.g. if the row was deleted in another writer between
+            // the prior read and this write).
+            _passes.value = store.listSummaries()
+            o
+        } ?: return@runIo failure(StorageError.IntegrityViolation(id))
+
+        telemetryGuard.onUserLabelUpdated(
+            type = outcome.summary.type,
+            hadPriorLabel = outcome.hadPriorLabel,
+            clearing = clearing,
+        )
+        StorageResult.Success(Unit)
+    }
+
     override suspend fun insertDocument(
         label: String,
         pdfBytes: ByteArray,
@@ -370,6 +402,16 @@ public class SqlCipherPassRepository internal constructor(
     ): StorageResult<T> {
         telemetryGuard.onScannableCardRejected(telemetryKind)
         return StorageResult.Failure(StorageError.ScannableCardRejected(reason))
+    }
+
+    /**
+     * Single emission point for a pass-side defensive rejection (today: user_label
+     * cap). Same discipline as [rejectDocument]: skip [failure] so `onStorageFailure`
+     * does not double-fire alongside `onPassRejected`.
+     */
+    private fun <T> rejectPass(kind: PassUpdateRejectedKind): StorageResult<T> {
+        telemetryGuard.onPassRejected(kind)
+        return StorageResult.Failure(StorageError.PassRejected(kind))
     }
 
     /**

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -121,11 +121,6 @@ public sealed interface ScannableCardRejectionReason {
 }
 
 /**
- * Stable telemetry-friendly enumeration of the open-ended failure space. New arms here
- * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
- * routing telemetry through enums rather than free-form strings.
- */
-/**
  * Why a [PassRepository.updatePassUserLabel] call was refused. One arm today; future
  * caps (illegal-character filters, locale-specific limits, etc.) would add arms here.
  * Mirrors [DocumentStorageRejectedKind] in shape but lives separately so a future
@@ -135,6 +130,11 @@ public enum class PassUpdateRejectedKind {
     LabelTooLong,
 }
 
+/**
+ * Stable telemetry-friendly enumeration of the open-ended failure space. New arms here
+ * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
+ * routing telemetry through enums rather than free-form strings.
+ */
 public enum class UnknownStorageFailureKind {
     DiskFull,
     PermissionDenied,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -75,6 +75,16 @@ public sealed interface StorageError {
     ) : StorageError
 
     /**
+     * A pass mutation (today: `updatePassUserLabel`) was refused by the storage-side
+     * defensive check (ADR 0007 D2). Mirrors [DocumentRejected]'s shape: rejection is
+     * not a generic storage failure, so [onStorageFailure] does NOT fire; the
+     * `onPassRejected` event fires instead. The pass row never changes on rejection.
+     */
+    public data class PassRejected(
+        public val kind: PassUpdateRejectedKind,
+    ) : StorageError
+
+    /**
      * The schema version on disk is newer than this build of `passes-storage` understands.
      * This happens when a user downgrades the wallet app. The DB is read-only-protected
      * until a forward-compatible build runs again.
@@ -115,6 +125,16 @@ public sealed interface ScannableCardRejectionReason {
  * are an API addition; new strings are not. Mirrors the `passes-core` discipline of
  * routing telemetry through enums rather than free-form strings.
  */
+/**
+ * Why a [PassRepository.updatePassUserLabel] call was refused. One arm today; future
+ * caps (illegal-character filters, locale-specific limits, etc.) would add arms here.
+ * Mirrors [DocumentStorageRejectedKind] in shape but lives separately so a future
+ * pass-side cap cannot silently collide with a document-side cap.
+ */
+public enum class PassUpdateRejectedKind {
+    LabelTooLong,
+}
+
 public enum class UnknownStorageFailureKind {
     DiskFull,
     PermissionDenied,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageTelemetryGuard.kt
@@ -49,6 +49,33 @@ public interface StorageTelemetryGuard {
     public fun onPassDeleted(type: PassType, signatureStatus: SignatureStatusKind)
 
     /**
+     * A pass row's `user_label` override was set or cleared. Emitted after the
+     * transaction commits and after the `passes` StateFlow is updated.
+     *
+     * Carries only enums and booleans: no `String` label content, no signed-identity
+     * field. The user's typed text never reaches telemetry. [hadPriorLabel] lets
+     * aggregate metrics distinguish "first rename" from "edit existing rename";
+     * [clearing] lets them distinguish "set a new value" from "remove the override".
+     *
+     * Adding a `String` (or `Pass`, or `PassField`) parameter to this event is a
+     * security-policy change per the no-PII discipline (ADR 0002 D7, reaffirmed in
+     * ADR 0007 D7).
+     */
+    public fun onUserLabelUpdated(
+        type: PassType,
+        hadPriorLabel: Boolean,
+        clearing: Boolean,
+    )
+
+    /**
+     * A pass mutation was refused by the storage-side defense-in-depth check
+     * (ADR 0007 D2). Fires for [PassRepository.updatePassUserLabel] today; sibling
+     * mutation paths would add to this aggregate. Emitted before any row is modified;
+     * storage state is unchanged on rejection.
+     */
+    public fun onPassRejected(kind: PassUpdateRejectedKind)
+
+    /**
      * A row failed to deserialize during a load or schema migration and was dropped.
      * Carries only the failure kind; the row identity is intentionally NOT part of the
      * event because the row is gone.
@@ -172,6 +199,7 @@ public enum class StorageFailureKind {
     Unknown,
     DocumentRejected,
     ScannableCardRejected,
+    PassRejected,
 }
 
 public enum class MigrationFailureKind {

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/Mapping.kt
@@ -32,4 +32,5 @@ internal fun StorageError.toFailureKind(): StorageFailureKind = when (this) {
     is StorageError.Unknown -> StorageFailureKind.Unknown
     is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
     is StorageError.ScannableCardRejected -> StorageFailureKind.ScannableCardRejected
+    is StorageError.PassRejected -> StorageFailureKind.PassRejected
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/PassStore.kt
@@ -21,6 +21,15 @@ internal interface PassStore {
     fun summaryById(id: PassRecordId): PassSummary?
     fun upsert(pass: Pass, signatureStatus: SignatureStatus, nowEpochMs: Long): UpsertOutcome
     fun delete(id: PassRecordId): DeleteOutcome?
+
+    /**
+     * Sets or clears the `user_label` column on the row matching [id]. Returns the
+     * outcome (carrying the pass type and whether a prior label was present, for
+     * telemetry) or `null` when no row matches. The caller is responsible for trimming
+     * and cap-checking [label] before invocation; the store treats [label] as already
+     * normalized.
+     */
+    fun updateUserLabel(id: PassRecordId, label: String?): UpdateUserLabelOutcome?
     fun close()
 }
 
@@ -32,4 +41,9 @@ internal data class UpsertOutcome(
 
 internal data class DeleteOutcome(
     val summary: PassSummary,
+)
+
+internal data class UpdateUserLabelOutcome(
+    val summary: PassSummary,
+    val hadPriorLabel: Boolean,
 )

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherPassStore.kt
@@ -74,6 +74,7 @@ internal class SqlCipherPassStore(
             signatureStatus = summary.signatureStatus,
             createdAt = summary.createdAt,
             updatedAt = summary.updatedAt,
+            userLabel = summary.userLabel,
         )
     }
 
@@ -198,6 +199,34 @@ internal class SqlCipherPassStore(
         return DeleteOutcome(summary)
     }
 
+    @Suppress("ReturnCount")
+    override fun updateUserLabel(id: PassRecordId, label: String?): UpdateUserLabelOutcome? {
+        // Read the prior summary before the UPDATE so `hadPriorLabel` reflects the row's
+        // state at call time. The post-UPDATE summary is what flows into the StateFlow.
+        // The three returns correspond to the three reachable "row is gone" arms (no
+        // prior, UPDATE matched zero rows, post-update re-read missed); collapsing them
+        // would hide the distinct race windows.
+        val prior = summaryById(id) ?: return null
+        val hadPriorLabel = prior.userLabel != null
+
+        val cv = ContentValues().apply {
+            if (label == null) putNull("user_label") else put("user_label", label)
+        }
+        // updated_at_epoch_ms is intentionally NOT touched (ADR 0007 D3): rename is
+        // metadata, not a canonical-payload mutation. Same posture as updateDocumentLabel
+        // ("rename is not a re-import") and updateScannableCard ("edit is not a re-insert").
+        val rows = db.update(
+            Schema.Tables.PASSES,
+            cv,
+            "id = ?",
+            arrayOf(id.value.toString()),
+        )
+        if (rows == 0) return null
+
+        val updated = summaryById(id) ?: return null
+        return UpdateUserLabelOutcome(summary = updated, hadPriorLabel = hadPriorLabel)
+    }
+
     override fun close() {
         // Close the SQLiteDatabase first, THEN zero the key buffer. The connection
         // pool may re-key connections during shutdown; zeroing first would corrupt
@@ -266,6 +295,8 @@ internal class SqlCipherPassStore(
                 telemetryGuard.onMigrationRowDropped(MigrationFailureKind.UnknownEnumValue)
                 return null
             }
+        val userLabelIdx = getColumnIndexOrThrow("user_label")
+        val userLabel = if (isNull(userLabelIdx)) null else getString(userLabelIdx)
         return PassSummary(
             id = PassRecordId(getLong(idIdx)),
             type = type,
@@ -277,6 +308,7 @@ internal class SqlCipherPassStore(
             signatureStatus = signatureStatus,
             createdAt = PassInstant(getLong(createdIdx)),
             updatedAt = PassInstant(getLong(updatedIdx)),
+            userLabel = userLabel,
         )
     }
 
@@ -284,6 +316,6 @@ internal class SqlCipherPassStore(
         const val SUMMARY_COLUMNS: String =
             "id, type, serial_number, organization_name, description, " +
                 "expiration_epoch_ms, voided, signature_status_kind, " +
-                "created_at_epoch_ms, updated_at_epoch_ms"
+                "created_at_epoch_ms, updated_at_epoch_ms, user_label"
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -464,6 +464,10 @@ class DocumentRepositoryTest {
             nowEpochMs: Long,
         ): UpsertOutcome = error("unused in document tests")
         override fun delete(id: PassRecordId): DeleteOutcome? = null
+        override fun updateUserLabel(
+            id: PassRecordId,
+            label: String?,
+        ): `is`.walt.passes.storage.internal.UpdateUserLabelOutcome? = null
         override fun close() = Unit
     }
 
@@ -500,5 +504,11 @@ class DocumentRepositoryTest {
         override fun onScannableCardCreated(format: ScannableFormat) = Unit
         override fun onScannableCardDeleted(format: ScannableFormat) = Unit
         override fun onScannableCardRejected(kind: ScannableCardRejectedKind) = Unit
+        override fun onUserLabelUpdated(
+            type: `is`.walt.passes.core.PassType,
+            hadPriorLabel: Boolean,
+            clearing: Boolean,
+        ) = Unit
+        override fun onPassRejected(kind: PassUpdateRejectedKind) = Unit
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PassRepositoryContractTest.kt
@@ -30,6 +30,7 @@ import `is`.walt.passes.storage.internal.ScannableCardInsertOutcome
 import `is`.walt.passes.storage.internal.ScannableCardInsertRequest
 import `is`.walt.passes.storage.internal.ScannableCardStore
 import `is`.walt.passes.storage.internal.ScannableCardUpdateRequest
+import `is`.walt.passes.storage.internal.UpdateUserLabelOutcome
 import `is`.walt.passes.storage.internal.UpsertOutcome
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -180,6 +181,188 @@ class PassRepositoryContractTest {
     }
 
     @Test
+    fun updatePassUserLabelSetsTheLabelAndEmitsUserLabelUpdatedTelemetry() = runTest {
+        val store = FakePassStore(
+            initial = listOf(sampleSummary(id = 1L, updatedAt = 500L)),
+        )
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 9_000L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+
+        val result = repo.updatePassUserLabel(PassRecordId(1L), "Mom's flight home")
+        check(result is StorageResult.Success)
+
+        assertThat(repo.passes.value.single().userLabel).isEqualTo("Mom's flight home")
+        // updated_at_epoch_ms is preserved (ADR 0007 D3): the FakePassStore's
+        // updateUserLabel does not touch the timestamp, mirroring the SQL UPDATE
+        // that does not include the column.
+        assertThat(repo.passes.value.single().updatedAt.epochMillis).isEqualTo(500L)
+        assertThat(telemetry.events).containsExactly(
+            "init:StrongBox",
+            "userlabel:BoardingPass:prior=false:clearing=false",
+        ).inOrder()
+    }
+
+    @Test
+    fun updatePassUserLabelClearsExistingOverrideAndReportsHadPrior() = runTest {
+        val store = FakePassStore(
+            initial = listOf(
+                sampleSummary(id = 1L, userLabel = "Mom's flight home"),
+            ),
+        )
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.Tee,
+        )
+
+        val result = repo.updatePassUserLabel(PassRecordId(1L), null)
+        check(result is StorageResult.Success)
+        assertThat(repo.passes.value.single().userLabel).isNull()
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "userlabel:BoardingPass:prior=true:clearing=true",
+        ).inOrder()
+    }
+
+    @Test
+    fun updatePassUserLabelTreatsBlankAfterTrimAsClear() = runTest {
+        val store = FakePassStore(
+            initial = listOf(sampleSummary(id = 1L, userLabel = "Mom's flight")),
+        )
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+
+        val result = repo.updatePassUserLabel(PassRecordId(1L), "   ")
+        check(result is StorageResult.Success)
+        assertThat(repo.passes.value.single().userLabel).isNull()
+        // clearing=true: defense-in-depth normalization (ADR 0007 D2) collapses
+        // whitespace-only labels to null so the surface never renders an
+        // invisible primary identity.
+        assertThat(telemetry.events).contains("userlabel:BoardingPass:prior=true:clearing=true")
+    }
+
+    @Test
+    fun updatePassUserLabelTrimsLeadingAndTrailingWhitespace() = runTest {
+        val store = FakePassStore(initial = listOf(sampleSummary(id = 1L)))
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+
+        val result = repo.updatePassUserLabel(PassRecordId(1L), "  Mom's flight   ")
+        check(result is StorageResult.Success)
+        // Internal whitespace is preserved; only leading/trailing is trimmed.
+        assertThat(repo.passes.value.single().userLabel).isEqualTo("Mom's flight")
+    }
+
+    @Test
+    fun updatePassUserLabelRejectsOverCapAndDoesNotTouchRow() = runTest {
+        val store = FakePassStore(
+            initial = listOf(sampleSummary(id = 1L, userLabel = "existing")),
+        )
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.Tee,
+        )
+
+        val overLong = "x".repeat(PassUserLabelBounds.MAX_USER_LABEL_CHARS + 1)
+        val result = repo.updatePassUserLabel(PassRecordId(1L), overLong)
+
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.PassRejected)
+        assertThat((result.error as StorageError.PassRejected).kind)
+            .isEqualTo(PassUpdateRejectedKind.LabelTooLong)
+        // Row is unchanged on rejection.
+        assertThat(repo.passes.value.single().userLabel).isEqualTo("existing")
+        // onPassRejected fires; onStorageFailure does NOT (rejection is not a generic
+        // failure — same discipline as DocumentRejected).
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "pass-rejected:LabelTooLong",
+        ).inOrder()
+    }
+
+    @Test
+    fun updatePassUserLabelCapPrecedesIntegrityViolationCheck() = runTest {
+        // Mirrors updateDocumentLabel's precedence: an over-long label against an
+        // unknown id surfaces as PassRejected, not IntegrityViolation. The cap is
+        // checked before the row is looked up.
+        val store = FakePassStore()
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.Software,
+        )
+
+        val overLong = "x".repeat(PassUserLabelBounds.MAX_USER_LABEL_CHARS + 1)
+        val result = repo.updatePassUserLabel(PassRecordId(404L), overLong)
+
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.PassRejected)
+    }
+
+    @Test
+    fun updatePassUserLabelOfUnknownIdReturnsIntegrityViolation() = runTest {
+        val store = FakePassStore()
+        val telemetry = RecordingGuard()
+        val repo = SqlCipherPassRepository(
+            store = store,
+            documentStore = NoOpDocumentStore,
+            scannableCardStore = NoOpScannableCardStore,
+            telemetryGuard = telemetry,
+            ioDispatcher = UnconfinedTestDispatcher(),
+            clock = { 1L },
+            keyBacking = KeyBacking.StrongBox,
+        )
+
+        val result = repo.updatePassUserLabel(PassRecordId(404L), "Mom's flight")
+        check(result is StorageResult.Failure)
+        check(result.error is StorageError.IntegrityViolation)
+        assertThat(telemetry.events).containsExactly(
+            "init:StrongBox",
+            "failure:IntegrityViolation:n/a",
+        ).inOrder()
+    }
+
+    @Test
     fun deleteIsIrreversibleNoUndoArmOnPublicSurface() {
         // Compile-time lock: the only mutating method on PassRepository for an existing row
         // is `delete(id)`. No `undelete`, `restore`, `softDelete`, or `archive` arms exist.
@@ -263,6 +446,18 @@ class PassRepositoryContractTest {
             return DeleteOutcome(summary)
         }
 
+        override fun updateUserLabel(
+            id: PassRecordId,
+            label: String?,
+        ): UpdateUserLabelOutcome? {
+            val prior = summaries[id.value] ?: return null
+            val hadPriorLabel = prior.userLabel != null
+            val updated = prior.copy(userLabel = label)
+            summaries[id.value] = updated
+            rows[id.value] = rows.getValue(id.value).copy(userLabel = label)
+            return UpdateUserLabelOutcome(summary = updated, hadPriorLabel = hadPriorLabel)
+        }
+
         var closeCount: Int = 0
             private set
 
@@ -313,6 +508,16 @@ class PassRepositoryContractTest {
         override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
             events += "card-rejected:${kind.name}"
         }
+        override fun onUserLabelUpdated(
+            type: PassType,
+            hadPriorLabel: Boolean,
+            clearing: Boolean,
+        ) {
+            events += "userlabel:${type.name}:prior=$hadPriorLabel:clearing=$clearing"
+        }
+        override fun onPassRejected(kind: PassUpdateRejectedKind) {
+            events += "pass-rejected:${kind.name}"
+        }
     }
 
     /**
@@ -348,7 +553,11 @@ class PassRepositoryContractTest {
     }
 
     private companion object {
-        fun sampleSummary(id: Long): PassSummary = PassSummary(
+        fun sampleSummary(
+            id: Long,
+            userLabel: String? = null,
+            updatedAt: Long = 1L,
+        ): PassSummary = PassSummary(
             id = PassRecordId(id),
             type = PassType.BoardingPass,
             serialNumber = "S$id",
@@ -358,7 +567,8 @@ class PassRepositoryContractTest {
             voided = false,
             signatureStatus = SignatureStatus.AppleVerified,
             createdAt = PassInstant(1L),
-            updatedAt = PassInstant(1L),
+            updatedAt = PassInstant(updatedAt),
+            userLabel = userLabel,
         )
 
         fun samplePass(serial: String): Pass = Pass(

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -48,6 +48,7 @@ class PublicApiSurfaceTest {
             StorageError.ScannableCardRejected(
                 ScannableCardRejectionReason.InvalidLabel(LabelRejection.Empty),
             ),
+            StorageError.PassRejected(PassUpdateRejectedKind.LabelTooLong),
         )
         val labels = errors.map { error ->
             when (error) {
@@ -72,6 +73,7 @@ class PublicApiSurfaceTest {
                     is ScannableCardRejectionReason.EncoderFailure ->
                         "card-rejected:enc:${r.reason::class.simpleName}"
                 }
+                is StorageError.PassRejected -> "pass-rejected:${error.kind.name}"
             }
         }
         assertThat(labels).containsExactly(
@@ -85,6 +87,7 @@ class PublicApiSurfaceTest {
             "unknown:DiskFull",
             "doc-rejected:OversizedAtStorage",
             "card-rejected:label:Empty",
+            "pass-rejected:LabelTooLong",
         ).inOrder()
     }
 
@@ -151,6 +154,7 @@ class PublicApiSurfaceTest {
             StorageError.ScannableCardRejected(
                 ScannableCardRejectionReason.InvalidPayload(PayloadRejection.Empty),
             ),
+            StorageError.PassRejected(PassUpdateRejectedKind.LabelTooLong),
         )
         val kinds = errors.map { error ->
             when (error) {
@@ -162,6 +166,7 @@ class PublicApiSurfaceTest {
                 is StorageError.Unknown -> StorageFailureKind.Unknown
                 is StorageError.DocumentRejected -> StorageFailureKind.DocumentRejected
                 is StorageError.ScannableCardRejected -> StorageFailureKind.ScannableCardRejected
+                is StorageError.PassRejected -> StorageFailureKind.PassRejected
             }
         }
         assertThat(kinds.toSet()).containsExactlyElementsIn(StorageFailureKind.entries)
@@ -188,8 +193,18 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun schemaDeclaresSevenTablesAndIsAtVersionFour() {
-        assertThat(Schema.VERSION).isEqualTo(4)
+    fun passUpdateRejectedKindCoversTheDocumentedArms() {
+        // ADR 0007 D2: today there is one arm (LabelTooLong). Adding new caps (e.g.
+        // illegal-character filters) requires a new arm here, which forces a deliberate
+        // edit and a matching change in StorageError.PassRejected handling.
+        assertThat(PassUpdateRejectedKind.entries.map { it.name }).containsExactly(
+            "LabelTooLong",
+        ).inOrder()
+    }
+
+    @Test
+    fun schemaDeclaresSevenTablesAndIsAtVersionFive() {
+        assertThat(Schema.VERSION).isEqualTo(5)
         assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
         assertThat(Schema.Tables.PASSES).isEqualTo("passes")
         assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
@@ -202,7 +217,7 @@ class PublicApiSurfaceTest {
         // + scannable_cards (v4 shape, no color_argb) + 1 scannable-card index
         // = 12 statements.
         assertThat(Schema.DDL).hasSize(12)
-        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3)
+        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3, 4)
     }
 
     @Test
@@ -401,6 +416,18 @@ class PublicApiSurfaceTest {
             override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
                 recorded += "card-rejected:${kind.name}"
             }
+
+            override fun onUserLabelUpdated(
+                type: PassType,
+                hadPriorLabel: Boolean,
+                clearing: Boolean,
+            ) {
+                recorded += "userlabel:${type.name}:prior=$hadPriorLabel:clearing=$clearing"
+            }
+
+            override fun onPassRejected(kind: PassUpdateRejectedKind) {
+                recorded += "pass-rejected:${kind.name}"
+            }
         }
         guard.onKeyProviderInitialized(KeyBacking.StrongBox)
         guard.onPassUpserted(PassType.BoardingPass, SignatureStatusKind.AppleVerified, false)
@@ -413,6 +440,8 @@ class PublicApiSurfaceTest {
         guard.onScannableCardCreated(ScannableFormat.Qr)
         guard.onScannableCardDeleted(ScannableFormat.Code128)
         guard.onScannableCardRejected(ScannableCardRejectedKind.PayloadInvalid)
+        guard.onUserLabelUpdated(PassType.Generic, hadPriorLabel = false, clearing = false)
+        guard.onPassRejected(PassUpdateRejectedKind.LabelTooLong)
 
         assertThat(recorded).containsExactly(
             "init:StrongBox",
@@ -426,6 +455,8 @@ class PublicApiSurfaceTest {
             "card-created:Qr",
             "card-deleted:Code128",
             "card-rejected:PayloadInvalid",
+            "userlabel:Generic:prior=false:clearing=false",
+            "pass-rejected:LabelTooLong",
         ).inOrder()
     }
 

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -496,6 +496,10 @@ class ScannableCardRepositoryTest {
             nowEpochMs: Long,
         ): UpsertOutcome = error("unused in scannable-card tests")
         override fun delete(id: PassRecordId): DeleteOutcome? = null
+        override fun updateUserLabel(
+            id: PassRecordId,
+            label: String?,
+        ): `is`.walt.passes.storage.internal.UpdateUserLabelOutcome? = null
         override fun close() = Unit
     }
 
@@ -540,5 +544,11 @@ class ScannableCardRepositoryTest {
         override fun onScannableCardRejected(kind: ScannableCardRejectedKind) {
             events += "card-rejected:${kind.name}"
         }
+        override fun onUserLabelUpdated(
+            type: PassType,
+            hadPriorLabel: Boolean,
+            clearing: Boolean,
+        ) = Unit
+        override fun onPassRejected(kind: PassUpdateRejectedKind) = Unit
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaDdlTest.kt
@@ -69,6 +69,31 @@ class SchemaDdlTest {
     }
 
     @Test
+    fun passesTableHasTheExpectedColumns() {
+        applyDdl().use { conn ->
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.PASSES})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).containsExactly(
+                "id",
+                "type",
+                "serial_number",
+                "organization_name",
+                "description",
+                "expiration_epoch_ms",
+                "voided",
+                "signature_status_kind",
+                "pass_json",
+                "created_at_epoch_ms",
+                "updated_at_epoch_ms",
+                "user_label",
+            )
+        }
+    }
+
+    @Test
     fun scannableCardsTableHasTheExpectedColumns() {
         applyDdl().use { conn ->
             val columns = mutableSetOf<String>()

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/SchemaMigrationTest.kt
@@ -64,6 +64,17 @@ class SchemaMigrationTest {
         }
     }
 
+    /**
+     * Applies the v4 schema (v1 + v1 -> v2 + v2 -> v3 + v3 -> v4). The v4 -> v5
+     * migration adds the nullable `user_label` column to `passes`.
+     */
+    private fun applyV4Ddl(conn: Connection) {
+        applyV3Ddl(conn)
+        conn.createStatement().use { stmt ->
+            for (sql in Schema.MIGRATIONS.getValue(3)) stmt.execute(sql)
+        }
+    }
+
     @Test
     fun migrationFromV1IntroducesDocumentsAndDocumentThumbnailsTables() {
         openMemoryDb().use { conn ->
@@ -208,6 +219,14 @@ class SchemaMigrationTest {
             // `sql` is the DDL the engine reconstructed; comparing it catches column,
             // ordering, and constraint drift across both creation paths. Auto-named
             // sqlite_* internal indexes are excluded since their names are nondeterministic.
+            //
+            // Whitespace is normalized (runs collapsed to a single space, then trimmed)
+            // because SQLite's `ALTER TABLE ADD COLUMN` rewrites sqlite_master.sql with
+            // its own formatting (typically `..., new_col TEXT)` tacked onto the original
+            // statement). The intent of this comparison is structural equivalence —
+            // same tables, same columns, same types, same constraints — not byte-for-
+            // byte source identity. Mismatched columns / types / constraint sets still
+            // fail; only whitespace and comma placement are normalized.
             val rs = stmt.executeQuery(
                 "SELECT type, name, tbl_name, sql FROM sqlite_master " +
                     "WHERE name NOT LIKE 'sqlite_%' " +
@@ -218,12 +237,20 @@ class SchemaMigrationTest {
                     rs.getString(1),
                     rs.getString(2),
                     rs.getString(3),
-                    rs.getString(4) ?: "",
+                    normalizeSql(rs.getString(4) ?: ""),
                 ).joinToString("|")
             }
         }
         return out
     }
+
+    private fun normalizeSql(sql: String): String =
+        sql
+            .replace(Regex("\\s+"), " ")
+            .replace(" ,", ",")
+            .replace(" )", ")")
+            .replace("( ", "(")
+            .trim()
 
     @Test
     fun migrationFromV2IntroducesScannableCardsTable() {
@@ -505,6 +532,85 @@ class SchemaMigrationTest {
                     stmt.executeQuery("SELECT COUNT(*) FROM ${Schema.Tables.DOCUMENTS}")
                         .also { it.next() }.getInt(1),
                 ).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
+    fun migrationFromV4AddsTheUserLabelColumnToPasses() {
+        openMemoryDb().use { conn ->
+            applyV4Ddl(conn)
+
+            for (sql in Schema.MIGRATIONS.getValue(4)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            val columns = mutableSetOf<String>()
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery("PRAGMA table_info(${Schema.Tables.PASSES})")
+                while (rs.next()) columns.add(rs.getString("name"))
+            }
+            assertThat(columns).contains("user_label")
+        }
+    }
+
+    @Test
+    fun migrationFromV4UserLabelColumnIsNullable() {
+        openMemoryDb().use { conn ->
+            applyV4Ddl(conn)
+            for (sql in Schema.MIGRATIONS.getValue(4)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            // A row inserted post-migration without specifying user_label must read NULL.
+            // The column has no DEFAULT clause and is nullable; SQLite stores NULL.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (1, 'BoardingPass', 'S1', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 1, 1)",
+            ).use { it.executeUpdate() }
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT user_label FROM ${Schema.Tables.PASSES} WHERE id = 1",
+                )
+                rs.next()
+                rs.getString("user_label")
+                assertThat(rs.wasNull()).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun preexistingV4PassRowSurvivesMigrationToV5WithNullUserLabel() {
+        openMemoryDb().use { conn ->
+            applyV4Ddl(conn)
+
+            // A pre-existing v4 pass row that pre-dates the user_label column.
+            conn.prepareStatement(
+                "INSERT INTO ${Schema.Tables.PASSES}" +
+                    "(id, type, serial_number, organization_name, description, voided, " +
+                    "signature_status_kind, pass_json, created_at_epoch_ms, updated_at_epoch_ms) " +
+                    "VALUES (42, 'BoardingPass', 'S42', 'AcmeAir', 'desc', 0, 'AppleVerified', " +
+                    "x'00', 100, 200)",
+            ).use { it.executeUpdate() }
+
+            for (sql in Schema.MIGRATIONS.getValue(4)) {
+                conn.createStatement().use { it.execute(sql) }
+            }
+
+            // Existing row is preserved and gets a NULL user_label after the migration.
+            conn.createStatement().use { stmt ->
+                val rs = stmt.executeQuery(
+                    "SELECT id, organization_name, user_label FROM ${Schema.Tables.PASSES}",
+                )
+                rs.next()
+                assertThat(rs.getLong("id")).isEqualTo(42L)
+                assertThat(rs.getString("organization_name")).isEqualTo("AcmeAir")
+                rs.getString("user_label")
+                assertThat(rs.wasNull()).isTrue()
+                assertThat(rs.next()).isFalse()
             }
         }
     }

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassFront.kt
@@ -61,6 +61,12 @@ import `is`.walt.passes.ui.theme.toComposeColor
  *   The default `PassLocale("en")` is a *fallback for tests and previews*; production
  *   callers (walt-android) MUST thread the device locale through, or the user sees
  *   English labels regardless of system language.
+ * @param userLabel Optional user-supplied display-label override (ADR 0007 D1). When
+ *   non-null, the front-of-card eyebrow renders the override as the primary identity
+ *   line with the signed `organizationName` as a sub-line beneath — the trust-caption
+ *   rule (ADR 0007 D5). When the override equals the signed `organizationName` after
+ *   pass.strings substitution (case-insensitive ASCII compare), the eyebrow renders
+ *   the signed name alone. Callers wire this from `StoredPass.userLabel`.
  * @param showSignatureBadge When `false`, the in-card `SignatureTrustBadge` pill is
  *   not rendered. Defaults to `true`. `onPassRendered` telemetry fires regardless —
  *   the band must still be derivable and recorded. Hosts that opt out MUST disclose
@@ -82,6 +88,7 @@ public fun PassFront(
     telemetry: UiTelemetryGuard,
     modifier: Modifier = Modifier,
     locale: PassLocale = PassLocale("en"),
+    userLabel: String? = null,
     nowEpochMillis: Long = System.currentTimeMillis(),
     showSignatureBadge: Boolean = true,
     showExpiredOverlay: Boolean = true,
@@ -99,7 +106,6 @@ public fun PassFront(
     // every image's contentEquals, which is megabytes of work on each recomposition
     // for a real PKPASS.
     val strings = remember(pass.locales, locale) { pass.resolveLocalizedStrings(locale) }
-    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
     androidx.compose.runtime.LaunchedEffect(pass, band) {
         telemetry.onPassRendered(pass.type, band)
     }
@@ -113,7 +119,8 @@ public fun PassFront(
             PassFrontSurface(
                 pass = pass,
                 band = band,
-                displayOrganizationName = displayOrganizationName,
+                userLabel = userLabel,
+                locale = locale,
                 passBackground = passBackground,
                 passForeground = passForeground,
                 passLabel = passLabel,
@@ -131,7 +138,8 @@ public fun PassFront(
 private fun PassFrontSurface(
     pass: Pass,
     band: SignatureBand,
-    displayOrganizationName: String,
+    userLabel: String?,
+    locale: PassLocale,
     passBackground: Color,
     passForeground: Color,
     passLabel: Color,
@@ -153,10 +161,14 @@ private fun PassFrontSurface(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Text(
-                    text = displayOrganizationName,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = passLabel,
+                // ADR 0007 D6: the front-of-card eyebrow routes through PassIdentityBlock
+                // so the trust-caption rule is enforced by the same composable
+                // walt-android's tile / lane / detail surfaces call.
+                PassIdentityBlock(
+                    pass = pass,
+                    userLabel = userLabel,
+                    locale = locale,
+                    primaryColor = passLabel,
                     modifier = Modifier.weight(1f),
                 )
                 if (showSignatureBadge) {

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
@@ -1,0 +1,104 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.lookupOrSelf
+import `is`.walt.passes.core.resolveLocalizedStrings
+
+/**
+ * The canonical renderer of a pkpass's visible identity (ADR 0007 D6). Given the parsed
+ * [pass] and an optional [userLabel] override, this composable renders:
+ *
+ * - [userLabel] == `null`: the substituted signed `organizationName` alone, matching the
+ *   pre-override eyebrow shape PassFront has always rendered.
+ * - [userLabel] non-null and distinct from the substituted `organizationName`: the
+ *   [userLabel] as the primary line and the signed `organizationName` as a sub-line
+ *   eyebrow underneath. Both on the same surface, both legible (the trust-caption
+ *   rule).
+ * - [userLabel] non-null and equal to the substituted `organizationName` (case-
+ *   insensitive ASCII compare after trim): the signed `organizationName` alone. The
+ *   eyebrow is suppressed because the primary identity already IS the signed
+ *   identity; the trust rule is satisfied trivially.
+ *
+ * Every UI surface that presents a pkpass's primary visible identity MUST route
+ * through this composable when a user-label override may be set. Bypassing it to
+ * render `userLabel` as bare primary identity is a trust-claim violation (ADR 0007
+ * D5). Walt-android's pkpass tile, lane row, and detail chrome are expected to call
+ * this rather than reading `StoredPass.userLabel` directly.
+ *
+ * Theming: the kernel chooses the structural shape and typographic hierarchy; the
+ * consumer chooses colors via [primaryColor] and [eyebrowColor]. Defaults route
+ * through [LocalContentColor] so a host that does not theme falls back to its
+ * surrounding `MaterialTheme.contentColor`.
+ *
+ * @param pass The parsed pass. `pass.organizationName` (after `pass.strings`
+ *   substitution against [locale]) is the signed identity surfaced as the eyebrow.
+ * @param userLabel The user-supplied override from `StoredPass.userLabel` /
+ *   `PassSummary.userLabel`. `null` means no override.
+ * @param locale Drives `pass.strings` substitution. Production callers MUST thread the
+ *   device locale through; the default is a fallback for tests and previews.
+ * @param primaryColor Color of the primary identity line (either the override or the
+ *   org name when no override). Defaults to [LocalContentColor].
+ * @param eyebrowColor Color of the signed-identity eyebrow underneath an override.
+ *   Defaults to [primaryColor] at 70% alpha — a single muted derivation so a host that
+ *   does not theme still gets visible hierarchy.
+ */
+@Suppress("LongParameterList")
+@Composable
+public fun PassIdentityBlock(
+    pass: Pass,
+    userLabel: String?,
+    modifier: Modifier = Modifier,
+    locale: PassLocale = PassLocale("en"),
+    primaryColor: Color = Color.Unspecified,
+    eyebrowColor: Color = Color.Unspecified,
+) {
+    val strings = remember(pass.locales, locale) { pass.resolveLocalizedStrings(locale) }
+    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
+
+    val resolvedPrimary = if (primaryColor == Color.Unspecified) LocalContentColor.current else primaryColor
+    val resolvedEyebrow = when {
+        eyebrowColor != Color.Unspecified -> eyebrowColor
+        else -> resolvedPrimary.copy(alpha = 0.7f)
+    }
+
+    val trimmedOverride = userLabel?.trim()?.takeIf { it.isNotEmpty() }
+    val shouldRenderOverride = trimmedOverride != null &&
+        !trimmedOverride.equals(displayOrganizationName.trim(), ignoreCase = true)
+
+    if (!shouldRenderOverride) {
+        Text(
+            text = displayOrganizationName,
+            style = MaterialTheme.typography.labelLarge,
+            color = resolvedPrimary,
+            modifier = modifier,
+        )
+        return
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = trimmedOverride!!,
+            style = MaterialTheme.typography.labelLarge,
+            color = resolvedPrimary,
+        )
+        Text(
+            text = displayOrganizationName,
+            style = MaterialTheme.typography.labelSmall,
+            color = resolvedEyebrow,
+        )
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
@@ -9,11 +9,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.lookupOrSelf
 import `is`.walt.passes.core.resolveLocalizedStrings
+import `is`.walt.passes.ui.core.isolated
 
 /**
  * The canonical renderer of a pkpass's visible identity (ADR 0007 D6). Given the parsed
@@ -36,24 +38,13 @@ import `is`.walt.passes.core.resolveLocalizedStrings
  * D5). Walt-android's pkpass tile, lane row, and detail chrome are expected to call
  * this rather than reading `StoredPass.userLabel` directly.
  *
- * Theming: the kernel chooses the structural shape and typographic hierarchy; the
- * consumer chooses colors via [primaryColor] and [eyebrowColor]. Defaults route
- * through [LocalContentColor] so a host that does not theme falls back to its
- * surrounding `MaterialTheme.contentColor`.
- *
- * @param pass The parsed pass. `pass.organizationName` (after `pass.strings`
- *   substitution against [locale]) is the signed identity surfaced as the eyebrow.
- * @param userLabel The user-supplied override from `StoredPass.userLabel` /
- *   `PassSummary.userLabel`. `null` means no override.
- * @param locale Drives `pass.strings` substitution. Production callers MUST thread the
- *   device locale through; the default is a fallback for tests and previews.
- * @param primaryColor Color of the primary identity line (either the override or the
- *   org name when no override). Defaults to [LocalContentColor].
- * @param eyebrowColor Color of the signed-identity eyebrow underneath an override.
- *   Defaults to [primaryColor] at 70% alpha — a single muted derivation so a host that
- *   does not theme still gets visible hierarchy.
+ * Both lines are fenced with FSI/PDI via [isolated] — both the user-supplied
+ * `userLabel` and the parsed-from-PKPASS `organizationName` are untrusted strings
+ * that could carry bidi-override characters. The fence prevents either line from
+ * reordering the other or surrounding chrome. Mirrors `ScannableCardTile` and
+ * `passes-pdf-ui::DocumentTile` for the analogous display-label fields.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList") // detekt functionThreshold=6; trips on six declared params.
 @Composable
 public fun PassIdentityBlock(
     pass: Pass,
@@ -72,15 +63,17 @@ public fun PassIdentityBlock(
         else -> resolvedPrimary.copy(alpha = 0.7f)
     }
 
-    val trimmedOverride = userLabel?.trim()?.takeIf { it.isNotEmpty() }
-    val shouldRenderOverride = trimmedOverride != null &&
-        !trimmedOverride.equals(displayOrganizationName.trim(), ignoreCase = true)
+    val override = userLabel
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && !it.equals(displayOrganizationName.trim(), ignoreCase = true) }
 
-    if (!shouldRenderOverride) {
+    if (override == null) {
         Text(
-            text = displayOrganizationName,
+            text = isolated(displayOrganizationName),
             style = MaterialTheme.typography.labelLarge,
             color = resolvedPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = modifier,
         )
         return
@@ -90,15 +83,25 @@ public fun PassIdentityBlock(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
+        // Primary line (user-supplied): cap at 2 lines, ellipsize. Mirrors
+        // ScannableCardTile / DocumentTile for analogous user-controlled labels.
         Text(
-            text = trimmedOverride!!,
+            text = isolated(override),
             style = MaterialTheme.typography.labelLarge,
             color = resolvedPrimary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
         )
+        // Eyebrow (signed identity): never truncate; mirrors ScannableCardTrustCaption's
+        // "trust caption never truncates" posture so the issuer identity stays visible
+        // even under bounded tile chrome.
         Text(
-            text = displayOrganizationName,
+            text = isolated(displayOrganizationName),
             style = MaterialTheme.typography.labelSmall,
             color = resolvedEyebrow,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Visible,
         )
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -51,16 +51,20 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
-    fun passFrontHasExactlyEightUserVisibleParameters() {
-        // (pass, signatureStatus, telemetry, modifier, locale, nowEpochMillis,
-        // showSignatureBadge, showExpiredOverlay). The last two are the wpass-hy2
-        // R2 host opt-outs (wpass-btz, wpass-d0k) — non-breaking defaults that
-        // preserve the original ADR 0003 D5 posture. Adding a ninth parameter
-        // (e.g. `expiredOverlay: ExpiredOverlayState` that lets a host *display*
-        // an arbitrary expiry state, or `signatureBand: SignatureBand` that lets
-        // a host override the badge band) would breach D5; review the ADR before
-        // changing this number.
-        assertUserVisibleParamCount("PassFrontKt", "PassFront", expected = 8)
+    fun passFrontHasExactlyNineUserVisibleParameters() {
+        // (pass, signatureStatus, telemetry, modifier, locale, userLabel,
+        // nowEpochMillis, showSignatureBadge, showExpiredOverlay).
+        // - userLabel (wpass-7xa / ADR 0007 D6) is the consumer-facing entry point
+        //   for the trust-caption rule; defaults to null so callers that do not
+        //   surface the rename feature see the legacy single-line eyebrow.
+        // - showSignatureBadge / showExpiredOverlay are the wpass-hy2 R2 host
+        //   opt-outs (wpass-btz, wpass-d0k) — non-breaking defaults that preserve
+        //   the original ADR 0003 D5 posture.
+        // Adding a tenth parameter (e.g. `expiredOverlay: ExpiredOverlayState`
+        // that lets a host *display* an arbitrary expiry state, or
+        // `signatureBand: SignatureBand` that lets a host override the badge band)
+        // would breach D5; review the relevant ADR before changing this number.
+        assertUserVisibleParamCount("PassFrontKt", "PassFront", expected = 9)
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -267,6 +267,23 @@ class PublicApiSurfaceTest {
     }
 
     @Test
+    fun passIdentityBlockIsPublicAndIsTheCanonicalTrustCaptionRenderer() {
+        // ADR 0007 D6: PassIdentityBlock is the kernel-owned Composable that enforces
+        // the trust-caption rule (signed organizationName remains visible when a
+        // user_label override is set). Walt-android's pkpass tile, lane row, and detail
+        // chrome are required to call this rather than rendering StoredPass.userLabel
+        // directly. Removing or renaming the symbol breaks the consumer contract; this
+        // test fails closed at JVM-test time so any such change is a deliberate edit.
+        val klass = Class.forName("is.walt.passes.ui.PassIdentityBlockKt")
+        // Compose may name-mangle Composables that take inline value-class parameters
+        // (Color is a value class, and the composable's default Color.Unspecified
+        // triggers the suffix). Accept any method whose name starts with
+        // "PassIdentityBlock" so the lock is robust to compiler-internal renames.
+        val methods = klass.declaredMethods.map { it.name }
+        assertThat(methods.any { it.startsWith("PassIdentityBlock") }).isTrue()
+    }
+
+    @Test
     fun argbColorIsAValueClassWrappingAnInt() {
         val color = ArgbColor(0xFFEE2200.toInt())
         assertThat(color.argb).isEqualTo(0xFFEE2200.toInt())

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -607,7 +607,9 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        composeRule.onNodeWithText("Tixly").assertIsDisplayed()
+        // Substring match because PassFront's eyebrow now routes through
+        // PassIdentityBlock, which fences with FSI/PDI (ADR 0007 D6).
+        composeRule.onNodeWithText("Tixly", substring = true).assertIsDisplayed()
     }
 
     @Test
@@ -681,9 +683,11 @@ class TrustClaimSurfaceTest {
                 PassIdentityBlock(pass = passFixture(), userLabel = null)
             }
         }
-        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+        // Substring match because the rendered text is FSI/PDI-fenced (see the
+        // dedicated bidi-isolation test below).
+        composeRule.onNodeWithText("Acme", substring = true).assertIsDisplayed()
         // No override → no second line. Exactly one node carries the org name.
-        val nodes = composeRule.onAllNodesWithText("Acme", substring = false)
+        val nodes = composeRule.onAllNodesWithText("Acme", substring = true)
             .fetchSemanticsNodes()
         assertThat(nodes).hasSize(1)
     }
@@ -701,8 +705,8 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        composeRule.onNodeWithText("Mom's flight home").assertIsDisplayed()
-        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+        composeRule.onNodeWithText("Mom's flight home", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Acme", substring = true).assertIsDisplayed()
     }
 
     @Test
@@ -716,7 +720,7 @@ class TrustClaimSurfaceTest {
             }
         }
         // "Acme" appears exactly once — the displayed signed org, not a duplicate.
-        val nodes = composeRule.onAllNodesWithText("Acme", substring = false)
+        val nodes = composeRule.onAllNodesWithText("Acme", substring = true)
             .fetchSemanticsNodes()
         assertThat(nodes).hasSize(1)
     }
@@ -738,8 +742,27 @@ class TrustClaimSurfaceTest {
                 )
             }
         }
-        composeRule.onNodeWithText("Mom's flight").assertIsDisplayed()
-        composeRule.onNodeWithText("Tixly").assertIsDisplayed()
+        composeRule.onNodeWithText("Mom's flight", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Tixly", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun passIdentityBlockFencesBothLinesWithBidiIsolation() {
+        // Defense in depth: both the user-supplied userLabel and the parsed-from-PKPASS
+        // organizationName are untrusted strings. PassIdentityBlock wraps each with
+        // FSI/PDI (passes-ui-core::isolated) so a bidi-override character in either
+        // value cannot reorder the other line or surrounding chrome. Mirrors
+        // securitySheetUrlIsBidiIsolated in shape.
+        composeRule.setContent {
+            ThemedHost {
+                PassIdentityBlock(
+                    pass = passFixture(),
+                    userLabel = "Mom's flight home",
+                )
+            }
+        }
+        composeRule.onNodeWithText("⁨Mom's flight home⁩").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨Acme⁩").assertIsDisplayed()
     }
 
     @Test
@@ -758,8 +781,8 @@ class TrustClaimSurfaceTest {
             }
         }
         // Both the override and the signed org name must be on the front of the card.
-        composeRule.onNodeWithText("Mom's flight home").assertIsDisplayed()
-        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+        composeRule.onNodeWithText("Mom's flight home", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Acme", substring = true).assertIsDisplayed()
         // Signature badge still renders.
         composeRule.onNodeWithText("Verified").assertIsDisplayed()
     }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/TrustClaimSurfaceTest.kt
@@ -671,6 +671,99 @@ class TrustClaimSurfaceTest {
     // Document-surface trust assertions (caption, tile bidi-isolation, lane wiring)
     // moved to passes-pdf-ui::DocumentTrustSurfaceTest with the composables (wpass-r4z).
 
+    // wpass-7xa / ADR 0007 D5+D6: PassIdentityBlock is the canonical renderer of the
+    // user-label trust-caption rule. The cases below lock the documented render paths.
+
+    @Test
+    fun passIdentityBlockNullOverrideShowsSignedOrgNameAlone() {
+        composeRule.setContent {
+            ThemedHost {
+                PassIdentityBlock(pass = passFixture(), userLabel = null)
+            }
+        }
+        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+        // No override → no second line. Exactly one node carries the org name.
+        val nodes = composeRule.onAllNodesWithText("Acme", substring = false)
+            .fetchSemanticsNodes()
+        assertThat(nodes).hasSize(1)
+    }
+
+    @Test
+    fun passIdentityBlockOverrideShowsBothUserLabelAndSignedOrgName() {
+        // The load-bearing trust-caption case: a user-renamed pass still surfaces the
+        // signed organizationName as a sub-line eyebrow so the issuer identity is not
+        // hidden. Both lines on the same surface.
+        composeRule.setContent {
+            ThemedHost {
+                PassIdentityBlock(
+                    pass = passFixture(),
+                    userLabel = "Mom's flight home",
+                )
+            }
+        }
+        composeRule.onNodeWithText("Mom's flight home").assertIsDisplayed()
+        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+    }
+
+    @Test
+    fun passIdentityBlockOverrideEqualToOrgNameSuppressesRedundantEyebrow() {
+        // ADR 0007 D5 edge case: case-insensitive equality between override and signed
+        // org name collapses to a single line. The trust rule is satisfied trivially
+        // because the primary identity already IS the signed identity.
+        composeRule.setContent {
+            ThemedHost {
+                PassIdentityBlock(pass = passFixture(), userLabel = "ACME")
+            }
+        }
+        // "Acme" appears exactly once — the displayed signed org, not a duplicate.
+        val nodes = composeRule.onAllNodesWithText("Acme", substring = false)
+            .fetchSemanticsNodes()
+        assertThat(nodes).hasSize(1)
+    }
+
+    @Test
+    fun passIdentityBlockSubstitutesOrgNameThroughLocalizedStrings() {
+        // Per PassFront's pass.strings discipline (wpass-38y) the eyebrow MUST
+        // substitute organizationName through the pass.strings table. PassIdentityBlock
+        // owns its own substitution so the rule holds in walt-android tile contexts
+        // that have no surrounding LocalLocalizedStrings provider.
+        composeRule.setContent {
+            ThemedHost {
+                PassIdentityBlock(
+                    pass = localizedFixture(
+                        organizationName = "#ORGNAME#",
+                        backFields = emptyList(),
+                    ),
+                    userLabel = "Mom's flight",
+                )
+            }
+        }
+        composeRule.onNodeWithText("Mom's flight").assertIsDisplayed()
+        composeRule.onNodeWithText("Tixly").assertIsDisplayed()
+    }
+
+    @Test
+    fun passFrontUserLabelParameterRoutesThroughPassIdentityBlock() {
+        // PassFront re-wires its eyebrow through PassIdentityBlock; the userLabel
+        // parameter is the consumer-facing entry point for the trust-caption rule.
+        composeRule.setContent {
+            ThemedHost {
+                PassFront(
+                    pass = passFixture(),
+                    signatureStatus = SignatureStatus.AppleVerified,
+                    nowEpochMillis = 0L,
+                    telemetry = telemetry,
+                    userLabel = "Mom's flight home",
+                )
+            }
+        }
+        // Both the override and the signed org name must be on the front of the card.
+        composeRule.onNodeWithText("Mom's flight home").assertIsDisplayed()
+        composeRule.onNodeWithText("Acme").assertIsDisplayed()
+        // Signature badge still renders.
+        composeRule.onNodeWithText("Verified").assertIsDisplayed()
+    }
+
     @Test
     fun importConfirmShowsTrustCaptionForAppleVerified() {
         composeRule.setContent {


### PR DESCRIPTION
## Summary

- Adds `passes.user_label` nullable column (v4 -> v5 schema migration) and `PassRepository.updatePassUserLabel(id, label)` — the third and final slice of the rename-APIs epic (wpass-osf), companion to walt-android `wlt-4dn.3` / GH #75. Siblings already shipped: #109 (updateDocumentLabel), #110 (updateScannableCard).
- Lands **ADR 0007** as the canonical reference for the trust-caption rule: when a pkpass's user_label override is set, every UI surface presenting that pass MUST also present the signed `organizationName`. Caption anchors on `organizationName`, not `description` (issuer identity > artifact-kind summary). updated_at is NOT bumped on user_label change (mirrors `updateDocumentLabel` / `updateScannableCard`).
- Introduces `PassIdentityBlock` in `passes-ui` as the **kernel-owned Composable** that enforces the trust-caption rule structurally (D6). `PassFront` re-wires its eyebrow through it; walt-android's pkpass tile / lane / detail surfaces are required to route through it rather than reading `StoredPass.userLabel` directly.
- Trim-blank-to-null normalization, 100-char cap, and case-insensitive equality suppression (so a rename equal to the signed org collapses to a single line) all locked by tests.

## Trust-claim posture

The signed `pass.json` body in `pass_json` BLOB is unchanged — user_label is a side-channel column. `Pass` (passes-core) is unchanged; the override never reaches the parser. `StorageTelemetryGuard.onUserLabelUpdated(type, hadPriorLabel, clearing)` carries no PII; the label text never enters telemetry.

## Test plan

- [x] `./gradlew :passes-storage:testDebugUnitTest` — 110 tests pass (new: schema v4 -> v5 migration walk-up, user_label column shape, updatePassUserLabel set/clear/trim-blank/over-cap/cap-precedes-IV/unknown-id, no updated_at bump)
- [x] `./gradlew :passes-ui:testDebugUnitTest` — 172 tests pass (new: PassIdentityBlock null/override/equality-suppressed/localized cases, PassFront userLabel parameter routes through PassIdentityBlock, PublicApiSurfaceTest lock on PassIdentityBlock symbol, ComposableSurfaceLockTest PassFront param count 8 -> 9)
- [x] `./gradlew testDebugUnitTest` — all modules green
- [x] `./gradlew assembleDebug` — debug build green across all modules
- [x] `./gradlew detekt` — no issues
- [ ] walt-android consumer wiring (`wlt-4dn.3`): rename UI calls `updatePassUserLabel`, reads `StoredPass.userLabel`, routes display through `PassIdentityBlock` per ADR 0007 D5+D6