### PR TITLE
passes-ui: extract resolvePassDisplayIdentity for list-row consumers (wpass-up1)

### DIFF
--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
@@ -1,0 +1,68 @@
+package `is`.walt.passes.ui
+
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.lookupOrSelf
+import `is`.walt.passes.core.resolveLocalizedStrings
+import `is`.walt.passes.ui.core.isolated
+
+/**
+ * Resolved visible identity for a pkpass, suitable for plugging into any consumer-
+ * authored title + subtitle row (and used internally by [PassIdentityBlock]).
+ *
+ * Both strings are already FSI/PDI-fenced via [isolated]; callers MUST NOT re-wrap
+ * them and MUST NOT inline the equality / trim / locale-substitution logic
+ * themselves (ADR 0007 D6). Rendering [primary] alone when [eyebrow] is non-null is
+ * a trust-claim violation: the signed `organizationName` MUST be displayed on the
+ * same surface whenever an override is active (ADR 0007 D5).
+ *
+ * - [primary]: the fenced primary label. When an override survives the override
+ *   rules it is the fenced override; otherwise it is the fenced (localized) signed
+ *   `organizationName`.
+ * - [eyebrow]: the fenced signed `organizationName`, present only when an override
+ *   is active and distinct from the signed identity. `null` means the primary
+ *   identity already IS the signed identity and the trust rule is satisfied
+ *   trivially.
+ */
+public data class PassDisplayIdentity(
+    public val primary: String,
+    public val eyebrow: String?,
+)
+
+/**
+ * Computes the resolved visible identity for [pass] + an optional [userLabel]
+ * override, per ADR 0007 D5 / D6. Pure: safe to call outside any Compose runtime
+ * (lifts the canonical trust-caption rule out of [PassIdentityBlock] so a consumer
+ * with a fixed row shape can render the strings into its own typography without
+ * re-implementing the trust contract).
+ *
+ * Rules, in order:
+ *  1. Substitute [Pass.organizationName] through the pass's strings table for
+ *     [locale] (Apple's documented `.lproj/pass.strings` lookup; misses fall
+ *     through to the raw value).
+ *  2. Trim [userLabel]; treat empty as no-override.
+ *  3. Case-insensitive ASCII compare the trimmed override against the trimmed
+ *     substituted `organizationName`; equality suppresses the override.
+ *  4. FSI/PDI-fence both surviving lines via [isolated].
+ *
+ * Mirrors the body of [PassIdentityBlock] verbatim; that composable now consumes
+ * this resolver so the trust contract has a single source of truth.
+ */
+public fun resolvePassDisplayIdentity(
+    pass: Pass,
+    userLabel: String?,
+    locale: PassLocale = PassLocale("en"),
+): PassDisplayIdentity {
+    val strings = pass.resolveLocalizedStrings(locale)
+    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
+
+    val override = userLabel
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && !it.equals(displayOrganizationName.trim(), ignoreCase = true) }
+
+    return if (override == null) {
+        PassDisplayIdentity(primary = isolated(displayOrganizationName), eyebrow = null)
+    } else {
+        PassDisplayIdentity(primary = isolated(override), eyebrow = isolated(displayOrganizationName))
+    }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
@@ -45,8 +45,9 @@ public data class PassDisplayIdentity(
  *     substituted `organizationName`; equality suppresses the override.
  *  4. FSI/PDI-fence both surviving lines via [isolated].
  *
- * Mirrors the body of [PassIdentityBlock] verbatim; that composable now consumes
- * this resolver so the trust contract has a single source of truth.
+ * This resolver is the single source of truth for the trust-caption rule;
+ * [PassIdentityBlock] is one consumer, and a list-row consumer with a fixed
+ * title + subtitle shape is the second.
  */
 public fun resolvePassDisplayIdentity(
     pass: Pass,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
@@ -13,16 +13,14 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassLocale
-import `is`.walt.passes.core.lookupOrSelf
-import `is`.walt.passes.core.resolveLocalizedStrings
-import `is`.walt.passes.ui.core.isolated
 
 /**
- * The canonical renderer of a pkpass's visible identity (ADR 0007 D6). Given the parsed
- * [pass] and an optional [userLabel] override, this composable renders:
+ * The canonical Compose renderer of a pkpass's visible identity (ADR 0007 D6). Given
+ * the parsed [pass] and an optional [userLabel] override, this composable renders:
  *
- * - [userLabel] == `null`: the substituted signed `organizationName` alone, matching the
- *   pre-override eyebrow shape PassFront has always rendered.
+ * - [userLabel] == `null` (or trimmed-empty): the substituted signed
+ *   `organizationName` alone, matching the pre-override eyebrow shape PassFront has
+ *   always rendered.
  * - [userLabel] non-null and distinct from the substituted `organizationName`: the
  *   [userLabel] as the primary line and the signed `organizationName` as a sub-line
  *   eyebrow underneath. Both on the same surface, both legible (the trust-caption
@@ -32,17 +30,21 @@ import `is`.walt.passes.ui.core.isolated
  *   eyebrow is suppressed because the primary identity already IS the signed
  *   identity; the trust rule is satisfied trivially.
  *
- * Every UI surface that presents a pkpass's primary visible identity MUST route
- * through this composable when a user-label override may be set. Bypassing it to
- * render `userLabel` as bare primary identity is a trust-claim violation (ADR 0007
- * D5). Walt-android's pkpass tile, lane row, and detail chrome are expected to call
- * this rather than reading `StoredPass.userLabel` directly.
+ * Every Compose surface that presents a pkpass's primary visible identity SHOULD
+ * route through this composable when a user-label override may be set. Consumers
+ * whose row shape is incompatible with a vertically stacked Column (single-line
+ * title + single-line subtitle in a fixed-layout list row, for example) MAY instead
+ * call [resolvePassDisplayIdentity] directly to obtain the same FSI/PDI-fenced
+ * `(primary, eyebrow)` pair and feed it into their own typography; that is the
+ * only kernel-blessed bypass. Inlining the comparison, trim, or fence on the
+ * consumer side is a trust-claim violation (ADR 0007 D5).
  *
- * Both lines are fenced with FSI/PDI via [isolated] — both the user-supplied
- * `userLabel` and the parsed-from-PKPASS `organizationName` are untrusted strings
- * that could carry bidi-override characters. The fence prevents either line from
- * reordering the other or surrounding chrome. Mirrors `ScannableCardTile` and
- * `passes-pdf-ui::DocumentTile` for the analogous display-label fields.
+ * Both lines are fenced with FSI/PDI via [resolvePassDisplayIdentity] — both the
+ * user-supplied `userLabel` and the parsed-from-PKPASS `organizationName` are
+ * untrusted strings that could carry bidi-override characters. The fence prevents
+ * either line from reordering the other or surrounding chrome. Mirrors
+ * `ScannableCardTile` and `passes-pdf-ui::DocumentTile` for the analogous
+ * display-label fields.
  */
 @Suppress("LongParameterList") // detekt functionThreshold=6; trips on six declared params.
 @Composable
@@ -54,8 +56,9 @@ public fun PassIdentityBlock(
     primaryColor: Color = Color.Unspecified,
     eyebrowColor: Color = Color.Unspecified,
 ) {
-    val strings = remember(pass.locales, locale) { pass.resolveLocalizedStrings(locale) }
-    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
+    val identity = remember(pass, userLabel, locale) {
+        resolvePassDisplayIdentity(pass, userLabel, locale)
+    }
 
     val resolvedPrimary = if (primaryColor == Color.Unspecified) LocalContentColor.current else primaryColor
     val resolvedEyebrow = when {
@@ -63,13 +66,9 @@ public fun PassIdentityBlock(
         else -> resolvedPrimary.copy(alpha = 0.7f)
     }
 
-    val override = userLabel
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() && !it.equals(displayOrganizationName.trim(), ignoreCase = true) }
-
-    if (override == null) {
+    if (identity.eyebrow == null) {
         Text(
-            text = isolated(displayOrganizationName),
+            text = identity.primary,
             style = MaterialTheme.typography.labelLarge,
             color = resolvedPrimary,
             maxLines = 1,
@@ -86,7 +85,7 @@ public fun PassIdentityBlock(
         // Primary line (user-supplied): cap at 2 lines, ellipsize. Mirrors
         // ScannableCardTile / DocumentTile for analogous user-controlled labels.
         Text(
-            text = isolated(override),
+            text = identity.primary,
             style = MaterialTheme.typography.labelLarge,
             color = resolvedPrimary,
             maxLines = 2,
@@ -96,7 +95,7 @@ public fun PassIdentityBlock(
         // "trust caption never truncates" posture so the issuer identity stays visible
         // even under bounded tile chrome.
         Text(
-            text = isolated(displayOrganizationName),
+            text = identity.eyebrow,
             style = MaterialTheme.typography.labelSmall,
             color = resolvedEyebrow,
             maxLines = 1,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassIdentityBlock.kt
@@ -56,7 +56,11 @@ public fun PassIdentityBlock(
     primaryColor: Color = Color.Unspecified,
     eyebrowColor: Color = Color.Unspecified,
 ) {
-    val identity = remember(pass, userLabel, locale) {
+    // Key on the fields the resolver actually reads. `Pass`'s data-class equals walks
+    // every ImageBytes via contentEquals, which is measurable on multi-MB strip/thumb
+    // images during recomposition; substituting the load-bearing inputs keeps the
+    // remember scope correct without paying that cost.
+    val identity = remember(pass.organizationName, pass.locales, userLabel, locale) {
         resolvePassDisplayIdentity(pass, userLabel, locale)
     }
 

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
@@ -1,0 +1,232 @@
+package `is`.walt.passes.ui
+
+import `is`.walt.passes.core.ColorValue
+import `is`.walt.passes.core.LocalizedStrings
+import `is`.walt.passes.core.Pass
+import `is`.walt.passes.core.PassColors
+import `is`.walt.passes.core.PassField
+import `is`.walt.passes.core.PassFields
+import `is`.walt.passes.core.PassLocale
+import `is`.walt.passes.core.PassType
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * JVM-pure coverage for the [resolvePassDisplayIdentity] resolver. The composable
+ * surface that consumes it is exercised by `TrustClaimSurfaceTest`; these tests
+ * lock the trust-caption rule (ADR 0007 D5 / D6) at the value-class boundary so a
+ * consumer reading the resolver in a non-Compose context (e.g. a list-row title
+ * driven by walt-android's `PassSummaryRow`) gets the same contract.
+ *
+ * "Fenced" below means each returned line is wrapped in U+2068 / U+2069 (FSI/PDI),
+ * the same isolation `PassIdentityBlock` has always applied. See
+ * `passes-ui-core::BidiIsolation`.
+ */
+class PassDisplayIdentityTest {
+
+    @Test
+    fun nullOverrideReturnsFencedOrgNameAsPrimaryAndNullEyebrow() {
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = null)
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun blankOverrideIsTreatedAsNoOverride() {
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = "   ")
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun emptyOverrideIsTreatedAsNoOverride() {
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = "")
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun distinctOverrideReturnsBothLinesFencedIndependently() {
+        val identity = resolvePassDisplayIdentity(
+            pass = passFixture(),
+            userLabel = "Mom's flight home",
+        )
+        assertThat(identity.primary).isEqualTo("⁨Mom's flight home⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Acme⁩")
+    }
+
+    @Test
+    fun overrideTrimmedBeforeFencing() {
+        // Leading/trailing whitespace is normalized but the override otherwise survives.
+        val identity = resolvePassDisplayIdentity(
+            pass = passFixture(),
+            userLabel = "  Mom's flight  ",
+        )
+        assertThat(identity.primary).isEqualTo("⁨Mom's flight⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Acme⁩")
+    }
+
+    @Test
+    fun overrideEqualToOrgNameIsSuppressed() {
+        // Case-insensitive ASCII compare after trim collapses to a single line. The
+        // trust rule is satisfied trivially: primary IS the signed identity.
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = "ACME")
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun overrideEqualToOrgNameWithSurroundingWhitespaceIsSuppressed() {
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = "  acme  ")
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun overrideSubstitutesOrgNameThroughLocalizedStrings() {
+        // Per `wpass-38y`, organizationName MUST substitute through pass.strings on
+        // every surface that renders it. The resolver owns the lookup so consumers
+        // without an ambient `LocalLocalizedStrings` (e.g. walt-android's tile) still
+        // see the localized signed identity in the eyebrow.
+        val identity = resolvePassDisplayIdentity(
+            pass = localizedFixture(
+                organizationName = "#ORGNAME#",
+                locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("#ORGNAME#" to "Tixly"))),
+            ),
+            userLabel = "Mom's flight",
+        )
+        assertThat(identity.primary).isEqualTo("⁨Mom's flight⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Tixly⁩")
+    }
+
+    @Test
+    fun nullOverrideStillSubstitutesOrgNameThroughLocalizedStrings() {
+        val identity = resolvePassDisplayIdentity(
+            pass = localizedFixture(
+                organizationName = "#ORGNAME#",
+                locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("#ORGNAME#" to "Tixly"))),
+            ),
+            userLabel = null,
+        )
+        assertThat(identity.primary).isEqualTo("⁨Tixly⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun overrideEqualToLocalizedOrgNameIsSuppressed() {
+        // The equality compare is against the SUBSTITUTED org name, not the raw key.
+        // A user who renames a pass to the localized issuer name still trips the
+        // suppression path.
+        val identity = resolvePassDisplayIdentity(
+            pass = localizedFixture(
+                organizationName = "#ORGNAME#",
+                locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("#ORGNAME#" to "Tixly"))),
+            ),
+            userLabel = "tixly",
+        )
+        assertThat(identity.primary).isEqualTo("⁨Tixly⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun localeFallbackSelectsLanguageMatchWhenExactMissing() {
+        // Apple's PKPASS locale chain: an exact `en-US` lookup falls back to `en` when
+        // only the language-only table is present. Resolver delegates to
+        // `Pass.resolveLocalizedStrings` for this; the test pins the resolver wires it
+        // up correctly rather than re-doing the chain itself.
+        val identity = resolvePassDisplayIdentity(
+            pass = localizedFixture(
+                organizationName = "#ORGNAME#",
+                locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("#ORGNAME#" to "Tixly"))),
+            ),
+            userLabel = null,
+            locale = PassLocale("en-US"),
+        )
+        assertThat(identity.primary).isEqualTo("⁨Tixly⁩")
+    }
+
+    @Test
+    fun missingOrgNameKeyFallsThroughRawForFence() {
+        // If pass.strings is empty (no locales), the org name is fenced verbatim.
+        val identity = resolvePassDisplayIdentity(
+            pass = passFixture(),
+            userLabel = null,
+            locale = PassLocale("en"),
+        )
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+    }
+
+    @Test
+    fun bidiCharactersInOverrideAreFencedNotStripped() {
+        // The fence is defense-in-depth; the resolver MUST NOT silently filter or
+        // alter bidi-override characters in the override. The fence isolates them.
+        val rtl = "‮BAD"
+        val identity = resolvePassDisplayIdentity(pass = passFixture(), userLabel = rtl)
+        assertThat(identity.primary).isEqualTo("⁨$rtl⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Acme⁩")
+    }
+
+    @Test
+    fun resolverIsPureAndCallableOutsideCompose() {
+        // No @Composable annotation needed -- the signature must remain JVM-only so
+        // walt-android's PassSummaryRow can call it from a non-Compose code path.
+        // PassLocale is a value class so the JVM method name carries a mangling
+        // suffix; match by prefix (mirrors PublicApiSurfaceTest's lock for
+        // PassIdentityBlock).
+        // Skip the synthetic `$default` overload Kotlin emits for the default-arg
+        // entry point; the direct entry is the trust-contract surface.
+        val method = Class.forName("is.walt.passes.ui.PassDisplayIdentityKt")
+            .declaredMethods
+            .first { it.name.startsWith("resolvePassDisplayIdentity") && !it.name.contains("\$default") }
+        // If anyone adds @Composable later the method gains a synthetic `Composer` /
+        // `\$changed` tail; the parameter count would jump. Lock to the documented
+        // (pass, userLabel, locale) shape (PassLocale erases to its underlying
+        // String at the JVM signature, so three params either way).
+        assertThat(method.parameterCount).isEqualTo(3)
+    }
+
+    private fun passFixture(): Pass = Pass(
+        type = PassType.Generic,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = "Acme",
+        expirationDate = null,
+        voided = false,
+        colors = PassColors(
+            foreground = ColorValue(0x000000),
+            background = ColorValue(0xFFFFFF),
+            label = ColorValue(0x444444),
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = "From", value = "JFK")),
+        ),
+        backFields = emptyList(),
+        barcode = null,
+        images = emptyMap(),
+        locales = emptyMap(),
+    )
+
+    private fun localizedFixture(
+        organizationName: String,
+        locales: Map<PassLocale, LocalizedStrings>,
+    ): Pass = Pass(
+        type = PassType.Generic,
+        serialNumber = "0",
+        description = "fixture",
+        organizationName = organizationName,
+        expirationDate = null,
+        voided = false,
+        colors = PassColors(
+            foreground = ColorValue(0x000000),
+            background = ColorValue(0xFFFFFF),
+            label = ColorValue(0x444444),
+        ),
+        frontFields = PassFields(
+            primary = listOf(PassField(key = "p", label = "From", value = "JFK")),
+        ),
+        backFields = emptyList(),
+        barcode = null,
+        images = emptyMap(),
+        locales = locales,
+    )
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
@@ -12,11 +12,12 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 /**
- * JVM-pure coverage for the [resolvePassDisplayIdentity] resolver. The composable
- * surface that consumes it is exercised by `TrustClaimSurfaceTest`; these tests
- * lock the trust-caption rule (ADR 0007 D5 / D6) at the value-class boundary so a
- * consumer reading the resolver in a non-Compose context (e.g. a list-row title
- * driven by walt-android's `PassSummaryRow`) gets the same contract.
+ * JVM-pure coverage for the [resolvePassDisplayIdentity] resolver (wpass-up1).
+ * The composable surface that consumes it is exercised by `TrustClaimSurfaceTest`;
+ * these tests lock the trust-caption rule (ADR 0007 D5 / D6) at the value-class
+ * boundary so a consumer reading the resolver in a non-Compose context (e.g. a
+ * list-row title driven by walt-android's `PassSummaryRow`) gets the same
+ * contract.
  *
  * "Fenced" below means each returned line is wrapped in U+2068 / U+2069 (FSI/PDI),
  * the same isolation `PassIdentityBlock` has always applied. See
@@ -172,16 +173,20 @@ class PassDisplayIdentityTest {
         // walt-android's PassSummaryRow can call it from a non-Compose code path.
         // PassLocale is a value class so the JVM method name carries a mangling
         // suffix; match by prefix (mirrors PublicApiSurfaceTest's lock for
-        // PassIdentityBlock).
-        // Skip the synthetic `$default` overload Kotlin emits for the default-arg
-        // entry point; the direct entry is the trust-contract surface.
+        // PassIdentityBlock). Skip the synthetic `$default` overload Kotlin emits
+        // for the default-arg entry point; the direct entry is the trust-contract
+        // surface.
+        //
+        // NOTE on failure mode: this lock is sensitive to Kotlin's value-class /
+        // default-arg name mangling. If a future toolchain changes the suffix
+        // shape and this test breaks, the most likely cause is mangling churn,
+        // not a regressed contract. Re-derive the prefix from `javap -p` on the
+        // compiled `PassDisplayIdentityKt` before assuming the resolver itself
+        // changed. Becoming @Composable, in contrast, would bump parameterCount
+        // by two (Composer + $changed) -- the assertion below catches that.
         val method = Class.forName("is.walt.passes.ui.PassDisplayIdentityKt")
             .declaredMethods
             .first { it.name.startsWith("resolvePassDisplayIdentity") && !it.name.contains("\$default") }
-        // If anyone adds @Composable later the method gains a synthetic `Composer` /
-        // `\$changed` tail; the parameter count would jump. Lock to the documented
-        // (pass, userLabel, locale) shape (PassLocale erases to its underlying
-        // String at the JVM signature, so three params either way).
         assertThat(method.parameterCount).isEqualTo(3)
     }
 


### PR DESCRIPTION
## Summary

- Lift PassIdentityBlock's trust-caption rule (trim / case-insensitive equality / locale-substituted `organizationName` / FSI/PDI fence) into a pure `resolvePassDisplayIdentity` returning `PassDisplayIdentity(primary, eyebrow)` with both lines already fenced.
- `PassIdentityBlock` now delegates to the resolver so the trust contract (ADR 0007 D5 / D6) has a single source of truth; consumers with a fixed single-line title + single-line subtitle row shape (walt-android's `PassSummaryRow`) can call the resolver directly and plug the pair into their own typography without re-implementing the rule.
- JVM-pure `PassDisplayIdentityTest` covers null/blank/empty override, distinct override, raw-and-localized equality suppression, locale fallback, `pass.strings` substitution, bidi-character fencing, and a reflection lock that fails closed if the resolver becomes `@Composable`.

Closes wpass-up1.

## Test plan

- [x] `:passes-ui:testDebugUnitTest` — 89/89 green
- [x] `:passes-ui:detekt` clean
- [x] PR review feedback addressed (narrow `remember` key off full `Pass`, fix source-of-truth wording in resolver KDoc, anchor test-file KDoc to wpass-up1, strengthen mangling-churn note on the reflection lock).
- [ ] Walt-android side adopts the resolver in `PassSummaryRow` (separate change in walt-android, blocked-by relationship not in this repo)