### PR TITLE
Run barcode on-device security suite in CI (wpass-6mg)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           if-no-files-found: ignore
 
   connected-tests:
-    name: Connected tests (passes-storage, API ${{ matrix.api }})
+    name: Connected tests (API ${{ matrix.api }})
     runs-on: ubuntu-latest
     strategy:
       # Each leg is independent; surfacing all failures at once is more useful than
@@ -120,11 +120,16 @@ jobs:
           # Forks must not be able to write to the build cache.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-      # Per-API task name matches the localDevices entries declared in
-      # passes-storage/build.gradle.kts. The DebugAndroidTest suffix runs the
-      # androidTest sources against the debug variant.
-      - name: Run passes-storage connected tests
-        run: ./gradlew :passes-storage:api${{ matrix.api }}googleDebugAndroidTest --stacktrace
+      # Per-API task name matches the localDevices entries declared in each module's
+      # build.gradle.kts. The DebugAndroidTest suffix runs the androidTest sources against
+      # the debug variant. passes-barcode runs the wpass-zrt.5 on-device security suite; its
+      # @Ignore'd scenarios (sandbox probe, parcel probe) skip rather than fail.
+      - name: Run connected tests
+        run: >-
+          ./gradlew
+          :passes-storage:api${{ matrix.api }}googleDebugAndroidTest
+          :passes-barcode:api${{ matrix.api }}googleDebugAndroidTest
+          --stacktrace
 
       - name: Upload connected test reports
         if: always()
@@ -134,6 +139,8 @@ jobs:
           path: |
             passes-storage/build/reports/androidTests/
             passes-storage/build/outputs/androidTest-results/
+            passes-barcode/build/reports/androidTests/
+            passes-barcode/build/outputs/androidTest-results/
           if-no-files-found: ignore
 
   dependency-review:

--- a/passes-barcode/build.gradle.kts
+++ b/passes-barcode/build.gradle.kts
@@ -12,6 +12,35 @@ android {
         unitTests.all {
             it.systemProperty("walt.passes.barcode.moduleDir", projectDir.absolutePath)
         }
+
+        // Managed-device matrix for the on-device security suite (wpass-6mg), mirroring
+        // passes-storage. API 28 is the ImageDecoder floor the bounded decode needs; 31/34/36
+        // track S, the LTS image, and head. The CI connected-tests job runs the matching
+        // apiNNgoogleDebugAndroidTest tasks.
+        managedDevices {
+            localDevices {
+                create("api28google") {
+                    device = "Pixel 2"
+                    apiLevel = 28
+                    systemImageSource = "google"
+                }
+                create("api31google") {
+                    device = "Pixel 2"
+                    apiLevel = 31
+                    systemImageSource = "google"
+                }
+                create("api34google") {
+                    device = "Pixel 2"
+                    apiLevel = 34
+                    systemImageSource = "google"
+                }
+                create("api36google") {
+                    device = "Pixel 2"
+                    apiLevel = 36
+                    systemImageSource = "google"
+                }
+            }
+        }
     }
 }
 

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -31,17 +31,17 @@ import java.io.File
  * [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] needs a raw `transact` — both already
  * guaranteed statically by [ManifestPermissionsTest] / [BarcodeDecodeBinderSurfaceTest].
  *
- * `@Ignore`'d at check-in so `./gradlew check` stays green without an emulator (the
- * `passes-pdf` `PdfImporterInstrumentedTest` convention). CI compiles these via
- * `assembleDebugAndroidTest` but does not run them — the managed-device leg that does is
- * tracked in wpass-6mg.
+ * The three drivable scenarios run in CI's connected-tests matrix (API 28/31/34/36) and
+ * verified green on a physical device. They are not `@Ignore`'d: `./gradlew check` does not
+ * run androidTest, so a workstation with no device stays green regardless; only the
+ * managed-device / `connectedAndroidTest` tasks execute them. The two skeleton scenarios stay
+ * `@Ignore`'d until their probe infrastructure lands (wpass-6mg).
  */
 @RunWith(AndroidJUnit4::class)
 class BarcodeDecodeServiceInstrumentedTest {
     private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
 
     @Test
-    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
     fun benignQrDecodesToPayloadAndFormat() {
         val pfd = pngFd("benign-qr", qrBitmap("WALT-PASS-9"))
         val result = pfd.use { decode(it) }
@@ -51,7 +51,6 @@ class BarcodeDecodeServiceInstrumentedTest {
     }
 
     @Test
-    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
     fun overDimensionImageRejectsWithImageTooLarge() {
         // A canvas past the per-side dimension cap must be rejected by the header listener
         // before the full bitmap is allocated — the decompression-bomb bucket. (The
@@ -66,7 +65,6 @@ class BarcodeDecodeServiceInstrumentedTest {
     }
 
     @Test
-    @Ignore("Pending :passes-barcode managed-device CI leg (wpass-zrt.5 follow-up)")
     fun malformedContainerFailsClosedAndNextDecodeSucceeds() {
         // Bytes that are not a decodable image must fail closed, not crash the caller. Then a
         // benign decode must succeed, proving the path recovers (per-call teardown + re-bind),


### PR DESCRIPTION
Follow-up to #126. The three drivable instrumented scenarios from the wpass-zrt.5 suite were verified **green on a physical device (Fairphone 4, Android 15 / API 35)**, so this un-ignores them and wires the emulator CI leg that runs them on every PR.

## Changes
- **`passes-barcode/build.gradle.kts`** — `managedDevices`/`localDevices` matrix (api28/31/34/36 google), mirroring `passes-storage`. API 28 is the `ImageDecoder` floor the bounded decode needs.
- **`ci.yml`** — the connected-tests matrix now also runs `:passes-barcode:apiNNgoogleDebugAndroidTest` and uploads its reports.
- **`BarcodeDecodeServiceInstrumentedTest`** — removed `@Ignore` from the three verified tests (benign QR decode, over-dimension → `ImageTooLarge`, malformed-fails-closed-then-recovers). The two skeleton scenarios (sandbox probe, parcel probe) stay `@Ignore`'d — they `SKIPPED` cleanly on-device.

## Local verification
`./gradlew :passes-barcode:connectedDebugAndroidTest` on FP4: **5 tests, 0 failures, 2 skipped** (the skeletons).

## Still open in wpass-6mg (not this PR)
- test-only `isolatedProcess` probe service (the sandbox-isolation assertion)
- raw-transact parcel probe
- over-area (under-per-side-cap) decompression-bomb fixture