### PR TITLE
Pure-JVM YUV-frame decode adapter (wpass-7xo.5)

### DIFF
--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
@@ -1,0 +1,108 @@
+package `is`.walt.passes.barcode
+
+import com.google.zxing.PlanarYUVLuminanceSource
+import `is`.walt.passes.core.BarcodeDecodeResult
+
+/**
+ * Pure-JVM live-camera frame entry point (wpass-7xo.5): decode a barcode/QR straight off a camera
+ * luminance (Y) plane, reusing the same [decodeLuminance] core and symbology allowlist the static
+ * still-image path uses. ONE decode implementation, ONE roster — the live path does not fork.
+ *
+ * NO CameraX / Android type crosses into this kernel. The consumer (walt-android, epic wlt-mwj)
+ * extracts the Y plane from its `ImageProxy` / `ImageAnalysis` frame and passes raw bytes plus the
+ * plane geometry in; the module stays KMP-friendly (`ByteArray` + `Int` only). The contract is
+ * identical to the static path: the [ScannableFormat][`is`.walt.passes.core.ScannableFormat] roster
+ * is enforced (PDF417/Aztec rejected), the payload is returned FAITHFULLY, and the result is only
+ * [BarcodeDecodeResult] — `{payload, format}`, `NoBarcodeFound`, or `DecodeFailed`. Nothing here
+ * interprets, classifies, or validates the bytes.
+ *
+ * ### Stride handling (ZXing #1387)
+ * An Android YUV_420_888 Y plane is rarely densely packed. Two HAL realities have to be stripped
+ * before ZXing sees the pixels, and getting them wrong feeds garbage rows into the binarizer:
+ *  - **rowStride > width** — the common case: each row is padded out to a hardware alignment, so
+ *    the real pixels occupy only the first [width] bytes of every [rowStride]-byte row. When the
+ *    plane is otherwise contiguous (`pixelStride == 1`) this is stripped with ZERO copy by handing
+ *    the buffer to [PlanarYUVLuminanceSource] with `dataWidth = rowStride`: it reads exactly [width]
+ *    bytes per row starting at `row * rowStride`, skipping the trailing padding for free.
+ *  - **pixelStride > 1** — some HALs interleave the Y samples (e.g. a semi-planar layout surfaced
+ *    with `pixelStride == 2`). [PlanarYUVLuminanceSource] assumes one contiguous byte per pixel, so
+ *    such a plane is first repacked into a tight `width * height` buffer.
+ *
+ * ### Signature decision
+ * The surface is kept deliberately minimal and robust to the wpass-7xo.3 HAL-variability spike,
+ * whose only lever is plane *layout*: [rowStride] and [pixelStride] are exposed because real HALs
+ * vary them, and `byte[] + ints` absorbs whatever the spike reports without a contract change.
+ * Crop ([left]/[top]) is NOT exposed in v1 — the full supplied plane is decoded (ZXing's binarizer
+ * already scans the whole frame); a consumer wanting a reticle crop hands in a pre-sliced sub-plane,
+ * and a crop overload can be added later without breaking callers. [reverseHorizontal] is exposed
+ * (default `false`) for the front-camera mirrored case, which the consumer cannot cheaply pre-apply.
+ *
+ * Geometry preconditions (positive dimensions, `rowStride >= width`, a buffer large enough for the
+ * stated layout) are caller-wiring errors, not decode outcomes, so they fail fast via [require]
+ * rather than widening the [BarcodeDecodeResult] surface; the result arms stay reserved for what the
+ * decode itself can produce.
+ */
+@Suppress("LongParameterList") // Each parameter is a distinct camera-plane fact; see "Signature decision".
+public fun decodeYPlane(
+    yPlane: ByteArray,
+    width: Int,
+    height: Int,
+    rowStride: Int,
+    pixelStride: Int = 1,
+    reverseHorizontal: Boolean = false,
+): BarcodeDecodeResult {
+    require(width > 0 && height > 0) {
+        "Frame dimensions must be positive (was ${width}x$height)."
+    }
+    require(pixelStride >= 1) { "pixelStride ($pixelStride) must be >= 1." }
+    require(rowStride >= width * pixelStride) {
+        "rowStride ($rowStride) cannot be smaller than width * pixelStride (${width * pixelStride})."
+    }
+    // Largest byte the per-row reads reach: last row start + last pixel offset within the row.
+    val maxIndex = (height - 1).toLong() * rowStride + (width - 1).toLong() * pixelStride
+    require(maxIndex < yPlane.size) {
+        "Y-plane buffer (${yPlane.size} bytes) too small for ${width}x$height " +
+            "at rowStride=$rowStride pixelStride=$pixelStride."
+    }
+
+    val (data, dataWidth) =
+        if (pixelStride == 1) {
+            // Contiguous rows: hand ZXing the buffer as-is; dataWidth = rowStride strips padding.
+            yPlane to rowStride
+        } else {
+            packTight(yPlane, width, height, rowStride, pixelStride) to width
+        }
+
+    val source =
+        PlanarYUVLuminanceSource(
+            data,
+            dataWidth,
+            height,
+            0,
+            0,
+            width,
+            height,
+            reverseHorizontal,
+        )
+    return decodeLuminance(source)
+}
+
+/** Collapse a row/pixel-strided Y plane into a dense `width * height` luminance buffer. */
+private fun packTight(
+    yPlane: ByteArray,
+    width: Int,
+    height: Int,
+    rowStride: Int,
+    pixelStride: Int,
+): ByteArray {
+    val packed = ByteArray(width * height)
+    var dst = 0
+    for (row in 0 until height) {
+        var src = row * rowStride
+        repeat(width) {
+            packed[dst++] = yPlane[src]
+            src += pixelStride
+        }
+    }
+    return packed
+}

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
@@ -29,13 +29,10 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  *    such a plane is first repacked into a tight `width * height` buffer.
  *
  * ### Signature decision
- * The surface is kept deliberately minimal and robust to the wpass-7xo.3 HAL-variability spike,
- * whose only lever is plane *layout*: [rowStride] and [pixelStride] are exposed because real HALs
- * vary them, and `byte[] + ints` absorbs whatever the spike reports without a contract change.
- * Crop ([left]/[top]) is NOT exposed in v1 — the full supplied plane is decoded (ZXing's binarizer
- * already scans the whole frame); a consumer wanting a reticle crop hands in a pre-sliced sub-plane,
- * and a crop overload can be added later without breaking callers. [reverseHorizontal] is exposed
- * (default `false`) for the front-camera mirrored case, which the consumer cannot cheaply pre-apply.
+ * [rowStride] and [pixelStride] are exposed because real HALs vary them (wpass-7xo.3 spike); the
+ * `byte[] + ints` shape absorbs the spike outcome without a contract change. Crop is NOT exposed in
+ * v1 — the full plane is decoded and a crop overload can be added later without breaking callers.
+ * [reverseHorizontal] is exposed (default `false`) for the front-camera mirrored case.
  *
  * Geometry preconditions (positive dimensions, `rowStride >= width`, a buffer large enough for the
  * stated layout) are caller-wiring errors, not decode outcomes, so they fail fast via [require]
@@ -55,8 +52,9 @@ public fun decodeYPlane(
         "Frame dimensions must be positive (was ${width}x$height)."
     }
     require(pixelStride >= 1) { "pixelStride ($pixelStride) must be >= 1." }
-    require(rowStride >= width * pixelStride) {
-        "rowStride ($rowStride) cannot be smaller than width * pixelStride (${width * pixelStride})."
+    val rowSpan = width.toLong() * pixelStride
+    require(rowStride >= rowSpan) {
+        "rowStride ($rowStride) cannot be smaller than width * pixelStride ($rowSpan)."
     }
     // Largest byte the per-row reads reach: last row start + last pixel offset within the row.
     val maxIndex = (height - 1).toLong() * rowStride + (width - 1).toLong() * pixelStride

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/YPlaneFrameDecodeTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/YPlaneFrameDecodeTest.kt
@@ -1,0 +1,118 @@
+package `is`.walt.passes.barcode
+
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.MultiFormatWriter
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * Smoke coverage for the live-camera frame path (wpass-7xo.5): prove a barcode survives the
+ * `Y-plane bytes + geometry → PlanarYUVLuminanceSource → decodeLuminance` route without a device
+ * or CameraX. Each case ENCODES a symbol with ZXing's own writer, lays the black/white matrix into
+ * a luminance plane (optionally with HAL row padding), and decodes it back — the exact pixel→symbol
+ * path the consumer's per-frame analyzer runs, minus the `ImageProxy` glue. The exhaustive stride /
+ * failure-arm / allowlist suite lives in the blocker wpass-7xo.6.
+ */
+class YPlaneFrameDecodeTest {
+    @Test
+    fun qrDecodesFromTightlyPackedYPlane() {
+        val plane = encodeYPlane("WALT-LIVE-7", BarcodeFormat.QR_CODE, 320, 320, rowPadding = 0)
+
+        assertThat(decodeYPlane(plane.bytes, plane.width, plane.height, rowStride = plane.width))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-LIVE-7", ScannableFormat.Qr))
+    }
+
+    @Test
+    fun qrDecodesThroughRowStridePadding() {
+        // The common HAL case (ZXing #1387): rowStride > width. Pad each row by 48 bytes of noise;
+        // a correct dataWidth = rowStride strips it, a wrong one feeds garbage into the binarizer.
+        val padding = 48
+        val plane = encodeYPlane("WALT-LIVE-7", BarcodeFormat.QR_CODE, 320, 320, rowPadding = padding)
+
+        assertThat(
+            decodeYPlane(
+                plane.bytes,
+                plane.width,
+                plane.height,
+                rowStride = plane.width + padding,
+            ),
+        ).isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-LIVE-7", ScannableFormat.Qr))
+    }
+
+    @Test
+    fun code128DecodesThroughRowStridePadding() {
+        val padding = 32
+        val plane = encodeYPlane("LOYALTY-ABC-123", BarcodeFormat.CODE_128, 600, 200, rowPadding = padding)
+
+        assertThat(
+            decodeYPlane(
+                plane.bytes,
+                plane.width,
+                plane.height,
+                rowStride = plane.width + padding,
+            ),
+        ).isEqualTo(BarcodeDecodeResult.DecodedBarcode("LOYALTY-ABC-123", ScannableFormat.Code128))
+    }
+
+    @Test
+    fun qrDecodesThroughInterleavedPixelStride() {
+        // A pixelStride == 2 semi-planar plane: real Y samples sit at even byte offsets, filler at
+        // the odd ones. The tight-repack path must lift exactly the luminance bytes back out.
+        val padding = 16
+        val plane = encodeYPlane("WALT-LIVE-7", BarcodeFormat.QR_CODE, 320, 320, rowPadding = 0)
+        val pixelStride = 2
+        val rowStride = plane.width * pixelStride + padding
+        val interleaved = ByteArray(rowStride * plane.height)
+        for (row in 0 until plane.height) {
+            for (col in 0 until plane.width) {
+                interleaved[row * rowStride + col * pixelStride] = plane.bytes[row * plane.width + col]
+            }
+        }
+
+        assertThat(
+            decodeYPlane(
+                interleaved,
+                plane.width,
+                plane.height,
+                rowStride = rowStride,
+                pixelStride = pixelStride,
+            ),
+        ).isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-LIVE-7", ScannableFormat.Qr))
+    }
+
+    private class YPlane(val bytes: ByteArray, val width: Int, val height: Int)
+
+    /**
+     * Encode [content] as [format] and render the matrix into a luminance plane: black module → 0x00,
+     * white → 0xFF. [rowPadding] appends that many filler bytes after each row so the plane's stride
+     * exceeds its width, reproducing the HAL padding the decoder must strip.
+     */
+    private fun encodeYPlane(
+        content: String,
+        format: BarcodeFormat,
+        width: Int,
+        height: Int,
+        rowPadding: Int,
+    ): YPlane {
+        val matrix = MultiFormatWriter().encode(content, format, width, height)
+        val w = matrix.width
+        val h = matrix.height
+        val rowStride = w + rowPadding
+        val bytes = ByteArray(rowStride * h)
+        for (y in 0 until h) {
+            val rowStart = y * rowStride
+            for (x in 0 until w) {
+                bytes[rowStart + x] = if (matrix.get(x, y)) BLACK else WHITE
+            }
+            // Leave padding bytes as 0x00 (black) so a stride bug would corrupt the right edge.
+        }
+        return YPlane(bytes, w, h)
+    }
+
+    private companion object {
+        const val BLACK = 0x00.toByte()
+        const val WHITE = 0xFF.toByte()
+    }
+}


### PR DESCRIPTION
## What

Adds `decodeYPlane(yPlane, width, height, rowStride, pixelStride = 1, reverseHorizontal = false)` to `passes-barcode-core`, the pure-JVM entry point the future in-process live-camera path (walt-android epic `wlt-mwj`) calls per frame. It builds a ZXing `PlanarYUVLuminanceSource` from a camera luminance plane and delegates to the existing `decodeLuminance` core — reusing the **same symbology allowlist and faithful-payload contract** as the static-image path. One decode implementation, one roster; the live path does not fork.

## Stride handling (ZXing #1387)

An Android `YUV_420_888` Y plane is rarely densely packed:
- **`rowStride > width`** (common HAL case) — stripped with **zero copy** by handing the buffer to ZXing with `dataWidth = rowStride`, which reads exactly `width` bytes per row.
- **`pixelStride > 1`** (interleaved/semi-planar) — repacked into a tight `width * height` buffer first.

## Signature decision

- **Exposes `rowStride` + `pixelStride`** — the levers real HALs vary (informed by the `wpass-7xo.3` variability spike); `byte[] + ints` absorbs whatever the spike reports without a contract change.
- **No crop (`left`/`top`) in v1** — the full supplied plane is decoded; a reticle-crop overload can be added later without breaking callers.
- **`reverseHorizontal` exposed** (default `false`) for the front-camera mirrored case.
- Geometry preconditions fail fast via `require` (caller-wiring errors), keeping the `BarcodeDecodeResult` arms reserved for actual decode outcomes.

## Constraints honored

- Pure JVM — zero CameraX/Android imports; module stays KMP-friendly.
- Returns only `BarcodeDecodeResult` (`{payload, ScannableFormat}` | `NoBarcodeFound` | `DecodeFailed`); no interpretation/classification.
- Allowlist enforced (PDF417/Aztec rejected) via the shared core.

## Tests

Smoke coverage (writer round-trip, no device): QR through a tightly-packed plane, QR + Code128 through `rowStride` padding, and QR through a `pixelStride == 2` interleaved plane. The exhaustive stride / failure-arm / allowlist suite is left to the blocker `wpass-7xo.6`.

`./gradlew :passes-barcode-core:check` green (tests + detekt).

Closes wpass-7xo.5.