### PR TITLE
fix(pdf): preserve aspect on full-page render + add closeButton slot (wlt-zxm)

### DIFF
--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -69,6 +69,13 @@ public fun FullScreenDocumentView(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
+    // Host-supplied close affordance; receives the same [onClose] the surface uses, so
+    // hosts can swap the default rectangular text button for an icon-only or branded
+    // chip without re-implementing the trust caption / pager scaffolding. Default
+    // preserves the original label-based render.
+    closeButton: @Composable (onClose: () -> Unit) -> Unit = { handler ->
+        CloseFullScreenButton(onClick = handler)
+    },
 ) {
     val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) { PdfThumbnailCache() }
@@ -109,7 +116,7 @@ public fun FullScreenDocumentView(
         }
 
         Box(modifier = Modifier.align(Alignment.TopStart)) {
-            CloseFullScreenButton(onClick = onClose)
+            closeButton(onClose)
         }
     }
 }

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/FullScreenDocumentView.kt
@@ -59,6 +59,12 @@ import `is`.walt.passes.ui.core.toComposeColor
  * Page cache: fit-resolution renders are cached per page; sub-rect renders are not
  * (cache-keying them would explode the key space and stale entries surface as a
  * sharper-but-wrong region after a pan).
+ *
+ * @param closeButton Host-supplied close affordance, rendered at [Alignment.TopStart].
+ *   The surface owns placement and [onClose] wiring; the host owns chrome, sizing, and
+ *   any inset / padding handling (the default applies its own padding, host overrides
+ *   should apply their own — e.g. `windowInsetsPadding(WindowInsets.statusBars)` on
+ *   edge-to-edge displays so the chip never slides under the system clock).
  */
 @Composable
 @Suppress("LongParameterList")
@@ -69,10 +75,6 @@ public fun FullScreenDocumentView(
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
-    // Host-supplied close affordance; receives the same [onClose] the surface uses, so
-    // hosts can swap the default rectangular text button for an icon-only or branded
-    // chip without re-implementing the trust caption / pager scaffolding. Default
-    // preserves the original label-based render.
     closeButton: @Composable (onClose: () -> Unit) -> Unit = { handler ->
         CloseFullScreenButton(onClick = handler)
     },

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
@@ -65,14 +65,18 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun fullScreenDocumentViewHasExactlySixUserVisibleParameters() {
-        // (doc, pdfFile, renderer, onClose, modifier, telemetry). D5: trust caption is
-        // composed inside the surface; no parameter omits it. Required onClose forces
-        // the host to provide a back path — there is no "stuck in full-screen" state.
+    fun fullScreenDocumentViewHasExactlySevenUserVisibleParameters() {
+        // (doc, pdfFile, renderer, onClose, modifier, telemetry, closeButton). D5:
+        // trust caption is composed inside the surface; no parameter omits it. Required
+        // onClose forces the host to provide a back path — there is no "stuck in
+        // full-screen" state. The seventh slot is a host-supplied close-button
+        // composable (icon vs. text, host chrome) that does not touch the trust caption
+        // or any other surface affordance, so D5 is unaffected. Bumping from 6 to 7 is
+        // the deliberate change for that slot, not a slip.
         assertUserVisibleParamCount(
             "FullScreenDocumentViewKt",
             "FullScreenDocumentView",
-            expected = 6,
+            expected = 7,
         )
     }
 

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -164,8 +164,15 @@ private fun rasterise(
     }
 }
 
-// FullPage keeps the legacy `null` transform (fit page to bitmap). SubRect maps the
-// sub-rect's page-point coords onto the full destination bitmap, sharp under zoom.
+// FullPage builds an aspect-preserving fit matrix (scale by the smaller axis, centre the
+// page inside the request box). The page's white letterbox bars are supplied by the
+// caller's `bitmap.eraseColor(Color.WHITE)`. The legacy `null`-transform path (fit page
+// to bitmap, ignoring source aspect) stretched portrait PDFs into a phone-screen-shaped
+// request, producing a visibly squished initial render at FullScreen scale; the
+// consumer-side `pageRectInSlot` math already assumes aspect-preserving letterboxing,
+// so this aligns the bitmap with where the consumer expects the page to sit. SubRect
+// maps the sub-rect's page-point coords onto the full destination bitmap, sharp under
+// zoom (callers fence the sub-rect's aspect against the request aspect already).
 private fun matrixFor(
     sourceRect: RenderSourceRect,
     pageWidth: Int,
@@ -174,7 +181,18 @@ private fun matrixFor(
     heightPx: Int,
 ): Matrix? =
     when (sourceRect) {
-        is RenderSourceRect.FullPage -> null
+        is RenderSourceRect.FullPage -> {
+            val scale = minOf(
+                widthPx.toFloat() / pageWidth.toFloat(),
+                heightPx.toFloat() / pageHeight.toFloat(),
+            )
+            val dx = (widthPx - pageWidth * scale) / 2f
+            val dy = (heightPx - pageHeight * scale) / 2f
+            Matrix().apply {
+                setScale(scale, scale)
+                postTranslate(dx, dy)
+            }
+        }
         is RenderSourceRect.SubRect -> {
             val srcLeft = sourceRect.left * pageWidth
             val srcTop = sourceRect.top * pageHeight

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -164,15 +164,9 @@ private fun rasterise(
     }
 }
 
-// FullPage builds an aspect-preserving fit matrix (scale by the smaller axis, centre the
-// page inside the request box). The page's white letterbox bars are supplied by the
-// caller's `bitmap.eraseColor(Color.WHITE)`. The legacy `null`-transform path (fit page
-// to bitmap, ignoring source aspect) stretched portrait PDFs into a phone-screen-shaped
-// request, producing a visibly squished initial render at FullScreen scale; the
-// consumer-side `pageRectInSlot` math already assumes aspect-preserving letterboxing,
-// so this aligns the bitmap with where the consumer expects the page to sit. SubRect
-// maps the sub-rect's page-point coords onto the full destination bitmap, sharp under
-// zoom (callers fence the sub-rect's aspect against the request aspect already).
+// FullPage: aspect-preserving fit (letterbox bars come from the caller's eraseColor),
+// matching the consumer's pageRectInSlot letterbox assumption. SubRect maps a unit-rect
+// of the page onto the full bitmap so zoomed regions stay sharp.
 private fun matrixFor(
     sourceRect: RenderSourceRect,
     pageWidth: Int,


### PR DESCRIPTION
## Summary
- `passes-pdf` `PdfRendererService.matrixFor(FullPage)` returns an aspect-preserving fit matrix (scale by min axis, centre) instead of `null`. Fixes the squished initial render that "evened out" after a pinch — the SubRect path already mapped page coordinates correctly via `pageRectInSlot`, so only the first render was wrong.
- `passes-pdf-ui` `FullScreenDocumentView` gains a host-supplied `closeButton: @Composable (onClose) -> Unit` slot (defaults to the existing `CloseFullScreenButton`). Lets consumers theme the affordance (e.g. icon-only X) without re-implementing the trust caption / pager scaffolding. `onClose` plumbing and `TopStart` placement stay owned by the kernel.
- `DocumentSurfaceLockTest` pinned param count bumped 6 → 7 with a comment explaining the new slot does not affect ADR 0005 D5.

Closes wlt-zxm (Bug 1: stretched render; Bug 2: close button is not themable).

## Test plan
- [x] `:passes-pdf:test :passes-pdf-ui:test` green
- [x] `:passes-pdf:detekt :passes-pdf-ui:detekt` green
- [x] `:passes-pdf:ktlintCheck :passes-pdf-ui:ktlintCheck` green
- [ ] On-device verification of the visual fix (deferred — walt-android-side branch `fullscreen-pdf-fix` consumes the new slot)