### PR TITLE
Pure-JVM ZXing barcode symbol decode (wpass-zrt.4)

### DIFF
--- a/passes-barcode/build.gradle.kts
+++ b/passes-barcode/build.gradle.kts
@@ -27,6 +27,12 @@ dependencies {
     // module's public surface — so implementation, not api.
     implementation(project(":passes-isolation"))
 
+    // Pure-JVM symbol decode (wpass-zrt.4). com.google.zxing:core is Apache-2.0 and carries
+    // ZERO native attack surface — it runs only inside the isolated sandbox and never on the
+    // public surface, so implementation, not api. ML Kit was rejected (telemetry + Play
+    // Services dep); zxing-cpp stays a sandboxed contingency only.
+    implementation(libs.zxing.core)
+
     testImplementation(libs.junit)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -36,13 +36,14 @@ import kotlin.coroutines.cancellation.CancellationException
 public class BarcodeDecodeService : Service() {
     private val config: BarcodeDecodeConfig = BarcodeDecodeConfig()
     private val watchdog: DecodeWatchdog = DecodeWatchdog(config.decodeTimeoutMs)
+    private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder()
 
     override fun onBind(intent: Intent): IBinder = BarcodeDecodeBinderProxy(buildImpl())
 
     private fun buildImpl(): BarcodeDecodeBinder =
         object : BarcodeDecodeBinder {
             override suspend fun decode(image: ParcelFileDescriptor): BarcodeDecodeResult =
-                doDecode(image, config, watchdog, BarcodeSymbolDecoder.NotYetImplemented)
+                doDecode(image, config, watchdog, symbolDecoder)
         }
 }
 

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeSymbolDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeSymbolDecoder.kt
@@ -5,9 +5,9 @@ import `is`.walt.passes.core.BarcodeDecodeResult
 
 /**
  * The symbol-decode step that runs on the bounded bitmap [BoundedBitmapDecoder] produced. Held
- * as a seam so wpass-zrt.3 (this bead, the bounded codec decode) and wpass-zrt.4 (the pure-JVM
- * ZXing symbol decode) compose without one re-touching the other: the service wires the
- * bounded decode now and swaps [NotYetImplemented] for the ZXing implementation when .4 lands.
+ * as a seam so the bounded codec decode (wpass-zrt.3) and the symbol decode (wpass-zrt.4)
+ * compose without one re-touching the other, and so [doDecode]'s orchestration is testable
+ * with a stubbed decoder. Fulfilled by [ZxingBarcodeSymbolDecoder] (pure-JVM ZXing) since .4.
  *
  * Returns only a pure [BarcodeDecodeResult] — `{payload, format}`, a no-symbol marker, or a
  * bucketed failure. The [Bitmap] never leaves the sandbox; nothing here may return it or its
@@ -15,17 +15,4 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  */
 internal fun interface BarcodeSymbolDecoder {
     fun decode(bitmap: Bitmap): BarcodeDecodeResult
-
-    companion object {
-        /**
-         * Stand-in until wpass-zrt.4 lands the real ZXing decode. A bitmap that decoded
-         * within the caps but has no symbology decoder behind it yet is reported as
-         * [BarcodeDecodeResult.NoBarcodeFound] — the image decoded cleanly, no barcode was
-         * located — which is exactly what a benign image with no barcode would return, so the
-         * arm is honest. The instrumented `benignQrDecodesToPayloadAndFormat` stays `@Ignore`d
-         * until .4 fills this in.
-         */
-        val NotYetImplemented: BarcodeSymbolDecoder =
-            BarcodeSymbolDecoder { BarcodeDecodeResult.NoBarcodeFound }
-    }
 }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BoundedBitmapDecoder.kt
@@ -104,6 +104,9 @@ internal fun decodeBoundedBitmap(
     return try {
         val bitmap =
             ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+                // Software-backed so the symbol decode can read pixels; a hardware bitmap (the
+                // default) refuses getPixels. This bitmap is analysed, never displayed.
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
                 rejection = headerRejection(info.mimeType, info.size.width, info.size.height, config)
                 if (rejection != null) {
                     // Force a 1x1 decode so the rejected path allocates nothing of size; the

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
@@ -25,9 +25,10 @@ import `is`.walt.passes.core.ScannableFormat
  * Symbology ALLOWLIST, not "decode everything": [POSSIBLE_FORMATS] pins the reader to exactly
  * the [ScannableFormat] roster Walt renders. PDF417/Aztec and the rest are deliberately not
  * enabled — restricting the reader narrows both the work and the parser surface a hostile
- * image can reach. A symbol whose format somehow falls outside the roster maps to
- * [BarcodeDecodeResult.DecodeFailed] with [DecodeFailureReason.UnsupportedBarcodeFormat]
- * rather than being forced into an ill-fitting arm.
+ * image can reach. Because the reader can only return a format already in the allowlist, the
+ * out-of-roster [DecodeFailureReason.UnsupportedBarcodeFormat] arm is a defensive guard the
+ * pinned hints make unreachable in practice; it exists so a later hint change can't silently
+ * force an unsupported symbol into an ill-fitting result.
  *
  * The payload is returned FAITHFULLY and is never interpreted here — classification and
  * validation stay downstream in the consumer (`QrPayloadClassifier` / `ScannableCardInputValidator`).
@@ -63,6 +64,7 @@ internal fun decodeLuminance(source: LuminanceSource): BarcodeDecodeResult {
     return try {
         val result = MultiFormatReader().decode(binary, DECODE_HINTS)
         val format =
+            // Defensive guard: the pinned allowlist makes a non-roster format unreachable here.
             ROSTER_BY_ZXING_FORMAT[result.barcodeFormat]
                 ?: return BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.UnsupportedBarcodeFormat)
         BarcodeDecodeResult.DecodedBarcode(result.text, format)

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
@@ -1,0 +1,94 @@
+package `is`.walt.passes.barcode.android
+
+import android.graphics.Bitmap
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.LuminanceSource
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.NotFoundException
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.ReaderException
+import com.google.zxing.common.HybridBinarizer
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+import `is`.walt.passes.core.ScannableFormat
+
+/**
+ * The pure-JVM ZXing symbol decode (wpass-zrt.4): reads a barcode off the bounded bitmap
+ * [BoundedBitmapDecoder] produced and returns only `{payload, format}`. com.google.zxing:core
+ * is Apache-2.0 and 100% JVM, so it adds ZERO native attack surface — the deciding reason it
+ * is chosen over a native decoder (which would sit outside the JVM security model with full
+ * address-space access) and over ML Kit (telemetry + Play-Services dep). It still runs only
+ * inside the `:barcodeDecoder` sandbox; the [Bitmap] and its pixels never leave this process.
+ *
+ * Symbology ALLOWLIST, not "decode everything": [POSSIBLE_FORMATS] pins the reader to exactly
+ * the [ScannableFormat] roster Walt renders. PDF417/Aztec and the rest are deliberately not
+ * enabled — restricting the reader narrows both the work and the parser surface a hostile
+ * image can reach. A symbol whose format somehow falls outside the roster maps to
+ * [BarcodeDecodeResult.DecodeFailed] with [DecodeFailureReason.UnsupportedBarcodeFormat]
+ * rather than being forced into an ill-fitting arm.
+ *
+ * The payload is returned FAITHFULLY and is never interpreted here — classification and
+ * validation stay downstream in the consumer (`QrPayloadClassifier` / `ScannableCardInputValidator`).
+ */
+internal class ZxingBarcodeSymbolDecoder : BarcodeSymbolDecoder {
+    override fun decode(bitmap: Bitmap): BarcodeDecodeResult {
+        val width = bitmap.width
+        val height = bitmap.height
+        if (width <= 0 || height <= 0) return BarcodeDecodeResult.NoBarcodeFound
+        // Requires a software-backed bitmap; BoundedBitmapDecoder pins ALLOCATOR_SOFTWARE so
+        // getPixels never hits the hardware-bitmap path. A stray IllegalStateException here is
+        // still contained as a failed decode by the service's doDecode catch.
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        return decodeLuminance(RGBLuminanceSource(width, height, pixels))
+    }
+}
+
+/**
+ * Decode a single barcode from [source], constrained to the roster allowlist. Kept top-level
+ * and Bitmap-free so the decode contract — roster mapping, the no-symbol arm, and the
+ * exception buckets — is unit-testable on the JVM by round-tripping through ZXing's writer,
+ * without the platform image codec or a live device.
+ *
+ * A fresh [MultiFormatReader] per call keeps the decode one-shot and stateless (the sandbox
+ * handles one image per bind). [NotFoundException] — no locatable symbol — is the benign
+ * [BarcodeDecodeResult.NoBarcodeFound]; a [ReaderException] (checksum/format) means a
+ * symbol-like region was found but could not be decoded cleanly, reported honestly as
+ * no usable barcode rather than a fabricated payload.
+ */
+internal fun decodeLuminance(source: LuminanceSource): BarcodeDecodeResult {
+    val binary = BinaryBitmap(HybridBinarizer(source))
+    return try {
+        val result = MultiFormatReader().decode(binary, DECODE_HINTS)
+        val format =
+            ROSTER_BY_ZXING_FORMAT[result.barcodeFormat]
+                ?: return BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.UnsupportedBarcodeFormat)
+        BarcodeDecodeResult.DecodedBarcode(result.text, format)
+    } catch (_: NotFoundException) {
+        BarcodeDecodeResult.NoBarcodeFound
+    } catch (_: ReaderException) {
+        BarcodeDecodeResult.NoBarcodeFound
+    }
+}
+
+/** The symbology allowlist: ZXing format → the [ScannableFormat] Walt renders. */
+private val ROSTER_BY_ZXING_FORMAT: Map<BarcodeFormat, ScannableFormat> =
+    mapOf(
+        BarcodeFormat.CODE_128 to ScannableFormat.Code128,
+        BarcodeFormat.EAN_13 to ScannableFormat.Ean13,
+        BarcodeFormat.UPC_A to ScannableFormat.UpcA,
+        BarcodeFormat.CODE_39 to ScannableFormat.Code39,
+        BarcodeFormat.QR_CODE to ScannableFormat.Qr,
+    )
+
+/**
+ * POSSIBLE_FORMATS pins the reader to the roster allowlist; TRY_HARDER trades a little CPU
+ * (already bounded by the [DecodeWatchdog]) for a better hit rate on photographed cards.
+ */
+private val DECODE_HINTS: Map<DecodeHintType, Any> =
+    mapOf(
+        DecodeHintType.POSSIBLE_FORMATS to ROSTER_BY_ZXING_FORMAT.keys.toList(),
+        DecodeHintType.TRY_HARDER to true,
+    )

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -63,7 +63,7 @@ class BarcodeDecodeServiceTest {
         val bitmap = Bitmap.createBitmap(2, 2, Bitmap.Config.ARGB_8888)
 
         val result =
-            doDecode(pfd, config, watchdog, BarcodeSymbolDecoder.NotYetImplemented) { _, _ ->
+            doDecode(pfd, config, watchdog, { BarcodeDecodeResult.NoBarcodeFound }) { _, _ ->
                 BoundedDecodeResult.Decoded(bitmap)
             }
 

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoderTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoderTest.kt
@@ -1,0 +1,108 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.RGBLuminanceSource
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * Pins the pure-JVM ZXing decode contract (wpass-zrt.4) without a device or the platform image
+ * codec: [decodeLuminance] takes a `LuminanceSource`, so each roster symbology is round-tripped
+ * by ENCODING it with ZXing's own [MultiFormatWriter] and decoding the result back. This is the
+ * exact pixel→symbol path the on-device decode runs minus the `Bitmap` glue (which is the
+ * instrumented half, wpass-zrt.5).
+ *
+ * What these assert:
+ *  - every [ScannableFormat] in the roster decodes back to its payload + format faithfully;
+ *  - the symbology allowlist holds — a format OUTSIDE the roster (PDF417) is not decoded;
+ *  - a clean image with no symbol is the honest [BarcodeDecodeResult.NoBarcodeFound].
+ */
+class ZxingBarcodeSymbolDecoderTest {
+    @Test
+    fun qrPayloadRoundTripsFaithfully() {
+        val source = encode("WALT-PASS-9", BarcodeFormat.QR_CODE, 320, 320)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-PASS-9", ScannableFormat.Qr))
+    }
+
+    @Test
+    fun code128RoundTrips() {
+        val source = encode("LOYALTY-ABC-123", BarcodeFormat.CODE_128, 600, 200)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("LOYALTY-ABC-123", ScannableFormat.Code128))
+    }
+
+    @Test
+    fun code39RoundTrips() {
+        val source = encode("MEMBER39", BarcodeFormat.CODE_39, 600, 200)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("MEMBER39", ScannableFormat.Code39))
+    }
+
+    @Test
+    fun ean13RoundTrips() {
+        // A valid 13-digit EAN-13 (trailing check digit included).
+        val source = encode("5901234123457", BarcodeFormat.EAN_13, 600, 200)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("5901234123457", ScannableFormat.Ean13))
+    }
+
+    @Test
+    fun upcaRoundTrips() {
+        // A valid 12-digit UPC-A.
+        val source = encode("036000291452", BarcodeFormat.UPC_A, 600, 200)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("036000291452", ScannableFormat.UpcA))
+    }
+
+    @Test
+    fun formatOutsideRosterIsNotDecoded() {
+        // PDF417 is intentionally absent from the v1 roster. With POSSIBLE_FORMATS pinned to
+        // the allowlist, the reader never tries a PDF417 decoder, so a genuine PDF417 symbol
+        // reads as no locatable barcode — proving the allowlist, not blind decode-everything.
+        val source = encode("BOARDING-PASS-PAYLOAD", BarcodeFormat.PDF_417, 600, 300)
+
+        assertThat(decodeLuminance(source)).isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+    }
+
+    @Test
+    fun blankImageReturnsNoBarcodeFound() {
+        val white = IntArray(120 * 120) { 0xFFFFFFFF.toInt() }
+
+        assertThat(decodeLuminance(RGBLuminanceSource(120, 120, white)))
+            .isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+    }
+
+    /** Encode [content] as [format] with ZXing's writer and expose it as a [RGBLuminanceSource]. */
+    private fun encode(
+        content: String,
+        format: BarcodeFormat,
+        width: Int,
+        height: Int,
+    ): RGBLuminanceSource {
+        val matrix = MultiFormatWriter().encode(content, format, width, height)
+        val w = matrix.width
+        val h = matrix.height
+        val pixels = IntArray(w * h)
+        for (y in 0 until h) {
+            val row = y * w
+            for (x in 0 until w) {
+                pixels[row + x] = if (matrix.get(x, y)) BLACK else WHITE
+            }
+        }
+        return RGBLuminanceSource(w, h, pixels)
+    }
+
+    private companion object {
+        const val BLACK = 0xFF000000.toInt()
+        const val WHITE = 0xFFFFFFFF.toInt()
+    }
+}


### PR DESCRIPTION
## Summary

Lands the symbol-decode step of the isolated barcode decode epic (wpass-zrt.4). Fills the `BarcodeSymbolDecoder` seam that wpass-zrt.3 left open, completing the codec→symbol path inside the `:barcodeDecoder` sandbox.

- New internal `ZxingBarcodeSymbolDecoder` backed by **`com.google.zxing:core`** (Apache-2.0, **zero native attack surface** — the deciding reason over a native decoder or ML Kit, which carries telemetry + a Play-Services dep and breaks the degoogled walt.is channel). zxing-cpp stays a sandboxed contingency only.
- **Symbology allowlist, not decode-everything**: `POSSIBLE_FORMATS` is pinned to exactly the `ScannableFormat` roster (Code128 / Ean13 / UpcA / Code39 / Qr). PDF417/Aztec et al. are not enabled; a format somehow outside the roster folds to `DecodeFailed(UnsupportedBarcodeFormat)`.
- Payload is returned **faithfully** and never interpreted here — classification/validation stay downstream in the consumer (`QrPayloadClassifier` / `ScannableCardInputValidator`).
- `BoundedBitmapDecoder` now pins `ALLOCATOR_SOFTWARE` so the analysed bitmap is pixel-readable (the default hardware bitmap refuses `getPixels`). The bitmap is analysed, never displayed, and never crosses the binder.
- Removed the `NotYetImplemented` placeholder now that the real decoder is wired into `BarcodeDecodeService`.

## Tests

`decodeLuminance` is `Bitmap`-free, so the decode contract is exercised purely on the JVM by round-tripping through ZXing's own `MultiFormatWriter`:
- all 5 roster formats encode→decode back to the exact `{payload, format}`;
- a genuine PDF417 symbol reads as `NoBarcodeFound` — proving the allowlist;
- a blank image returns `NoBarcodeFound`.

`./gradlew :passes-barcode:check` is green (unit tests, ktlint, detekt, Android lint).

## Out of scope (follow-ups)

- The instrumented on-device decode (`benignQrDecodesToPayloadAndFormat`) stays `@Ignore`d pending fixtures + the `:passes-barcode` device CI matrix — owned by **wpass-zrt.5** (security suite), which gates the epic ship.
- License/advisory note: `com.google.zxing:core` is Apache-2.0; no open advisory for the pure-JVM core at 3.5.4.