### PR TITLE
fix: correct flipped EAN-13 check-digit weights (#135)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -66,7 +66,7 @@ internal object ScannableFormatConstraints {
     // a correctly-sized payload and only verifies the check digit.
     private fun validateEan13(payload: String): PayloadRejection? {
         // EAN-13: rightmost digit is the check digit. Weights from right (excluding check
-        // digit) alternate 1, 3, 1, 3 ...; sum mod 10, then (10 - sum mod 10) mod 10.
+        // digit) alternate 3, 1, 3, 1 ...; sum mod 10, then (10 - sum mod 10) mod 10.
         val digits = payload.map { it.digitToInt() }
         val expected = ean13CheckDigit(digits.dropLast(1))
         return if (expected == digits.last()) null else PayloadRejection.InvalidCheckDigit(ScannableFormat.Ean13)
@@ -82,9 +82,9 @@ internal object ScannableFormatConstraints {
 
     private fun ean13CheckDigit(twelveDigits: List<Int>): Int {
         var sum = 0
-        // Index from the right: position 0 = weight 1, position 1 = weight 3, alternating.
+        // Index from the right: position 0 = weight 3, position 1 = weight 1, alternating.
         for ((indexFromRight, digit) in twelveDigits.asReversed().withIndex()) {
-            sum += digit * if (indexFromRight % 2 == 0) 1 else 3
+            sum += digit * if (indexFromRight % 2 == 0) 3 else 1
         }
         return (10 - sum % 10) % 10
     }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -28,8 +28,16 @@ class ScannableCardInputValidatorTest {
 
     @Test
     fun ean13HappyPathWithValidCheckDigit() {
-        val result = validate("1234567890120", ScannableFormat.Ean13)
-        assertSuccessWithPayload(result, "1234567890120")
+        // Check digit 8 for data 123456789012 (weights from right: 3,1,3,1...).
+        val result = validate("1234567890128", ScannableFormat.Ean13)
+        assertSuccessWithPayload(result, "1234567890128")
+    }
+
+    @Test
+    fun ean13HappyPathRealWorldBarcode() {
+        // Real EAN-13 (check digit 1); guards against the flipped-weights regression in #135.
+        val result = validate("4006381333931", ScannableFormat.Ean13)
+        assertSuccessWithPayload(result, "4006381333931")
     }
 
     @Test
@@ -179,6 +187,14 @@ class ScannableCardInputValidatorTest {
         assertThat(rejection).isInstanceOf(PayloadRejection.InvalidCheckDigit::class.java)
         rejection as PayloadRejection.InvalidCheckDigit
         assertThat(rejection.format).isEqualTo(ScannableFormat.Ean13)
+    }
+
+    @Test
+    fun ean13FlippedWeightCheckDigitRejected() {
+        // #135 regression: 1234567890120 validates only under the old, flipped weights
+        // (rightmost data digit weighted 1 instead of 3). It must now be rejected.
+        val rejection = expectPayloadRejection("1234567890120", ScannableFormat.Ean13)
+        assertThat(rejection).isInstanceOf(PayloadRejection.InvalidCheckDigit::class.java)
     }
 
     // ---- UPC-A structural ----


### PR DESCRIPTION
Fixes #135.

## Problem
`ean13CheckDigit` in `ScannableFormatConstraints.kt` reverses the 12 data digits, then weights `indexFromRight == 0` (the **rightmost** data digit) by **1**. EAN-13 requires that position to carry weight **3** (weights alternate 3,1,3,1… from the right). The result: **valid EAN-13 codes were rejected** as `InvalidCheckDigit`.

## Verification
Confirmed independently three ways before changing code:
1. **Standard** — [barcode-coder spec](https://barcode-coder.com/en/ean-13-specification-102.html): rightmost data digit is weighted ×3.
2. **Internal consistency** — the sibling `upcACheckDigit` (correct) weights the rightmost data digit ×3; the EAN-13 function disagreed with it.
3. **Worked example** — real barcode `4006381333931` (true check digit `1`): correct algorithm → `1` ✓; buggy code → `7` ✗.

## Changes
- Flip the weight to `3 else 1`; fix the two stale comments.
- The prior happy-path test used `1234567890120`, which validates *only* under the flipped weights — it encoded the bug and would have masked the fix. Replaced with genuinely valid codes (`1234567890128`, real-world `4006381333931`) and added a regression test asserting `1234567890120` is now rejected.

## Testing
`./gradlew :passes-core:test --tests ScannableCardInputValidatorTest` — all pass.