### PR TITLE
Bounded bitmap decode inside the barcode sandbox (wpass-zrt.3)

### DIFF
--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -24,47 +24,22 @@ internal data class BarcodeDecodeConfig(
     val allowedMimeTypes: Set<String> = DEFAULT_ALLOWED_MIME_TYPES,
 ) {
     companion object {
-        /**
-         * File-size cap on the compressed bytes read off the descriptor, mirroring
-         * `passes-storage`'s `DocumentBounds` / `PdfImportConfig` 25 MB. Bounds the only
-         * input a decompression bomb with *small* dimensions could weaponise (the
-         * dimension/area caps catch the small-file-huge-canvas shape; this catches the
-         * large-file shape).
-         */
+        /** Catches the large-file bomb shape; mirrors `PdfImportConfig` / storage's 25 MB. */
         const val DEFAULT_MAX_BYTES: Long = 25L * 1024 * 1024
 
-        /**
-         * Per-side pixel cap, checked from the header before allocation. A true
-         * decompression bomb advertises absurd dimensions (tens of thousands of px per
-         * side) in a tiny file; this fires on it instantly. Set well above any real
-         * card photo's longest edge.
-         */
+        /** Per-side header cap; a bomb advertising absurd dimensions trips it before allocation. */
         const val DEFAULT_MAX_DIMENSION_PX: Int = 12_000
 
         /**
-         * Total-pixel (megapixel) cap, checked from the header before allocation. At
-         * ARGB_8888 the backing bitmap is 4 bytes/px, so this bounds the largest allocation
-         * the decoder can be asked for to ~200 MB. Generous enough for high-resolution phone
-         * photos (~50 MP) yet a hard ceiling against a bomb that stays under [maxDimensionPx]
-         * on each axis but multiplies to a huge canvas. An image past this returns
-         * [is.walt.passes.core.DecodeFailureReason.ImageTooLarge].
+         * Megapixel header cap catching the small-file-huge-canvas bomb that stays under
+         * [maxDimensionPx] per axis. ~50 MP bounds the ARGB_8888 allocation to ~200 MB.
          */
         const val DEFAULT_MAX_AREA_PX: Long = 50_000_000L
 
-        /**
-         * Wall-clock budget for one decode, mirroring `PdfImportConfig`'s 5 s render
-         * timeout. On expiry [DecodeWatchdog] terminates the isolated process rather than
-         * let a slow/malicious descriptor block a sandbox binder thread indefinitely
-         * (the slow-loris follow-up flagged on wpass-zrt.3).
-         */
+        /** Decode wall-clock budget; on expiry [DecodeWatchdog] kills the sandbox (slow-loris guard). */
         const val DEFAULT_DECODE_TIMEOUT_MS: Long = 5_000L
 
-        /**
-         * Container allowlist, checked against the header's reported MIME type. Limited to
-         * the still-image formats a user-picked card photo realistically arrives in; an
-         * animated or exotic container outside this set is rejected before decode rather
-         * than handed to a wider swath of codec surface.
-         */
+        /** Still-image containers a card photo realistically arrives in; others are refused before decode. */
         val DEFAULT_ALLOWED_MIME_TYPES: Set<String> =
             setOf(
                 "image/jpeg",

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -1,0 +1,77 @@
+package `is`.walt.passes.barcode.android
+
+/**
+ * Defensive caps for the bounded image decode that runs inside the `:barcodeDecoder`
+ * sandbox (wpass-zrt.3). The image-codec step is the dominant RCE surface (CVE-2023-4863
+ * libwebp / CVE-2020-16010 class) and the decompression-bomb DoS surface, so every limit
+ * here is enforced *before* the platform decoder allocates a full-size bitmap.
+ *
+ * Layered the way `passes-pdf`'s `PdfImportConfig` is: [maxBytes] bounds the compressed
+ * bytes read off the descriptor before any decode; [maxDimensionPx] / [maxAreaPx] are
+ * checked from the decoded *header* (via `ImageDecoder.OnHeaderDecodedListener`) before the
+ * backing bitmap is allocated; [allowedMimeTypes] rejects containers outside the still-image
+ * roster at the same header step; [decodeTimeoutMs] is the watchdog budget that bounds a
+ * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]).
+ *
+ * Exposed as constants so tests and the service refer to the same numbers and changing a
+ * default is a deliberate, test-breaking edit.
+ */
+internal data class BarcodeDecodeConfig(
+    val maxBytes: Long = DEFAULT_MAX_BYTES,
+    val maxDimensionPx: Int = DEFAULT_MAX_DIMENSION_PX,
+    val maxAreaPx: Long = DEFAULT_MAX_AREA_PX,
+    val decodeTimeoutMs: Long = DEFAULT_DECODE_TIMEOUT_MS,
+    val allowedMimeTypes: Set<String> = DEFAULT_ALLOWED_MIME_TYPES,
+) {
+    companion object {
+        /**
+         * File-size cap on the compressed bytes read off the descriptor, mirroring
+         * `passes-storage`'s `DocumentBounds` / `PdfImportConfig` 25 MB. Bounds the only
+         * input a decompression bomb with *small* dimensions could weaponise (the
+         * dimension/area caps catch the small-file-huge-canvas shape; this catches the
+         * large-file shape).
+         */
+        const val DEFAULT_MAX_BYTES: Long = 25L * 1024 * 1024
+
+        /**
+         * Per-side pixel cap, checked from the header before allocation. A true
+         * decompression bomb advertises absurd dimensions (tens of thousands of px per
+         * side) in a tiny file; this fires on it instantly. Set well above any real
+         * card photo's longest edge.
+         */
+        const val DEFAULT_MAX_DIMENSION_PX: Int = 12_000
+
+        /**
+         * Total-pixel (megapixel) cap, checked from the header before allocation. At
+         * ARGB_8888 the backing bitmap is 4 bytes/px, so this bounds the largest allocation
+         * the decoder can be asked for to ~200 MB. Generous enough for high-resolution phone
+         * photos (~50 MP) yet a hard ceiling against a bomb that stays under [maxDimensionPx]
+         * on each axis but multiplies to a huge canvas. An image past this returns
+         * [is.walt.passes.core.DecodeFailureReason.ImageTooLarge].
+         */
+        const val DEFAULT_MAX_AREA_PX: Long = 50_000_000L
+
+        /**
+         * Wall-clock budget for one decode, mirroring `PdfImportConfig`'s 5 s render
+         * timeout. On expiry [DecodeWatchdog] terminates the isolated process rather than
+         * let a slow/malicious descriptor block a sandbox binder thread indefinitely
+         * (the slow-loris follow-up flagged on wpass-zrt.3).
+         */
+        const val DEFAULT_DECODE_TIMEOUT_MS: Long = 5_000L
+
+        /**
+         * Container allowlist, checked against the header's reported MIME type. Limited to
+         * the still-image formats a user-picked card photo realistically arrives in; an
+         * animated or exotic container outside this set is rejected before decode rather
+         * than handed to a wider swath of codec surface.
+         */
+        val DEFAULT_ALLOWED_MIME_TYPES: Set<String> =
+            setOf(
+                "image/jpeg",
+                "image/png",
+                "image/webp",
+                "image/heif",
+                "image/heic",
+            )
+    }
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
 
 /**
  * The isolated-process decode service (wpass-zrt.2) — THE security gate for hostile-image
@@ -25,22 +26,61 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  * to wander) and never through the caller's main-process heap. The bytes are read only
  * here, inside the sandbox.
  *
- * The actual bounded codec decode (wpass-zrt.3) and ZXing symbol decode (wpass-zrt.4) land
- * behind this surface. Until then [decode] closes the handed-over fd and returns the empty
- * arm, which exercises the full bind / PFD-handoff / teardown path without decoding any
- * bytes — the plumbing this bead delivers, proven without the decoder it hosts.
+ * The decode itself runs in two composed steps (see [doDecode]): the bounded codec decode
+ * (wpass-zrt.3) caps file size, container format, and canvas dimensions before the platform
+ * decoder allocates, under a [DecodeWatchdog] that kills the process on a slow/hung input;
+ * the symbol decode (wpass-zrt.4) reads the barcode off the produced bitmap. Only the pure
+ * `{payload, format}` result crosses back — the bitmap is recycled inside the sandbox.
  */
 public class BarcodeDecodeService : Service() {
+    private val config: BarcodeDecodeConfig = BarcodeDecodeConfig()
+    private val watchdog: DecodeWatchdog = DecodeWatchdog(config.decodeTimeoutMs)
+
     override fun onBind(intent: Intent): IBinder = BarcodeDecodeBinderProxy(buildImpl())
 
     private fun buildImpl(): BarcodeDecodeBinder =
         object : BarcodeDecodeBinder {
-            override suspend fun decode(image: ParcelFileDescriptor): BarcodeDecodeResult {
-                // wpass-zrt.3 (bounded bitmap decode) + wpass-zrt.4 (ZXing) replace this
-                // body with the real decode, which reads `image` before closing it. The
-                // stub closes the fd it owns so the round-trip path leaks nothing.
-                runCatching { image.close() }
-                return BarcodeDecodeResult.NoBarcodeFound
-            }
+            override suspend fun decode(image: ParcelFileDescriptor): BarcodeDecodeResult =
+                doDecode(image, config, watchdog, BarcodeSymbolDecoder.NotYetImplemented)
         }
 }
+
+/**
+ * One decode: read and bound-decode [image] to a bitmap under [watchdog], hand the bitmap to
+ * [symbolDecoder], recycle it, and close the descriptor. Top-level and seam-injected so the
+ * orchestration is unit-testable without a live isolated process; the production service
+ * passes [BarcodeDecodeConfig], a real [DecodeWatchdog], and the ZXing decoder. [boundedDecode]
+ * defaults to the real [decodeBoundedFromPfd]; tests substitute it so the orchestration runs
+ * without the platform image codec.
+ *
+ * Containment is total: a bounded-decode rejection becomes a [BarcodeDecodeResult.DecodeFailed]
+ * with the bucketed reason, and any Throwable that escapes the inner decode (the watchdog has
+ * already handled the *hang* case by killing the process) folds to
+ * [DecodeFailureReason.ImageDecodeFailed] rather than crashing the sandbox uncleanly. The
+ * descriptor is closed on every path. No payload, bytes, or image metadata is logged — the
+ * function emits nothing.
+ */
+internal suspend fun doDecode(
+    image: ParcelFileDescriptor,
+    config: BarcodeDecodeConfig,
+    watchdog: DecodeWatchdog,
+    symbolDecoder: BarcodeSymbolDecoder,
+    boundedDecode: (ParcelFileDescriptor, BarcodeDecodeConfig) -> BoundedDecodeResult = ::decodeBoundedFromPfd,
+): BarcodeDecodeResult =
+    try {
+        watchdog.guard {
+            when (val decoded = boundedDecode(image, config)) {
+                is BoundedDecodeResult.Rejected -> BarcodeDecodeResult.DecodeFailed(decoded.reason)
+                is BoundedDecodeResult.Decoded ->
+                    try {
+                        symbolDecoder.decode(decoded.bitmap)
+                    } finally {
+                        decoded.bitmap.recycle()
+                    }
+            }
+        }
+    } catch (_: Throwable) {
+        BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed)
+    } finally {
+        runCatching { image.close() }
+    }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -6,6 +6,7 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import `is`.walt.passes.core.BarcodeDecodeResult
 import `is`.walt.passes.core.DecodeFailureReason
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * The isolated-process decode service (wpass-zrt.2) — THE security gate for hostile-image
@@ -79,6 +80,9 @@ internal suspend fun doDecode(
                     }
             }
         }
+    } catch (e: CancellationException) {
+        // Never fold cancellation into a result — let structured concurrency unwind.
+        throw e
     } catch (_: Throwable) {
         BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed)
     } finally {

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeSymbolDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeSymbolDecoder.kt
@@ -1,0 +1,31 @@
+package `is`.walt.passes.barcode.android
+
+import android.graphics.Bitmap
+import `is`.walt.passes.core.BarcodeDecodeResult
+
+/**
+ * The symbol-decode step that runs on the bounded bitmap [BoundedBitmapDecoder] produced. Held
+ * as a seam so wpass-zrt.3 (this bead, the bounded codec decode) and wpass-zrt.4 (the pure-JVM
+ * ZXing symbol decode) compose without one re-touching the other: the service wires the
+ * bounded decode now and swaps [NotYetImplemented] for the ZXing implementation when .4 lands.
+ *
+ * Returns only a pure [BarcodeDecodeResult] — `{payload, format}`, a no-symbol marker, or a
+ * bucketed failure. The [Bitmap] never leaves the sandbox; nothing here may return it or its
+ * pixels.
+ */
+internal fun interface BarcodeSymbolDecoder {
+    fun decode(bitmap: Bitmap): BarcodeDecodeResult
+
+    companion object {
+        /**
+         * Stand-in until wpass-zrt.4 lands the real ZXing decode. A bitmap that decoded
+         * within the caps but has no symbology decoder behind it yet is reported as
+         * [BarcodeDecodeResult.NoBarcodeFound] — the image decoded cleanly, no barcode was
+         * located — which is exactly what a benign image with no barcode would return, so the
+         * arm is honest. The instrumented `benignQrDecodesToPayloadAndFormat` stays `@Ignore`d
+         * until .4 fills this in.
+         */
+        val NotYetImplemented: BarcodeSymbolDecoder =
+            BarcodeSymbolDecoder { BarcodeDecodeResult.NoBarcodeFound }
+    }
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
@@ -1,0 +1,139 @@
+package `is`.walt.passes.barcode.android
+
+import android.graphics.ImageDecoder
+import android.os.ParcelFileDescriptor
+import `is`.walt.passes.core.DecodeFailureReason
+import java.io.ByteArrayOutputStream
+import java.io.FileInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.nio.ByteBuffer
+
+/**
+ * Decodes a candidate image to a [Bitmap] *inside* the `:barcodeDecoder` sandbox with the
+ * wpass-zrt.3 caps applied before the platform decoder allocates a full-size bitmap. This is
+ * the dominant hostile-input surface (CVE-2023-4863 libwebp / CVE-2020-16010 class), so it
+ * runs only here — never in the caller's process — and every cap is a pre-allocation gate.
+ *
+ * The decode is the same `ImageDecoder` + `OnHeaderDecodedListener` lever `passes-ui`'s
+ * `BoundedImage` uses, but for analysis rather than display: `BoundedImage` is display-only
+ * and capped-raster, so its bitmap cannot be reused to find barcode pixels. The produced
+ * bitmap stays inside the sandbox; the ZXing symbol decode (wpass-zrt.4) consumes it here and
+ * only `{payload, format}` ever crosses back over the binder.
+ *
+ * Read [pfd] into a bounded byte array and decode it under [config]. The descriptor is read
+ * but not closed here — the service that owns the handed-over fd closes it. Pulling the
+ * compressed bytes into the sandbox heap is fine: isolation keeps them off the *caller's*
+ * heap, which is the trust claim; the file-size cap bounds how many can be read.
+ *
+ * Stays a top-level function (not a class) so its two phases are unit-testable without a live
+ * service: [readBoundedBytes] against a pipe, and [headerRejection] against the cap table.
+ */
+internal fun decodeBoundedFromPfd(
+    pfd: ParcelFileDescriptor,
+    config: BarcodeDecodeConfig,
+): BoundedDecodeResult {
+    val read =
+        runCatching {
+            FileInputStream(pfd.fileDescriptor).use { readBoundedBytes(it, config.maxBytes) }
+        }
+    val bytes = read.getOrNull()
+    return when {
+        read.isFailure -> BoundedDecodeResult.Rejected(DecodeFailureReason.SourceUnreadable)
+        bytes == null -> BoundedDecodeResult.Rejected(DecodeFailureReason.ImageTooLarge)
+        else -> decodeBoundedBitmap(bytes, config)
+    }
+}
+
+/**
+ * Read at most [maxBytes] from [input], returning null the moment the source exceeds the cap
+ * (a large-file decompression bomb) so no oversized buffer is ever fully read. Reads stop
+ * early on the first over-cap byte rather than draining the whole stream.
+ */
+internal fun readBoundedBytes(input: InputStream, maxBytes: Long): ByteArray? {
+    val out = ByteArrayOutputStream()
+    val buffer = ByteArray(DEFAULT_READ_CHUNK)
+    var total = 0L
+    while (true) {
+        val n = input.read(buffer)
+        if (n < 0) break
+        total += n
+        if (total > maxBytes) return null
+        out.write(buffer, 0, n)
+    }
+    return out.toByteArray()
+}
+
+/**
+ * The pure header-cap decision: given the container [mimeType] and decoded-but-not-allocated
+ * [width]/[height] reported to the `OnHeaderDecodedListener`, return the reason to reject, or
+ * null to proceed. Extracted from [decodeBoundedBitmap] so the cap math and the format
+ * allowlist are unit-testable without driving the platform decoder (whose native decode the
+ * JVM test runtime cannot exercise — that half is the instrumented suite, wpass-zrt.5).
+ *
+ * A container outside [BarcodeDecodeConfig.allowedMimeTypes] folds to
+ * [DecodeFailureReason.ImageDecodeFailed]: from the caller's view an unsupported container is
+ * simply one this decoder will not turn into pixels. Over-dimension or over-area folds to
+ * [DecodeFailureReason.ImageTooLarge] — the decompression-bomb bucket.
+ */
+internal fun headerRejection(
+    mimeType: String?,
+    width: Int,
+    height: Int,
+    config: BarcodeDecodeConfig,
+): DecodeFailureReason? =
+    when {
+        mimeType !in config.allowedMimeTypes -> DecodeFailureReason.ImageDecodeFailed
+        width > config.maxDimensionPx || height > config.maxDimensionPx -> DecodeFailureReason.ImageTooLarge
+        width.toLong() * height.toLong() > config.maxAreaPx -> DecodeFailureReason.ImageTooLarge
+        else -> null
+    }
+
+/**
+ * Decode [rawBytes] with the header-gate caps from [config]. The header listener fires before
+ * the backing bitmap is allocated, so a disallowed container or an over-cap canvas is
+ * rejected before the decoder commits memory. Full Throwable containment — including
+ * [OutOfMemoryError] — folds every escape to a [BoundedDecodeResult.Rejected]; this function
+ * never throws, so a hostile image can crash neither the sandbox cleanly nor (via the
+ * service's own containment) the caller.
+ *
+ * Visible-for-tests so the decompression-bomb, disallowed-format, and malformed-container
+ * cases assert on `BoundedDecodeResult` directly without binding the service.
+ */
+internal fun decodeBoundedBitmap(
+    rawBytes: ByteArray,
+    config: BarcodeDecodeConfig,
+): BoundedDecodeResult {
+    val source = ImageDecoder.createSource(ByteBuffer.wrap(rawBytes))
+    var rejection: DecodeFailureReason? = null
+    return try {
+        val bitmap =
+            ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+                rejection = headerRejection(info.mimeType, info.size.width, info.size.height, config)
+                if (rejection != null) {
+                    // Force a 1x1 decode so the rejected path allocates nothing of size; the
+                    // bitmap is discarded below.
+                    decoder.setTargetSize(1, 1)
+                }
+            }
+        rejection?.let {
+            bitmap.recycle()
+            BoundedDecodeResult.Rejected(it)
+        } ?: BoundedDecodeResult.Decoded(bitmap)
+    } catch (_: IOException) {
+        // Genuine parse failure, unless a bounds/format rejection was already in flight.
+        BoundedDecodeResult.Rejected(rejection ?: DecodeFailureReason.ImageDecodeFailed)
+    } catch (_: IllegalArgumentException) {
+        // setTargetSize(1, 1) can throw for formats that refuse arbitrary sizing; the
+        // rejection that triggered it already fired in the listener, so preserve it.
+        BoundedDecodeResult.Rejected(rejection ?: DecodeFailureReason.ImageDecodeFailed)
+    } catch (_: OutOfMemoryError) {
+        // A canvas that slipped the header caps (or a pathological parse) must not take the
+        // process down uncontained; bucket it as too-large.
+        BoundedDecodeResult.Rejected(rejection ?: DecodeFailureReason.ImageTooLarge)
+    } catch (_: RuntimeException) {
+        BoundedDecodeResult.Rejected(rejection ?: DecodeFailureReason.ImageDecodeFailed)
+    }
+}
+
+private const val DEFAULT_READ_CHUNK = 64 * 1024

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
@@ -4,7 +4,6 @@ import android.graphics.ImageDecoder
 import android.os.ParcelFileDescriptor
 import `is`.walt.passes.core.DecodeFailureReason
 import java.io.ByteArrayOutputStream
-import java.io.FileInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.nio.ByteBuffer
@@ -21,10 +20,11 @@ import java.nio.ByteBuffer
  * bitmap stays inside the sandbox; the ZXing symbol decode (wpass-zrt.4) consumes it here and
  * only `{payload, format}` ever crosses back over the binder.
  *
- * Read [pfd] into a bounded byte array and decode it under [config]. The descriptor is read
- * but not closed here — the service that owns the handed-over fd closes it. Pulling the
- * compressed bytes into the sandbox heap is fine: isolation keeps them off the *caller's*
- * heap, which is the trust claim; the file-size cap bounds how many can be read.
+ * Read [pfd] into a bounded byte array and decode it under [config]. The read goes through a
+ * `dup()` so the stream's `close()` releases only the duplicate and [pfd] survives for its
+ * single owner ([doDecode]) to close — the same idiom as the PDF importer, avoiding a
+ * double-close of the source fd. Pulling the compressed bytes into the sandbox heap is fine:
+ * isolation keeps them off the *caller's* heap; the file-size cap bounds how many can be read.
  *
  * Stays a top-level function (not a class) so its two phases are unit-testable without a live
  * service: [readBoundedBytes] against a pipe, and [headerRejection] against the cap table.
@@ -35,7 +35,7 @@ internal fun decodeBoundedFromPfd(
 ): BoundedDecodeResult {
     val read =
         runCatching {
-            FileInputStream(pfd.fileDescriptor).use { readBoundedBytes(it, config.maxBytes) }
+            ParcelFileDescriptor.AutoCloseInputStream(pfd.dup()).use { readBoundedBytes(it, config.maxBytes) }
         }
     val bytes = read.getOrNull()
     return when {
@@ -90,15 +90,10 @@ internal fun headerRejection(
     }
 
 /**
- * Decode [rawBytes] with the header-gate caps from [config]. The header listener fires before
- * the backing bitmap is allocated, so a disallowed container or an over-cap canvas is
- * rejected before the decoder commits memory. Full Throwable containment — including
- * [OutOfMemoryError] — folds every escape to a [BoundedDecodeResult.Rejected]; this function
- * never throws, so a hostile image can crash neither the sandbox cleanly nor (via the
- * service's own containment) the caller.
- *
- * Visible-for-tests so the decompression-bomb, disallowed-format, and malformed-container
- * cases assert on `BoundedDecodeResult` directly without binding the service.
+ * Decode [rawBytes] under the [headerRejection] caps, which fire before the backing bitmap is
+ * allocated. Full Throwable containment — including [OutOfMemoryError] — folds every escape to
+ * a [BoundedDecodeResult.Rejected]; this function never throws. The platform-decode integration
+ * is the instrumented half (wpass-zrt.5); the cap decision is unit-tested via [headerRejection].
  */
 internal fun decodeBoundedBitmap(
     rawBytes: ByteArray,

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedDecodeResult.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedDecodeResult.kt
@@ -1,0 +1,18 @@
+package `is`.walt.passes.barcode.android
+
+import android.graphics.Bitmap
+import `is`.walt.passes.core.DecodeFailureReason
+
+/**
+ * The outcome of the bounded codec decode (wpass-zrt.3): either a [Bitmap] that cleared every
+ * cap, or a bucketed rejection. Module-internal and never crosses the binder — the bitmap is
+ * consumed by the symbol decode and recycled inside the sandbox; only the pure
+ * `{payload, format}` of [is.walt.passes.core.BarcodeDecodeResult] crosses back.
+ */
+internal sealed interface BoundedDecodeResult {
+    /** The image decoded within all caps. The caller owns [bitmap] and must recycle it. */
+    data class Decoded(val bitmap: Bitmap) : BoundedDecodeResult
+
+    /** The image was rejected before or during decode; [reason] buckets it for telemetry. */
+    data class Rejected(val reason: DecodeFailureReason) : BoundedDecodeResult
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
@@ -1,0 +1,49 @@
+package `is`.walt.passes.barcode.android
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Timeout-then-kill for the bounded image decode, the barcode counterpart of `passes-pdf`'s
+ * `RenderWatchdog`. The decode path has two ways to hang indefinitely: a slow-loris
+ * descriptor handed across the bind (the read off the fd blocks while the synchronous binder
+ * transaction holds a sandbox binder thread — flagged on wpass-zrt.3), and a pathological
+ * container that sends the platform codec into a long parse. Either would starve the decode
+ * process without a hard wall-clock bound. On expiry the watchdog terminates the isolated
+ * process; the main process then observes the dropped binder as a
+ * [android.os.RemoteException] and surfaces
+ * [is.walt.passes.core.DecodeFailureReason.DecoderUnavailable].
+ *
+ * Killing the process (rather than cancelling the coroutine) is deliberate: coroutine
+ * cancellation is cooperative and only fires at suspension points, but the decode is a
+ * blocking read plus a synchronous `ImageDecoder` call with none. The kill timer is launched
+ * as a *sibling* of the guarded work — its own `delay` runs on the coroutine framework's
+ * timer and fires regardless of what the guarded block is doing, including blocking in a
+ * native frame. If the block returns first, the sibling timer is cancelled in the `finally`
+ * and no kill happens. The cost on expiry is one re-bind on the next decode, paid by the
+ * main process; the benefit is that no image can lock the decoder indefinitely.
+ *
+ * [killer] is injected so unit tests exercise the timeout path without taking down the test
+ * JVM. The default is [ProcessKiller.Real].
+ */
+internal class DecodeWatchdog(
+    private val timeoutMs: Long,
+    private val killer: ProcessKiller = ProcessKiller.Real,
+) {
+    suspend fun <T> guard(block: suspend () -> T): T =
+        coroutineScope {
+            val killerJob =
+                launch {
+                    delay(timeoutMs)
+                    killer.killSelf()
+                }
+            try {
+                withContext(Dispatchers.IO) { block() }
+            } finally {
+                killerJob.cancel()
+            }
+        }
+}

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ProcessKiller.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ProcessKiller.kt
@@ -1,0 +1,23 @@
+package `is`.walt.passes.barcode.android
+
+import android.os.Process
+
+/**
+ * Indirection over `Process.killProcess(Process.myPid())` so [DecodeWatchdog] is testable
+ * without taking down the test JVM. Production code uses [Real]; unit tests substitute a
+ * fake that records the kill and returns.
+ *
+ * A barcode-local copy of `passes-pdf`'s `ProcessKiller` rather than a shared type: the two
+ * isolated services are independent peers (only the bind/memfd plumbing is shared, via
+ * `passes-isolation`), and the kill is one line with no policy to centralise. `internal`
+ * because nothing outside this module references it.
+ */
+internal interface ProcessKiller {
+    fun killSelf()
+
+    object Real : ProcessKiller {
+        override fun killSelf() {
+            Process.killProcess(Process.myPid())
+        }
+    }
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -1,0 +1,134 @@
+package `is`.walt.passes.barcode.android
+
+import android.graphics.Bitmap
+import android.os.ParcelFileDescriptor
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+import `is`.walt.passes.core.ScannableFormat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Behavioural coverage for [doDecode], the service-side orchestration that composes the
+ * bounded codec decode (wpass-zrt.3) with the symbol decode (wpass-zrt.4). The bounded-decode
+ * step is injected so these run without the platform `ImageDecoder`; what they pin is the
+ * contract around it:
+ *
+ *  - a bounded-decode rejection maps to `DecodeFailed` with the same reason;
+ *  - a decoded bitmap is handed to the symbol decoder, and its result is returned;
+ *  - the bitmap is recycled inside the sandbox on every decoded path (it never crosses back);
+ *  - a Throwable from either the bounded decode or the symbol decode is contained as
+ *    `DecodeFailed(ImageDecodeFailed)` rather than escaping;
+ *  - the source descriptor is closed on every outcome.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class BarcodeDecodeServiceTest {
+    @Test
+    fun boundedRejectionMapsToDecodeFailedAndClosesPfd() = runTest {
+        val pfd = TrackingPfd(pipeReadEnd())
+
+        val result =
+            doDecode(pfd, config, watchdog, neverCalledSymbolDecoder()) { _, _ ->
+                BoundedDecodeResult.Rejected(DecodeFailureReason.ImageTooLarge)
+            }
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageTooLarge))
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
+    fun decodedBitmapGoesToSymbolDecoderAndIsRecycled() = runTest {
+        val pfd = TrackingPfd(pipeReadEnd())
+        val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+        val decoded = BarcodeDecodeResult.DecodedBarcode("PASS-9", ScannableFormat.Qr)
+
+        val result =
+            doDecode(pfd, config, watchdog, { decoded }) { _, _ ->
+                BoundedDecodeResult.Decoded(bitmap)
+            }
+
+        assertThat(result).isEqualTo(decoded)
+        assertThat(bitmap.isRecycled).isTrue()
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
+    fun cleanDecodeWithNoSymbolReturnsNoBarcodeFound() = runTest {
+        val pfd = TrackingPfd(pipeReadEnd())
+        val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+
+        val result =
+            doDecode(pfd, config, watchdog, BarcodeSymbolDecoder.NotYetImplemented) { _, _ ->
+                BoundedDecodeResult.Decoded(bitmap)
+            }
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+        assertThat(bitmap.isRecycled).isTrue()
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
+    fun symbolDecoderThrowIsContainedAndBitmapStillRecycled() = runTest {
+        val pfd = TrackingPfd(pipeReadEnd())
+        val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
+
+        val result =
+            doDecode(pfd, config, watchdog, { error("symbol decode blew up") }) { _, _ ->
+                BoundedDecodeResult.Decoded(bitmap)
+            }
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed))
+        assertThat(bitmap.isRecycled).isTrue()
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
+    fun boundedDecodeThrowIsContainedAndPfdClosed() = runTest {
+        val pfd = TrackingPfd(pipeReadEnd())
+
+        val result =
+            doDecode(pfd, config, watchdog, neverCalledSymbolDecoder()) { _, _ ->
+                error("codec blew up")
+            }
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed))
+        assertThat(pfd.closed).isTrue()
+    }
+
+    // --------------------------------------------------------------------- helpers
+
+    private val config = BarcodeDecodeConfig()
+
+    // Long timeout + recording killer: the fast test blocks never trip it, and it cannot
+    // take down the test JVM if they ever did.
+    private val watchdog = DecodeWatchdog(timeoutMs = 60_000L, killer = NoopKiller())
+
+    private fun neverCalledSymbolDecoder(): BarcodeSymbolDecoder =
+        BarcodeSymbolDecoder { error("symbol decoder must not be called on a rejected/failed decode") }
+
+    private fun pipeReadEnd(): ParcelFileDescriptor {
+        val pipe = ParcelFileDescriptor.createPipe()
+        runCatching { pipe[1].close() }
+        return pipe[0]
+    }
+
+    private class NoopKiller : ProcessKiller {
+        override fun killSelf() = Unit
+    }
+
+    /** Wraps a real PFD to record whether [doDecode] closed it in its `finally`. */
+    private class TrackingPfd(wrapped: ParcelFileDescriptor) : ParcelFileDescriptor(wrapped) {
+        var closed: Boolean = false
+            private set
+
+        override fun close() {
+            closed = true
+            super.close()
+        }
+    }
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -100,6 +100,23 @@ class BarcodeDecodeServiceTest {
         assertThat(pfd.closed).isTrue()
     }
 
+    @Test
+    fun decodeBoundedFromPfdRejectsOverSizeWithoutClosingSourcePfd() {
+        // Drives the real fd glue (dup + AutoCloseInputStream) the orchestration tests stub
+        // out. A tiny size cap trips ImageTooLarge before any ImageDecoder work, and the
+        // source PFD must survive — the read closes only its dup, leaving the single close to
+        // doDecode. Regresses the double-close footgun the dup idiom prevents.
+        val pipe = ParcelFileDescriptor.createPipe()
+        val readEnd = pipe[0]
+        ParcelFileDescriptor.AutoCloseOutputStream(pipe[1]).use { it.write(ByteArray(64)) }
+
+        val result = decodeBoundedFromPfd(readEnd, BarcodeDecodeConfig(maxBytes = 4))
+
+        assertThat(result).isEqualTo(BoundedDecodeResult.Rejected(DecodeFailureReason.ImageTooLarge))
+        assertThat(readEnd.fileDescriptor.valid()).isTrue()
+        readEnd.close()
+    }
+
     // --------------------------------------------------------------------- helpers
 
     private val config = BarcodeDecodeConfig()

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoderTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoderTest.kt
@@ -1,0 +1,106 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.DecodeFailureReason
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+/**
+ * Pins the two pure halves of the bounded decode (wpass-zrt.3): the file-size cap
+ * ([readBoundedBytes]) and the header-cap decision table ([headerRejection]). The platform
+ * `ImageDecoder` integration these feed — that the header listener fires before allocation and
+ * that OOM is contained — is the instrumented half (wpass-zrt.5); the policy that decides
+ * accept-vs-reject is exercised here on the JVM where it can be enumerated exhaustively.
+ */
+class BoundedBitmapDecoderTest {
+    // ------------------------------------------------------------------ size cap
+
+    @Test
+    fun readBoundedBytesReturnsAllBytesWhenUnderCap() {
+        val bytes = ByteArray(1000) { (it % 251).toByte() }
+
+        val read = readBoundedBytes(ByteArrayInputStream(bytes), maxBytes = 4096)
+
+        assertThat(read).isNotNull()
+        assertThat(read!!.toList()).isEqualTo(bytes.toList())
+    }
+
+    @Test
+    fun readBoundedBytesReturnsExactlyAtCapBoundary() {
+        val bytes = ByteArray(4096) { 1 }
+
+        val read = readBoundedBytes(ByteArrayInputStream(bytes), maxBytes = 4096)
+
+        assertThat(read).isNotNull()
+        assertThat(read!!.size).isEqualTo(4096)
+    }
+
+    @Test
+    fun readBoundedBytesRejectsOneByteOverCap() {
+        // A large-file decompression bomb: one byte past the cap fails the whole read.
+        val bytes = ByteArray(4097) { 1 }
+
+        val read = readBoundedBytes(ByteArrayInputStream(bytes), maxBytes = 4096)
+
+        assertThat(read).isNull()
+    }
+
+    @Test
+    fun readBoundedBytesHandlesEmptyStream() {
+        val read = readBoundedBytes(ByteArrayInputStream(ByteArray(0)), maxBytes = 4096)
+
+        assertThat(read).isNotNull()
+        assertThat(read!!.size).isEqualTo(0)
+    }
+
+    // ------------------------------------------------------------- header cap table
+
+    @Test
+    fun headerRejectionAcceptsAllowedFormatWithinCaps() {
+        assertThat(headerRejection("image/png", width = 1024, height = 768, config = config)).isNull()
+        assertThat(headerRejection("image/jpeg", width = 4000, height = 3000, config = config)).isNull()
+        assertThat(headerRejection("image/webp", width = 8000, height = 6000, config = config)).isNull()
+    }
+
+    @Test
+    fun headerRejectionRejectsDisallowedFormatAsImageDecodeFailed() {
+        // A container outside the still-image roster is one this decoder won't turn into
+        // pixels — bucketed as a decode failure, not a size failure.
+        assertThat(headerRejection("image/gif", width = 10, height = 10, config = config))
+            .isEqualTo(DecodeFailureReason.ImageDecodeFailed)
+        assertThat(headerRejection("image/svg+xml", width = 10, height = 10, config = config))
+            .isEqualTo(DecodeFailureReason.ImageDecodeFailed)
+        assertThat(headerRejection(null, width = 10, height = 10, config = config))
+            .isEqualTo(DecodeFailureReason.ImageDecodeFailed)
+    }
+
+    @Test
+    fun headerRejectionRejectsOverWideOrTallAsImageTooLarge() {
+        val overSide = config.maxDimensionPx + 1
+        assertThat(headerRejection("image/png", width = overSide, height = 10, config = config))
+            .isEqualTo(DecodeFailureReason.ImageTooLarge)
+        assertThat(headerRejection("image/png", width = 10, height = overSide, config = config))
+            .isEqualTo(DecodeFailureReason.ImageTooLarge)
+    }
+
+    @Test
+    fun headerRejectionRejectsOverAreaAsImageTooLarge() {
+        // The decompression-bomb shape that stays under the per-side cap but multiplies to a
+        // huge canvas: both sides legal, product over the megapixel cap.
+        val side = config.maxDimensionPx
+        assertThat(side.toLong() * side.toLong()).isGreaterThan(config.maxAreaPx)
+        assertThat(headerRejection("image/png", width = side, height = side, config = config))
+            .isEqualTo(DecodeFailureReason.ImageTooLarge)
+    }
+
+    @Test
+    fun headerRejectionFormatCheckPrecedesSizeCheck() {
+        // A disallowed format that is also over-cap reports the format reason; the allowlist
+        // is the first gate.
+        assertThat(
+            headerRejection("image/gif", width = config.maxDimensionPx + 1, height = 10, config = config),
+        ).isEqualTo(DecodeFailureReason.ImageDecodeFailed)
+    }
+
+    private val config = BarcodeDecodeConfig()
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DecodeWatchdogTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DecodeWatchdogTest.kt
@@ -1,0 +1,89 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+/**
+ * Pins the timeout-then-kill behaviour of [DecodeWatchdog], the only mechanism stopping a
+ * slow-loris descriptor or a hung codec parse from holding a sandbox binder thread forever.
+ * If the kill path silently regresses, the bounded-decode caps stop being load-bearing
+ * because an attacker can simply force a hang instead of an over-cap canvas.
+ *
+ * Two timeout shapes, mirroring `passes-pdf`'s `RenderWatchdogTest`:
+ *  - a cooperatively-suspending block (delay-based polling), and
+ *  - an uncancellable native-shape block ([Thread.sleep] polling).
+ *
+ * The second is the one that matters: the production read-off-the-fd + `ImageDecoder` call is
+ * a blocking sequence with no suspension points, so a `withTimeout`-based watchdog would never
+ * fire against it. The sibling-timer design fires regardless.
+ */
+class DecodeWatchdogTest {
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun timeoutFiresKillerForCooperativelySuspendingBlock() =
+        runBlocking {
+            val killer = RecordingKiller()
+            val watchdog = DecodeWatchdog(timeoutMs = TIMEOUT_MS, killer = killer)
+
+            val job =
+                launch {
+                    watchdog.guard {
+                        while (killer.killCount == 0) delay(POLL_MS)
+                    }
+                }
+            job.join()
+
+            assertThat(killer.killCount).isEqualTo(1)
+        }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun timeoutFiresKillerForUncancellableNativeShapedBlock() =
+        runBlocking {
+            val killer = RecordingKiller()
+            val watchdog = DecodeWatchdog(timeoutMs = TIMEOUT_MS, killer = killer)
+
+            val job =
+                launch {
+                    watchdog.guard {
+                        // Synchronous polling stands in for the uncancellable read + native
+                        // decode frame; the sibling timer fires regardless and we release
+                        // ourselves once the recorded kill is observed.
+                        while (killer.killCount == 0) Thread.sleep(POLL_MS)
+                    }
+                }
+            job.join()
+
+            assertThat(killer.killCount).isEqualTo(1)
+        }
+
+    @Test(timeout = TEST_TIMEOUT_MS)
+    fun fastPathDoesNotKill() =
+        runBlocking {
+            val killer = RecordingKiller()
+            val watchdog = DecodeWatchdog(timeoutMs = LONG_TIMEOUT_MS, killer = killer)
+
+            val result = watchdog.guard { "ok" }
+
+            assertThat(result).isEqualTo("ok")
+            assertThat(killer.killCount).isEqualTo(0)
+        }
+
+    private companion object {
+        const val TIMEOUT_MS = 50L
+        const val LONG_TIMEOUT_MS = 5_000L
+        const val POLL_MS = 5L
+        const val TEST_TIMEOUT_MS = 3_000L
+    }
+}
+
+private class RecordingKiller : ProcessKiller {
+    @Volatile
+    var killCount: Int = 0
+        private set
+
+    override fun killSelf() {
+        killCount += 1
+    }
+}


### PR DESCRIPTION
## wpass-zrt.3 — Bounded bitmap decode inside the barcode sandbox

Decodes the picked image to a bitmap **inside the `:barcodeDecoder` isolated process** with pre-allocation caps. The image-codec step is the dominant hostile-input RCE surface (CVE-2023-4863 libwebp / CVE-2020-16010 class) and the decompression-bomb DoS surface, so every cap is enforced before the platform decoder allocates a full-size bitmap.

### What landed (`:passes-barcode`)
- **`BarcodeDecodeConfig`** — file-size (25 MB), per-side dimension (12000 px), megapixel (50 MP), decode-timeout (5 s) caps + still-image MIME allowlist (jpeg/png/webp/heif/heic).
- **`BoundedBitmapDecoder`** — bounded read off a `dup()`'d fd (large-file bomb), then `ImageDecoder` with a header listener that rejects disallowed containers and over-cap canvases **before** allocation (same lever as `passes-ui` `BoundedImage`, for analysis not display). Full `Throwable` containment incl. `OutOfMemoryError`; never throws.
- **`DecodeWatchdog` + `ProcessKiller`** — timeout-then-kill analog of `passes-pdf`'s `RenderWatchdog`, bounding a slow-loris descriptor / hung codec parse (the slow-loris follow-up flagged in PR #123 review).
- **`BarcodeSymbolDecoder.NotYetImplemented`** — seam for the pure-JVM ZXing decode (wpass-zrt.4).
- **`BarcodeDecodeService`** wires read → bounded decode (under watchdog) → symbol decode → recycle bitmap → close fd, off-main-thread, no logging.

### Tests
JVM coverage for the size cap, the header-cap decision table, the watchdog kill path (incl. the uncancellable-block shape), the decode orchestration (containment + teardown), and the real fd glue (`dup` ownership / no double-close). detekt, ktlint, and lint pass. Public API surface unchanged (all new types `internal`).

### Boundaries
- A disallowed container maps to `ImageDecodeFailed` (no image-format arm in `DecodeFailureReason`); over-dimension/area maps to `ImageTooLarge`.
- On-device caps/bomb fixtures + CI device matrix to un-ignore the instrumented bomb assertion remain **wpass-zrt.5**.

### Review fixes (2nd commit)
- Read via `AutoCloseInputStream(pfd.dup())` so the source fd is closed exactly once (mirrors the PDF importer); fixes a double-close.
- Rethrow `CancellationException` ahead of the generic `Throwable` arm.
- Added the fd-path JVM test; trimmed KDoc that restated the code.
