### PR TITLE
Add :passes-barcode module + BarcodeImageDecoder facade (wpass-zrt.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,16 +10,17 @@ The trust claim: every security-and-privacy-critical behavior Walt makes about p
 
 ## Architecture Rules
 
-- Seven Gradle modules:
+- Eight Gradle modules:
   - `passes-core` — pure Kotlin/JVM. Parser, model, signature verifier, `.strings` parser, `TelemetryGuard` interface. NO Android framework dependencies.
   - `passes-pdf-core` — pure Kotlin/JVM. PdfDocument model, header sniffer, import config, `DocumentTelemetryGuard` interface. NO Android framework dependencies.
   - `passes-pdf` — Android-only. Isolated-process PDF renderer service (ADR 0005 D3). Wraps Android's `PdfRenderer` behind a hand-rolled binder with no extraction surface.
+  - `passes-barcode` — Android-only. Isolated-process barcode/QR-from-image decode service (wpass-zrt). `BarcodeImageDecoder` facade takes an image source over a bind, decodes inside a permissionless sandbox, and returns only `{payload, ScannableFormat}` (pure `BarcodeDecodeResult` from `passes-core`); never a Bitmap or source bytes. No classification/validation here.
   - `passes-storage` — Android-only. SQLCipher with Keystore-sourced key, Android Auto Backup exclusion, irreversible deletion logic.
   - `passes-ui-core` — Android + Compose. Tiny shared substrate for both UI modules: `ArgbColor`, `Color` conversion, the `isolated()` BiDi (FSI/PDI) helper. NO trust-claim-bearing surfaces of its own; existence is to keep `passes-ui` and `passes-pdf-ui` from depending on each other for these primitives.
   - `passes-ui` — Android + Compose. PKPASS surfaces only — pass front/back composables, B3 URL confirmation sheet, expired badge, bounded image rendering, `PassesTheme` / `PassesSemantics`. Themable via tokens passed in by the consumer.
   - `passes-pdf-ui` — Android + Compose. PDF-document surfaces only — `DocumentView`, `DocumentTile`, `DocumentsLane`, `DocumentTrustCaption`, `DocumentTheme` / `DocumentSemantics`. Depends on `passes-pdf` (for `PdfRendererBinder`) and `passes-pdf-core` (for `PdfDocument`); themed via its own sibling `LocalDocumentSemantics`, NOT through `PassesSemantics`.
 - `passes-core` and `passes-pdf-core` have NO Android framework dependencies (KMP-friendly).
-- `passes-storage`, `passes-pdf`, `passes-ui`, and `passes-pdf-ui` are independent peers (no edges among them at this level). The single permitted exception is `passes-pdf-ui → passes-pdf`, since the document-rendering surface needs `PdfRendererBinder` to take pages from.
+- `passes-storage`, `passes-pdf`, `passes-barcode`, `passes-ui`, and `passes-pdf-ui` are independent peers (no edges among them at this level). The single permitted exception is `passes-pdf-ui → passes-pdf`, since the document-rendering surface needs `PdfRendererBinder` to take pages from.
 - `passes-ui` and `passes-pdf-ui` both depend on `passes-ui-core`. Neither depends on the other.
 - DECISIVE CONSTRAINT: walt-android consumes this code directly; trust-claim-bearing logic lives ONLY here, never reimplemented in walt-android.
 

--- a/passes-barcode/build.gradle.kts
+++ b/passes-barcode/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    alias(libs.plugins.walt.passes.android.library)
+    alias(libs.plugins.walt.passes.quality)
+}
+
+android {
+    namespace = "is.walt.passes.barcode"
+}
+
+dependencies {
+    // Pure decode-result types (BarcodeDecodeResult, ScannableFormat) live in passes-core and
+    // are part of this module's public surface, so expose them transitively via `api`.
+    api(project(":passes-core"))
+    api(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.junit)
+
+    androidTestImplementation(libs.androidx.test.junit)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.truth)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
+}

--- a/passes-barcode/build.gradle.kts
+++ b/passes-barcode/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
 
 android {
     namespace = "is.walt.passes.barcode"
+
+    // Inject the module dir so ManifestPermissionsTest can resolve src/main/AndroidManifest.xml
+    // regardless of the JVM cwd (mirrors passes-pdf).
+    testOptions {
+        unitTests.all {
+            it.systemProperty("walt.passes.barcode.moduleDir", projectDir.absolutePath)
+        }
+    }
 }
 
 dependencies {

--- a/passes-barcode/consumer-rules.pro
+++ b/passes-barcode/consumer-rules.pro
@@ -1,0 +1,4 @@
+# Consumer ProGuard rules contributed by passes-barcode.
+# Empty for now: the decode facade is a plain Kotlin interface and the isolated decode
+# service (wpass-zrt.2) will be referenced by manifest entries AGP keeps automatically, so
+# R8 has no special-case stripping risk to head off here yet.

--- a/passes-barcode/src/main/AndroidManifest.xml
+++ b/passes-barcode/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  passes-barcode library manifest. Mirrors passes-pdf: this module hosts the kernel's
+  barcode/QR-from-image decode boundary (wpass-zrt). The isolated-process decode SERVICE
+  declaration lands with wpass-zrt.2, alongside the service class it names; declaring it
+  here before the class exists would fail manifest merging, so this skeleton manifest
+  carries only the security invariant it must never violate.
+
+  ZERO uses-permission entries by design, and it stays that way. The decode service that
+  arrives in wpass-zrt.2 runs android:isolatedProcess="true", android:exported="false",
+  inherits no app permissions, and reaches no Keystore/DPAN/card material. Adding any
+  uses-permission entry to this manifest is a security-policy change requiring re-review.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeImageDecoder.kt
@@ -1,0 +1,41 @@
+package `is`.walt.passes.barcode.android
+
+import android.content.Context
+import `is`.walt.passes.core.BarcodeDecodeResult
+
+/**
+ * The single consumer-facing entry point for decoding a barcode/QR from a user-picked static
+ * image (wpass-zrt). Analogue of [is.walt.passes.pdf.android.PdfImporter] for the decode
+ * boundary: it owns the trust-claim-bearing orchestration the consumer (walt-android) would
+ * otherwise have to reassemble — materializing the image across a bind into the isolated
+ * decode process, running a bounded codec + pure-JVM ZXing decode inside the sandbox, and
+ * returning only `{payload, format}`.
+ *
+ * Routing every decode through this seam is what keeps the repository's DECISIVE CONSTRAINT
+ * honest: the hostile-input boundary lives here, not parallel-implemented in walt-android.
+ * The facade returns no `Bitmap` and no source bytes, and does not classify or validate the
+ * payload — the consumer routes the returned payload through `passes-core`'s
+ * `QrPayloadClassifier` and `ScannableCardInputValidator`.
+ *
+ * The isolated decode service and its plumbing land in wpass-zrt.2–.4; this interface and its
+ * result contract ([BarcodeDecodeResult]) are the surface those beads fill in behind.
+ */
+public interface BarcodeImageDecoder {
+    /**
+     * Decode the first barcode found in [source]. Returns
+     * [BarcodeDecodeResult.DecodedBarcode] on success, [BarcodeDecodeResult.NoBarcodeFound]
+     * when the image decoded but held no recognizable symbol, or
+     * [BarcodeDecodeResult.DecodeFailed] folded onto a
+     * [is.walt.passes.core.DecodeFailureReason] at the first failing step. The isolated
+     * decode process is torn down before this method returns, regardless of outcome.
+     *
+     * The caller retains ownership of [source] and is responsible for closing any
+     * [ParcelFileDescriptor][android.os.ParcelFileDescriptor] it holds.
+     */
+    public suspend fun decode(source: BarcodeImageSource): BarcodeDecodeResult
+
+    public companion object {
+        public fun create(context: Context): BarcodeImageDecoder =
+            DefaultBarcodeImageDecoder(context.applicationContext)
+    }
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeImageSource.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeImageSource.kt
@@ -1,0 +1,33 @@
+package `is`.walt.passes.barcode.android
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+
+/**
+ * The two shapes a candidate image can enter the decoder in. Deliberately the same closed
+ * pair as [is.walt.passes.pdf.android.PdfImportSource]: every byte that reaches the isolated
+ * decode process is sourced from either an Android `ContentResolver` URI (the
+ * `ACTION_OPEN_DOCUMENT` / photo-picker path the walt-android consumer wires) or from a
+ * `ParcelFileDescriptor` the consumer has already opened.
+ *
+ * There is intentionally no `Path` / `File` / `ByteArray` arm. A path arm would let a future
+ * contributor route bytes from disk-cached locations the consumer never intended; a
+ * `ByteArray` arm would mean the hostile image had already been pulled into the caller's
+ * main-process heap before reaching the sandbox, defeating the whole isolation point. The
+ * image crosses to the decode process only as a file descriptor.
+ *
+ * Ownership: the caller retains ownership of the [ContentResolver], the [Uri], and any
+ * [ParcelFileDescriptor] passed in. The decoder reads from these but does not close them;
+ * closing remains the caller's responsibility once `decode` returns.
+ */
+public sealed interface BarcodeImageSource {
+    public class ContentUri(
+        public val uri: Uri,
+        public val resolver: ContentResolver,
+    ) : BarcodeImageSource
+
+    public class FileDescriptor(
+        public val pfd: ParcelFileDescriptor,
+    ) : BarcodeImageSource
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
@@ -15,6 +15,7 @@ import `is`.walt.passes.core.DecodeFailureReason
  * here replaces this single return; the public surface above does not change.
  */
 internal class DefaultBarcodeImageDecoder(
+    // held for the wpass-zrt.2 isolated-process bind
     @Suppress("unused") private val appContext: Context,
 ) : BarcodeImageDecoder {
     override suspend fun decode(source: BarcodeImageSource): BarcodeDecodeResult =

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
@@ -1,0 +1,22 @@
+package `is`.walt.passes.barcode.android
+
+import android.content.Context
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+
+/**
+ * Default [BarcodeImageDecoder]. Holds the application [Context] the isolated-process bind
+ * will need and owns the decode orchestration seam.
+ *
+ * The isolated decode service it binds to lands in wpass-zrt.2 (service + memfd/bind
+ * plumbing), with bounded codec decode in wpass-zrt.3 and ZXing decode in wpass-zrt.4. Until
+ * that service exists there is genuinely no decoder to bind, so [decode] reports
+ * [DecodeFailureReason.DecoderUnavailable] rather than fabricating a result. Wiring the bind
+ * here replaces this single return; the public surface above does not change.
+ */
+internal class DefaultBarcodeImageDecoder(
+    @Suppress("unused") private val appContext: Context,
+) : BarcodeImageDecoder {
+    override suspend fun decode(source: BarcodeImageSource): BarcodeDecodeResult =
+        BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable)
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ManifestPermissionsTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ManifestPermissionsTest.kt
@@ -1,0 +1,49 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.xml.sax.InputSource
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Pins the zero-permissions invariant on `passes-barcode`'s source manifest, making the
+ * manifest's headline security claim structural rather than aspirational (the same
+ * discipline [PublicApiSurfaceTest] applies to the facade surface). The decode service that
+ * lands in wpass-zrt.2 will run in an isolated process and inherit no app permissions; the
+ * value of that control depends entirely on this module never declaring a `uses-permission`
+ * entry, which manifest merging would otherwise fold into the consumer app's runtime set.
+ *
+ * The service-presence assertion is intentionally absent until wpass-zrt.2 adds the service
+ * (and its `isolatedProcess`/`exported` attributes) alongside the class it names; this test
+ * mirrors the zero-permission half of `passes-pdf`'s `ManifestPermissionsTest`.
+ *
+ * Parses the source manifest (not the merged one) because the source is the authoritative
+ * artifact this repository owns, and runs pure-JVM so a permission addition fails the local
+ * `./gradlew check` before CI or instrumentation can hide it.
+ */
+class ManifestPermissionsTest {
+    @Test
+    fun sourceManifestDeclaresZeroUsesPermission() {
+        val manifest = manifestFile()
+        assertThat(manifest.exists()).isTrue()
+
+        val factory = DocumentBuilderFactory.newInstance().apply { isNamespaceAware = true }
+        val doc = factory.newDocumentBuilder().parse(InputSource(manifest.inputStream()))
+
+        val usesPermission = doc.getElementsByTagNameNS(ANDROID_NS, "uses-permission")
+        assertThat(usesPermission.length).isEqualTo(0)
+
+        val anyUsesPermission = doc.getElementsByTagName("uses-permission")
+        assertThat(anyUsesPermission.length).isEqualTo(0)
+    }
+
+    private fun manifestFile(): File {
+        val moduleDir = System.getProperty("walt.passes.barcode.moduleDir") ?: "."
+        return File(moduleDir, "src/main/AndroidManifest.xml")
+    }
+
+    private companion object {
+        const val ANDROID_NS = "http://schemas.android.com/apk/res/android"
+    }
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/PublicApiSurfaceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/PublicApiSurfaceTest.kt
@@ -1,0 +1,109 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * Locks the public surface of the barcode decode facade (wpass-zrt.1), mirroring the
+ * allowlist discipline of `passes-pdf`'s `PublicApiSurfaceTest` and
+ * `ScannableCardSurfaceTest`. The facade's entire reason to exist is to be the *only* decode
+ * entry point; a reflection lock makes "exactly one decode method, returning only
+ * {payload, format}" structural rather than aspirational, so a future contributor cannot
+ * quietly grow the surface (e.g. a `decodeToBitmap`, a `lastImage`, a raw-bytes accessor)
+ * without tripping a test before review.
+ *
+ * Pure-JVM by construction: it reflects on shapes and exercises the pure result arms, and
+ * never constructs the Android-typed [BarcodeImageSource] arms, so it needs no Robolectric.
+ */
+class PublicApiSurfaceTest {
+    @Test
+    fun decoderHasExactlyDecode() {
+        val methodNames =
+            BarcodeImageDecoder::class
+                .java
+                .declaredMethods
+                .map { it.name.substringBefore('$') }
+                .toSet()
+        assertThat(methodNames).containsExactly("decode")
+    }
+
+    @Test
+    fun decodeTakesImageSourceAndIsSuspend() {
+        val decode =
+            BarcodeImageDecoder::class.java.declaredMethods.single { it.name == "decode" }
+        val params = decode.parameterTypes
+        assertThat(params).hasLength(2)
+        assertThat(params[0].name).isEqualTo("is.walt.passes.barcode.android.BarcodeImageSource")
+        // suspend fun adds the Continuation tail; its presence is what proves no synchronous
+        // side-channel return shape leaks.
+        assertThat(params[1].name).isEqualTo("kotlin.coroutines.Continuation")
+    }
+
+    @Test
+    fun createTakesContextAndReturnsDecoder() {
+        val create =
+            BarcodeImageDecoder.Companion::class.java.declaredMethods.single { it.name == "create" }
+        assertThat(create.parameterTypes.map { it.name })
+            .containsExactly("android.content.Context")
+        assertThat(create.returnType).isEqualTo(BarcodeImageDecoder::class.java)
+    }
+
+    @Test
+    fun imageSourceHasExactlyTwoArms() {
+        // Java reflection (not kotlin-reflect, which is off the test classpath): the two
+        // arms are declared as nested classes of the sealed interface.
+        val arms = BarcodeImageSource::class.java.declaredClasses.map { it.simpleName }.toSet()
+        assertThat(arms).containsExactly("ContentUri", "FileDescriptor")
+    }
+
+    @Test
+    fun decodeResultArmsAreReachableViaWhen() {
+        val results: List<BarcodeDecodeResult> =
+            listOf(
+                BarcodeDecodeResult.DecodedBarcode(payload = "X", format = ScannableFormat.Qr),
+                BarcodeDecodeResult.NoBarcodeFound,
+                BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable),
+            )
+        val branches =
+            results.map { result ->
+                when (result) {
+                    is BarcodeDecodeResult.DecodedBarcode -> "decoded"
+                    is BarcodeDecodeResult.NoBarcodeFound -> "none"
+                    is BarcodeDecodeResult.DecodeFailed -> "failed"
+                }
+            }
+        assertThat(branches).containsExactly("decoded", "none", "failed").inOrder()
+    }
+
+    @Test
+    fun decodedBarcodeReportsOnlyPayloadAndFormat() {
+        // The success arm carries exactly the two fields the trust claim permits — no Bitmap,
+        // no source bytes. Adding a third constructor parameter trips this lock.
+        val componentNames =
+            BarcodeDecodeResult.DecodedBarcode::class
+                .java
+                .declaredMethods
+                .map { it.name }
+                .filter { it.startsWith("component") }
+        assertThat(componentNames).hasSize(2)
+
+        val decoded = BarcodeDecodeResult.DecodedBarcode(payload = "PASS", format = ScannableFormat.Code128)
+        assertThat(decoded.payload).isEqualTo("PASS")
+        assertThat(decoded.format).isEqualTo(ScannableFormat.Code128)
+    }
+
+    @Test
+    fun decodeFailureReasonRosterIsPinned() {
+        assertThat(DecodeFailureReason.entries.map { it.name })
+            .containsExactly(
+                "SourceUnreadable",
+                "ImageDecodeFailed",
+                "ImageTooLarge",
+                "UnsupportedBarcodeFormat",
+                "DecoderUnavailable",
+            )
+    }
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
@@ -1,0 +1,60 @@
+package `is`.walt.passes.core
+
+/**
+ * The outcome of decoding a barcode/QR from a user-supplied static image (wpass-zrt). A pure
+ * model type so it lives in `passes-core` next to [ScannableFormat] and is reachable by both
+ * the Android decode facade (`:passes-barcode`) and any consumer branching on the result,
+ * without either depending on the other.
+ *
+ * Sealed for compile-time exhaustiveness, mirroring [ParseResult]. Two trust-claim
+ * invariants are encoded in the shape itself:
+ *
+ *  1. The decoder returns the payload FAITHFULLY and never auto-acts on it. Classification
+ *     and validation stay downstream in the consumer's call to [QrPayloadClassifier] and
+ *     `ScannableCardInputValidator`; nothing here interprets the bytes.
+ *  2. No arm carries a `Bitmap` or the source image bytes. The isolated decode process
+ *     (wpass-zrt.2) returns only `{payload, format}` over the binder — the hostile image
+ *     never crosses back into the caller's address space.
+ */
+public sealed interface BarcodeDecodeResult {
+    /**
+     * A single barcode was located and decoded. [payload] is the raw decoded string exactly
+     * as the symbol carried it; [format] is the symbology, constrained to the
+     * [ScannableFormat] roster Walt renders. A symbol decoded in a format outside that roster
+     * is reported as [DecodeFailed] with [DecodeFailureReason.UnsupportedBarcodeFormat], not
+     * forced into an ill-fitting arm.
+     */
+    public data class DecodedBarcode(
+        public val payload: String,
+        public val format: ScannableFormat,
+    ) : BarcodeDecodeResult
+
+    /** The image decoded cleanly but carried no barcode the decoder could locate. */
+    public data object NoBarcodeFound : BarcodeDecodeResult
+
+    /** Decoding could not complete; [reason] buckets the failure for telemetry. */
+    public data class DecodeFailed(public val reason: DecodeFailureReason) : BarcodeDecodeResult
+}
+
+/**
+ * Why a decode attempt failed, bucketed to the threat-model steps on wpass-zrt so telemetry
+ * can tell "we never read the file" from "the codec rejected it" from "the sandbox went
+ * away." Enum (not free text) keeps the surface enumerable and the telemetry cardinality
+ * bounded.
+ */
+public enum class DecodeFailureReason {
+    /** The image source could not be opened or read across the bind. */
+    SourceUnreadable,
+
+    /** The platform image codec could not decode the container into pixels. */
+    ImageDecodeFailed,
+
+    /** The image exceeded the bounded-decode dimension/megapixel/size caps (decompression-bomb guard). */
+    ImageTooLarge,
+
+    /** A symbol was found but its symbology is outside the [ScannableFormat] roster. */
+    UnsupportedBarcodeFormat,
+
+    /** The isolated decode process could not be bound or terminated before returning a result. */
+    DecoderUnavailable,
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ rootProject.name = "walt-passes-android"
 include(":passes-core")
 include(":passes-pdf-core")
 include(":passes-pdf")
+include(":passes-barcode")
 include(":passes-storage")
 include(":passes-ui-core")
 include(":passes-ui")


### PR DESCRIPTION
## What

Scaffolds the kernel-side barcode/QR-from-image decode boundary (epic **wpass-zrt**, task **wpass-zrt.1**) — the consumer-facing facade analogous to `PdfImporter.create()`, with the isolated decode service itself deferred to wpass-zrt.2–.4.

New Android-only **`:passes-barcode`** module mirroring `:passes-pdf`:

- **`BarcodeImageDecoder`** facade + `create(context)`; `suspend decode(source)` returns a sealed result.
- **`BarcodeImageSource`** sealed type (`ContentUri | FileDescriptor`) — same closed pair as `PdfImportSource`; the image crosses to the sandbox only as a file descriptor, never a `Path`/`File`/`ByteArray`.
- **`BarcodeDecodeResult`** (pure, in `passes-core`, reuses `ScannableFormat`): `DecodedBarcode(payload, format) | NoBarcodeFound | DecodeFailed(reason)`, with a `DecodeFailureReason` roster bucketed to the wpass-zrt threat model.
- **`DefaultBarcodeImageDecoder`** shell — returns `DecoderUnavailable` until the isolated service lands; the public surface does not change then.

## Trust-claim enforcement (structural, not aspirational)

- **`PublicApiSurfaceTest`** allowlist-locks the facade to exactly `decode()`, pins the source/result arms and failure roster, and asserts the success arm carries only `{payload, format}` — no `Bitmap`, no source bytes.
- **`ManifestPermissionsTest`** parses the source manifest and asserts zero `uses-permission` elements (zero-permission half of `passes-pdf`'s precedent; service-attribute half follows in wpass-zrt.2). Added in response to PR review.

## Docs / wiring

- `settings.gradle.kts` includes `:passes-barcode`; `CLAUDE.md` updated (seven → eight modules, added as an independent peer).

## Verification

`:passes-barcode:testDebugUnitTest`, `:passes-core:test`, `:passes-barcode:detekt`, `:passes-barcode:lintDebug` — all green.

## Not in scope (follow-on beads)

wpass-zrt.2 (isolatedProcess decode service + bind/memfd plumbing), .3 (bounded bitmap decode), .4 (pure-JVM ZXing decode), .5 (security suite), .6 (share plumbing with PDF render).