### PR TITLE
test(passes-document): inject wall clock for ImageDocument.importedAt

### DIFF
--- a/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
@@ -54,7 +54,12 @@ internal class DefaultDocumentImporter(
     private val config: DocumentImportConfig,
     private val pdfImport: suspend (ByteArray, String, PdfPersist) -> PdfImportResult,
     private val imageDecode: suspend (ByteArray, Int) -> ImageDecodeOutcome,
+    // Monotonic clock for telemetry durations only. Must NOT be used for importedAt: the
+    // [wallClock] below supplies wall time for the persisted record.
     private val now: () -> Long,
+    // Wall clock for the stamped importedAt. Seam-injected so a test can pin it; `now` cannot
+    // serve here because it is monotonic (elapsedRealtime), not epoch time.
+    private val wallClock: () -> Long,
     private val idGenerator: () -> String,
 ) : DocumentImporter {
 
@@ -152,7 +157,7 @@ internal class DefaultDocumentImporter(
             byteCount = bytes.size.toLong(),
             widthPx = decoded.widthPx,
             heightPx = decoded.heightPx,
-            importedAtEpochMs = System.currentTimeMillis(),
+            importedAtEpochMs = wallClock(),
         )
         guard.onImportSucceeded(
             ImageImportSucceededEvent(
@@ -265,6 +270,7 @@ internal class DefaultDocumentImporter(
                     }
                 },
                 now = { SystemClock.elapsedRealtime() },
+                wallClock = { System.currentTimeMillis() },
                 idGenerator = { UUID.randomUUID().toString() },
             )
         }

--- a/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
+++ b/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
@@ -100,6 +100,8 @@ class DocumentImporterTest {
         assertThat(imported.doc.widthPx).isEqualTo(800)
         assertThat(imported.doc.heightPx).isEqualTo(600)
         assertThat(imported.doc.byteCount).isEqualTo(pngBytes.size.toLong())
+        // importedAt is stamped from the injected wall clock, not System.currentTimeMillis().
+        assertThat(imported.doc.importedAtEpochMs).isEqualTo(FIXED_WALL_CLOCK_MS)
         assertThat(maxPxRequested).isEqualTo(DocumentImportConfig.DEFAULT_MAX_IMAGE_DECODE_PX)
         val image = persisted.single() as DocumentPersist.Image
         assertThat(image.bytes).isEqualTo(pngBytes)
@@ -162,12 +164,14 @@ class DocumentImporterTest {
         imageDecode: suspend (ByteArray, Int) -> ImageDecodeOutcome =
             { _, _ -> ImageDecodeOutcome.Rejected(ImageDecodeRejectedKind.NotAnImage) },
         imageTelemetry: ImageImportTelemetryGuard = ImageImportTelemetryGuard.NoOp,
+        wallClock: () -> Long = { FIXED_WALL_CLOCK_MS },
     ): DefaultDocumentImporter =
         DefaultDocumentImporter(
             config = DocumentImportConfig(imageTelemetryGuard = imageTelemetry),
             pdfImport = pdfImport,
             imageDecode = imageDecode,
             now = { 0L },
+            wallClock = wallClock,
             idGenerator = { "fixed-id" },
         )
 
@@ -196,5 +200,10 @@ class DocumentImporterTest {
         override fun onImportFailed(event: ImageImportFailedEvent) {
             events += "failed:${event.outcome.name}"
         }
+    }
+
+    private companion object {
+        // Arbitrary fixed epoch-ms the injected wall clock returns, so importedAt is pinnable.
+        const val FIXED_WALL_CLOCK_MS: Long = 1_700_000_000_000L
     }
 }


### PR DESCRIPTION
## What

`DefaultDocumentImporter.importImage` stamped `ImageDocument.importedAtEpochMs` via `System.currentTimeMillis()` directly, while telemetry durations use the injected monotonic `now` (`SystemClock.elapsedRealtime()`). That left `importedAt` un-pinnable in tests, and `now` can't serve as the source because it is monotonic, not epoch time.

This adds a seam-injected `wallClock: () -> Long` alongside `now`:
- `now` stays monotonic, for durations only (KDoc clarifies the split).
- `wallClock` supplies wall time for the persisted `importedAt`; production wires `{ System.currentTimeMillis() }`.

## Why

Surfaced by the `wpass-bsf` kernel review as a minor testability gap. Cheap to close since the file already injects clocks.

## Test

`DocumentImporterTest` now pins `importedAt` to a fixed epoch via the injected `wallClock`. Clean re-run: 7 tests, 0 failures.

## Scope

Limited to the image arm per the review. `DefaultPdfImporter` (`passes-pdf`) has the identical direct-`currentTimeMillis` pattern; left out of scope and flagged in the commit body for a separate decision.