### PR TITLE
PDF full-screen: fix zoom aspect-ratio stretch + consumer-styleable open affordance (wpass-qz2)

### DIFF
--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -2,10 +2,12 @@ package `is`.walt.passes.pdf.ui
 
 import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -295,6 +297,46 @@ class DocumentViewInstrumentedTest {
         composeRule.onNodeWithContentDescription("Page 1 of 1").assertIsDisplayed()
         composeRule.onNodeWithContentDescription("Page 1 of 1").performClick()
         assertThat(tapped).isTrue()
+    }
+
+    @Test
+    fun customFullScreenAffordanceReplacesTheDefaultAndKeepsTheKernelBehaviour() {
+        // wpass-emn: a host-supplied affordance replaces the kernel's default banner
+        // (no "Tap for full screen" text), is itself a tap target for the open callback,
+        // and does NOT consume the page tap — the page remains the primary affordance.
+        val recorder = RecordingBinder()
+        var affordanceTaps = 0
+        var pageTaps = 0
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onOpenFullScreen = { pageTaps++ },
+                    fullScreenAffordance = { onOpen ->
+                        Text(
+                            text = "Open it",
+                            modifier = Modifier.clickable {
+                                affordanceTaps++
+                                onOpen()
+                            },
+                        )
+                    },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onAllNodesWithText("Tap for full screen").assertCountEquals(0)
+
+        composeRule.onNodeWithText("Open it").assertIsDisplayed()
+        composeRule.onNodeWithText("Open it").performClick()
+        assertThat(affordanceTaps).isEqualTo(1)
+
+        // The page itself still opens full screen independently of the custom affordance.
+        val pageTapsBefore = pageTaps
+        composeRule.onNodeWithContentDescription("Page 1 of 1").performClick()
+        assertThat(pageTaps).isGreaterThan(pageTapsBefore)
     }
 
     @Test

--- a/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-pdf-ui/src/androidTest/kotlin/is/walt/passes/pdf/ui/DocumentViewInstrumentedTest.kt
@@ -340,6 +340,36 @@ class DocumentViewInstrumentedTest {
     }
 
     @Test
+    fun defaultBannerDocksBelowThePageAndDoesNotOverlapIt() {
+        // wpass-emn review: with no custom affordance the neutral banner must dock below
+        // the page (original layout), never float over it — bottom-of-page content
+        // (barcodes, QR, signatures) must stay visible for default consumers.
+        val recorder = RecordingBinder()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = doc(pageCount = 1),
+                    pdfFile = pipeRead,
+                    renderer = recorder,
+                    onOpenFullScreen = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        val pageBottom = composeRule
+            .onNodeWithContentDescription("Page 1 of 1")
+            .getUnclippedBoundsInRoot()
+            .bottom
+        val bannerTop = composeRule
+            .onNodeWithText("Tap for full screen")
+            .getUnclippedBoundsInRoot()
+            .top
+
+        assertThat(bannerTop.value).isAtLeast(pageBottom.value)
+    }
+
+    @Test
     fun fullScreenSurfaceShowsTheTrustCaption() {
         // wpass-jil / ADR 0005 Z.8: the trust caption is docked on the full-screen
         // surface and visible at first composition. The bitmap-availability path is

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -59,14 +59,16 @@ import `is`.walt.passes.ui.core.toComposeColor
  *  - Inline surface is fixed 1x: no pinch-zoom, no pan, no double-tap. Zoom lives only
  *    on the full-screen detail surface (wpass-ny4 / wpass-jil).
  *
- * @param fullScreenAffordance Host-supplied open-full-screen affordance, composed only
- *   when [onOpenFullScreen] is non-null and floated over the bottom-centre of the page
- *   region. Mirrors the `closeButton` slot on [FullScreenDocumentView]: the surface owns
- *   placement and wiring (it is handed the open callback), the host owns chrome — shape,
- *   corner radius, leading icon, label, padding (wpass-emn). The default renders the
- *   kernel's neutral banner so existing label-and-colour-only consumers are unchanged.
- *   This slot cannot suppress the trust caption or the page tap target; both are
- *   structural and independent of it.
+ * @param fullScreenAffordance Optional host-supplied open-full-screen affordance, used
+ *   only when [onOpenFullScreen] is also non-null. Mirrors the `closeButton` slot on
+ *   [FullScreenDocumentView]: the host owns chrome — shape, corner radius, leading icon,
+ *   label, padding (wpass-emn). When supplied it is **floated over the bottom-centre of
+ *   the page** (matching Walt's pill design, which overlaps the page edge); the host
+ *   accepts that overlap as part of choosing a floating affordance. When `null` (the
+ *   default) the kernel's neutral banner is **docked below the page** exactly as before,
+ *   so consumers that do not pass this slot are unchanged and the page is never obscured.
+ *   Either way this slot cannot suppress the trust caption or the page tap target; both
+ *   are structural and independent of it.
  *
  * Bitmap ownership: the LRU cache stores native [Bitmap]s and recycles them on
  * eviction; the renderer service has already pre-recycled its source-side copy
@@ -94,9 +96,7 @@ public fun DocumentView(
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     onOpenFullScreen: (() -> Unit)? = null,
-    fullScreenAffordance: @Composable (onOpen: () -> Unit) -> Unit = { onOpen ->
-        FullScreenBanner(onClick = onOpen)
-    },
+    fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)? = null,
 ) {
     val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) { PdfThumbnailCache() }
@@ -112,22 +112,17 @@ public fun DocumentView(
     ) {
         DocumentTrustCaption()
 
-        // `laneBackground` is painted behind the pager only — it is the document-surface
-        // tone the rasterised page sits on (showing through ContentScale.Fit letterbox
-        // bars). The trust caption above sits on the consumer's background, reading as
-        // host screen chrome. The page region is a Box so the open-full-screen affordance
-        // can float over its bottom edge (wpass-emn) rather than dock below it.
+        // `laneBackground` paints behind the pager only — the document-surface tone the
+        // page sits on (showing through ContentScale.Fit letterbox bars). The page region
+        // is a Box so a host-supplied affordance can float over its bottom edge.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
                 .background(semantics.laneBackground.toComposeColor()),
         ) {
-            // When the host wires `onOpenFullScreen`, a tap anywhere on the page region
-            // launches the full-screen surface — the affordance is a discoverability
-            // hint, the page itself is the primary tap target. `.clickable` and the
-            // pager's drag handling coexist: Compose routes quick press-and-release to
-            // the click handler and horizontal drag to the pager.
+            // Page tap opens full screen; clickable and the pager's drag coexist (Compose
+            // routes quick press-release to the click, horizontal drag to the pager).
             val pagerModifier = Modifier
                 .fillMaxSize()
                 .let {
@@ -145,13 +140,9 @@ public fun DocumentView(
                 )
             }
 
-            // wpass-jil / wpass-emn: open-full-screen affordance. Opt-in via
-            // `onOpenFullScreen` — hosts without a full-screen route render nothing here
-            // (the page tap above remains the affordance). When wired, the host-supplied
-            // `fullScreenAffordance` floats over the bottom-centre of the page; the
-            // default is the kernel's neutral banner. The trust caption sits above this
-            // Box in the Column, so the affordance can never overlap or suppress it.
-            if (onOpenFullScreen != null) {
+            // A host-supplied affordance floats over the page bottom-centre (wpass-emn);
+            // the host accepts that overlap by choosing a floating affordance.
+            if (onOpenFullScreen != null && fullScreenAffordance != null) {
                 Box(
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
@@ -161,13 +152,20 @@ public fun DocumentView(
                 }
             }
         }
+
+        // No custom affordance: the neutral banner docks below the page (original
+        // layout), so default consumers' page content is never obscured. The trust
+        // caption above this Column cannot be pushed off-screen by it.
+        if (onOpenFullScreen != null && fullScreenAffordance == null) {
+            FullScreenBanner(onClick = onOpenFullScreen)
+        }
     }
 }
 
-// wpass-jil: the kernel's neutral default open-full-screen affordance, floated over the
-// page bottom. Label and colours come from DocumentSemantics so the host owns wording
-// and styling; a host wanting a different register (pill, leading icon, placement)
-// supplies its own via DocumentView's `fullScreenAffordance` slot (wpass-emn).
+// wpass-jil: the kernel's neutral default open-full-screen affordance, docked below the
+// page. Label and colours come from DocumentSemantics; a host wanting a different
+// register (pill, leading icon, floating placement) supplies its own via DocumentView's
+// `fullScreenAffordance` slot (wpass-emn).
 @Composable
 private fun FullScreenBanner(onClick: () -> Unit) {
     val semantics = LocalDocumentSemantics.current

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -59,6 +59,15 @@ import `is`.walt.passes.ui.core.toComposeColor
  *  - Inline surface is fixed 1x: no pinch-zoom, no pan, no double-tap. Zoom lives only
  *    on the full-screen detail surface (wpass-ny4 / wpass-jil).
  *
+ * @param fullScreenAffordance Host-supplied open-full-screen affordance, composed only
+ *   when [onOpenFullScreen] is non-null and floated over the bottom-centre of the page
+ *   region. Mirrors the `closeButton` slot on [FullScreenDocumentView]: the surface owns
+ *   placement and wiring (it is handed the open callback), the host owns chrome — shape,
+ *   corner radius, leading icon, label, padding (wpass-emn). The default renders the
+ *   kernel's neutral banner so existing label-and-colour-only consumers are unchanged.
+ *   This slot cannot suppress the trust caption or the page tap target; both are
+ *   structural and independent of it.
+ *
  * Bitmap ownership: the LRU cache stores native [Bitmap]s and recycles them on
  * eviction; the renderer service has already pre-recycled its source-side copy
  * before returning. On dispose the cache is cleared so every retained pixel buffer
@@ -85,6 +94,9 @@ public fun DocumentView(
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     onOpenFullScreen: (() -> Unit)? = null,
+    fullScreenAffordance: @Composable (onOpen: () -> Unit) -> Unit = { onOpen ->
+        FullScreenBanner(onClick = onOpen)
+    },
 ) {
     val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) { PdfThumbnailCache() }
@@ -103,47 +115,59 @@ public fun DocumentView(
         // `laneBackground` is painted behind the pager only — it is the document-surface
         // tone the rasterised page sits on (showing through ContentScale.Fit letterbox
         // bars). The trust caption above sits on the consumer's background, reading as
-        // host screen chrome.
-        //
-        // When the host wires `onOpenFullScreen`, a tap anywhere on the page region
-        // launches the full-screen surface — the banner below is a discoverability
-        // affordance, the page itself is the primary tap target. `.clickable` and
-        // the pager's drag handling coexist: Compose's gesture system routes quick
-        // press-and-release to the click handler and horizontal drag to the pager.
-        val pagerModifier = Modifier
-            .fillMaxWidth()
-            .weight(1f)
-            .background(semantics.laneBackground.toComposeColor())
-            .let {
-                if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
+        // host screen chrome. The page region is a Box so the open-full-screen affordance
+        // can float over its bottom edge (wpass-emn) rather than dock below it.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .background(semantics.laneBackground.toComposeColor()),
+        ) {
+            // When the host wires `onOpenFullScreen`, a tap anywhere on the page region
+            // launches the full-screen surface — the affordance is a discoverability
+            // hint, the page itself is the primary tap target. `.clickable` and the
+            // pager's drag handling coexist: Compose routes quick press-and-release to
+            // the click handler and horizontal drag to the pager.
+            val pagerModifier = Modifier
+                .fillMaxSize()
+                .let {
+                    if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
+                }
+                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+            HorizontalPager(state = pagerState, modifier = pagerModifier) { page ->
+                DocumentPage(
+                    document = doc,
+                    pageIndex = page,
+                    pdfFile = pdfFile,
+                    renderer = renderer,
+                    cache = cache,
+                    telemetry = telemetry,
+                )
             }
-            .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
-        HorizontalPager(state = pagerState, modifier = pagerModifier) { page ->
-            DocumentPage(
-                document = doc,
-                pageIndex = page,
-                pdfFile = pdfFile,
-                renderer = renderer,
-                cache = cache,
-                telemetry = telemetry,
-            )
-        }
 
-        // wpass-jil: full-screen banner. Opt-in via `onOpenFullScreen` — hosts without
-        // a full-screen route render no banner, which is a legitimate configuration
-        // (the affordance is the page tap above). When wired, the banner is a docked
-        // discoverability hint below the pager, above any other host chrome. The trust
-        // caption sits above the pager in this Column so the banner cannot push it
-        // off-screen.
-        if (onOpenFullScreen != null) {
-            FullScreenBanner(onClick = onOpenFullScreen)
+            // wpass-jil / wpass-emn: open-full-screen affordance. Opt-in via
+            // `onOpenFullScreen` — hosts without a full-screen route render nothing here
+            // (the page tap above remains the affordance). When wired, the host-supplied
+            // `fullScreenAffordance` floats over the bottom-centre of the page; the
+            // default is the kernel's neutral banner. The trust caption sits above this
+            // Box in the Column, so the affordance can never overlap or suppress it.
+            if (onOpenFullScreen != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp),
+                ) {
+                    fullScreenAffordance(onOpenFullScreen)
+                }
+            }
         }
     }
 }
 
-// wpass-jil: docked banner inside DocumentView whose tap launches the full-screen
-// detail surface. Label and colours come from DocumentSemantics so the host owns the
-// wording and styling.
+// wpass-jil: the kernel's neutral default open-full-screen affordance, floated over the
+// page bottom. Label and colours come from DocumentSemantics so the host owns wording
+// and styling; a host wanting a different register (pill, leading icon, placement)
+// supplies its own via DocumentView's `fullScreenAffordance` slot (wpass-emn).
 @Composable
 private fun FullScreenBanner(onClick: () -> Unit) {
     val semantics = LocalDocumentSemantics.current

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * never shown against a changed transform.
  */
 @Composable
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 internal fun ZoomableImage(
     bitmap: ImageBitmap,
     contentDescription: String,
@@ -128,6 +128,15 @@ internal fun ZoomableImage(
                             offset = Offset.Zero
                         } else {
                             scale = doubleTapScale
+                            offset = Offset.Zero
+                            // Double-tap raises scale without a transform edge, so the
+                            // snapshotFlow never fires; request the sharp sub-rect render
+                            // explicitly to keep wpass-f4b parity with the pinch path.
+                            if (slotSize != IntSize.Zero) {
+                                onZoomedRegionChanged?.invoke(
+                                    visiblePageSubRect(doubleTapScale, Offset.Zero, slotSize, pageAspect),
+                                )
+                            }
                         }
                     },
                 )

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/internal/ZoomableImage.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -22,8 +24,11 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import `is`.walt.passes.pdf.android.RenderSourceRect
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
@@ -32,14 +37,19 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * the only call site. Translation is clamped to the slot bounds so the bitmap cannot
  * be panned entirely off-screen.
  *
- * When [pageAspect] is supplied, [visibleRect] math accounts for ContentScale.Fit
+ * When [pageAspect] is supplied, [visiblePageSubRect] math accounts for ContentScale.Fit
  * letterbox bars in the bitmap so the emitted [RenderSourceRect.SubRect] matches the
  * region of the actual page the user pinched (`wpass-6ag` review C3).
  *
  * When [zoomedReplacement] is non-null and the user is not actively transforming, it
  * overrides the displayed image — the sub-rect render that the caller fetched in
- * response to the previous settle. Starting a new gesture clears the override (the
- * caller's [onTransformStarted] callback lets it drop the stale bitmap).
+ * response to the previous settle. The replacement carries the visible region's own
+ * aspect ratio (the renderer rasterises it uniformly, `wpass-fdh`), so it is placed at
+ * the on-screen box that region currently occupies via [visiblePageBoxOnScreen] rather
+ * than stretched to fill the slot — laneBackground shows around it where the viewport
+ * extends past the page edge. Starting a new gesture (or any double-tap) clears the
+ * override through the caller's [onTransformStarted] callback so a stale region is
+ * never shown against a changed transform.
  */
 @Composable
 @Suppress("LongParameterList", "LongMethod")
@@ -85,15 +95,23 @@ internal fun ZoomableImage(
                         onTransformStarted?.invoke()
                     } else if (scale > minScale && slotSize != IntSize.Zero) {
                         onZoomedRegionChanged?.invoke(
-                            visibleRect(scale, offset, slotSize, pageAspect),
+                            visiblePageSubRect(scale, offset, slotSize, pageAspect),
                         )
                     }
                 }
         }
     }
 
+    val density = LocalDensity.current
     val transforming = transformableState.isTransformInProgress
-    val displayReplacement = zoomedReplacement != null && !transforming
+    // Only honour the replacement while genuinely zoomed in. A double-tap reset drops
+    // scale to minScale without a transform edge, so this gate (not just !transforming)
+    // is what keeps a stale sub-rect from being shown over the reset full page.
+    val replacementBox = if (zoomedReplacement != null && !transforming && scale > minScale) {
+        visiblePageBoxOnScreen(scale, offset, slotSize, pageAspect)
+    } else {
+        null
+    }
 
     Box(
         modifier = modifier
@@ -102,6 +120,9 @@ internal fun ZoomableImage(
             .pointerInput(Unit) {
                 detectTapGestures(
                     onDoubleTap = {
+                        // Any double-tap changes the transform; drop the stale sub-rect
+                        // so it is never displayed against the new scale/offset.
+                        onTransformStarted?.invoke()
                         if (scale > minScale) {
                             scale = minScale
                             offset = Offset.Zero
@@ -114,14 +135,22 @@ internal fun ZoomableImage(
             .transformable(state = transformableState, canPan = { scale > minScale }),
         contentAlignment = Alignment.Center,
     ) {
-        if (displayReplacement) {
-            // The replacement is already the visible region rasterised at viewport
-            // resolution; draw it filling the slot with no transform.
+        if (replacementBox != null) {
+            // The replacement is the visible page region rasterised at viewport
+            // resolution with its native aspect ratio. Place it at the on-screen box
+            // that region occupies; FillBounds is exact because the box and the bitmap
+            // share that aspect, so no axis is independently scaled (`wpass-fdh`).
             Image(
                 bitmap = zoomedReplacement!!,
                 contentDescription = contentDescription,
-                contentScale = ContentScale.Fit,
-                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset { IntOffset(replacementBox.left.roundToInt(), replacementBox.top.roundToInt()) }
+                    .size(
+                        with(density) { replacementBox.width.toDp() },
+                        with(density) { replacementBox.height.toDp() },
+                    ),
             )
         } else {
             Image(
@@ -142,44 +171,94 @@ internal fun ZoomableImage(
 }
 
 /**
- * Maps the currently-visible region of the displayed page into a normalised page rect.
- *
- * When [pageAspect] is supplied, the helper computes the on-screen page rect inside the
- * slot (slot minus ContentScale.Fit letterbox bars), maps the visible window into that
- * rect's coordinates, then normalises. When [pageAspect] is null the slot is treated
- * as filling the page (legacy behaviour from the inline surface).
+ * Slot-pixel rectangle of the page region the viewport currently shows. [page] is the
+ * on-screen page rect (slot minus ContentScale.Fit letterbox); `i*` is its intersection
+ * with the visible window, both in the untransformed slot coordinate space. `null` when
+ * the viewport sits entirely in the letterbox (zero-area intersection).
  */
-@Suppress("ReturnCount")
-private fun visibleRect(
+private data class VisibleRegion(
+    val ix0: Float,
+    val iy0: Float,
+    val ix1: Float,
+    val iy1: Float,
+    val page: PageRectInSlot,
+    val visLeft: Float,
+    val visTop: Float,
+)
+
+private fun visibleRegion(
     scale: Float,
     offset: Offset,
     slotSize: IntSize,
     pageAspect: Float?,
-): RenderSourceRect.SubRect {
+): VisibleRegion? {
     val slotW = slotSize.width.toFloat()
     val slotH = slotSize.height.toFloat()
-    val pageOnScreen = pageRectInSlot(slotW, slotH, pageAspect)
+    val page = pageRectInSlot(slotW, slotH, pageAspect)
     // Visible window in slot pixels at the current zoom: the slot mapped back through
     // the graphicsLayer transform.
     val visW = slotW / scale
     val visH = slotH / scale
     val visLeft = slotW / 2f - offset.x / scale - visW / 2f
     val visTop = slotH / 2f - offset.y / scale - visH / 2f
-    val ix0 = maxOf(visLeft, pageOnScreen.left)
-    val iy0 = maxOf(visTop, pageOnScreen.top)
-    val ix1 = minOf(visLeft + visW, pageOnScreen.left + pageOnScreen.width)
-    val iy1 = minOf(visTop + visH, pageOnScreen.top + pageOnScreen.height)
-    val nLeft = ((ix0 - pageOnScreen.left) / pageOnScreen.width).coerceIn(0f, 1f)
-    val nTop = ((iy0 - pageOnScreen.top) / pageOnScreen.height).coerceIn(0f, 1f)
-    val nRight = ((ix1 - pageOnScreen.left) / pageOnScreen.width).coerceIn(0f, 1f)
-    val nBottom = ((iy1 - pageOnScreen.top) / pageOnScreen.height).coerceIn(0f, 1f)
-    // Pan entirely into letterbox would zero-area the intersection; the renderer
-    // rejects zero-area rects, so emit a tiny centred fallback.
+    val ix0 = maxOf(visLeft, page.left)
+    val iy0 = maxOf(visTop, page.top)
+    val ix1 = minOf(visLeft + visW, page.left + page.width)
+    val iy1 = minOf(visTop + visH, page.top + page.height)
+    if (ix1 <= ix0 || iy1 <= iy0) return null
+    return VisibleRegion(ix0, iy0, ix1, iy1, page, visLeft, visTop)
+}
+
+/**
+ * Maps the currently-visible region of the displayed page into a normalised page rect
+ * for the renderer's [RenderSourceRect.SubRect]. When [pageAspect] is null the slot is
+ * treated as filling the page (legacy behaviour from the inline surface).
+ */
+@Suppress("ReturnCount")
+internal fun visiblePageSubRect(
+    scale: Float,
+    offset: Offset,
+    slotSize: IntSize,
+    pageAspect: Float?,
+): RenderSourceRect.SubRect {
+    // Pan entirely into letterbox zero-areas the intersection; the renderer rejects
+    // zero-area rects, so emit a tiny centred fallback.
+    val r = visibleRegion(scale, offset, slotSize, pageAspect)
+        ?: return RenderSourceRect.SubRect(0.49f, 0.49f, 0.51f, 0.51f)
+    val nLeft = ((r.ix0 - r.page.left) / r.page.width).coerceIn(0f, 1f)
+    val nTop = ((r.iy0 - r.page.top) / r.page.height).coerceIn(0f, 1f)
+    val nRight = ((r.ix1 - r.page.left) / r.page.width).coerceIn(0f, 1f)
+    val nBottom = ((r.iy1 - r.page.top) / r.page.height).coerceIn(0f, 1f)
     if (nRight <= nLeft || nBottom <= nTop) {
         return RenderSourceRect.SubRect(0.49f, 0.49f, 0.51f, 0.51f)
     }
     return RenderSourceRect.SubRect(nLeft, nTop, nRight, nBottom)
 }
+
+/**
+ * On-screen (viewport-pixel) box the visible page region occupies. Derived from the same
+ * intersection as [visiblePageSubRect], so the box always has the rendered region's
+ * aspect ratio — placing the (aspect-faithful) replacement bitmap here can never stretch
+ * it. `null` when the viewport sits entirely in the letterbox.
+ */
+internal fun visiblePageBoxOnScreen(
+    scale: Float,
+    offset: Offset,
+    slotSize: IntSize,
+    pageAspect: Float?,
+): ScreenBox? {
+    val r = visibleRegion(scale, offset, slotSize, pageAspect) ?: return null
+    // The visible window [visLeft, visTop, +visW, +visH] scales by `scale` to fill the
+    // slot, so a base-space point bx maps to screen (bx - visLeft) * scale.
+    return ScreenBox(
+        left = (r.ix0 - r.visLeft) * scale,
+        top = (r.iy0 - r.visTop) * scale,
+        width = (r.ix1 - r.ix0) * scale,
+        height = (r.iy1 - r.iy0) * scale,
+    )
+}
+
+internal data class ScreenBox(val left: Float, val top: Float, val width: Float, val height: Float)
 
 private data class PageRectInSlot(val left: Float, val top: Float, val width: Float, val height: Float)
 

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/DocumentSurfaceLockTest.kt
@@ -33,13 +33,14 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun documentViewHasExactlySixUserVisibleParameters() {
-        // (doc, pdfFile, renderer, modifier, telemetry, onOpenFullScreen). D5: still no
-        // flag to hide the trust caption. The sixth slot is the wpass-jil full-screen
-        // navigation callback with a `null` default — when null the banner is hidden,
-        // when non-null the banner appears and invokes the callback on tap. Bumping
-        // from 5 to 6 is the deliberate change for that issue, not a slip.
-        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 6)
+    fun documentViewHasExactlySevenUserVisibleParameters() {
+        // (doc, pdfFile, renderer, modifier, telemetry, onOpenFullScreen,
+        // fullScreenAffordance). D5: still no flag to hide the trust caption. The seventh
+        // slot is the wpass-emn host-supplied open-full-screen affordance composable — it
+        // restyles/places the open hint only and cannot touch the trust caption or the
+        // page tap target, so D5/D8 are unaffected. Bumping from 6 to 7 is the deliberate
+        // change for that slot, not a slip.
+        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 7)
     }
 
     @Test

--- a/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/internal/ZoomablePlacementTest.kt
+++ b/passes-pdf-ui/src/test/kotlin/is/walt/passes/pdf/ui/internal/ZoomablePlacementTest.kt
@@ -1,0 +1,89 @@
+package `is`.walt.passes.pdf.ui.internal
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the no-stretch invariant of the full-screen zoom path (`wpass-fdh`): the on-screen
+ * box the replacement bitmap is placed into ([visiblePageBoxOnScreen]) always has the
+ * same aspect ratio as the page region the renderer rasterised for it
+ * ([visiblePageSubRect]). Equal aspects mean no axis is ever independently scaled, so the
+ * page cannot display stretched at any zoom/pan — including when the viewport clamps
+ * against the page's letterbox edge, which was the bug's intermittent trigger.
+ */
+class ZoomablePlacementTest {
+
+    // Box aspect must equal the sub-rect's aspect expressed in page pixels:
+    //   (right-left)/(bottom-top) * pageAspect.
+    private fun assertBoxMatchesRegion(
+        scale: Float,
+        offset: Offset,
+        slotSize: IntSize,
+        pageAspect: Float?,
+    ) {
+        val box = visiblePageBoxOnScreen(scale, offset, slotSize, pageAspect)
+        val rect = visiblePageSubRect(scale, offset, slotSize, pageAspect)
+        assertThat(box).isNotNull()
+        val fallbackAspect = slotSize.width.toFloat() / slotSize.height.toFloat()
+        val regionAspectInPagePx =
+            (rect.right - rect.left) / (rect.bottom - rect.top) * (pageAspect ?: fallbackAspect)
+        assertThat(box!!.width / box.height)
+            .isWithin(0.01f)
+            .of(regionAspectInPagePx)
+    }
+
+    @Test
+    fun centredZoomOnSquareSlotMatchingPageHasNoStretch() {
+        assertBoxMatchesRegion(2f, Offset.Zero, IntSize(1000, 1000), pageAspect = 1f)
+    }
+
+    @Test
+    fun portraitPageZoomedAndPannedToLetterboxEdgeHasNoStretch() {
+        // The reported trigger: portrait page (aspect 0.7) in a square slot leaves side
+        // letterbox. Pan fully right at 2x so the left letterbox bar enters the viewport.
+        assertBoxMatchesRegion(2f, Offset(500f, 0f), IntSize(1000, 1000), pageAspect = 0.7f)
+    }
+
+    @Test
+    fun landscapePageZoomedAndPannedToTopEdgeHasNoStretch() {
+        assertBoxMatchesRegion(3f, Offset(0f, 700f), IntSize(1080, 1920), pageAspect = 1.4f)
+    }
+
+    @Test
+    fun nullPageAspectFallbackHasNoStretch() {
+        assertBoxMatchesRegion(2.5f, Offset(-200f, 100f), IntSize(1200, 800), pageAspect = null)
+    }
+
+    @Test
+    fun pannedToLetterboxEdgeProducesExpectedBoxGeometry() {
+        // Concrete numbers for the trigger case so a regression in the mapping (not just
+        // the aspect) is caught. Portrait page 0.7 in 1000x1000: pageRect x[150,850].
+        // scale 2, offsetX 500 -> visLeft 0, visible base x[0,500]; clamp to page ->
+        // ix[150,500]. Screen: left (150-0)*2=300, width (500-150)*2=700.
+        val box = visiblePageBoxOnScreen(2f, Offset(500f, 0f), IntSize(1000, 1000), pageAspect = 0.7f)!!
+        assertThat(box.left).isWithin(0.5f).of(300f)
+        assertThat(box.width).isWithin(0.5f).of(700f)
+        assertThat(box.top).isWithin(0.5f).of(0f)
+        assertThat(box.height).isWithin(0.5f).of(1000f)
+    }
+
+    @Test
+    fun viewportEntirelyInLetterboxYieldsNoBox() {
+        // A degenerate offset that places the visible window wholly in the side bar.
+        // Defensive: the production gate also requires scale > minScale, but the helper
+        // must report null rather than a zero/negative-area box.
+        val box = visiblePageBoxOnScreen(
+            scale = 10f,
+            offset = Offset(4500f, 0f),
+            slotSize = IntSize(1000, 1000),
+            pageAspect = 0.7f,
+        )
+        // Either null (no intersection) or a strictly positive-area box — never inverted.
+        if (box != null) {
+            assertThat(box.width).isGreaterThan(0f)
+            assertThat(box.height).isGreaterThan(0f)
+        }
+    }
+}

--- a/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
+++ b/passes-pdf/src/main/kotlin/is/walt/passes/pdf/android/PdfRendererService.kt
@@ -13,6 +13,7 @@ import android.system.OsConstants
 import `is`.walt.passes.pdf.DocumentRejectedKind
 import `is`.walt.passes.pdf.PdfImportConfig
 import java.io.IOException
+import kotlin.math.roundToInt
 
 /**
  * The isolated-process renderer service. Declared in this module's manifest with
@@ -101,6 +102,31 @@ internal suspend fun doRender(
     }
 }
 
+/**
+ * Output bitmap dimensions for a sub-rect render. The sub-rect is rasterised at a single
+ * uniform [scale] so the page region keeps its native aspect ratio; the output is the
+ * largest such bitmap fitting within the requested [maxWidthPx] x [maxHeightPx] bound
+ * (already clamped under the 4 MP cap by the caller). [widthPx] / [heightPx] therefore
+ * carry the region's own aspect, never the slot's — drawing them undistorted is what
+ * makes the wpass-fdh stretch impossible by construction.
+ */
+internal data class SubRectOutputDims(val widthPx: Int, val heightPx: Int, val scale: Float)
+
+internal fun subRectOutputDims(
+    sourceRect: RenderSourceRect.SubRect,
+    pageWidth: Int,
+    pageHeight: Int,
+    maxWidthPx: Int,
+    maxHeightPx: Int,
+): SubRectOutputDims {
+    val srcWidth = (sourceRect.right - sourceRect.left) * pageWidth
+    val srcHeight = (sourceRect.bottom - sourceRect.top) * pageHeight
+    val scale = minOf(maxWidthPx / srcWidth, maxHeightPx / srcHeight)
+    val w = (srcWidth * scale).roundToInt().coerceIn(1, maxWidthPx)
+    val h = (srcHeight * scale).roundToInt().coerceIn(1, maxHeightPx)
+    return SubRectOutputDims(w, h, scale)
+}
+
 // Strict ordering rules out zero-area rects (would produce a degenerate Matrix); the
 // unit-square bound keeps the consumer's failures visible instead of silently blank.
 internal fun isSourceRectValid(sourceRect: RenderSourceRect): Boolean =
@@ -143,20 +169,39 @@ private fun rasterise(
     heightPx: Int,
     sourceRect: RenderSourceRect,
 ): RenderResult.Ok {
-    val bitmap = Bitmap.createBitmap(widthPx, heightPx, Bitmap.Config.ARGB_8888)
+    // Output dimensions and transform both derive from the source rect. FullPage fills
+    // the requested bitmap (letterbox bars are the caller's eraseColor). SubRect sizes
+    // the bitmap to the region's own aspect ratio and scales it uniformly, so the page
+    // can never be stretched at the source (wpass-fdh).
+    val outWidth: Int
+    val outHeight: Int
+    val transform: Matrix
+    when (sourceRect) {
+        is RenderSourceRect.FullPage -> {
+            outWidth = widthPx
+            outHeight = heightPx
+            transform = fullPageMatrix(p.width, p.height, widthPx, heightPx)
+        }
+        is RenderSourceRect.SubRect -> {
+            val dims = subRectOutputDims(sourceRect, p.width, p.height, widthPx, heightPx)
+            outWidth = dims.widthPx
+            outHeight = dims.heightPx
+            transform = subRectMatrix(sourceRect, p.width, p.height, dims.scale)
+        }
+    }
+    val bitmap = Bitmap.createBitmap(outWidth, outHeight, Bitmap.Config.ARGB_8888)
     try {
         // PdfRenderer.Page.render() draws PDF content on top of existing pixels without
         // clearing them. Pages that rely on the implicit white page background otherwise
         // rasterise as content-on-transparent and compose against the host's dark surface,
         // hiding white-on-page artwork (GitHub #92: QR codes vanish in dark mode).
         bitmap.eraseColor(Color.WHITE)
-        val transform = matrixFor(sourceRect, p.width, p.height, widthPx, heightPx)
         p.render(bitmap, null, transform, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         val pageAspect = p.width.toFloat() / p.height.toFloat()
         return RenderResult.Ok(
-            sharedMemory = packIntoSharedMemory(bitmap, widthPx, heightPx),
-            widthPx = widthPx,
-            heightPx = heightPx,
+            sharedMemory = packIntoSharedMemory(bitmap, outWidth, outHeight),
+            widthPx = outWidth,
+            heightPx = outHeight,
             pageAspect = pageAspect,
         )
     } finally {
@@ -164,40 +209,38 @@ private fun rasterise(
     }
 }
 
-// FullPage: aspect-preserving fit (letterbox bars come from the caller's eraseColor),
-// matching the consumer's pageRectInSlot letterbox assumption. SubRect maps a unit-rect
-// of the page onto the full bitmap so zoomed regions stay sharp.
-private fun matrixFor(
-    sourceRect: RenderSourceRect,
+// Aspect-preserving fit of the whole page into the requested bitmap; letterbox bars come
+// from the caller's eraseColor, matching the consumer's pageRectInSlot assumption.
+private fun fullPageMatrix(pageWidth: Int, pageHeight: Int, widthPx: Int, heightPx: Int): Matrix {
+    val scale = minOf(
+        widthPx.toFloat() / pageWidth.toFloat(),
+        heightPx.toFloat() / pageHeight.toFloat(),
+    )
+    val dx = (widthPx - pageWidth * scale) / 2f
+    val dy = (heightPx - pageHeight * scale) / 2f
+    return Matrix().apply {
+        setScale(scale, scale)
+        postTranslate(dx, dy)
+    }
+}
+
+// Single uniform scale (the same factor on both axes) maps the sub-rect onto a bitmap
+// sized to the region's aspect ratio. The pre-wpass-fdh code scaled X and Y
+// independently to fill a fixed bitmap, which stretched the page whenever the visible
+// region's aspect differed from the requested bitmap's.
+private fun subRectMatrix(
+    sourceRect: RenderSourceRect.SubRect,
     pageWidth: Int,
     pageHeight: Int,
-    widthPx: Int,
-    heightPx: Int,
-): Matrix? =
-    when (sourceRect) {
-        is RenderSourceRect.FullPage -> {
-            val scale = minOf(
-                widthPx.toFloat() / pageWidth.toFloat(),
-                heightPx.toFloat() / pageHeight.toFloat(),
-            )
-            val dx = (widthPx - pageWidth * scale) / 2f
-            val dy = (heightPx - pageHeight * scale) / 2f
-            Matrix().apply {
-                setScale(scale, scale)
-                postTranslate(dx, dy)
-            }
-        }
-        is RenderSourceRect.SubRect -> {
-            val srcLeft = sourceRect.left * pageWidth
-            val srcTop = sourceRect.top * pageHeight
-            val srcWidth = (sourceRect.right - sourceRect.left) * pageWidth
-            val srcHeight = (sourceRect.bottom - sourceRect.top) * pageHeight
-            Matrix().apply {
-                setScale(widthPx / srcWidth, heightPx / srcHeight)
-                preTranslate(-srcLeft, -srcTop)
-            }
-        }
+    scale: Float,
+): Matrix {
+    val srcLeft = sourceRect.left * pageWidth
+    val srcTop = sourceRect.top * pageHeight
+    return Matrix().apply {
+        setScale(scale, scale)
+        preTranslate(-srcLeft, -srcTop)
     }
+}
 
 private fun packIntoSharedMemory(bitmap: Bitmap, widthPx: Int, heightPx: Int): SharedMemory {
     val byteCount = widthPx * heightPx * BYTES_PER_PIXEL

--- a/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/SubRectOutputDimsTest.kt
+++ b/passes-pdf/src/test/kotlin/is/walt/passes/pdf/android/SubRectOutputDimsTest.kt
@@ -1,0 +1,81 @@
+package `is`.walt.passes.pdf.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pins the uniform-scale contract of the sub-rect renderer (`wpass-fdh`). The output
+ * bitmap must carry the sub-rect's own page-pixel aspect ratio so the page is never
+ * stretched at the source. The pre-fix code scaled X and Y independently to fill a
+ * fixed bitmap; every assertion here would fail against that.
+ */
+class SubRectOutputDimsTest {
+
+    private fun assertAspectPreserved(
+        rect: RenderSourceRect.SubRect,
+        pageWidth: Int,
+        pageHeight: Int,
+        maxWidthPx: Int,
+        maxHeightPx: Int,
+    ) {
+        val dims = subRectOutputDims(rect, pageWidth, pageHeight, maxWidthPx, maxHeightPx)
+        val srcWidth = (rect.right - rect.left) * pageWidth
+        val srcHeight = (rect.bottom - rect.top) * pageHeight
+        // The defining no-stretch property: output aspect == region aspect (within the
+        // sub-pixel rounding of integer bitmap dimensions).
+        assertThat(dims.widthPx.toFloat() / dims.heightPx.toFloat())
+            .isWithin(0.02f)
+            .of(srcWidth / srcHeight)
+        // Never exceeds the requested bound (which the caller clamped under the 4 MP cap).
+        assertThat(dims.widthPx).isAtMost(maxWidthPx)
+        assertThat(dims.heightPx).isAtMost(maxHeightPx)
+        assertThat(dims.widthPx).isAtLeast(1)
+        assertThat(dims.heightPx).isAtLeast(1)
+    }
+
+    @Test
+    fun wideRegionOnSquarePagePreservesAspect() {
+        assertAspectPreserved(
+            RenderSourceRect.SubRect(0f, 0f, 1f, 0.5f),
+            pageWidth = 1000, pageHeight = 1000, maxWidthPx = 800, maxHeightPx = 800,
+        )
+    }
+
+    @Test
+    fun tallRegionOnSquarePagePreservesAspect() {
+        assertAspectPreserved(
+            RenderSourceRect.SubRect(0.25f, 0f, 0.5f, 1f),
+            pageWidth = 1000, pageHeight = 1000, maxWidthPx = 800, maxHeightPx = 800,
+        )
+    }
+
+    @Test
+    fun offCentreRegionOnPortraitPagePreservesAspect() {
+        assertAspectPreserved(
+            RenderSourceRect.SubRect(0.1f, 0.1f, 0.6f, 0.4f),
+            pageWidth = 850, pageHeight = 1100, maxWidthPx = 1080, maxHeightPx = 1920,
+        )
+    }
+
+    @Test
+    fun fullUnitRectMatchesPageAspect() {
+        assertAspectPreserved(
+            RenderSourceRect.SubRect(0f, 0f, 1f, 1f),
+            pageWidth = 850, pageHeight = 1100, maxWidthPx = 720, maxHeightPx = 1280,
+        )
+    }
+
+    @Test
+    fun outputFitsWithinBoundAndScaleIsUniform() {
+        // A region whose aspect forces the height bound to dominate; the chosen scale
+        // must size the width strictly within the slot, not stretch to fill it.
+        val dims = subRectOutputDims(
+            RenderSourceRect.SubRect(0.4f, 0f, 0.6f, 1f),
+            pageWidth = 1000, pageHeight = 1000, maxWidthPx = 800, maxHeightPx = 800,
+        )
+        // region 200x1000 (aspect 0.2): height-bound, so scale = 800/1000 = 0.8.
+        assertThat(dims.scale).isWithin(1e-4f).of(0.8f)
+        assertThat(dims.widthPx).isEqualTo(160)
+        assertThat(dims.heightPx).isEqualTo(800)
+    }
+}


### PR DESCRIPTION
Closes the two child beads of epic **wpass-qz2** (PDF detail + full-screen view improvements, Walt consumer request `wlt-cjv` / `wlt-o72`). Both surface in `passes-pdf` / `passes-pdf-ui`. The two design decisions were confirmed by the walt-android consumer team (slot-over-tokens for the affordance; full renderer+UI fix for the aspect bug).

## wpass-fdh (P1 bug) — full-screen PDF stretches beyond native aspect ratio when zoomed

**Root cause.** The full-screen zoom *replacement* path distorted the page. `PdfRendererService.matrixFor`'s `SubRect` branch scaled X and Y independently (`setScale(widthPx/srcWidth, heightPx/srcHeight)`) to fill a fixed bitmap, and `ZoomableImage` drew that replacement with `ContentScale.Fit` + `fillMaxSize()`. Whenever a pinch/pan clamped the visible window against the page's letterbox edge, the region's aspect diverged from the slot's and the page stretched. The base full-page render was already uniform, which is why the distortion was intermittent.

**Fix — stretching impossible by construction.**
- Renderer rasterises a sub-rect at a single **uniform** scale into a bitmap sized to the region's own aspect (`subRectOutputDims`), still within the 4 MP cap (ADR 0005 D7). The honest output dims flow back through the existing wire fields — no new attack surface or capability in the isolated process.
- `ZoomableImage` places the (now aspect-faithful) replacement at the on-screen box the region occupies (`visiblePageBoxOnScreen`) instead of filling the slot; `laneBackground` shows where the viewport extends past the page edge. A double-tap now also clears the stale sub-rect so it can't be shown against a changed transform.

## wpass-emn (P2) — full-screen open affordance not consumer-styleable

The affordance was a full-width, square-cornered text banner with only label + colours themeable, forcing consumers wanting a different register (Walt's centred rounded pill with a leading glyph) to suppress the kernel banner and lose the kernel-provided page tap target.

- Adds a `fullScreenAffordance` composable slot to `DocumentView`, mirroring `FullScreenDocumentView`'s `closeButton` slot. Host owns shape, corner radius, icon, label, padding; the kernel keeps the page tap target and the non-suppressible `DocumentTrustCaption`.
- The affordance floats over the bottom-centre of the page region (matching the requested design) rather than docking below it.
- Default renders the existing neutral banner, so label-and-colour-only consumers are unchanged. No new `DocumentSemantics` tokens (keeps the brand-visuals-via-slot convention).

## Trust surface
- `DocumentTrustCaption` remains non-suppressible; the affordance slot cannot touch it.
- No share / export / print / open-with affordance added.
- `DocumentView` parameter count bumps 6 → 7; `DocumentSurfaceLockTest` updated with rationale.

## Testing
- New JVM unit tests pin the no-stretch invariant on both sides: `SubRectOutputDimsTest` (renderer, uniform scale) and `ZoomablePlacementTest` (UI box aspect == rendered region aspect), including the letterbox-edge case that triggered the bug.
- `:passes-pdf` and `:passes-pdf-ui` unit tests + `detekt` pass; instrumented sources compile.
- Instrumented (`androidTest`) suites — including a new custom-affordance test and the existing pinch/zoom coverage — run on-device in CI (no local device available).

Beads: wpass-fdh, wpass-emn (children of wpass-qz2)
