### PR TITLE
ScannableCardScreen consumer-fit: showLabel param + bound white backing (wpass-1wu)

### DIFF
--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -1,12 +1,13 @@
 package `is`.walt.passes.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -21,39 +22,53 @@ import `is`.walt.passes.ui.core.isolated
 /**
  * Full-screen surface for scanning a [ScannableCard]. Wraps [ScannableCardView] with
  * minimal chrome: the user-controlled label up top (FSI/PDI isolated), the barcode
- * itself rendered at its full nominal size, and the non-suppressible
- * [ScannableCardTrustCaption] docked at the bottom.
+ * itself rendered at its full nominal size on a content-sized white backing, and the
+ * non-suppressible [ScannableCardTrustCaption] docked at the bottom.
+ *
+ * The white backing is sized to the code (plus a quiet-zone margin), not to the whole
+ * screen (wpass-1wu.2 / Walt wlt-n5z): the rest of the surface is transparent so the
+ * host's background shows through instead of a full white wash in a tall slot. ZXing
+ * bakes the scan quiet zone into the matrix (`ZxingBarcodeEncoder`), so scannability is
+ * preserved; [CODE_QUIET_ZONE] adds visual breathing room inside the card and the
+ * QR/1D `ContentScale` split in [ScannableCardView] is unchanged.
  *
  * Trust contract: the caption is composed unconditionally at the bottom of the screen
  * (C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`), structurally separate from any host
  * navigation chrome. There is no parameter, theme token, or overload that hides it.
+ * [showLabel] gates ONLY the top label `Text`; it cannot suppress the barcode, the
+ * payload caption, or the trust caption.
  *
  * No share / save-to-photos / print affordance, and no overflow menu. The user came
  * here to scan, then back out — those are the only two paths off this surface. Host
  * navigation chrome (back button, screen title) is supplied by the consumer's
  * scaffold; this composable is the body only.
+ *
+ * @param showLabel when false, the built-in label is not rendered. Defaults to true so
+ *   every existing caller is unchanged. Hosts that render their own title above this
+ *   surface (e.g. an editable self-title) pass false to avoid a duplicate (Walt wlt-tct).
  */
 @Composable
 public fun ScannableCardScreen(
     card: ScannableCard,
     modifier: Modifier = Modifier,
+    showLabel: Boolean = true,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surface),
+        modifier = modifier.fillMaxSize(),
     ) {
-        Text(
-            text = isolated(card.label),
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 16.dp),
-        )
+        if (showLabel) {
+            Text(
+                text = isolated(card.label),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
+            )
+        }
 
         Box(
             modifier = Modifier
@@ -62,14 +77,23 @@ public fun ScannableCardScreen(
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            // POS-scan fallback for GH #102; only the detail surface is large
-            // enough. A11y rationale lives on ScannableCardView.
-            ScannableCardView(
-                card = card,
-                showPayloadCaption = true,
-            )
+            Surface(
+                color = MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                // POS-scan fallback for GH #102; only the detail surface is large
+                // enough. A11y rationale lives on ScannableCardView.
+                ScannableCardView(
+                    card = card,
+                    showPayloadCaption = true,
+                    modifier = Modifier.padding(CODE_QUIET_ZONE),
+                )
+            }
         }
 
         ScannableCardTrustCaption(modifier = Modifier.fillMaxWidth())
     }
 }
+
+/** White-card padding around the code. The scan quiet zone is in the matrix; this is visual. */
+private val CODE_QUIET_ZONE = 16.dp

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -174,13 +174,17 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
-    fun scannableCardScreenHasExactlyTwoUserVisibleParameters() {
-        // (card, modifier). The trust caption is composed inside the surface; no
-        // parameter omits it.
+    fun scannableCardScreenHasExactlyThreeUserVisibleParameters() {
+        // (card, modifier, showLabel). `showLabel` (wpass-1wu.1 / Walt wlt-tct) gates
+        // ONLY the top label Text so a host rendering its own title avoids a duplicate;
+        // it cannot omit the barcode, the payload caption, or the bottom-docked
+        // non-suppressible ScannableCardTrustCaption (C2 in SCANNABLE_CARD_THREAT_MODEL.md).
+        // Adding a fourth parameter — anything that could hide the trust caption — would
+        // breach C2; review the threat model before changing this number.
         assertUserVisibleParamCount(
             "ScannableCardScreenKt",
             "ScannableCardScreen",
-            expected = 2,
+            expected = 3,
         )
     }
 

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -174,6 +174,31 @@ class ScannableCardTrustSurfaceTest {
     }
 
     @Test
+    fun fullScreenHidesLabelWhenShowLabelFalse() {
+        // wpass-1wu.1 / Walt wlt-tct: a host that renders its own title above the kernel
+        // surface passes showLabel = false to drop the duplicate built-in label.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(card = qrFixture(label = "Library card"), showLabel = false)
+            }
+        }
+        composeRule.onNodeWithText("⁨Library card⁩").assertDoesNotExist()
+    }
+
+    @Test
+    fun fullScreenShowLabelFalseStillRendersTrustAndPayloadCaptions() {
+        // showLabel gates ONLY the top label; it must NOT be able to suppress the
+        // bottom-docked non-suppressible trust caption (C2) or the payload caption.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(card = qrFixture(label = "Library card"), showLabel = false)
+            }
+        }
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
+    }
+
+    @Test
     fun placeholderUnverifiedArtifactStyleStillRendersCaption() {
         // PassesSemantics ships UnverifiedArtifactStyle.Placeholder so the surfaces
         // compose under a default-constructed semantics (tests / previews). Lock that


### PR DESCRIPTION
## Summary

Two consumer-fit UI adjustments to `passes-ui`'s full-screen `ScannableCardScreen`, surfaced by Walt's generated-code detail screen (android epic `wlt-u2b`). Tracked here as epic **wpass-1wu** with children wpass-1wu.1 and wpass-1wu.2; both land in this single PR.

The **trust contract is invariant**: `ScannableCardTrustCaption` stays bottom-docked and non-suppressible (C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`), and `ComposableSurfaceLockTest`'s parameter-surface assertion is updated in lockstep.

## wpass-1wu.1 — `showLabel` param (Walt wlt-tct)

`ScannableCardScreen` always rendered `card.label` above the barcode. Walt's generated-code detail screen renders its own **editable** self-title above the kernel surface, so the kernel label was a duplicate.

- Added `showLabel: Boolean = true`, gating **only** the top label `Text`.
- Default `true` keeps every existing caller unchanged; the consumer passes `showLabel = false`.
- `showLabel` **cannot** hide the barcode, the payload caption, or the trust caption.

## wpass-1wu.2 — bound the white backing to the code (Walt wlt-n5z)

The screen painted `.background(surface)` across the full `fillMaxSize` column, so in a tall slot a 240dp QR floated inside a large white field.

- The code now sits on a **content-sized rounded `Surface`** (white backing + quiet-zone padding); the rest of the surface is transparent so the host's brand gradient shows through.
- ZXing bakes the scan quiet zone into the matrix (`ZxingBarcodeEncoder`), so scannability is preserved. Barcode min sizes (`ScannableCardView.minRenderSizeDp`) and the QR/1D `ContentScale` split are unchanged.
- No new public parameter.

## Trust-contract / test changes

- `ComposableSurfaceLockTest`: `scannableCardScreen…` lock updated `2 → 3` user-visible params, with a comment pinning that a 4th param (anything that could hide the caption) breaches C2.
- `ScannableCardTrustSurfaceTest`: added `fullScreenHidesLabelWhenShowLabelFalse` and `fullScreenShowLabelFalseStillRendersTrustAndPayloadCaptions` — the latter pins that `showLabel = false` still renders the trust caption + payload caption.

## Two judgment calls for android-team review

1. **White-card corner shape**: used `RoundedCornerShape(16.dp)` + a 16dp internal quiet-zone margin so the card reads as intentional against a gradient. No theme token exists for this; happy to flatten or tokenize if preferred.
2. **Backing color**: kept `MaterialTheme.colorScheme.surface` (matches the original token) rather than forcing pure white. The barcode bitmap carries its own white background + ZXing quiet zone, so scannability does not depend on this; only the 16dp padding ring takes the `surface` color.

## Testing

- `./gradlew :passes-ui:testDebugUnitTest --tests ComposableSurfaceLockTest --tests ScannableCardTrustSurfaceTest` — green
- `./gradlew :passes-ui:detekt` — green
