### PR TITLE
Land runtime sandbox-isolation probes + area-bomb fixture (wpass-6mg, wpass-zrt.5)

### DIFF
--- a/passes-barcode/src/androidTest/AndroidManifest.xml
+++ b/passes-barcode/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  androidTest-only manifest for passes-barcode. Declares a test-only isolated probe service
+  used by BarcodeDecodeServiceInstrumentedTest.decodeProcessCannotReachAppDataOrKeystore to
+  run code INSIDE an isolated process and prove the sandbox cannot reach app data, the
+  Keystore, or the network (the runtime companion to ManifestPermissionsTest's static pin).
+
+  This service exists ONLY in the test APK; it ships no decode logic and never touches the
+  main manifest. It mirrors BarcodeDecodeService's sandbox declaration exactly — isolated,
+  not exported, in its own process — so the privileges it probes are the same ones the real
+  :barcodeDecoder process runs under.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <service
+            android:name="is.walt.passes.barcode.android.BarcodeSandboxProbeService"
+            android:isolatedProcess="true"
+            android:exported="false"
+            android:process=":probe" />
+    </application>
+
+</manifest>

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -1,8 +1,16 @@
 package `is`.walt.passes.barcode.android
 
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.os.IBinder
+import android.os.Parcel
 import android.os.ParcelFileDescriptor
+import android.os.Process
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
@@ -12,30 +20,35 @@ import `is`.walt.passes.core.BarcodeDecodeResult
 import `is`.walt.passes.core.DecodeFailureReason
 import `is`.walt.passes.core.ScannableFormat
 import kotlinx.coroutines.runBlocking
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.zip.CRC32
+import java.util.zip.Deflater
 
 /**
  * On-device half of the wpass-zrt.5 security suite: what only a real device can prove — that
  * the real codec, driven across the real bind into the real isolated process, upholds the
  * contracts the JVM suites pin (faithfulness, caps, surface lock, allowlist). Drivable
  * scenarios go through the public [BarcodeImageDecoder] facade end-to-end with no test seam;
- * fixtures are generated in-process (ZXing writer → [Bitmap] → PNG fd) so the corpus is
- * auditable in source.
+ * fixtures are generated in-process (ZXing writer → [Bitmap] → PNG fd, or crafted raw PNG
+ * bytes for the canvas bomb) so the corpus is auditable in source.
  *
- * Two scenarios stay documented skeletons because the facade deliberately gives the caller no
- * handle inside the sandbox: [decodeProcessCannotReachAppDataOrKeystore] needs code running in
- * the isolated process (a test-only `isolatedProcess` probe service), and
- * [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] needs a raw `transact` — both already
- * guaranteed statically by [ManifestPermissionsTest] / [BarcodeDecodeBinderSurfaceTest].
+ * The two runtime-isolation scenarios that the facade deliberately gives the caller no handle
+ * for — [decodeProcessCannotReachAppDataOrKeystore] and
+ * [decodeServiceReturnsNoBitmapOrSourceBytesOverBinder] — drop below the facade: the first
+ * binds a test-only `isolatedProcess` probe ([BarcodeSandboxProbeService]) to run privilege
+ * checks from inside the sandbox; the second raw-`transact`s the real service and inspects the
+ * reply parcel. They are the runtime companions to the static pins in [ManifestPermissionsTest]
+ * and [BarcodeDecodeBinderSurfaceTest].
  *
- * The three drivable scenarios run in CI's connected-tests matrix (API 28/31/34/36) and
- * verified green on a physical device. They are not `@Ignore`'d: `./gradlew check` does not
- * run androidTest, so a workstation with no device stays green regardless; only the
- * managed-device / `connectedAndroidTest` tasks execute them. The two skeleton scenarios stay
- * `@Ignore`'d until their probe infrastructure lands (wpass-6mg).
+ * These run in CI's connected-tests matrix (API 28/31/34/36) and are verified on a physical
+ * device. None are `@Ignore`'d: `./gradlew check` does not run androidTest, so a workstation
+ * with no device stays green regardless; only the managed-device / `connectedAndroidTest`
+ * tasks execute them.
  */
 @RunWith(AndroidJUnit4::class)
 class BarcodeDecodeServiceInstrumentedTest {
@@ -53,12 +66,29 @@ class BarcodeDecodeServiceInstrumentedTest {
     @Test
     fun overDimensionImageRejectsWithImageTooLarge() {
         // A canvas past the per-side dimension cap must be rejected by the header listener
-        // before the full bitmap is allocated — the decompression-bomb bucket. (The
-        // small-file-huge-canvas PNG bomb that stays under the per-side cap needs a crafted
-        // fixture; tracked with the corpus follow-up.)
+        // before the full bitmap is allocated — the decompression-bomb bucket. The companion
+        // under-per-side-cap area bomb is [overAreaImageRejectsWithImageTooLarge].
         val overSide = BarcodeDecodeConfig.DEFAULT_MAX_DIMENSION_PX + 1
         val pfd = pngFd("over-dimension", solidBitmap(overSide, 8))
         val result = pfd.use { decode(it) }
+
+        assertThat(result)
+            .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageTooLarge))
+    }
+
+    @Test
+    fun overAreaImageRejectsWithImageTooLarge() {
+        // The small-file/huge-canvas bomb: each side stays UNDER the per-side cap but the area
+        // (width * height) exceeds the megapixel cap, so the header listener must reject before
+        // the ~200 MB ARGB allocation. Crafted as raw PNG bytes (valid IHDR, minimal IDAT) so
+        // the fixture is tiny — generating it as a real bitmap would incur the very allocation
+        // the cap exists to prevent.
+        val side = 8_000 // 8000 * 8000 = 64 MP > 50 MP area cap; 8000 < 12000 per-side cap
+        val png = hugeCanvasPng(side, side)
+        assertThat(png.size).isLessThan(1_024) // genuinely a small file
+        val file = File.createTempFile("area-bomb", ".png", context.cacheDir).apply { writeBytes(png) }
+        val result =
+            ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { decode(it) }
 
         assertThat(result)
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageTooLarge))
@@ -82,29 +112,122 @@ class BarcodeDecodeServiceInstrumentedTest {
     }
 
     @Test
-    @Ignore("Needs a test-only isolatedProcess probe service (wpass-zrt.5 follow-up)")
-    fun decodeProcessCannotReachAppDataOrKeystore() {
-        // Bind a test-only probe service declared android:isolatedProcess="true" in the
-        // androidTest manifest; from inside that process attempt a privileged call (open the
-        // app's files dir / load an AndroidKeyStore entry / open the SQLCipher DB file) and
-        // assert it fails with SecurityException (or FileNotFound for the unreachable
-        // app-data path). The decode UID must reach none of them. This is the runtime
-        // companion to the static manifest pin in ManifestPermissionsTest and the contractual
-        // go/no-go boundary from walt-android wlt-58a.1.
+    fun zeroByteSourceFailsClosed() {
+        // The 0-byte corpus case: an empty descriptor has no decodable image and must fail
+        // closed, never crash the sandbox or the caller.
+        val empty = File.createTempFile("empty", ".png", context.cacheDir)
+        val result =
+            ParcelFileDescriptor.open(empty, ParcelFileDescriptor.MODE_READ_ONLY).use { decode(it) }
+
+        assertThat(result).isInstanceOf(BarcodeDecodeResult.DecodeFailed::class.java)
     }
 
     @Test
-    @Ignore("Structurally covered by BarcodeDecodeBinderSurfaceTest; on-device parcel probe is a follow-up")
+    fun truncatedPngFailsClosed() {
+        // A truncated container (valid PNG header, body cut off mid-stream) is the corrupt-image
+        // corpus case: the decoder must fail closed rather than read past the bytes it has.
+        val full = ByteArrayOutputStream()
+            .also { qrBitmap("TRUNCATED").compress(Bitmap.CompressFormat.PNG, 100, it) }
+            .toByteArray()
+        val truncated = full.copyOf(full.size / 2)
+        val file = File.createTempFile("truncated", ".png", context.cacheDir).apply { writeBytes(truncated) }
+        val result =
+            ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { decode(it) }
+
+        assertThat(result).isInstanceOf(BarcodeDecodeResult.DecodeFailed::class.java)
+    }
+
+    @Test
+    fun decodeProcessCannotReachAppDataOrKeystore() {
+        // The headline runtime go/no-go (walt-android wlt-58a.1): bind a test-only probe
+        // declared android:isolatedProcess="true" and, from inside that process, attempt the
+        // privileged calls the decode UID must never make — read the app's private sentinel,
+        // touch the Keystore, open a socket — asserting each is blocked. Proves at runtime what
+        // ManifestPermissionsTest pins statically. The probe also reports its UID so we confirm
+        // the checks ran in an isolated UID, not the app's.
+        val sentinel = File(context.filesDir, "sandbox-sentinel.txt").apply { writeText("app-only-secret") }
+        val (binder, conn) = bind(BarcodeSandboxProbeService::class.java)
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        try {
+            data.writeString(sentinel.absolutePath)
+            binder.transact(BarcodeSandboxProbeService.CODE_PROBE, data, reply, 0)
+            val probeUid = reply.readInt()
+            val appDataBlocked = reply.readInt() == 1
+            val keystoreBlocked = reply.readInt() == 1
+            val networkBlocked = reply.readInt() == 1
+
+            // Ran in an isolated UID, not the app's: app data, Keystore, and network are all out
+            // of reach. (App IDs at/above 90000 are the isolated ranges — app-zygote 90000-98999
+            // and regular isolated 99000-99999.)
+            assertThat(probeUid).isNotEqualTo(Process.myUid())
+            assertThat(probeUid % PER_USER_UID_RANGE).isAtLeast(FIRST_ISOLATED_APP_ID)
+            assertThat(appDataBlocked).isTrue()
+            assertThat(keystoreBlocked).isTrue()
+            assertThat(networkBlocked).isTrue()
+        } finally {
+            data.recycle()
+            reply.recycle()
+            context.unbindService(conn)
+            sentinel.delete()
+        }
+    }
+
+    @Test
     fun decodeServiceReturnsNoBitmapOrSourceBytesOverBinder() {
-        // A raw transact (not the facade) against BarcodeDecodeService, reflecting over the
-        // reply parcel to assert no Bitmap and no byte[] cross the binder — the runtime
-        // companion to the surface lock in BarcodeDecodeBinderSurfaceTest.
+        // A raw transact (not the facade) against the real BarcodeDecodeService, inspecting the
+        // reply parcel to assert only the pure {tag, payload, format} result crosses back — the
+        // runtime companion to the surface lock in BarcodeDecodeBinderSurfaceTest. A Bitmap or
+        // the source bytes would be kilobytes-to-megabytes and leave trailing parcel data; the
+        // pure result is a few tens of bytes with nothing after it.
+        val pfd = pngFd("raw-transact", qrBitmap("RAW-TRANSACT-OK"))
+        val (binder, conn) = bind(BarcodeDecodeService::class.java)
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        try {
+            data.writeTypedObject(pfd, 0)
+            binder.transact(BarcodeDecodeBinderProxy.CODE_DECODE, data, reply, 0)
+
+            assertThat(reply.readInt()).isEqualTo(BarcodeDecodeBinderProxy.TAG_DECODED)
+            assertThat(reply.readString()).isEqualTo("RAW-TRANSACT-OK")
+            assertThat(ScannableFormatWire.decode(reply.readInt())).isEqualTo(ScannableFormat.Qr)
+            // Nothing smuggled after the documented result shape.
+            assertThat(reply.dataAvail()).isEqualTo(0)
+            assertThat(reply.dataSize()).isLessThan(MAX_PURE_REPLY_BYTES)
+        } finally {
+            data.recycle()
+            reply.recycle()
+            context.unbindService(conn)
+            pfd.close()
+        }
     }
 
     private fun decode(pfd: ParcelFileDescriptor): BarcodeDecodeResult =
         runBlocking {
             BarcodeImageDecoder.create(context).decode(BarcodeImageSource.FileDescriptor(pfd))
         }
+
+    /** Bind [serviceClass] and block until connected, returning the binder and its connection. */
+    private fun bind(serviceClass: Class<out Service>): Pair<IBinder, ServiceConnection> {
+        val latch = CountDownLatch(1)
+        var binder: IBinder? = null
+        val conn =
+            object : ServiceConnection {
+                override fun onServiceConnected(name: ComponentName?, service: IBinder) {
+                    binder = service
+                    latch.countDown()
+                }
+
+                override fun onServiceDisconnected(name: ComponentName?) = Unit
+            }
+        check(context.bindService(Intent(context, serviceClass), conn, Context.BIND_AUTO_CREATE)) {
+            "bindService failed for ${serviceClass.name}"
+        }
+        check(latch.await(BIND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            "service did not connect: ${serviceClass.name}"
+        }
+        return binder!! to conn
+    }
 
     private fun qrBitmap(payload: String): Bitmap {
         val matrix = MultiFormatWriter().encode(payload, BarcodeFormat.QR_CODE, 480, 480)
@@ -126,5 +249,70 @@ class BarcodeDecodeServiceInstrumentedTest {
         file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
         bitmap.recycle()
         return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+    }
+
+    /**
+     * Craft raw PNG bytes whose IHDR declares a [width] x [height] canvas with a minimal IDAT.
+     * The header listener rejects on dimensions before the IDAT is consumed, so the body only
+     * has to be well-formed enough to reach that header callback — which is what keeps the
+     * fixture a few hundred bytes instead of a multi-hundred-MB allocation.
+     */
+    private fun hugeCanvasPng(width: Int, height: Int): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.write(PNG_SIGNATURE)
+        val ihdr =
+            ByteArrayOutputStream().apply {
+                writeIntBe(width)
+                writeIntBe(height)
+                write(8) // bit depth
+                write(6) // color type: RGBA
+                write(0) // compression
+                write(0) // filter
+                write(0) // interlace
+            }.toByteArray()
+        writeChunk(out, "IHDR", ihdr)
+        writeChunk(out, "IDAT", deflate(byteArrayOf(0, 0, 0, 0)))
+        writeChunk(out, "IEND", ByteArray(0))
+        return out.toByteArray()
+    }
+
+    private fun writeChunk(out: ByteArrayOutputStream, type: String, data: ByteArray) {
+        out.writeIntBe(data.size)
+        val typeBytes = type.toByteArray(Charsets.US_ASCII)
+        out.write(typeBytes)
+        out.write(data)
+        val crc = CRC32().apply { update(typeBytes); update(data) }
+        out.writeIntBe(crc.value.toInt())
+    }
+
+    private fun ByteArrayOutputStream.writeIntBe(value: Int) {
+        write((value ushr 24) and 0xFF)
+        write((value ushr 16) and 0xFF)
+        write((value ushr 8) and 0xFF)
+        write(value and 0xFF)
+    }
+
+    private fun deflate(input: ByteArray): ByteArray {
+        val deflater = Deflater().apply { setInput(input); finish() }
+        val out = ByteArrayOutputStream()
+        val buffer = ByteArray(64)
+        while (!deflater.finished()) {
+            out.write(buffer, 0, deflater.deflate(buffer))
+        }
+        deflater.end()
+        return out.toByteArray()
+    }
+
+    private companion object {
+        const val BIND_TIMEOUT_SECONDS = 10L
+        const val MAX_PURE_REPLY_BYTES = 256
+
+        // Android packs (userId * 100000 + appId); an appId at/above the isolated floor proves
+        // the UID is an isolated one rather than the app's own.
+        const val PER_USER_UID_RANGE = 100_000
+        const val FIRST_ISOLATED_APP_ID = 90_000
+
+        val PNG_SIGNATURE =
+            byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
     }
 }

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -78,11 +78,8 @@ class BarcodeDecodeServiceInstrumentedTest {
 
     @Test
     fun overAreaImageRejectsWithImageTooLarge() {
-        // The small-file/huge-canvas bomb: each side stays UNDER the per-side cap but the area
-        // (width * height) exceeds the megapixel cap, so the header listener must reject before
-        // the ~200 MB ARGB allocation. Crafted as raw PNG bytes (valid IHDR, minimal IDAT) so
-        // the fixture is tiny — generating it as a real bitmap would incur the very allocation
-        // the cap exists to prevent.
+        // Each side stays under the per-side cap but area exceeds the megapixel cap; crafted as
+        // raw PNG so the header rejects before the ~200 MB allocation a real bitmap would need.
         val side = 8_000 // 8000 * 8000 = 64 MP > 50 MP area cap; 8000 < 12000 per-side cap
         val png = hugeCanvasPng(side, side)
         assertThat(png.size).isLessThan(1_024) // genuinely a small file
@@ -139,19 +136,18 @@ class BarcodeDecodeServiceInstrumentedTest {
 
     @Test
     fun decodeProcessCannotReachAppDataOrKeystore() {
-        // The headline runtime go/no-go (walt-android wlt-58a.1): bind a test-only probe
-        // declared android:isolatedProcess="true" and, from inside that process, attempt the
-        // privileged calls the decode UID must never make — read the app's private sentinel,
-        // touch the Keystore, open a socket — asserting each is blocked. Proves at runtime what
-        // ManifestPermissionsTest pins statically. The probe also reports its UID so we confirm
-        // the checks ran in an isolated UID, not the app's.
+        // Headline runtime go/no-go (walt-android wlt-58a.1): from inside the isolated probe,
+        // app data, Keystore, and network are all blocked and the checks ran in an isolated UID
+        // — the runtime proof of what ManifestPermissionsTest pins statically.
         val sentinel = File(context.filesDir, "sandbox-sentinel.txt").apply { writeText("app-only-secret") }
         val (binder, conn) = bind(BarcodeSandboxProbeService::class.java)
         val data = Parcel.obtain()
         val reply = Parcel.obtain()
         try {
             data.writeString(sentinel.absolutePath)
-            binder.transact(BarcodeSandboxProbeService.CODE_PROBE, data, reply, 0)
+            check(binder.transact(BarcodeSandboxProbeService.CODE_PROBE, data, reply, 0)) {
+                "probe transact not handled"
+            }
             val probeUid = reply.readInt()
             val appDataBlocked = reply.readInt() == 1
             val keystoreBlocked = reply.readInt() == 1
@@ -175,18 +171,18 @@ class BarcodeDecodeServiceInstrumentedTest {
 
     @Test
     fun decodeServiceReturnsNoBitmapOrSourceBytesOverBinder() {
-        // A raw transact (not the facade) against the real BarcodeDecodeService, inspecting the
-        // reply parcel to assert only the pure {tag, payload, format} result crosses back — the
-        // runtime companion to the surface lock in BarcodeDecodeBinderSurfaceTest. A Bitmap or
-        // the source bytes would be kilobytes-to-megabytes and leave trailing parcel data; the
-        // pure result is a few tens of bytes with nothing after it.
+        // Raw transact against the real service: only the pure {tag, payload, format} crosses
+        // back with no trailing data — a Bitmap or source bytes would be orders larger. Runtime
+        // companion to the surface lock in BarcodeDecodeBinderSurfaceTest.
         val pfd = pngFd("raw-transact", qrBitmap("RAW-TRANSACT-OK"))
         val (binder, conn) = bind(BarcodeDecodeService::class.java)
         val data = Parcel.obtain()
         val reply = Parcel.obtain()
         try {
             data.writeTypedObject(pfd, 0)
-            binder.transact(BarcodeDecodeBinderProxy.CODE_DECODE, data, reply, 0)
+            check(binder.transact(BarcodeDecodeBinderProxy.CODE_DECODE, data, reply, 0)) {
+                "decode transact not handled"
+            }
 
             assertThat(reply.readInt()).isEqualTo(BarcodeDecodeBinderProxy.TAG_DECODED)
             assertThat(reply.readString()).isEqualTo("RAW-TRANSACT-OK")

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeSandboxProbeService.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeSandboxProbeService.kt
@@ -1,0 +1,70 @@
+package `is`.walt.passes.barcode.android
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
+import android.os.Process
+import java.io.File
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.security.KeyStore
+
+/**
+ * Test-only isolated-process probe (wpass-6mg). Declared `android:isolatedProcess="true"`,
+ * `android:exported="false"`, `android:process=":probe"` in the androidTest manifest so its
+ * binder transactions execute under the same kind of isolated UID the real
+ * [BarcodeDecodeService] runs under. It is the runtime companion to [ManifestPermissionsTest]:
+ * that test pins the sandbox declaration statically; this service proves at runtime that the
+ * sandbox actually denies the privileges the decode UID must never hold.
+ *
+ * The single [CODE_PROBE] transaction runs three privilege checks from inside the isolated
+ * process and reports each as blocked/not-blocked, plus the process UID so the caller can
+ * confirm the code really ran in an isolated UID and not the app UID. No app data, key
+ * material, or network traffic ever needs to cross back — only the pass/fail verdicts do.
+ */
+class BarcodeSandboxProbeService : Service() {
+    override fun onBind(intent: Intent): IBinder = ProbeBinder()
+
+    private class ProbeBinder : Binder() {
+        override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean =
+            when (code) {
+                CODE_PROBE -> {
+                    val sentinelPath = data.readString().orEmpty()
+                    reply?.apply {
+                        writeInt(Process.myUid())
+                        writeInt(appDataBlocked(sentinelPath).toWire())
+                        writeInt(keystoreBlocked().toWire())
+                        writeInt(networkBlocked().toWire())
+                    }
+                    true
+                }
+                else -> super.onTransact(code, data, reply, flags)
+            }
+
+        /** Reading the app's private sentinel file must fail: the isolated UID is not the app UID. */
+        private fun appDataBlocked(sentinelPath: String): Boolean =
+            runCatching { File(sentinelPath).readBytes() }.isFailure
+
+        /** Touching the Keystore daemon must fail: an isolated UID may not bind keystore2. */
+        private fun keystoreBlocked(): Boolean =
+            runCatching {
+                KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.containsAlias("probe-nonexistent")
+            }.isFailure
+
+        /** Opening a socket must fail: an isolated process is denied network access. */
+        private fun networkBlocked(): Boolean =
+            runCatching {
+                Socket().use { it.connect(InetSocketAddress("10.255.255.1", 80), CONNECT_TIMEOUT_MS) }
+            }.isFailure
+
+        private fun Boolean.toWire(): Int = if (this) 1 else 0
+    }
+
+    companion object {
+        const val CODE_PROBE: Int = IBinder.FIRST_CALL_TRANSACTION
+
+        private const val CONNECT_TIMEOUT_MS = 1_000
+    }
+}

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeSandboxProbeService.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeSandboxProbeService.kt
@@ -6,9 +6,10 @@ import android.os.Binder
 import android.os.IBinder
 import android.os.Parcel
 import android.os.Process
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
 import java.io.File
-import java.net.InetSocketAddress
-import java.net.Socket
 import java.security.KeyStore
 
 /**
@@ -53,18 +54,21 @@ class BarcodeSandboxProbeService : Service() {
                 KeyStore.getInstance("AndroidKeyStore").apply { load(null) }.containsAlias("probe-nonexistent")
             }.isFailure
 
-        /** Opening a socket must fail: an isolated process is denied network access. */
+        // The AF_INET socket() syscall must be denied (EPERM/EACCES): it is gated on the AID_INET
+        // gid the isolated sandbox lacks. Probing the syscall tests the capability itself, unlike
+        // a connect() that would time out for an unreachable host even with network access.
         private fun networkBlocked(): Boolean =
-            runCatching {
-                Socket().use { it.connect(InetSocketAddress("10.255.255.1", 80), CONNECT_TIMEOUT_MS) }
-            }.isFailure
+            try {
+                Os.close(Os.socket(OsConstants.AF_INET, OsConstants.SOCK_STREAM, 0))
+                false
+            } catch (e: ErrnoException) {
+                e.errno == OsConstants.EPERM || e.errno == OsConstants.EACCES
+            }
 
         private fun Boolean.toWire(): Int = if (this) 1 else 0
     }
 
     companion object {
         const val CODE_PROBE: Int = IBinder.FIRST_CALL_TRANSACTION
-
-        private const val CONNECT_TIMEOUT_MS = 1_000
     }
 }


### PR DESCRIPTION
## What

Lands the three remaining items that gated **wpass-zrt.5**'s headline runtime sandbox-isolation assertion, tracked as **wpass-6mg**. These are the on-device companions to the static pins in `ManifestPermissionsTest` and `BarcodeDecodeBinderSurfaceTest`.

### 1. Runtime sandbox-isolation probe (`decodeProcessCannotReachAppDataOrKeystore`)
New test-only `isolatedProcess` probe service (`BarcodeSandboxProbeService`) declared in a new `src/androidTest/AndroidManifest.xml`, mirroring `BarcodeDecodeService`'s sandbox declaration (isolated, not exported, own process). The test binds it and, **from inside the isolated process**, attempts the privileged calls the decode UID must never make:
- reading the app's private sentinel file → blocked,
- touching the Keystore daemon (`containsAlias`) → blocked,
- opening a socket → blocked.

It also reports its UID so the test confirms the checks ran in an isolated UID, not the app's. This is the contractual go/no-go boundary inherited from walt-android wlt-58a.1.

### 2. Raw-transact parcel probe (`decodeServiceReturnsNoBitmapOrSourceBytesOverBinder`)
A raw `transact` against the real `BarcodeDecodeService`, inspecting the reply parcel to assert only the pure `{tag, payload, format}` result crosses back — no trailing data, total size well under any `Bitmap`/source-bytes payload.

### 3. Over-area decompression-bomb fixture (`overAreaImageRejectsWithImageTooLarge`)
A hand-crafted small-file/huge-canvas PNG (8000×8000 = 64 MP) that stays under the 12000px per-side cap but trips the 50 MP area cap, rejected at the header listener before allocation. Crafted as raw PNG bytes so the fixture is <1 KB rather than a ~200 MB allocation.

Also broadens the malformed corpus with 0-byte and truncated-PNG fail-closed cases (wpass-zrt.5 corpus bullets).

## Verification

- All **8** `BarcodeDecodeServiceInstrumentedTest` scenarios pass on a physical **FP4 (Android 15)**.
- JVM `:passes-barcode:check`, `ktlintCheck`, and `detekt` are green.
- CI's connected-tests matrix (API 28/31/34/36) runs the full suite — no `@Ignore`'d skeletons remain.

## Issues

Closes wpass-6mg. Unblocks and completes wpass-zrt.5 (runtime isolation assertion now real).
