### PR TITLE
refactor: promote PdfDocument to sealed Document + dispatch DocumentView (wpass-gyn)

### DIFF
--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/Document.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/Document.kt
@@ -1,0 +1,35 @@
+package `is`.walt.passes.pdf
+
+/**
+ * The sealed supertype for every kind of imported, non-signature-verified document Walt
+ * stores alongside signed passes. [PdfDocument] is the sole arm today; an image arm lands
+ * in a later step of wpass-i9x. The fields here are exactly what the document surfaces
+ * (tile, lane, trust caption) read in common; kind-specific fields like `pageCount` live
+ * on the [PdfDocument] arm, never on the supertype.
+ *
+ * Like [Pass] in `passes-core`, documents are a *sibling* concept (ADR 0005 D1) and share
+ * no superclass with passes. They are not signature-verified (D5); the trust caption is
+ * sourced from [provenance], which has a single arm by design.
+ *
+ * [displayLabel] is supplied at import time by the consumer; the model layer never derives
+ * it from document content or metadata, which is part of the no-extraction-from-content
+ * discipline (D4). Callers should pass a filename if they have one and a date-based
+ * fallback otherwise.
+ */
+public sealed interface Document {
+    public val id: DocumentId
+    public val displayLabel: String
+    public val byteCount: Long
+    public val importedAtEpochMs: Long
+    public val provenance: Provenance
+}
+
+/**
+ * Opaque identifier for a stored [Document]. Each arm wraps its id in a value class so
+ * calling code cannot accidentally substitute a `String` from another domain (a pass id,
+ * a filename, a user input) into APIs that expect a document id. Sealed so the set of
+ * id kinds tracks the set of [Document] arms.
+ */
+public sealed interface DocumentId {
+    public val value: String
+}

--- a/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
+++ b/passes-pdf-core/src/main/kotlin/is/walt/passes/pdf/PdfDocument.kt
@@ -3,16 +3,18 @@ package `is`.walt.passes.pdf
 /**
  * Opaque identifier for a stored [PdfDocument]. Wrapped in a value class so calling code
  * cannot accidentally substitute a `String` from another domain (a pass id, a filename, a
- * user input) into APIs that expect a document id.
+ * user input) into APIs that expect a document id. The [DocumentId] arm for PDFs.
  */
 @JvmInline
-public value class PdfDocumentId(public val value: String)
+public value class PdfDocumentId(public override val value: String) : DocumentId
 
 /**
- * The pure-Kotlin model for a successfully-imported PDF. Mirrors the role [Pass] plays in
- * `passes-core` for pkpass archives, but is deliberately a *sibling* concept (per ADR 0005
- * D1) — `PdfDocument` and `Pass` share no superclass. Documents are not signature-verified
- * (D5); their trust caption is sourced from [provenance], which has a single arm by design.
+ * The pure-Kotlin model for a successfully-imported PDF — the sole [Document] arm today.
+ * Mirrors the role [Pass] plays in `passes-core` for pkpass archives, but is deliberately
+ * a *sibling* concept (per ADR 0005 D1) — `PdfDocument` and `Pass` share no superclass.
+ * Documents are not signature-verified (D5); their trust caption is sourced from
+ * [provenance], which has a single arm by design. [pageCount] is the PDF-specific field
+ * that lives on this arm rather than on the [Document] supertype.
  *
  * The displayed [displayLabel] is supplied at import time by the consumer; the model layer
  * never derives it from PDF metadata, because metadata is part of the
@@ -20,16 +22,16 @@ public value class PdfDocumentId(public val value: String)
  * one and a date-based fallback ("PDF, added <date>") otherwise.
  */
 public data class PdfDocument(
-    public val id: PdfDocumentId,
-    public val displayLabel: String,
-    public val byteCount: Long,
+    public override val id: PdfDocumentId,
+    public override val displayLabel: String,
+    public override val byteCount: Long,
     public val pageCount: Int,
-    public val importedAtEpochMs: Long,
-    public val provenance: Provenance = Provenance.UserProvided,
-)
+    public override val importedAtEpochMs: Long,
+    public override val provenance: Provenance = Provenance.UserProvided,
+) : Document
 
 /**
- * Where a [PdfDocument] came from. Single arm by design: the only legitimate source today
+ * Where a [Document] came from. Single arm by design: the only legitimate source today
  * is the user importing a file from their device. The arm exists not because there are
  * alternatives but because *not having* this enum would let a future contributor add a
  * silent "downloaded by Walt" provenance without a code-review trail.

--- a/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
+++ b/passes-pdf-ui/src/main/kotlin/is/walt/passes/pdf/ui/DocumentView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import `is`.walt.passes.pdf.Document
 import `is`.walt.passes.pdf.DocumentTelemetryGuard
 import `is`.walt.passes.pdf.PdfDocument
 import `is`.walt.passes.pdf.android.PdfRendererBinder
@@ -31,8 +32,41 @@ import `is`.walt.passes.pdf.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
 /**
+ * Presentation of a [Document] — the public entry point the consumer composes. This is a
+ * dispatcher on the sealed [Document] type: it selects the surface for the concrete arm and
+ * forwards the consumer's parameters unchanged. [PdfDocument] is the sole arm today and
+ * routes to [PdfDocumentView]; a future image arm adds its own branch here without touching
+ * the PDF render path. The trust caption is non-suppressible inside every arm — this
+ * dispatcher adds no parameter that could omit it, so the [DocumentSurfaceLockTest] shape
+ * lock and [DocumentTrustSurfaceTest] visible-text lock hold across the seam.
+ */
+@Composable
+@Suppress("LongParameterList")
+public fun DocumentView(
+    doc: Document,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    modifier: Modifier = Modifier,
+    telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
+    onOpenFullScreen: (() -> Unit)? = null,
+    fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)? = null,
+) {
+    when (doc) {
+        is PdfDocument -> PdfDocumentView(
+            doc = doc,
+            pdfFile = pdfFile,
+            renderer = renderer,
+            modifier = modifier,
+            telemetry = telemetry,
+            onOpenFullScreen = onOpenFullScreen,
+            fullScreenAffordance = fullScreenAffordance,
+        )
+    }
+}
+
+/**
  * Presentation of a [PdfDocument] — a non-suppressible trust caption above a swipeable
- * pager of rasterised pages. `DocumentView` fills the bounds the consumer gives it and
+ * pager of rasterised pages. `PdfDocumentView` fills the bounds the consumer gives it and
  * does NOT assume a full screen: the caption takes its natural height, the pager takes
  * the rest, and each page is letterboxed into the pager slot rather than sized from a
  * fixed aspect ratio — so a short consumer slot can never make a page overflow upward
@@ -89,7 +123,7 @@ import `is`.walt.passes.ui.core.toComposeColor
  */
 @Composable
 @Suppress("LongParameterList")
-public fun DocumentView(
+private fun PdfDocumentView(
     doc: PdfDocument,
     pdfFile: ParcelFileDescriptor,
     renderer: PdfRendererBinder,


### PR DESCRIPTION
## What

Step 2 of epic **wpass-i9x** (generalize Document to cover images). PDF-only structural refactor — no image arm, no behavior change.

- New `sealed interface Document { id; displayLabel; byteCount; importedAtEpochMs; provenance }` in `passes-pdf-core`, with `PdfDocument` as the **sole arm** (`data class PdfDocument(...) : Document`, keeping its PDF-specific `pageCount`).
- New `sealed interface DocumentId`; `PdfDocumentId` is its only arm. Keeps id type-safety generalized so a future arm gets its own id kind rather than borrowing the PDF one.
- `Provenance`'s single-arm trust-policy comment generalized to `Document` (enum unchanged).
- `DocumentView` is now a **dispatcher on the sealed type**: `when (doc) { is PdfDocument -> PdfDocumentView(...) }`. The entire PDF render path moved verbatim into a private `PdfDocumentView`; the public parameter shape is unchanged (still 7 params, doc widened `PdfDocument` → `Document`).

## Why

This is the structural seam that lets **Step 4 (wpass-bsf)** add the image arm by adding one `when` branch, without touching the PDF render path.

## Trust / guard tests

All surface-lock and trust guard tests pass with **zero assertion changes** (the `displayLabel` no-extraction-from-content discipline, the `application/pdf` + `ACTION_SEND` bytecode scans, and the `DocumentView` 7-param shape lock all hold):

```
./gradlew :passes-pdf-core:test :passes-pdf-ui:testDebugUnitTest :passes-pdf-ui:detekt   # green
./gradlew :passes-pdf:testDebugUnitTest :passes-storage:testDebugUnitTest                 # green
./gradlew :passes-pdf-ui:compileDebugAndroidTestKotlin                                    # green
```