### PR TITLE
passes-ui: add Summary-shaped resolvePassDisplayIdentity overload (wpass-aaf)

### DIFF
--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.ui
 
+import `is`.walt.passes.core.LocalizedStrings
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassLocale
 import `is`.walt.passes.core.lookupOrSelf
@@ -30,32 +31,34 @@ public data class PassDisplayIdentity(
 )
 
 /**
- * Computes the resolved visible identity for [pass] + an optional [userLabel]
- * override, per ADR 0007 D5 / D6. Pure: safe to call outside any Compose runtime
- * (lifts the canonical trust-caption rule out of [PassIdentityBlock] so a consumer
- * with a fixed row shape can render the strings into its own typography without
- * re-implementing the trust contract).
+ * Computes the resolved visible identity from a raw [organizationName] + optional
+ * [userLabel] override + an optional pre-resolved [localizedStrings] table, per
+ * ADR 0007 D5 / D6. The Summary-shaped overload: list-row consumers that hold a
+ * `PassSummary` (and therefore do NOT carry the pass's `locales` map, since the
+ * projection is explicitly designed to avoid locale I/O) call this directly with
+ * `LocalizedStrings.Empty`, which makes the substitution a pure pass-through and
+ * fences the raw `organizationName` verbatim. Detail-view consumers that DO hold
+ * a resolved strings table can pass it in; the [Pass]-bearing overload below
+ * delegates here after running the locale chain.
  *
  * Rules, in order:
- *  1. Substitute [Pass.organizationName] through the pass's strings table for
- *     [locale] (Apple's documented `.lproj/pass.strings` lookup; misses fall
- *     through to the raw value).
+ *  1. Substitute [organizationName] through [localizedStrings] (Apple's documented
+ *     `.lproj/pass.strings` lookup; misses fall through to the raw value, and
+ *     [LocalizedStrings.Empty] makes every lookup a miss).
  *  2. Trim [userLabel]; treat empty as no-override.
  *  3. Case-insensitive ASCII compare the trimmed override against the trimmed
  *     substituted `organizationName`; equality suppresses the override.
  *  4. FSI/PDI-fence both surviving lines via [isolated].
  *
- * This resolver is the single source of truth for the trust-caption rule;
- * [PassIdentityBlock] is one consumer, and a list-row consumer with a fixed
- * title + subtitle shape is the second.
+ * This is the primitive form of the resolver and the single source of truth for
+ * the trust-caption rule.
  */
 public fun resolvePassDisplayIdentity(
-    pass: Pass,
+    organizationName: String,
     userLabel: String?,
-    locale: PassLocale = PassLocale("en"),
+    localizedStrings: LocalizedStrings = LocalizedStrings.Empty,
 ): PassDisplayIdentity {
-    val strings = pass.resolveLocalizedStrings(locale)
-    val displayOrganizationName = strings.lookupOrSelf(pass.organizationName)
+    val displayOrganizationName = localizedStrings.lookupOrSelf(organizationName)
 
     val override = userLabel
         ?.trim()
@@ -67,3 +70,21 @@ public fun resolvePassDisplayIdentity(
         PassDisplayIdentity(primary = isolated(override), eyebrow = isolated(displayOrganizationName))
     }
 }
+
+/**
+ * The [Pass]-bearing convenience overload. Resolves the pass's strings table for
+ * [locale] via Apple's documented locale-fallback chain (see
+ * [Pass.resolveLocalizedStrings]) and delegates to the Summary-shaped primitive
+ * above. Detail-view callers holding a full [Pass] should prefer this overload;
+ * list-row callers holding only a `PassSummary` should call the primitive
+ * directly with `LocalizedStrings.Empty`.
+ */
+public fun resolvePassDisplayIdentity(
+    pass: Pass,
+    userLabel: String?,
+    locale: PassLocale = PassLocale("en"),
+): PassDisplayIdentity = resolvePassDisplayIdentity(
+    organizationName = pass.organizationName,
+    userLabel = userLabel,
+    localizedStrings = pass.resolveLocalizedStrings(locale),
+)

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/PassDisplayIdentity.kt
@@ -31,27 +31,19 @@ public data class PassDisplayIdentity(
 )
 
 /**
- * Computes the resolved visible identity from a raw [organizationName] + optional
- * [userLabel] override + an optional pre-resolved [localizedStrings] table, per
- * ADR 0007 D5 / D6. The Summary-shaped overload: list-row consumers that hold a
- * `PassSummary` (and therefore do NOT carry the pass's `locales` map, since the
- * projection is explicitly designed to avoid locale I/O) call this directly with
- * `LocalizedStrings.Empty`, which makes the substitution a pure pass-through and
- * fences the raw `organizationName` verbatim. Detail-view consumers that DO hold
- * a resolved strings table can pass it in; the [Pass]-bearing overload below
- * delegates here after running the locale chain.
+ * Computes the resolved visible identity per ADR 0007 D5 / D6. Primitive form;
+ * the single source of truth for the trust-caption rule.
  *
  * Rules, in order:
  *  1. Substitute [organizationName] through [localizedStrings] (Apple's documented
- *     `.lproj/pass.strings` lookup; misses fall through to the raw value, and
- *     [LocalizedStrings.Empty] makes every lookup a miss).
+ *     `.lproj/pass.strings` lookup; misses fall through to the raw value).
  *  2. Trim [userLabel]; treat empty as no-override.
  *  3. Case-insensitive ASCII compare the trimmed override against the trimmed
  *     substituted `organizationName`; equality suppresses the override.
  *  4. FSI/PDI-fence both surviving lines via [isolated].
  *
- * This is the primitive form of the resolver and the single source of truth for
- * the trust-caption rule.
+ * Pass [LocalizedStrings.Empty] when no strings table is available; every lookup
+ * becomes a pass-through and the raw [organizationName] is fenced verbatim.
  */
 public fun resolvePassDisplayIdentity(
     organizationName: String,

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
@@ -249,22 +249,9 @@ class PassDisplayIdentityTest {
 
     @Test
     fun resolverIsPureAndCallableOutsideCompose() {
-        // No @Composable annotation needed -- the signatures must remain JVM-only
-        // so walt-android's PassSummaryRow can call them from a non-Compose code
-        // path. Skip the synthetic `$default` overloads Kotlin emits for the
-        // default-arg entries; the direct entries are the trust-contract surface.
-        //
-        // NOTE on failure mode: this lock is sensitive to Kotlin's value-class /
-        // default-arg name mangling. If a future toolchain changes the suffix
-        // shape and this test breaks, the most likely cause is mangling churn,
-        // not a regressed contract. Re-derive the names from `javap -p` on the
-        // compiled `PassDisplayIdentityKt` before assuming the resolver itself
-        // changed. Becoming @Composable, in contrast, would bump parameterCount
-        // by two (Composer + $changed) -- the assertion below catches that.
-        //
-        // Two overloads are expected after wpass-aaf: the Summary-shaped
-        // primitive (organizationName, userLabel, localizedStrings) and the
-        // Pass-bearing convenience (pass, userLabel, locale). Both are 3-arg.
+        // Two 3-arg overloads, neither @Composable (would add Composer + $changed
+        // and bump parameterCount). On mangling churn, re-derive names from
+        // `javap -p` on the compiled `PassDisplayIdentityKt`.
         val methods = Class.forName("is.walt.passes.ui.PassDisplayIdentityKt")
             .declaredMethods
             .filter { it.name.startsWith("resolvePassDisplayIdentity") && !it.name.contains("\$default") }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PassDisplayIdentityTest.kt
@@ -168,26 +168,108 @@ class PassDisplayIdentityTest {
     }
 
     @Test
+    fun summaryShapedOverloadFencesRawOrgNameWithEmptyStringsTable() {
+        // The PassSummaryRow path: consumer has no `locales` map (PassSummary
+        // deliberately drops it to avoid I/O). `LocalizedStrings.Empty` makes the
+        // lookup a no-op and the resolver fences the raw `organizationName`
+        // verbatim.
+        val identity = resolvePassDisplayIdentity(
+            organizationName = "Acme",
+            userLabel = null,
+        )
+        assertThat(identity.primary).isEqualTo("⁨Acme⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun summaryShapedOverloadSubstitutesThroughExplicitStringsTable() {
+        // Detail-screen path: caller resolved the strings table elsewhere and hands
+        // it in. The resolver substitutes through it just like the Pass-bearing
+        // overload would.
+        val identity = resolvePassDisplayIdentity(
+            organizationName = "#ORGNAME#",
+            userLabel = "Mom's flight",
+            localizedStrings = LocalizedStrings(mapOf("#ORGNAME#" to "Tixly")),
+        )
+        assertThat(identity.primary).isEqualTo("⁨Mom's flight⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Tixly⁩")
+    }
+
+    @Test
+    fun summaryShapedOverloadSuppressesOverrideEqualToSubstitutedOrgName() {
+        val identity = resolvePassDisplayIdentity(
+            organizationName = "#ORGNAME#",
+            userLabel = "tixly",
+            localizedStrings = LocalizedStrings(mapOf("#ORGNAME#" to "Tixly")),
+        )
+        assertThat(identity.primary).isEqualTo("⁨Tixly⁩")
+        assertThat(identity.eyebrow).isNull()
+    }
+
+    @Test
+    fun summaryShapedOverloadFencesUserLabelBidiCharacters() {
+        val rtl = "‮BAD"
+        val identity = resolvePassDisplayIdentity(
+            organizationName = "Acme",
+            userLabel = rtl,
+        )
+        assertThat(identity.primary).isEqualTo("⁨$rtl⁩")
+        assertThat(identity.eyebrow).isEqualTo("⁨Acme⁩")
+    }
+
+    @Test
+    fun summaryShapedOverloadWithRawKeyAndEmptyStringsTableShowsRawKey() {
+        // Honesty check: if a consumer hands in the raw `#ORGNAME#` column and
+        // does NOT supply a strings table, the resolver fences the raw key. This
+        // is the documented behavior; the kernel's job is the trust fence, not
+        // post-hoc localization. (A consumer that needs the localized name in a
+        // list row should denormalize at storage write time.)
+        val identity = resolvePassDisplayIdentity(
+            organizationName = "#ORGNAME#",
+            userLabel = null,
+        )
+        assertThat(identity.primary).isEqualTo("⁨#ORGNAME#⁩")
+    }
+
+    @Test
+    fun passOverloadAgreesWithSummaryOverloadOnIdenticalInputs() {
+        // The Pass-bearing overload is just a convenience wrapper that resolves
+        // the strings table for `locale` and delegates. Lock that equivalence so
+        // a future change to either path can't drift the trust contract.
+        val locales = mapOf(PassLocale("en") to LocalizedStrings(mapOf("#ORGNAME#" to "Tixly")))
+        val pass = localizedFixture(organizationName = "#ORGNAME#", locales = locales)
+        val viaPass = resolvePassDisplayIdentity(pass = pass, userLabel = "Mom's flight")
+        val viaSummary = resolvePassDisplayIdentity(
+            organizationName = pass.organizationName,
+            userLabel = "Mom's flight",
+            localizedStrings = locales.getValue(PassLocale("en")),
+        )
+        assertThat(viaPass).isEqualTo(viaSummary)
+    }
+
+    @Test
     fun resolverIsPureAndCallableOutsideCompose() {
-        // No @Composable annotation needed -- the signature must remain JVM-only so
-        // walt-android's PassSummaryRow can call it from a non-Compose code path.
-        // PassLocale is a value class so the JVM method name carries a mangling
-        // suffix; match by prefix (mirrors PublicApiSurfaceTest's lock for
-        // PassIdentityBlock). Skip the synthetic `$default` overload Kotlin emits
-        // for the default-arg entry point; the direct entry is the trust-contract
-        // surface.
+        // No @Composable annotation needed -- the signatures must remain JVM-only
+        // so walt-android's PassSummaryRow can call them from a non-Compose code
+        // path. Skip the synthetic `$default` overloads Kotlin emits for the
+        // default-arg entries; the direct entries are the trust-contract surface.
         //
         // NOTE on failure mode: this lock is sensitive to Kotlin's value-class /
         // default-arg name mangling. If a future toolchain changes the suffix
         // shape and this test breaks, the most likely cause is mangling churn,
-        // not a regressed contract. Re-derive the prefix from `javap -p` on the
+        // not a regressed contract. Re-derive the names from `javap -p` on the
         // compiled `PassDisplayIdentityKt` before assuming the resolver itself
         // changed. Becoming @Composable, in contrast, would bump parameterCount
         // by two (Composer + $changed) -- the assertion below catches that.
-        val method = Class.forName("is.walt.passes.ui.PassDisplayIdentityKt")
+        //
+        // Two overloads are expected after wpass-aaf: the Summary-shaped
+        // primitive (organizationName, userLabel, localizedStrings) and the
+        // Pass-bearing convenience (pass, userLabel, locale). Both are 3-arg.
+        val methods = Class.forName("is.walt.passes.ui.PassDisplayIdentityKt")
             .declaredMethods
-            .first { it.name.startsWith("resolvePassDisplayIdentity") && !it.name.contains("\$default") }
-        assertThat(method.parameterCount).isEqualTo(3)
+            .filter { it.name.startsWith("resolvePassDisplayIdentity") && !it.name.contains("\$default") }
+        assertThat(methods).hasSize(2)
+        methods.forEach { assertThat(it.parameterCount).isEqualTo(3) }
     }
 
     private fun passFixture(): Pass = Pass(


### PR DESCRIPTION
## Summary

Closes wpass-aaf. Addresses the Android-team feedback on #112: `resolvePassDisplayIdentity(pass, userLabel, locale)` took a full `Pass`, but the bead's acceptance criterion was that walt-android's `PassSummaryRow` could call it -- and `PassSummary` deliberately carries only the raw `organizationName` column and no `locales` table (its kdoc explicitly says "does not pay for image or locale I/O"). The list-row consumer therefore could not call the resolver without materializing a full `StoredPass` per row.

This change adds a primitive overload:

    public fun resolvePassDisplayIdentity(
        organizationName: String,
        userLabel: String?,
        localizedStrings: LocalizedStrings = LocalizedStrings.Empty,
    ): PassDisplayIdentity

`PassSummary` callers pass `LocalizedStrings.Empty`; the lookup is a no-op and the raw `organizationName` is fenced verbatim. Detail-screen callers that already hold a resolved strings table can pass it in. The `Pass`-bearing convenience overload now delegates to the primitive after running `pass.resolveLocalizedStrings(locale)`, so the trust contract has one source of truth.

PR review feedback applied in a follow-up commit (`00fca7e`):
- Trimmed the primitive's KDoc to the four numbered rules + one sentence on `LocalizedStrings.Empty`. The "list-row vs detail-view" routing prose was duplicated in the convenience overload's KDoc.
- Collapsed the reflection-test header block to the durable signal: two 3-arg overloads, `@Composable` would bump `parameterCount` by two, mangling churn -> `javap -p`. Dropped the `wpass-aaf` changelog paragraph.

Note: `PassSummary.organizationName` stores the raw column value. Pkpasses whose `organizationName` resolves only through a strings table will surface the raw `#KEY#` in list rows until walt-android either denormalizes the localized value at storage write time or joins the strings table in. That is a storage-projection concern (out of scope here); the trust contract (fence the signed name) is satisfied either way.

## Test plan

- [x] `:passes-ui:testDebugUnitTest` from inside the feature worktree -- green
- [x] `:passes-ui:detekt` -- clean
- [x] Five new tests cover the Summary-shaped overload (empty-strings fence, explicit strings substitution, suppression against substituted name, bidi-character fence, raw-key honesty); one delegation-equivalence test pins that the Pass overload agrees with the primitive on identical inputs
- [x] Reflection lock now expects two 3-arg overloads; would still trip on accidental `@Composable`
- [ ] Walt-android adopts the new overload in `PassSummaryRow` (separate change in walt-android)