### PR TITLE
feat(document): composite barcoded-image artifact (wpass-8lu)

### DIFF
--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -722,3 +722,117 @@ for `Intent.ACTION_SEND` / `application/pdf` stays green across both arms.
 | I3       | `DocumentImporterTest`: PDF magic routes to the PDF backend, image magic to the image backend, unrecognized bytes touch neither; original bytes reach `persist`. |
 | I4       | `passes-storage` `SchemaMigrationTest.migrationFromV5AddsDocumentFormatAndDimensionColumns` + `...DefaultsExistingDocumentsToPdfFormat...`; `DocumentRepositoryTest` image-insert tests. |
 | I5       | `DocumentSurfaceLockTest` (9-param lock + `ImageDecodeBinder`-interface lock); `DocumentTrustSurfaceTest.imageDocumentViewRendersTheNonSuppressibleTrustCaption`; existing `application/pdf` / `ACTION_SEND` bytecode scan. |
+
+## Addendum 2026-06-17: Composite artifact — `Document = PDF | image | barcoded-image`
+
+Tracks: `wpass-8lu` (first-class composite artifact: image + extracted/generated
+barcode, one wallet item). Consumer-requested by walt-android epic `wlt-yjn5`
+(add-to-wallet UX rethink); blocks consumer `wlt-u3tk → wlt-2ub2`. Follow-on to the
+2026-06-16 image addendum (`wpass-i9x`). Module names below are the post-`wpass-xmp`
+names (`passes-document-core` / `passes-document-ui`, formerly `passes-pdf-core` /
+`passes-pdf-ui`).
+
+### Context
+
+A common add-flow input is a photographed or screenshotted membership / loyalty card
+that *carries a barcode* — the user wants both the picture (to recognise the card) and
+a crisp, re-renderable native barcode (to scan at a terminal). The image-only arm
+(`wpass-i9x`) covers the barcode-*less* case; a separate `ScannableCard` (ADR 0001)
+covers the barcode-*only* case. The composite is the union: ONE artifact carrying an
+image AND a barcode extracted from that image. Rather than a fourth artifact tower or a
+host-side join of two rows, it is a **third `Document` arm** that is a strict superset
+of `ImageDocument`, so it reuses the image isolation, storage, trust-caption, and
+display substrate verbatim and degrades to a plain `ImageDocument` when no code is
+found. The decisions below record only what is **new or different** for the composite.
+
+### C1. `Document` gains a third arm: `BarcodedImageDocument`
+
+`passes-document-core` adds `BarcodedImageDocument` (with `BarcodedImageDocumentId`)
+alongside `PdfDocument` and `ImageDocument`. It carries every `ImageDocument` field
+(`widthPx` / `heightPx`, original bytes persisted) PLUS `barcodePayload: String` and
+`barcodeFormat: ScannableFormat`. It shares no superclass with `Pass` (D1 unchanged)
+and has no `SignatureStatus` (D5 unchanged — a barcode extracted from a user image is
+not a verified credential). The arm exists **only when a code was actually found and
+(consumer-side) confirmed**; an image with no barcode stays an `ImageDocument`, never a
+`BarcodedImageDocument` with an empty payload. This forces a deliberate, security-
+reviewed edit to `passes-document-core`'s `PublicApiSurfaceTest` arm-set lock, in the
+same audit register as adding a binder method. `passes-document-core` takes a new
+pure-JVM `api` edge to `passes-core` for `ScannableFormat` (mirrors
+`passes-barcode-core → passes-core`; adds no Android dependency).
+
+### C2. Barcode extraction runs in the isolated worker — the load-bearing constraint
+
+The user-imported image is the hostile-input surface (the same `CVE-2023-4863`
+libwebp / codec-RCE class D3 and `wpass-i9x` exist to contain). Extracting a barcode
+from it means decoding the image and running a symbol reader over the pixels — both
+MUST happen in the permissionless sandbox, never in the host process. The importer
+reuses `passes-barcode`'s existing isolated `BarcodeImageDecoder` (the static-image
+posture, `wpass-zrt`): the original bytes are decoded in-sandbox and **only**
+`{payload, ScannableFormat}` (the pure `BarcodeDecodeResult` from `passes-core`) crosses
+the binder — never a `Bitmap`, never the source bytes. No `BitmapFactory` / `ImageDecoder`
+/ ZXing call touches user-image bytes in the host process. This is the same invariant
+that gates `wpass-i9x` acceptance, extended to the barcode read.
+
+The composite import runs **two** isolated decodes of the same bytes — the image-decode
+sandbox (for the display raster / thumbnail / dimensions) and the barcode-decode sandbox
+(for the symbol) — each on its **own** `memfd` PFD materialized from the single bounded
+read. The source fd is still read exactly once (no offset corruption); holding the
+compressed bytes in a host `ByteArray` is not a decode and is not the RCE surface.
+
+### C3. Confirm-before-persist; first code wins; graceful degradation
+
+A misread barcode that only surfaces at a checkout terminal is a real failure mode.
+`DocumentImporter.import` therefore gains a `confirmBarcode: suspend (payload, format) ->
+Boolean` hook, invoked with the decoded value **before anything is persisted**, so the
+consumer can gate on its `BarcodeCreateConfirmSheet` (the decoded payload is the value
+shown for verification). Returning `true` persists a composite; returning `false`
+degrades to a plain image. The default accepts every read. When an image yields no code,
+the extraction fails, or confirmation is declined, the import lands on `ImportedImage`
+(plain `Document.Image`) — extraction failure NEVER fails the whole import. When an
+image contains several codes, the kernel returns the **first** detected code (consumer
+decision, `wlt-yjn5`; ZXing's `MultiFormatReader` stops at the first match). No content
+beyond the barcode is extracted (D4 holds: no EXIF / XMP / payload-derived label).
+
+### C4. Storage: `documents` schema v6 → v7 (forward-only)
+
+The `documents` table gains nullable `barcode_payload TEXT` / `barcode_format TEXT`
+columns. A row is a composite **iff** both are non-null; the `format` column stays the
+image container format (`'png' / 'jpeg' / 'webp'`), so a composite reads back as an
+image row that additionally carries a barcode — there is **no** new `format` value and
+**no** third reject enum. `barcode_format` stores the `ScannableFormat` name, matching
+the `scannable_cards.format` vocabulary; an unrecognised name (DB tampering only — this
+module is the sole writer) decodes to "no barcode" rather than throwing on a list query.
+`insertDocument`'s sealed `DocumentInsert` gains a `BarcodedImage` arm. The D7 size and
+label caps apply; the page cap does not (a composite is a single-page image). The barcode
+is carried on the SAME row as its image — one artifact, one wallet entry, never a
+host-side join. Migration is forward-only per ADR 0002; existing rows read back NULL.
+
+### C5. The composite reuses `DocumentView` for its image half; the barcode UI is consumer-composed
+
+`DocumentView` dispatches `BarcodedImageDocument` to the **same** `ImageDocumentView` as
+a plain image, over the **same** `imageFile` / `imageDecoder` backend pair — so the
+dispatcher gains NO new parameter and the `DocumentSurfaceLockTest` 9-param shape lock
+stays green. The non-suppressible `DocumentTrustCaption` (D5) is therefore present
+unchanged. The generated barcode and its format switcher are **not** rendered here: they
+are composed by the consumer with `passes-ui`'s `ScannableCardView` + `passes-core`'s
+`BarcodeEncoder.encode(payload, format)`, which re-encodes the one stored payload across
+symbologies. This keeps the two UI towers (`passes-ui` for PKPASS/scannable surfaces,
+`passes-document-ui` for document surfaces) independent — the composite is the one place
+they are *combined*, and that combination lives in the consumer, not in a new kernel
+cross-tower edge. D8 (no share-out) holds.
+
+### Telemetry discipline (unchanged, reaffirmed)
+
+The composite import reuses the image `onImportSucceeded` event verbatim — byte count /
+format / dimensions only. The decoded barcode **payload is never written to telemetry**;
+a composite import is indistinguishable from a plain image import in the telemetry stream.
+
+### Tests pinning this addendum
+
+| Decision | Test                                                                                                  |
+|----------|-------------------------------------------------------------------------------------------------------|
+| C1       | `passes-document-core` `PublicApiSurfaceTest`: `Document` has exactly `PdfDocument` + `ImageDocument` + `BarcodedImageDocument`; the composite shape is exercised. |
+| C2       | `passes-document` `DocumentImporterTest.imageWithBarcodeRoutesToCompositeAndPersistsPayloadAndFormat` (the barcode seam sees the same ORIGINAL bytes; only `{payload, format}` cross); on-device `wpass-k9t`. |
+| C3       | `DocumentImporterTest`: no-code / extraction-failure / declined-confirmation all degrade to `ImportedImage`; `confirmHookSeesTheDecodedPayloadBeforePersist`; `pdfWithEmbeddedBytesNeverRunsBarcodeExtraction`. |
+| C4       | `passes-storage` `SchemaMigrationTest` (v6→v7 barcode columns, version/DDL/migration-keys locks in `PublicApiSurfaceTest`); `DocumentRepositoryTest` composite round-trip + plain-image-null-barcode tests. |
+| C5       | `DocumentSurfaceLockTest` (9-param lock holds — composite adds no `DocumentView` param); `DocumentTrustSurfaceTest`; `application/pdf` / `ACTION_SEND` bytecode scan stays green. |

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -782,11 +782,16 @@ compressed bytes in a host `ByteArray` is not a decode and is not the RCE surfac
 ### C3. Confirm-before-persist; first code wins; graceful degradation
 
 A misread barcode that only surfaces at a checkout terminal is a real failure mode.
-`DocumentImporter.import` therefore gains a `confirmBarcode: suspend (payload, format) ->
-Boolean` hook, invoked with the decoded value **before anything is persisted**, so the
+`DocumentImporter.import` therefore gains a `confirmBarcode: (suspend (payload, format) ->
+Boolean)?` hook, invoked with the decoded value **before anything is persisted**, so the
 consumer can gate on its `BarcodeCreateConfirmSheet` (the decoded payload is the value
 shown for verification). Returning `true` persists a composite; returning `false`
-degrades to a plain image. The default accepts every read. When an image yields no code,
+degrades to a plain image. The hook is **`null` by default, and that default means the
+composite path is opt-in: with no hook the isolated barcode extraction does NOT run at
+all** — the import is a plain image at zero extra cost, identical to the wpass-i9x
+behavior, and an incidental barcode in a photo the user only wanted to store is never
+silently turned into a composite. A consumer wanting composites without a confirm UX can
+pass `{ _, _ -> true }` explicitly. When (with the hook supplied) an image yields no code,
 the extraction fails, or confirmation is declined, the import lands on `ImportedImage`
 (plain `Document.Image`) — extraction failure NEVER fails the whole import. When an
 image contains several codes, the kernel returns the **first** detected code (consumer

--- a/passes-document-core/build.gradle.kts
+++ b/passes-document-core/build.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 }
 
 dependencies {
+    // ScannableFormat is the symbology the BarcodedImageDocument arm carries (wpass-8lu). Both
+    // modules are pure-JVM/-core, so this adds no Android edge; it mirrors passes-barcode-core
+    // depending on passes-core for the same enum.
+    api(project(":passes-core"))
+
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }

--- a/passes-document-core/src/main/kotlin/is/walt/passes/document/BarcodedImageDocument.kt
+++ b/passes-document-core/src/main/kotlin/is/walt/passes/document/BarcodedImageDocument.kt
@@ -1,0 +1,54 @@
+package `is`.walt.passes.document
+
+import `is`.walt.passes.core.ScannableFormat
+
+/**
+ * Opaque identifier for a stored [BarcodedImageDocument]. A distinct [DocumentId] arm — sibling
+ * to [ImageDocumentId] and [PdfDocumentId] — so a composite id cannot be substituted for a
+ * plain-image id (or vice versa) in APIs that expect one specific kind.
+ */
+@JvmInline
+public value class BarcodedImageDocumentId(public override val value: String) : DocumentId
+
+/**
+ * The pure-Kotlin model for a composite artifact: a stored still image PLUS a barcode that was
+ * extracted from that image at import time (wpass-8lu). The THIRD [Document] arm, and a strict
+ * superset of [ImageDocument] — every image field is here, plus the decoded [barcodePayload] and
+ * its [barcodeFormat]. It is one artifact id rendering as one wallet row, never a host-side join
+ * of an image entity and a card entity.
+ *
+ * Relationship to the other arms:
+ *
+ *  - The image half ([widthPx] / [heightPx] / persisted original bytes) is identical to
+ *    [ImageDocument]; the display surface renders it through the SAME isolated image-decode
+ *    sandbox (`passes-image`). The dimensions are the bounded raster Walt decoded in the
+ *    sandbox, never an in-process decode of the untrusted source bytes.
+ *  - The barcode half ([barcodePayload] / [barcodeFormat]) was produced by the isolated
+ *    still-image barcode decoder (`passes-barcode`): the original image bytes were decoded
+ *    in-sandbox and only the payload + [ScannableFormat] crossed the binder, matching the
+ *    wpass-i9x isolation invariant. The host process never ran a codec over the source bytes.
+ *
+ * When an imported image yields NO barcode, the importer degrades to a plain [ImageDocument]
+ * rather than producing a [BarcodedImageDocument] with an empty payload — the composite arm
+ * exists only when a code was actually found and (consumer-side) confirmed.
+ *
+ * [barcodePayload] is the verbatim decoded symbol contents; the consumer re-encodes it across
+ * symbologies with `passes-core`'s `BarcodeEncoder` for the detail-surface format switcher, so a
+ * single stored payload backs every rendered symbology. [barcodeFormat] is the symbology the
+ * code was originally detected as — the switcher's initial selection.
+ *
+ * [displayLabel] is supplied at import time by the consumer; the model never derives it from
+ * image metadata (EXIF / XMP) or from the barcode payload, part of the
+ * no-extraction-from-content discipline (D4).
+ */
+public data class BarcodedImageDocument(
+    public override val id: BarcodedImageDocumentId,
+    public override val displayLabel: String,
+    public override val byteCount: Long,
+    public val widthPx: Int,
+    public val heightPx: Int,
+    public val barcodePayload: String,
+    public val barcodeFormat: ScannableFormat,
+    public override val importedAtEpochMs: Long,
+    public override val provenance: Provenance = Provenance.UserProvided,
+) : Document

--- a/passes-document-core/src/test/kotlin/is/walt/passes/document/PublicApiSurfaceTest.kt
+++ b/passes-document-core/src/test/kotlin/is/walt/passes/document/PublicApiSurfaceTest.kt
@@ -124,10 +124,12 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun documentSealedHierarchyHasExactlyThePdfAndImageArms() {
-        // Document is the sealed supertype; both arms are assignable to it, and each id to
-        // DocumentId. Adding a third arm is a deliberate, test-breaking edit here (and a
-        // security review, since each arm is an untrusted-content surface — ADR 0005).
+    fun documentSealedHierarchyHasExactlyThePdfImageAndBarcodedImageArms() {
+        // Document is the sealed supertype; all arms are assignable to it, and each id to
+        // DocumentId. Adding a fourth arm is a deliberate, test-breaking edit here (and a
+        // security review, since each arm is an untrusted-content surface — ADR 0005). The
+        // third arm (BarcodedImageDocument, wpass-8lu) is a composite: an image plus a barcode
+        // extracted from it in the isolated decoder.
         val pdf: Document =
             PdfDocument(
                 id = PdfDocumentId("p"),
@@ -145,16 +147,29 @@ class PublicApiSurfaceTest {
                 heightPx = 1,
                 importedAtEpochMs = 0L,
             )
+        val barcodedImage: Document =
+            BarcodedImageDocument(
+                id = BarcodedImageDocumentId("b"),
+                displayLabel = "b",
+                byteCount = 0,
+                widthPx = 1,
+                heightPx = 1,
+                barcodePayload = "PAYLOAD",
+                barcodeFormat = `is`.walt.passes.core.ScannableFormat.Code128,
+                importedAtEpochMs = 0L,
+            )
         val arms =
-            listOf(pdf, image).map { doc ->
+            listOf(pdf, image, barcodedImage).map { doc ->
                 when (doc) {
                     is PdfDocument -> "pdf"
                     is ImageDocument -> "image"
+                    is BarcodedImageDocument -> "barcodedImage"
                 }
             }
-        assertThat(arms).containsExactly("pdf", "image").inOrder()
+        assertThat(arms).containsExactly("pdf", "image", "barcodedImage").inOrder()
         assertThat(pdf.id).isInstanceOf(PdfDocumentId::class.java)
         assertThat(image.id).isInstanceOf(ImageDocumentId::class.java)
+        assertThat(barcodedImage.id).isInstanceOf(BarcodedImageDocumentId::class.java)
     }
 
     @Test

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentImage.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentImage.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.unit.IntSize
 import `is`.walt.passes.image.android.ImageDecodeBinder
 import `is`.walt.passes.image.android.ImageDecodeRejectedKind
 import `is`.walt.passes.image.android.ImageDecodeResult
+import `is`.walt.passes.document.DocumentId
 import `is`.walt.passes.document.DocumentTelemetryGuard
-import `is`.walt.passes.document.ImageDocument
 import `is`.walt.passes.document.ui.internal.decodeImage
 import `is`.walt.passes.document.ui.internal.discardImageResult
 import kotlinx.coroutines.NonCancellable
@@ -57,10 +57,16 @@ public sealed interface DocumentImageState {
  *
  * [imageFile] is the ORIGINAL image bytes opened by the caller; it is owned by the caller and
  * must remain open while the composable is composed. Close after composition ends.
+ *
+ * [documentId] is used only as the produceState restart key (so a different document re-decodes);
+ * it is the [DocumentId] supertype, not a concrete arm, so the same facade renders the image of an
+ * [ImageDocument][`is`.walt.passes.document.ImageDocument] and the image half of a
+ * [BarcodedImageDocument][`is`.walt.passes.document.BarcodedImageDocument] (wpass-8lu) — the
+ * barcode half is rendered by the consumer with `passes-ui`, never here.
  */
 @Composable
 public fun rememberDocumentImage(
-    document: ImageDocument,
+    documentId: DocumentId,
     imageFile: ParcelFileDescriptor,
     decoder: ImageDecodeBinder,
     targetSizePx: IntSize,
@@ -70,7 +76,7 @@ public fun rememberDocumentImage(
     val heightPx = targetSizePx.height.coerceAtLeast(1)
     val state: State<DocumentImageState> = produceState<DocumentImageState>(
         initialValue = DocumentImageState.Loading,
-        document.id,
+        documentId,
         widthPx,
         heightPx,
         decoder,

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -25,7 +25,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.image.android.ImageDecodeBinder
+import `is`.walt.passes.document.BarcodedImageDocument
 import `is`.walt.passes.document.Document
+import `is`.walt.passes.document.DocumentId
 import `is`.walt.passes.document.DocumentTelemetryGuard
 import `is`.walt.passes.document.ImageDocument
 import `is`.walt.passes.document.PdfDocument
@@ -38,10 +40,13 @@ import `is`.walt.passes.ui.core.toComposeColor
  * dispatcher on the sealed [Document] type: it selects the surface for the concrete arm and
  * forwards the consumer's parameters. [PdfDocument] routes to [PdfDocumentView] (a swipeable
  * pager over the isolated PDF renderer); [ImageDocument] routes to [ImageDocumentView] (a
- * single, no-pager image over the isolated image-decode sandbox). The trust caption is
- * non-suppressible inside every arm — this dispatcher adds no parameter that could omit it, so
- * the [DocumentSurfaceLockTest] shape lock and [DocumentTrustSurfaceTest] visible-text lock
- * hold across the seam.
+ * single, no-pager image over the isolated image-decode sandbox); [BarcodedImageDocument]
+ * (wpass-8lu) routes to the SAME [ImageDocumentView] for its image half — the generated barcode
+ * and format switcher are composed by the consumer with `passes-ui`, so this surface stays
+ * image-only and the two UI towers remain independent. The trust caption is non-suppressible
+ * inside every arm — this dispatcher adds no parameter that could omit it, so the
+ * [DocumentSurfaceLockTest] shape lock and [DocumentTrustSurfaceTest] visible-text lock hold
+ * across the seam.
  *
  * The backend handles are kind-specific and nullable: a consumer supplies the [pdfFile] /
  * [renderer] pair for a [PdfDocument] and the [imageFile] / [imageDecoder] pair for an
@@ -73,9 +78,24 @@ public fun DocumentView(
             fullScreenAffordance = fullScreenAffordance,
         )
         is ImageDocument -> ImageDocumentView(
-            doc = doc,
+            documentId = doc.id,
             imageFile = requireNotNull(imageFile) { "DocumentView(ImageDocument) requires a non-null imageFile" },
             decoder = requireNotNull(imageDecoder) { "DocumentView(ImageDocument) requires a non-null imageDecoder" },
+            modifier = modifier,
+            telemetry = telemetry,
+        )
+        // wpass-8lu: a composite renders its IMAGE half through the same isolated image-decode
+        // surface as a plain image (same imageFile / imageDecoder pair, no new DocumentView
+        // parameter). The generated barcode + format switcher are composed by the consumer with
+        // passes-ui, keeping the two UI towers independent — this surface stays image-only.
+        is BarcodedImageDocument -> ImageDocumentView(
+            documentId = doc.id,
+            imageFile = requireNotNull(imageFile) {
+                "DocumentView(BarcodedImageDocument) requires a non-null imageFile"
+            },
+            decoder = requireNotNull(imageDecoder) {
+                "DocumentView(BarcodedImageDocument) requires a non-null imageDecoder"
+            },
             modifier = modifier,
             telemetry = telemetry,
         )
@@ -240,7 +260,7 @@ private fun PdfDocumentView(
  */
 @Composable
 private fun ImageDocumentView(
-    doc: ImageDocument,
+    documentId: DocumentId,
     imageFile: ParcelFileDescriptor,
     decoder: ImageDecodeBinder,
     modifier: Modifier = Modifier,
@@ -270,7 +290,7 @@ private fun ImageDocumentView(
                 TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1)
             }
             val state = rememberDocumentImage(
-                document = doc,
+                documentId = documentId,
                 imageFile = imageFile,
                 decoder = decoder,
                 targetSizePx = IntSize(requestWidthPx, requestHeightPx),

--- a/passes-document/build.gradle.kts
+++ b/passes-document/build.gradle.kts
@@ -27,6 +27,12 @@ dependencies {
     // PdfImporter (the PDF backend) is invoked internally; its types do not escape on the
     // public surface, so implementation, not api.
     implementation(project(":passes-pdf"))
+    // Composite-artifact extraction (wpass-8lu): the isolated still-image barcode decoder. Its
+    // BarcodeImageDecoder / BarcodeImageSource are invoked internally inside create(); only the
+    // pure BarcodeDecodeResult (from passes-core, already transitively api) is read, so the
+    // passes-barcode types do not escape the public surface — implementation, not api. This is
+    // the same sniff-and-branch role extended to a third isolated backend, not a new peer edge.
+    implementation(project(":passes-barcode"))
     // Shared memfd plumbing: the sniffed bytes are materialized once into a sealed in-RAM PFD
     // and handed to whichever backend wins, so a one-shot fd source is read exactly once
     // (no offset-corruption between the sniff read and the backend read). Internal seam.

--- a/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
+++ b/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
@@ -1,0 +1,161 @@
+package `is`.walt.passes.document
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.ParcelFileDescriptor
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.BarcodeEncoder
+import `is`.walt.passes.core.BarcodeMatrix
+import `is`.walt.passes.core.EncodeResult
+import `is`.walt.passes.core.ScannableFormat
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * On-device end-to-end for the composite (barcoded-image) artifact arm (wpass-8lu) — the
+ * follow-on to the image-document on-device suite (wpass-0jw). This is what only a real device
+ * proves: the public [DocumentImporter] facade, with NO test seam, driving the real
+ * `memfd` materialization and BOTH isolated services (the `passes-image` decode sandbox for the
+ * display raster + the `passes-barcode` decode sandbox for the symbol) across the real bind, and
+ * folding the live `BarcodeDecodeResult` onto the right [DocumentImportResult] arm.
+ *
+ * The isolation invariant under test: the host process never decodes the user-image bytes — the
+ * barcode payload is produced inside the permissionless `passes-barcode` sandbox and only
+ * `{payload, ScannableFormat}` crosses the binder. (`BarcodeDecodeServiceInstrumentedTest`
+ * pins the sandbox's own privilege/surface contracts; here we prove the orchestrator wires it.)
+ *
+ * Fixtures are generated in-process from `passes-core`'s [BarcodeEncoder] (matrix → scaled
+ * [Bitmap] → PNG fd), so the corpus is auditable in source and this module needs no ZXing
+ * dependency. The storage write path for [DocumentInsert.BarcodedImage] is the image path plus
+ * two TEXT columns and is covered by the JVM/Robolectric round-trip and the v6→v7
+ * `SchemaMigrationTest`; this suite focuses on the device-only isolated import.
+ *
+ * Runs in CI's connected-tests matrix and on a physical device. Not `@Ignore`'d: `./gradlew
+ * check` does not run androidTest, so a workstation with no device stays green; only
+ * `connectedAndroidTest` / managed-device tasks execute it.
+ */
+@RunWith(AndroidJUnit4::class)
+class CompositeImportInstrumentedTest {
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun imageCarryingAQrCodeImportsAsACompositeWithTheDecodedPayload() {
+        val payload = "WALT-COMPOSITE-8LU"
+        val source = pngFd("composite-qr", barcodeBitmap(payload, ScannableFormat.Qr))
+
+        val persisted = mutableListOf<DocumentPersist>()
+        val result = source.use {
+            runBlocking {
+                importer().import(
+                    source = DocumentImportSource.FileDescriptor(it),
+                    displayLabel = "membership.png",
+                    persist = { p -> persisted += p },
+                )
+            }
+        }
+
+        val composite = result as DocumentImportResult.ImportedBarcodedImage
+        assertThat(composite.doc.barcodePayload).isEqualTo(payload)
+        assertThat(composite.doc.barcodeFormat).isEqualTo(ScannableFormat.Qr)
+        assertThat(composite.doc.widthPx).isGreaterThan(0)
+        assertThat(composite.doc.heightPx).isGreaterThan(0)
+
+        // The SAME single row carries the image bytes AND the barcode — one artifact.
+        val persistedComposite = persisted.single() as DocumentPersist.BarcodedImage
+        assertThat(persistedComposite.format).isEqualTo(ImageFormat.Png)
+        assertThat(persistedComposite.barcodePayload).isEqualTo(payload)
+        assertThat(persistedComposite.barcodeFormat).isEqualTo(ScannableFormat.Qr)
+        assertThat(persistedComposite.thumbnailBytes).isNotEmpty()
+    }
+
+    @Test
+    fun declinedConfirmationPersistsAPlainImageNotAComposite() {
+        // The confirm-before-usable gate: a real code is present, but the consumer declines (a
+        // suspected misread). Nothing composite is persisted; the artifact degrades to an image.
+        val source = pngFd("declined-qr", barcodeBitmap("MAYBE-MISREAD", ScannableFormat.Qr))
+
+        val persisted = mutableListOf<DocumentPersist>()
+        val result = source.use {
+            runBlocking {
+                importer().import(
+                    source = DocumentImportSource.FileDescriptor(it),
+                    displayLabel = "card.png",
+                    confirmBarcode = { _, _ -> false },
+                    persist = { p -> persisted += p },
+                )
+            }
+        }
+
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    @Test
+    fun imageWithNoBarcodeDegradesToPlainImage() {
+        // A barcode-less photo: extraction finds nothing in the sandbox, the import degrades to a
+        // plain Document.Image (the wpass-i9x graceful-degradation path).
+        val source = pngFd("no-barcode", solidBitmap(512, 384))
+
+        val persisted = mutableListOf<DocumentPersist>()
+        val result = source.use {
+            runBlocking {
+                importer().import(
+                    source = DocumentImportSource.FileDescriptor(it),
+                    displayLabel = "photo.png",
+                    persist = { p -> persisted += p },
+                )
+            }
+        }
+
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    private fun importer(): DocumentImporter = DocumentImporter.create(context)
+
+    /**
+     * Render [payload] as [format] via the kernel encoder, scaling each module up and padding a
+     * white quiet zone so the isolated decoder reliably re-reads it after the import-time
+     * downscale. Returns an ARGB_8888 bitmap.
+     */
+    private fun barcodeBitmap(payload: String, format: ScannableFormat): Bitmap {
+        val matrix: BarcodeMatrix =
+            when (val r = BarcodeEncoder.encode(payload, format)) {
+                is EncodeResult.Success -> r.matrix
+                is EncodeResult.Failure -> error("fixture encode failed: ${r.reason}")
+            }
+        val scale = 8
+        val quiet = 4 * scale
+        val width = matrix.width * scale + quiet * 2
+        val height = matrix.height * scale + quiet * 2
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(Color.WHITE)
+        for (my in 0 until matrix.height) {
+            for (mx in 0 until matrix.width) {
+                if (!matrix.isSet(mx, my)) continue
+                val left = quiet + mx * scale
+                val top = quiet + my * scale
+                for (py in top until top + scale) {
+                    for (px in left until left + scale) {
+                        bitmap.setPixel(px, py, Color.BLACK)
+                    }
+                }
+            }
+        }
+        return bitmap
+    }
+
+    private fun solidBitmap(width: Int, height: Int): Bitmap =
+        Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).apply { eraseColor(Color.WHITE) }
+
+    private fun pngFd(name: String, bitmap: Bitmap): ParcelFileDescriptor {
+        val file = File.createTempFile(name, ".png", context.cacheDir)
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        bitmap.recycle()
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+    }
+}

--- a/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
+++ b/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
@@ -53,6 +53,7 @@ class CompositeImportInstrumentedTest {
                 importer().import(
                     source = DocumentImportSource.FileDescriptor(it),
                     displayLabel = "membership.png",
+                    confirmBarcode = { _, _ -> true },
                     persist = { p -> persisted += p },
                 )
             }
@@ -106,6 +107,7 @@ class CompositeImportInstrumentedTest {
                 importer().import(
                     source = DocumentImportSource.FileDescriptor(it),
                     displayLabel = "photo.png",
+                    confirmBarcode = { _, _ -> true },
                     persist = { p -> persisted += p },
                 )
             }

--- a/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
+++ b/passes-document/src/androidTest/kotlin/is/walt/passes/document/CompositeImportInstrumentedTest.kt
@@ -158,6 +158,10 @@ class CompositeImportInstrumentedTest {
         val file = File.createTempFile(name, ".png", context.cacheDir)
         file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
         bitmap.recycle()
-        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        // Unlink immediately: the open descriptor keeps the inode alive for the importer's read,
+        // so nothing accumulates in cacheDir across repeated device/CI runs (review rec 1).
+        file.delete()
+        return pfd
     }
 }

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
@@ -74,7 +74,7 @@ internal class DefaultDocumentImporter(
     override suspend fun import(
         source: DocumentImportSource,
         displayLabel: String,
-        confirmBarcode: suspend (payload: String, format: ScannableFormat) -> Boolean,
+        confirmBarcode: (suspend (payload: String, format: ScannableFormat) -> Boolean)?,
         persist: suspend (DocumentPersist) -> Unit,
     ): DocumentImportResult {
         val bytes = readBounded(source) ?: return DocumentImportResult.Unrecognized
@@ -126,7 +126,7 @@ internal class DefaultDocumentImporter(
         format: ImageFormat,
         displayLabel: String,
         persist: suspend (DocumentPersist) -> Unit,
-        confirmBarcode: suspend (String, ScannableFormat) -> Boolean,
+        confirmBarcode: (suspend (String, ScannableFormat) -> Boolean)?,
     ): DocumentImportResult {
         val startedAt = now()
         val guard = config.imageTelemetryGuard
@@ -209,17 +209,24 @@ internal class DefaultDocumentImporter(
     }
 
     /**
-     * Runs the isolated barcode extraction and the consumer's confirm gate. Returns the
-     * `(payload, format)` to persist as a composite, or `null` to degrade to a plain image —
+     * Opts into and runs the isolated barcode extraction plus the consumer's confirm gate. When
+     * [confirmBarcode] is `null` the caller has not opted into composites: extraction does NOT run
+     * (no isolated barcode-decode cost) and the result is always a plain image. Otherwise returns
+     * the `(payload, format)` to persist as a composite, or `null` to degrade to a plain image —
      * for no detected code, an extraction failure, OR a declined/failed confirmation. A
      * `CancellationException` from the confirm hook propagates (structured concurrency); any
      * other throw is swallowed to a declined confirmation so a confirm-UI bug cannot fail the
      * whole import.
      */
+    // ReturnCount: three guard-style early exits (not-opted-in, no code, declined) each read as a
+    // distinct reason to stay a plain image; collapsing them behind one expression would obscure
+    // which condition degraded the artifact. Same precedent as importImage above.
+    @Suppress("ReturnCount")
     private suspend fun extractConfirmedBarcode(
         bytes: ByteArray,
-        confirmBarcode: suspend (String, ScannableFormat) -> Boolean,
+        confirmBarcode: (suspend (String, ScannableFormat) -> Boolean)?,
     ): DecodedBarcode? {
+        if (confirmBarcode == null) return null
         val decoded = barcodeExtract(bytes) as? BarcodeDecodeResult.DecodedBarcode ?: return null
         val confirmed = try {
             confirmBarcode(decoded.payload, decoded.format)

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
@@ -6,6 +6,10 @@ import android.graphics.Bitmap
 import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
 import android.os.SystemClock
+import `is`.walt.passes.barcode.android.BarcodeImageDecoder
+import `is`.walt.passes.barcode.android.BarcodeImageSource
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.image.android.BoundedImageDecoder
 import `is`.walt.passes.image.android.ImageDecodeRejectedKind
 import `is`.walt.passes.image.android.ImageDecodeResult
@@ -45,10 +49,19 @@ internal typealias PdfPersist = suspend (String, ByteArray, Int, ByteArray) -> U
  * [DocumentRejectedKind.StorageHandoffFailed] is translated to it so a persist failure reads
  * the same regardless of document kind.
  */
+// LongParameterList: every parameter is an injected seam (three isolated-backend seams plus the
+// two clocks and the id generator) so the orchestration is unit-tested without a live binder.
+// Bundling them into a holder would only relocate the list and obscure what each seam fakes.
+@Suppress("LongParameterList")
 internal class DefaultDocumentImporter(
     private val config: DocumentImportConfig,
     private val pdfImport: suspend (ByteArray, String, PdfPersist) -> PdfImportResult,
     private val imageDecode: suspend (ByteArray, Int) -> ImageDecodeOutcome,
+    // Composite-artifact seam (wpass-8lu): runs the isolated still-image barcode decoder over the
+    // SAME once-read bytes the image decode saw, on its own memfd. Returns the pure
+    // BarcodeDecodeResult; the host never decodes the source bytes. Seam-injected so the
+    // orchestration is unit-tested without a live binder.
+    private val barcodeExtract: suspend (ByteArray) -> BarcodeDecodeResult,
     // Monotonic clock for telemetry durations only. Must NOT be used for importedAt: the
     // [wallClock] below supplies wall time for the persisted record.
     private val now: () -> Long,
@@ -61,6 +74,7 @@ internal class DefaultDocumentImporter(
     override suspend fun import(
         source: DocumentImportSource,
         displayLabel: String,
+        confirmBarcode: suspend (payload: String, format: ScannableFormat) -> Boolean,
         persist: suspend (DocumentPersist) -> Unit,
     ): DocumentImportResult {
         val bytes = readBounded(source) ?: return DocumentImportResult.Unrecognized
@@ -69,7 +83,7 @@ internal class DefaultDocumentImporter(
             else -> {
                 val format = sniffImageFormat(bytes)
                 if (format != null) {
-                    importImage(bytes, format, displayLabel, persist)
+                    importImage(bytes, format, displayLabel, persist, confirmBarcode)
                 } else {
                     DocumentImportResult.Unrecognized
                 }
@@ -112,6 +126,7 @@ internal class DefaultDocumentImporter(
         format: ImageFormat,
         displayLabel: String,
         persist: suspend (DocumentPersist) -> Unit,
+        confirmBarcode: suspend (String, ScannableFormat) -> Boolean,
     ): DocumentImportResult {
         val startedAt = now()
         val guard = config.imageTelemetryGuard
@@ -127,17 +142,15 @@ internal class DefaultDocumentImporter(
             is ImageDecodeOutcome.Decoded -> outcome
         }
 
+        // Composite path (wpass-8lu): extract a barcode from the same bytes in the isolated
+        // decoder. A found+confirmed code makes this a composite; anything else (no code,
+        // extraction failure, declined confirmation) degrades to a plain image — extraction never
+        // fails the import. Resolved BEFORE persist so nothing is stored until the consumer's
+        // confirm step has run ("before the code becomes usable").
+        val barcode = extractConfirmedBarcode(bytes, confirmBarcode)
+
         runCatching {
-            persist(
-                DocumentPersist.Image(
-                    label = displayLabel,
-                    bytes = bytes,
-                    thumbnailBytes = decoded.thumbnailBytes,
-                    format = format,
-                    widthPx = decoded.widthPx,
-                    heightPx = decoded.heightPx,
-                ),
-            )
+            persist(buildPersist(barcode, displayLabel, bytes, decoded, format))
         }.getOrElse { t ->
             if (t is CancellationException) throw t
             guard.onImportFailed(
@@ -146,25 +159,106 @@ internal class DefaultDocumentImporter(
             return DocumentImportResult.StorageHandoffFailed
         }
 
-        val doc = ImageDocument(
-            id = ImageDocumentId(idGenerator()),
-            displayLabel = displayLabel,
-            byteCount = bytes.size.toLong(),
-            widthPx = decoded.widthPx,
-            heightPx = decoded.heightPx,
-            importedAtEpochMs = wallClock(),
-        )
+        val byteCount = bytes.size.toLong()
+        // Same no-PII telemetry event for both arms: it carries only byte count / format /
+        // dimensions, never the decoded payload, so a composite import emits no barcode contents.
         guard.onImportSucceeded(
             ImageImportSucceededEvent(
-                byteCount = doc.byteCount,
+                byteCount = byteCount,
                 format = format,
-                widthPx = doc.widthPx,
-                heightPx = doc.heightPx,
+                widthPx = decoded.widthPx,
+                heightPx = decoded.heightPx,
                 durationMillis = now() - startedAt,
             ),
         )
-        return DocumentImportResult.ImportedImage(doc)
+        return buildImportedResult(barcode, displayLabel, byteCount, decoded)
     }
+
+    private fun buildImportedResult(
+        barcode: DecodedBarcode?,
+        displayLabel: String,
+        byteCount: Long,
+        decoded: ImageDecodeOutcome.Decoded,
+    ): DocumentImportResult {
+        val importedAt = wallClock()
+        return if (barcode != null) {
+            DocumentImportResult.ImportedBarcodedImage(
+                BarcodedImageDocument(
+                    id = BarcodedImageDocumentId(idGenerator()),
+                    displayLabel = displayLabel,
+                    byteCount = byteCount,
+                    widthPx = decoded.widthPx,
+                    heightPx = decoded.heightPx,
+                    barcodePayload = barcode.payload,
+                    barcodeFormat = barcode.format,
+                    importedAtEpochMs = importedAt,
+                ),
+            )
+        } else {
+            DocumentImportResult.ImportedImage(
+                ImageDocument(
+                    id = ImageDocumentId(idGenerator()),
+                    displayLabel = displayLabel,
+                    byteCount = byteCount,
+                    widthPx = decoded.widthPx,
+                    heightPx = decoded.heightPx,
+                    importedAtEpochMs = importedAt,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Runs the isolated barcode extraction and the consumer's confirm gate. Returns the
+     * `(payload, format)` to persist as a composite, or `null` to degrade to a plain image —
+     * for no detected code, an extraction failure, OR a declined/failed confirmation. A
+     * `CancellationException` from the confirm hook propagates (structured concurrency); any
+     * other throw is swallowed to a declined confirmation so a confirm-UI bug cannot fail the
+     * whole import.
+     */
+    private suspend fun extractConfirmedBarcode(
+        bytes: ByteArray,
+        confirmBarcode: suspend (String, ScannableFormat) -> Boolean,
+    ): DecodedBarcode? {
+        val decoded = barcodeExtract(bytes) as? BarcodeDecodeResult.DecodedBarcode ?: return null
+        val confirmed = try {
+            confirmBarcode(decoded.payload, decoded.format)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            false
+        }
+        return if (confirmed) DecodedBarcode(decoded.payload, decoded.format) else null
+    }
+
+    private fun buildPersist(
+        barcode: DecodedBarcode?,
+        displayLabel: String,
+        bytes: ByteArray,
+        decoded: ImageDecodeOutcome.Decoded,
+        format: ImageFormat,
+    ): DocumentPersist =
+        if (barcode != null) {
+            DocumentPersist.BarcodedImage(
+                label = displayLabel,
+                bytes = bytes,
+                thumbnailBytes = decoded.thumbnailBytes,
+                format = format,
+                widthPx = decoded.widthPx,
+                heightPx = decoded.heightPx,
+                barcodePayload = barcode.payload,
+                barcodeFormat = barcode.format,
+            )
+        } else {
+            DocumentPersist.Image(
+                label = displayLabel,
+                bytes = bytes,
+                thumbnailBytes = decoded.thumbnailBytes,
+                format = format,
+                widthPx = decoded.widthPx,
+                heightPx = decoded.heightPx,
+            )
+        }
 
     private fun readBounded(source: DocumentImportSource): ByteArray? {
         val stream = openSource(source) ?: return null
@@ -225,6 +319,16 @@ internal class DefaultDocumentImporter(
         data class Rejected(val kind: ImageDecodeRejectedKind) : ImageDecodeOutcome
     }
 
+    /**
+     * A confirmed barcode to persist as a composite — the pure `(payload, format)` distilled from
+     * the isolated [BarcodeDecodeResult] once the consumer's confirm gate passed. Internal so the
+     * importer never threads a raw [BarcodeDecodeResult] (with its reject arms) past the seam.
+     */
+    internal data class DecodedBarcode(
+        val payload: String,
+        val format: ScannableFormat,
+    )
+
     internal companion object {
         // Read buffer for the bounded materialization loop. 64 KiB matches the
         // InputStream.copyTo default and keeps the read syscall count low.
@@ -243,6 +347,7 @@ internal class DefaultDocumentImporter(
             val pfdFactory = MemfdPfdFactory(MEMFD_DEBUG_NAME)
             val pdfImporter = PdfImporter.create(appContext, config.pdfConfig)
             val imageDecoder = BoundedImageDecoder.create(appContext)
+            val barcodeDecoder = BarcodeImageDecoder.create(appContext)
             return DefaultDocumentImporter(
                 config = config,
                 pdfImport = { bytes, label, persist ->
@@ -260,6 +365,16 @@ internal class DefaultDocumentImporter(
                             is ImageDecodeResult.Rejected -> ImageDecodeOutcome.Rejected(r.kind)
                             is ImageDecodeResult.Ok -> encodeRasterToThumbnail(r)
                         }
+                    } finally {
+                        runCatching { pfd.close() }
+                    }
+                },
+                barcodeExtract = { bytes ->
+                    // A second memfd over the same bytes — the image-decode and barcode-extract
+                    // sandboxes each consume their own fd; the source was still read exactly once.
+                    val pfd = pfdFactory.fromBytes(bytes)
+                    try {
+                        barcodeDecoder.decode(BarcodeImageSource.FileDescriptor(pfd))
                     } finally {
                         runCatching { pfd.close() }
                     }

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImportResult.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImportResult.kt
@@ -29,6 +29,17 @@ public sealed interface DocumentImportResult {
 
     public data class ImportedImage(public val doc: ImageDocument) : DocumentImportResult
 
+    /**
+     * A composite artifact was imported (wpass-8lu): an image whose isolated barcode extraction
+     * found a code AND (when a `confirmBarcode` hook is supplied) the consumer confirmed it. The
+     * [doc]'s `barcodePayload` is the value the consumer already saw in its confirm step. An
+     * image with no detected barcode, a failed/rejected extraction, or a declined confirmation
+     * lands on [ImportedImage] instead — the composite arm exists only for a live, kept barcode.
+     */
+    public data class ImportedBarcodedImage(
+        public val doc: BarcodedImageDocument,
+    ) : DocumentImportResult
+
     public data class PdfRejected(public val kind: DocumentRejectedKind) : DocumentImportResult
 
     public data class ImageRejected(public val kind: ImageDecodeRejectedKind) : DocumentImportResult

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
@@ -16,12 +16,14 @@ import `is`.walt.passes.core.ScannableFormat
  * KDoc makes: composing this by hand in the consumer would be the parallel-implementation
  * pattern the repository's DECISIVE CONSTRAINT forbids.
  *
- * Composite artifacts (wpass-8lu): the image branch additionally runs the isolated still-image
- * barcode decoder (`passes-barcode`) over the SAME once-read bytes. When a code is found the
- * import yields a [DocumentImportResult.ImportedBarcodedImage]; when none is found (or the
- * extraction fails, or the consumer declines via `confirmBarcode`) it degrades to a plain
- * [DocumentImportResult.ImportedImage]. Barcode extraction never runs in the host process; only
- * the decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant.
+ * Composite artifacts (wpass-8lu): when the caller opts in by supplying a `confirmBarcode` hook,
+ * the image branch additionally runs the isolated still-image barcode decoder (`passes-barcode`)
+ * over the SAME once-read bytes. When a code is found the import yields a
+ * [DocumentImportResult.ImportedBarcodedImage]; when none is found (or the extraction fails, or
+ * the consumer declines via `confirmBarcode`) it degrades to a plain
+ * [DocumentImportResult.ImportedImage]. Without the hook (the default) no extraction runs and the
+ * result is always a plain image. Barcode extraction never runs in the host process; only the
+ * decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant.
  *
  * Storage is wired through a `persist` callback rather than a `PassRepository` dependency so
  * `passes-document` stays independent of `passes-storage` (matching `PdfImporter`). The
@@ -43,22 +45,24 @@ public interface DocumentImporter {
      * [displayLabel] is supplied by the consumer; the importer never derives it from the
      * source's metadata (ADR 0005 D4). It is forwarded verbatim to [persist].
      *
-     * [confirmBarcode] gates the composite path (wpass-8lu): for an image whose isolated barcode
-     * extraction found a code, it is invoked with the decoded `(payload, format)` BEFORE anything
-     * is persisted, so the consumer can show its `BarcodeCreateConfirmSheet` and let the user
-     * verify the read (a misread barcode at a checkout is a real failure). Returning `true`
-     * persists a composite ([DocumentPersist.BarcodedImage]); returning `false` degrades to a
-     * plain image ([DocumentPersist.Image]). The default accepts every read, so a consumer that
-     * does not gate gets the composite whenever a code is present. It is never called for PDFs,
-     * for images with no detected barcode, or when extraction fails. A `CancellationException`
-     * from the hook propagates; any other throw is treated as a declined confirmation (degrade
-     * to image) so a confirm-UI bug cannot fail the whole import.
+     * [confirmBarcode] opts into and gates the composite path (wpass-8lu). It is **`null` by
+     * default**, which means barcode extraction does NOT run at all: an imported image is always a
+     * plain [DocumentImportResult.ImportedImage], identical to the wpass-i9x behavior and with no
+     * isolated barcode-decode cost. A consumer that wants composites supplies the hook; only then
+     * does the importer run the isolated extraction. When a code is found the hook is invoked with
+     * the decoded `(payload, format)` BEFORE anything is persisted, so the consumer can show its
+     * `BarcodeCreateConfirmSheet` and let the user verify the read (a misread barcode at a checkout
+     * is a real failure). Returning `true` persists a composite ([DocumentPersist.BarcodedImage]);
+     * returning `false` degrades to a plain image. A consumer that wants composites with no confirm
+     * UX can pass `{ _, _ -> true }` to accept every read. The hook is never called for PDFs, for
+     * images with no detected barcode, or when extraction fails. A `CancellationException` from the
+     * hook propagates; any other throw is treated as a declined confirmation (degrade to image) so
+     * a confirm-UI bug cannot fail the whole import.
      */
     public suspend fun import(
         source: DocumentImportSource,
         displayLabel: String,
-        confirmBarcode: suspend (payload: String, format: ScannableFormat) -> Boolean =
-            { _, _ -> true },
+        confirmBarcode: (suspend (payload: String, format: ScannableFormat) -> Boolean)? = null,
         persist: suspend (DocumentPersist) -> Unit,
     ): DocumentImportResult
 

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.document
 
 import android.content.Context
+import `is`.walt.passes.core.ScannableFormat
 
 /**
  * The single document-import entry point. Magic-byte-sniffs the source as PDF or image and
@@ -14,6 +15,13 @@ import android.content.Context
  * still happens inside the isolated backends. The trust claim is the same one `PdfImporter`'s
  * KDoc makes: composing this by hand in the consumer would be the parallel-implementation
  * pattern the repository's DECISIVE CONSTRAINT forbids.
+ *
+ * Composite artifacts (wpass-8lu): the image branch additionally runs the isolated still-image
+ * barcode decoder (`passes-barcode`) over the SAME once-read bytes. When a code is found the
+ * import yields a [DocumentImportResult.ImportedBarcodedImage]; when none is found (or the
+ * extraction fails, or the consumer declines via `confirmBarcode`) it degrades to a plain
+ * [DocumentImportResult.ImportedImage]. Barcode extraction never runs in the host process; only
+ * the decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant.
  *
  * Storage is wired through a `persist` callback rather than a `PassRepository` dependency so
  * `passes-document` stays independent of `passes-storage` (matching `PdfImporter`). The
@@ -34,10 +42,23 @@ public interface DocumentImporter {
      *
      * [displayLabel] is supplied by the consumer; the importer never derives it from the
      * source's metadata (ADR 0005 D4). It is forwarded verbatim to [persist].
+     *
+     * [confirmBarcode] gates the composite path (wpass-8lu): for an image whose isolated barcode
+     * extraction found a code, it is invoked with the decoded `(payload, format)` BEFORE anything
+     * is persisted, so the consumer can show its `BarcodeCreateConfirmSheet` and let the user
+     * verify the read (a misread barcode at a checkout is a real failure). Returning `true`
+     * persists a composite ([DocumentPersist.BarcodedImage]); returning `false` degrades to a
+     * plain image ([DocumentPersist.Image]). The default accepts every read, so a consumer that
+     * does not gate gets the composite whenever a code is present. It is never called for PDFs,
+     * for images with no detected barcode, or when extraction fails. A `CancellationException`
+     * from the hook propagates; any other throw is treated as a declined confirmation (degrade
+     * to image) so a confirm-UI bug cannot fail the whole import.
      */
     public suspend fun import(
         source: DocumentImportSource,
         displayLabel: String,
+        confirmBarcode: suspend (payload: String, format: ScannableFormat) -> Boolean =
+            { _, _ -> true },
         persist: suspend (DocumentPersist) -> Unit,
     ): DocumentImportResult
 

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
@@ -1,11 +1,14 @@
 package `is`.walt.passes.document
 
+import `is`.walt.passes.core.ScannableFormat
+
 /**
  * What [DocumentImporter] hands its `persist` callback on the success path — a sealed
  * discriminator over the document kinds. The consumer's lambda maps this to
  * `passes-storage`'s `DocumentInsert` (PDF → `DocumentInsert.Pdf`, image →
- * `DocumentInsert.Image`); the importer stays storage-agnostic, exactly as `PdfImporter`'s
- * callback keeps `passes-pdf` and `passes-storage` independent peers.
+ * `DocumentInsert.Image`, composite → `DocumentInsert.BarcodedImage`); the importer stays
+ * storage-agnostic, exactly as `PdfImporter`'s callback keeps `passes-pdf` and `passes-storage`
+ * independent peers.
  *
  * Modelled as a sealed interface (not a widened nullable parameter list) so the consumer's
  * mapping is exhaustive and a caller cannot persist an image with a page count or a PDF with
@@ -35,5 +38,21 @@ public sealed interface DocumentPersist {
         public val format: ImageFormat,
         public val widthPx: Int,
         public val heightPx: Int,
+    ) : DocumentPersist
+
+    /**
+     * A composite artifact (wpass-8lu): an image plus a barcode extracted from it, persisted as
+     * ONE row. The image half mirrors [Image]; [barcodePayload] / [barcodeFormat] are the
+     * isolated-decode result. The consumer maps this to `DocumentInsert.BarcodedImage`.
+     */
+    public data class BarcodedImage(
+        public override val label: String,
+        public override val bytes: ByteArray,
+        public override val thumbnailBytes: ByteArray,
+        public val format: ImageFormat,
+        public val widthPx: Int,
+        public val heightPx: Int,
+        public val barcodePayload: String,
+        public val barcodeFormat: ScannableFormat,
     ) : DocumentPersist
 }

--- a/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
+++ b/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
@@ -3,6 +3,9 @@ package `is`.walt.passes.document
 import android.os.ParcelFileDescriptor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.DecodeFailureReason
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.document.DefaultDocumentImporter.ImageDecodeOutcome
 import `is`.walt.passes.image.android.ImageDecodeRejectedKind
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -152,6 +155,120 @@ class DocumentImporterTest {
         assertThat(imageCalled).isFalse()
     }
 
+    // -- composite artifact (wpass-8lu) ---------------------------------------------
+
+    @Test
+    fun imageWithBarcodeRoutesToCompositeAndPersistsPayloadAndFormat() = runTest {
+        var extractSawBytes: ByteArray? = null
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), widthPx = 640, heightPx = 480) },
+            barcodeExtract = { bytes ->
+                extractSawBytes = bytes
+                BarcodeDecodeResult.DecodedBarcode("PASS-12345", ScannableFormat.Code128)
+            },
+        )
+
+        val result = importer.import(source(pngBytes), "card.png") { persisted += it }
+
+        val imported = result as DocumentImportResult.ImportedBarcodedImage
+        assertThat(imported.doc.widthPx).isEqualTo(640)
+        assertThat(imported.doc.heightPx).isEqualTo(480)
+        assertThat(imported.doc.barcodePayload).isEqualTo("PASS-12345")
+        assertThat(imported.doc.barcodeFormat).isEqualTo(ScannableFormat.Code128)
+        assertThat(imported.doc.byteCount).isEqualTo(pngBytes.size.toLong())
+        // The barcode decoder saw the SAME ORIGINAL bytes the image decoder did.
+        assertThat(extractSawBytes).isEqualTo(pngBytes)
+        val persistedComposite = persisted.single() as DocumentPersist.BarcodedImage
+        assertThat(persistedComposite.bytes).isEqualTo(pngBytes)
+        assertThat(persistedComposite.format).isEqualTo(ImageFormat.Png)
+        assertThat(persistedComposite.barcodePayload).isEqualTo("PASS-12345")
+        assertThat(persistedComposite.barcodeFormat).isEqualTo(ScannableFormat.Code128)
+        assertThat(persistedComposite.thumbnailBytes).isEqualTo(byteArrayOf(7))
+    }
+
+    @Test
+    fun imageWithNoBarcodeDegradesToPlainImage() = runTest {
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.NoBarcodeFound },
+        )
+
+        val result = importer.import(source(pngBytes), "plain.png") { persisted += it }
+
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    @Test
+    fun barcodeExtractionFailureDegradesToPlainImageRatherThanFailingImport() = runTest {
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed) },
+        )
+        val result = importer.import(source(pngBytes), "plain.png") {}
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+    }
+
+    @Test
+    fun declinedConfirmationDegradesToPlainImageAndPersistsNoBarcode() = runTest {
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode("MAYBE-MISREAD", ScannableFormat.Qr) },
+        )
+
+        val result = importer.import(
+            source = source(pngBytes),
+            displayLabel = "card.png",
+            confirmBarcode = { _, _ -> false },
+            persist = { persisted += it },
+        )
+
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    @Test
+    fun confirmHookSeesTheDecodedPayloadBeforePersist() = runTest {
+        val confirmArgs = mutableListOf<Pair<String, ScannableFormat>>()
+        var persistedBeforeConfirm = false
+        var confirmed = false
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode("SEEN-FIRST", ScannableFormat.Ean13) },
+        )
+
+        importer.import(
+            source = source(pngBytes),
+            displayLabel = "card.png",
+            persist = { if (!confirmed) persistedBeforeConfirm = true },
+            confirmBarcode = { payload, format ->
+                confirmArgs += payload to format
+                confirmed = true
+                true
+            },
+        )
+
+        assertThat(confirmArgs).containsExactly("SEEN-FIRST" to ScannableFormat.Ean13)
+        assertThat(persistedBeforeConfirm).isFalse()
+    }
+
+    @Test
+    fun pdfWithEmbeddedBytesNeverRunsBarcodeExtraction() = runTest {
+        var extractionCalled = false
+        val importer = importer(
+            pdfImport = { _, _, _ -> PdfImportResult.Imported(pdfDoc("x.pdf", 10, 1)) },
+            barcodeExtract = {
+                extractionCalled = true
+                BarcodeDecodeResult.NoBarcodeFound
+            },
+        )
+        importer.import(source(pdfBytes), "x.pdf") {}
+        assertThat(extractionCalled).isFalse()
+    }
+
     // -- helpers --------------------------------------------------------------------
 
     private fun importer(
@@ -159,6 +276,10 @@ class DocumentImporterTest {
             { _, _, _ -> PdfImportResult.Rejected(DocumentRejectedKind.NotAPdf) },
         imageDecode: suspend (ByteArray, Int) -> ImageDecodeOutcome =
             { _, _ -> ImageDecodeOutcome.Rejected(ImageDecodeRejectedKind.NotAnImage) },
+        // Default: no barcode found, so an image import yields a plain ImportedImage. Composite
+        // tests override this to a DecodedBarcode.
+        barcodeExtract: suspend (ByteArray) -> BarcodeDecodeResult =
+            { BarcodeDecodeResult.NoBarcodeFound },
         imageTelemetry: ImageImportTelemetryGuard = ImageImportTelemetryGuard.NoOp,
         wallClock: () -> Long = { FIXED_WALL_CLOCK_MS },
     ): DefaultDocumentImporter =
@@ -166,6 +287,7 @@ class DocumentImporterTest {
             config = DocumentImportConfig(imageTelemetryGuard = imageTelemetry),
             pdfImport = pdfImport,
             imageDecode = imageDecode,
+            barcodeExtract = barcodeExtract,
             now = { 0L },
             wallClock = wallClock,
             idGenerator = { "fixed-id" },

--- a/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
+++ b/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
@@ -8,6 +8,7 @@ import `is`.walt.passes.core.DecodeFailureReason
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.document.DefaultDocumentImporter.ImageDecodeOutcome
 import `is`.walt.passes.image.android.ImageDecodeRejectedKind
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -169,7 +170,12 @@ class DocumentImporterTest {
             },
         )
 
-        val result = importer.import(source(pngBytes), "card.png") { persisted += it }
+        val result = importer.import(
+            source = source(pngBytes),
+            displayLabel = "card.png",
+            confirmBarcode = { _, _ -> true },
+            persist = { persisted += it },
+        )
 
         val imported = result as DocumentImportResult.ImportedBarcodedImage
         assertThat(imported.doc.widthPx).isEqualTo(640)
@@ -195,7 +201,12 @@ class DocumentImporterTest {
             barcodeExtract = { BarcodeDecodeResult.NoBarcodeFound },
         )
 
-        val result = importer.import(source(pngBytes), "plain.png") { persisted += it }
+        val result = importer.import(
+            source = source(pngBytes),
+            displayLabel = "plain.png",
+            confirmBarcode = { _, _ -> true },
+            persist = { persisted += it },
+        )
 
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
         assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
@@ -207,8 +218,81 @@ class DocumentImporterTest {
             imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
             barcodeExtract = { BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed) },
         )
-        val result = importer.import(source(pngBytes), "plain.png") {}
+        val result = importer.import(
+            source = source(pngBytes),
+            displayLabel = "plain.png",
+            confirmBarcode = { _, _ -> true },
+            persist = {},
+        )
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+    }
+
+    @Test
+    fun withoutAConfirmHookExtractionIsSkippedAndTheResultIsAPlainImage() = runTest {
+        // Opt-in default (wpass-8lu review rec 2): no hook -> no isolated barcode round-trip, and a
+        // present code never silently produces a composite.
+        var extractionCalled = false
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = {
+                extractionCalled = true
+                BarcodeDecodeResult.DecodedBarcode("INCIDENTAL", ScannableFormat.Qr)
+            },
+        )
+
+        val result = importer.import(source(pngBytes), "photo.png") { persisted += it }
+
+        assertThat(extractionCalled).isFalse()
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    @Test
+    fun confirmHookThrowingNonCancellationDegradesToPlainImage() = runTest {
+        // A confirm-UI bug must not fail the whole import: a non-cancellation throw is treated as
+        // a declined confirmation and the artifact degrades to a plain image.
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode("CODE", ScannableFormat.Qr) },
+        )
+
+        val result = importer.import(
+            source = source(pngBytes),
+            displayLabel = "card.png",
+            confirmBarcode = { _, _ -> error("confirm UI crashed") },
+            persist = { persisted += it },
+        )
+
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+    }
+
+    @Test
+    fun confirmHookCancellationPropagatesOutOfImportAndPersistsNothing() = runTest {
+        // CancellationException must propagate to preserve structured concurrency (not be swallowed
+        // to a declined confirmation), and nothing is persisted because confirm runs before persist.
+        var persisted = false
+        var propagated = false
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode("CODE", ScannableFormat.Qr) },
+        )
+
+        try {
+            importer.import(
+                source = source(pngBytes),
+                displayLabel = "card.png",
+                confirmBarcode = { _, _ -> throw CancellationException("scope cancelled") },
+                persist = { persisted = true },
+            )
+        } catch (_: CancellationException) {
+            propagated = true
+        }
+
+        assertThat(propagated).isTrue()
+        assertThat(persisted).isFalse()
     }
 
     @Test
@@ -265,7 +349,13 @@ class DocumentImporterTest {
                 BarcodeDecodeResult.NoBarcodeFound
             },
         )
-        importer.import(source(pdfBytes), "x.pdf") {}
+        // Opt in to composites; the PDF branch must STILL never run image-barcode extraction.
+        importer.import(
+            source = source(pdfBytes),
+            displayLabel = "x.pdf",
+            confirmBarcode = { _, _ -> true },
+            persist = {},
+        )
         assertThat(extractionCalled).isFalse()
     }
 

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/DocumentRow.kt
@@ -1,5 +1,7 @@
 package `is`.walt.passes.storage
 
+import `is`.walt.passes.core.ScannableFormat
+
 /**
  * Defensive caps `passes-storage` re-checks before inserting a document row. The
  * authoritative source for size and page count is ADR 0005 D7; the renderer-service in
@@ -81,6 +83,25 @@ public sealed interface DocumentInsert {
         public val widthPx: Int,
         public val heightPx: Int,
     ) : DocumentInsert
+
+    /**
+     * A composite artifact (wpass-8lu): a still image plus a barcode extracted from it, persisted
+     * as ONE row. The image half is identical to [Image] — [format] is one of the image arms of
+     * [DocumentFormat], [widthPx] / [heightPx] are the sandbox raster dimensions. The barcode
+     * half is [barcodePayload] (the decoded symbol contents) plus [barcodeFormat] (the symbology
+     * it was detected as). Passing [DocumentFormat.Pdf] as [format] is a caller bug; a composite
+     * is always image-backed.
+     */
+    public data class BarcodedImage(
+        public override val label: String,
+        public override val bytes: ByteArray,
+        public override val thumbnailBytes: ByteArray,
+        public val format: DocumentFormat,
+        public val widthPx: Int,
+        public val heightPx: Int,
+        public val barcodePayload: String,
+        public val barcodeFormat: ScannableFormat,
+    ) : DocumentInsert
 }
 
 /**
@@ -94,6 +115,12 @@ public sealed interface DocumentInsert {
  * the image formats use [widthPx] / [heightPx]. The fields not relevant to a row's kind are
  * the column defaults — [pageCount] is `1` for image rows (an image is a single page),
  * [widthPx] / [heightPx] are `null` for PDF rows.
+ *
+ * [barcodePayload] / [barcodeFormat] are non-null ONLY for a composite artifact (wpass-8lu) —
+ * an image row that also carries a barcode extracted from it. A consumer rebuilds a
+ * `BarcodedImageDocument` when both are present and an `ImageDocument` otherwise; they are
+ * always `null` for PDF rows and for plain image rows. The pair is the composite discriminator
+ * on top of the image [format] (the barcode does not change the container format).
  */
 public data class DocumentRow(
     public val id: DocumentRecordId,
@@ -104,4 +131,6 @@ public data class DocumentRow(
     public val widthPx: Int?,
     public val heightPx: Int?,
     public val importedAtEpochMs: Long,
+    public val barcodePayload: String? = null,
+    public val barcodeFormat: ScannableFormat? = null,
 )

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/Schema.kt
@@ -14,7 +14,7 @@ package `is`.walt.passes.storage
 public object Schema {
     public const val DATABASE_NAME: String = "walt_passes.db"
 
-    public const val VERSION: Int = 6
+    public const val VERSION: Int = 7
 
     public object Tables {
         public const val SCHEMA_META: String = "schema_meta"
@@ -165,6 +165,25 @@ public object Schema {
     )
 
     /**
+     * v6 -> v7 migration. Adds the composite-artifact columns (wpass-8lu): a barcode extracted
+     * from an imported image, carried on the same `documents` row as the image it came from so
+     * the composite stays ONE artifact / ONE row.
+     *
+     *  - `barcode_payload` — the verbatim decoded symbol contents.
+     *  - `barcode_format` — the [ScannableFormat][`is`.walt.passes.core.ScannableFormat] name
+     *    the code was detected as (stored as the name, matching `scannable_cards.format`).
+     *
+     * Both nullable: NULL for every existing row (PDF or plain image) and for any future image
+     * with no detected barcode. A row is a composite iff BOTH are non-null; the `format` column
+     * stays the image container format ('png' / 'jpeg' / 'webp'), so a composite reads back as an
+     * image row that additionally carries a barcode. Pure additive ALTERs; no row can fail.
+     */
+    private val V6_TO_V7_ADD_BARCODE: List<String> = listOf(
+        "ALTER TABLE documents ADD COLUMN barcode_payload TEXT",
+        "ALTER TABLE documents ADD COLUMN barcode_format TEXT",
+    )
+
+    /**
      * The DDL block that brings a fresh database to [VERSION]. Statements are listed in
      * dependency order (parent tables before child tables); they are executed in a single
      * transaction by the implementation.
@@ -220,7 +239,8 @@ public object Schema {
             PRIMARY KEY (pass_id, locale_tag)
         )
         """.trimIndent(),
-    ) + V2_DOCUMENT_TABLES + V4_SCANNABLE_CARD_TABLES + V5_TO_V6_ADD_DOCUMENT_FORMAT
+    ) + V2_DOCUMENT_TABLES + V4_SCANNABLE_CARD_TABLES + V5_TO_V6_ADD_DOCUMENT_FORMAT +
+        V6_TO_V7_ADD_BARCODE
 
     /**
      * Schema migrations, keyed by `fromVersion`. Forward-only per ADR 0002. Each entry's
@@ -246,6 +266,10 @@ public object Schema {
      * v5 -> v6 generalizes `documents` from PDF-only to PDF + image (ADR 0005, amended for
      * wpass-i9x): adds the `format` discriminator and nullable `width_px` / `height_px`.
      * Pure additive; existing rows default to `format = 'pdf'`.
+     *
+     * v6 -> v7 adds the composite-artifact columns `barcode_payload` / `barcode_format`
+     * (wpass-8lu): a barcode extracted from an imported image, carried on the same row. Pure
+     * additive; existing rows read back NULL (no barcode).
      */
     public val MIGRATIONS: Map<Int, List<String>> = mapOf(
         1 to V2_DOCUMENT_TABLES,
@@ -253,5 +277,6 @@ public object Schema {
         3 to V3_TO_V4_DROP_COLOR_COLUMN,
         4 to V4_TO_V5_ADD_USER_LABEL,
         5 to V5_TO_V6_ADD_DOCUMENT_FORMAT,
+        6 to V6_TO_V7_ADD_BARCODE,
     )
 }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -158,12 +158,16 @@ public class SqlCipherPassRepository internal constructor(
         // applies only to the PDF arm — images cannot exceed it by construction.
         val pageCount = when (insert) {
             is DocumentInsert.Pdf -> insert.pageCount
-            is DocumentInsert.Image -> IMAGE_PAGE_COUNT
+            is DocumentInsert.Image, is DocumentInsert.BarcodedImage -> IMAGE_PAGE_COUNT
         }
         val (format, widthPx, heightPx) = when (insert) {
             is DocumentInsert.Pdf -> Triple(DocumentFormat.Pdf, null, null)
             is DocumentInsert.Image -> Triple(insert.format, insert.widthPx, insert.heightPx)
+            is DocumentInsert.BarcodedImage -> Triple(insert.format, insert.widthPx, insert.heightPx)
         }
+        // Non-null only for the composite arm; a plain image / PDF persists NULL barcode columns.
+        val barcodePayload = (insert as? DocumentInsert.BarcodedImage)?.barcodePayload
+        val barcodeFormat = (insert as? DocumentInsert.BarcodedImage)?.barcodeFormat
 
         rejectionKindOrNull(insert, byteCount)?.let { kind ->
             return@runIo rejectDocument(kind)
@@ -180,6 +184,8 @@ public class SqlCipherPassRepository internal constructor(
                     heightPx = heightPx,
                     thumbnailBytes = insert.thumbnailBytes,
                     nowEpochMs = clock(),
+                    barcodePayload = barcodePayload,
+                    barcodeFormat = barcodeFormat,
                 ),
             )
             // Re-read the full ordered list rather than prepending in-memory: matches the

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/DocumentStore.kt
@@ -1,5 +1,6 @@
 package `is`.walt.passes.storage.internal
 
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.storage.DocumentFormat
 import `is`.walt.passes.storage.DocumentRecordId
 import `is`.walt.passes.storage.DocumentRow
@@ -39,6 +40,9 @@ internal interface DocumentStore {
  * an image, a single page), and [widthPx] / [heightPx] carry the image dimensions (or `null`
  * for a PDF). [bytes] is the original document bytes; the store writes them to the reused
  * `pdf_bytes` BLOB column verbatim.
+ *
+ * [barcodePayload] / [barcodeFormat] are non-null only for a composite artifact (wpass-8lu) — an
+ * image row that also carries an extracted barcode — and `null` for PDF and plain image rows.
  */
 internal data class DocumentInsertRequest(
     val displayLabel: String,
@@ -49,6 +53,8 @@ internal data class DocumentInsertRequest(
     val heightPx: Int?,
     val thumbnailBytes: ByteArray,
     val nowEpochMs: Long,
+    val barcodePayload: String? = null,
+    val barcodeFormat: ScannableFormat? = null,
 )
 
 internal data class DocumentInsertOutcome(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/internal/SqlCipherDocumentStore.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.storage.internal
 
 import android.content.ContentValues
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.storage.DocumentFormat
 import `is`.walt.passes.storage.DocumentRecordId
 import `is`.walt.passes.storage.DocumentRow
@@ -26,11 +27,16 @@ internal class SqlCipherDocumentStore(
         val out = ArrayList<DocumentRow>()
         db.rawQuery(
             "SELECT id, display_label, byte_count, format, page_count, width_px, height_px, " +
-                "imported_at_epoch_ms " +
+                "imported_at_epoch_ms, barcode_payload, barcode_format " +
                 "FROM ${Schema.Tables.DOCUMENTS} ORDER BY imported_at_epoch_ms DESC, id DESC",
             emptyArray(),
         ).use { c ->
             while (c.moveToNext()) {
+                // A barcode is present only when BOTH columns decode: a payload with an
+                // unrecognised format name (DB tampering only — this module is the sole writer)
+                // reads back as no barcode rather than a half-composite.
+                val payload = if (c.isNull(8)) null else c.getString(8)
+                val barcodeFormat = if (c.isNull(9)) null else c.getString(9).toScannableFormatOrNull()
                 out += DocumentRow(
                     id = DocumentRecordId(c.getLong(0)),
                     displayLabel = c.getString(1),
@@ -40,6 +46,8 @@ internal class SqlCipherDocumentStore(
                     widthPx = if (c.isNull(5)) null else c.getInt(5),
                     heightPx = if (c.isNull(6)) null else c.getInt(6),
                     importedAtEpochMs = c.getLong(7),
+                    barcodePayload = if (barcodeFormat == null) null else payload,
+                    barcodeFormat = if (payload == null) null else barcodeFormat,
                 )
             }
         }
@@ -59,6 +67,16 @@ internal class SqlCipherDocumentStore(
                 if (request.widthPx == null) putNull("width_px") else put("width_px", request.widthPx)
                 if (request.heightPx == null) putNull("height_px") else put("height_px", request.heightPx)
                 put("imported_at_epoch_ms", request.nowEpochMs)
+                if (request.barcodePayload == null) {
+                    putNull("barcode_payload")
+                } else {
+                    put("barcode_payload", request.barcodePayload)
+                }
+                if (request.barcodeFormat == null) {
+                    putNull("barcode_format")
+                } else {
+                    put("barcode_format", request.barcodeFormat.name)
+                }
             }
             val rowId = db.insertOrThrow(Schema.Tables.DOCUMENTS, null, docCv)
             val thumbCv = ContentValues().apply {
@@ -79,6 +97,8 @@ internal class SqlCipherDocumentStore(
                     widthPx = request.widthPx,
                     heightPx = request.heightPx,
                     importedAtEpochMs = request.nowEpochMs,
+                    barcodePayload = request.barcodePayload,
+                    barcodeFormat = request.barcodeFormat,
                 ),
             )
         } finally {
@@ -149,3 +169,12 @@ private fun String.toDocumentFormat(): DocumentFormat = when (this) {
     "webp" -> DocumentFormat.WebP
     else -> DocumentFormat.Pdf
 }
+
+/**
+ * The on-disk vocabulary for the `barcode_format` column: the [ScannableFormat] name, matching
+ * `scannable_cards.format` (`SqlCipherScannableCardStore`). An unrecognised value (only possible
+ * from out-of-band DB tampering) decodes to `null`, which the row mapper treats as "no barcode"
+ * rather than throwing on a list query.
+ */
+private fun String.toScannableFormatOrNull(): ScannableFormat? =
+    ScannableFormat.entries.firstOrNull { it.name == this }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -402,6 +402,55 @@ class DocumentRepositoryTest {
     }
 
     @Test
+    fun insertBarcodedImagePersistsImageFieldsAndBarcodePayloadAndFormat() = runTest {
+        val docs = FakeDocumentStore()
+        val repo = repo(docs, RecordingGuard())
+
+        val image = ByteArray(2048) { 0x55 }
+        val result = repo.insertDocument(
+            DocumentInsert.BarcodedImage(
+                label = "membership.png",
+                bytes = image,
+                thumbnailBytes = ByteArray(64) { 0x22 },
+                format = DocumentFormat.Png,
+                widthPx = 600,
+                heightPx = 400,
+                barcodePayload = "MEMBER-99887",
+                barcodeFormat = ScannableFormat.Code128,
+            ),
+        )
+
+        check(result is StorageResult.Success)
+        val row = repo.observeDocuments().first().single()
+        // The barcode is carried on the SAME row as the image — one artifact, one wallet entry.
+        assertThat(row.format).isEqualTo(DocumentFormat.Png)
+        assertThat(row.widthPx).isEqualTo(600)
+        assertThat(row.heightPx).isEqualTo(400)
+        assertThat(row.pageCount).isEqualTo(1)
+        assertThat(row.barcodePayload).isEqualTo("MEMBER-99887")
+        assertThat(row.barcodeFormat).isEqualTo(ScannableFormat.Code128)
+    }
+
+    @Test
+    fun insertPlainImageLeavesBarcodeFieldsNull() = runTest {
+        val docs = FakeDocumentStore()
+        val repo = repo(docs, RecordingGuard())
+        repo.insertDocument(
+            DocumentInsert.Image(
+                label = "plain.png",
+                bytes = ByteArray(32),
+                thumbnailBytes = ByteArray(8),
+                format = DocumentFormat.Png,
+                widthPx = 10,
+                heightPx = 10,
+            ),
+        )
+        val row = repo.observeDocuments().first().single()
+        assertThat(row.barcodePayload).isNull()
+        assertThat(row.barcodeFormat).isNull()
+    }
+
+    @Test
     fun insertImageDocumentStillEnforcesTheByteCap() = runTest {
         val repo = repo(FakeDocumentStore(), RecordingGuard())
         val rejected = repo.insertDocument(
@@ -489,6 +538,8 @@ class DocumentRepositoryTest {
                 widthPx = request.widthPx,
                 heightPx = request.heightPx,
                 importedAtEpochMs = request.nowEpochMs,
+                barcodePayload = request.barcodePayload,
+                barcodeFormat = request.barcodeFormat,
             )
             entries[id.value] = Entry(row, request.bytes.copyOf(), request.thumbnailBytes.copyOf())
             return DocumentInsertOutcome(id = id, row = row)

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/PublicApiSurfaceTest.kt
@@ -203,8 +203,8 @@ class PublicApiSurfaceTest {
     }
 
     @Test
-    fun schemaDeclaresSevenTablesAndIsAtVersionSix() {
-        assertThat(Schema.VERSION).isEqualTo(6)
+    fun schemaDeclaresSevenTablesAndIsAtVersionSeven() {
+        assertThat(Schema.VERSION).isEqualTo(7)
         assertThat(Schema.Tables.SCHEMA_META).isEqualTo("schema_meta")
         assertThat(Schema.Tables.PASSES).isEqualTo("passes")
         assertThat(Schema.Tables.PASS_IMAGES).isEqualTo("pass_images")
@@ -216,9 +216,10 @@ class PublicApiSurfaceTest {
         // + documents + 1 document index + document_thumbnails
         // + scannable_cards (v4 shape, no color_argb) + 1 scannable-card index
         // + 3 v5->v6 document ALTERs (format / width_px / height_px)
-        // = 15 statements.
-        assertThat(Schema.DDL).hasSize(15)
-        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3, 4, 5)
+        // + 2 v6->v7 document ALTERs (barcode_payload / barcode_format)
+        // = 17 statements.
+        assertThat(Schema.DDL).hasSize(17)
+        assertThat(Schema.MIGRATIONS.keys).containsExactly(1, 2, 3, 4, 5, 6)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a first-class **composite artifact** — a stored image plus a barcode extracted from it in the isolated decode worker — persisted as **one wallet item** (one id, one row). Follow-on to wpass-i9x (image-document generalization). Implements kernel bead `wpass-8lu`; unblocks consumer `wlt-u3tk → wlt-2ub2` under epic `wlt-yjn5`.

### Design
Third `Document` arm (`BarcodedImageDocument`), not a new tower — a strict superset of `ImageDocument` that reuses the image isolation/storage/UI substrate and degrades to a plain `ImageDocument` when no code is found.

- **passes-document-core** — `BarcodedImageDocument` + `BarcodedImageDocumentId`; new `api(passes-core)` edge for `ScannableFormat`.
- **passes-storage** — schema **v6→v7**: nullable `barcode_payload` / `barcode_format` columns (composite = image row + non-null barcode pair; image `format` unchanged). `DocumentInsert.BarcodedImage`; barcode fields on `DocumentRow` / `DocumentInsertRequest`. Format-name vocab matches `scannable_cards`.
- **passes-document** — `import()` gains an **opt-in** `confirmBarcode` hook (`null` default = no extraction at all → plain image at zero cost; supplying it runs the isolated `BarcodeImageDecoder` over a second memfd of the same once-read bytes and gates the result **before persist**). Folds onto `ImportedBarcodedImage`, degrading to `ImportedImage` on no-code / extraction-failure / declined-confirm. New `implementation(passes-barcode)` edge.
- **passes-document-ui** — `DocumentView` routes the new arm to the existing `ImageDocumentView` (image half only; same `imageFile`/`imageDecoder` pair → 9-param `SurfaceLock` unchanged). The barcode + format switcher are consumer-composed via `passes-ui`, keeping the two UI towers independent.

### Isolation invariant
Barcode extraction never runs in the host process; only `{payload, ScannableFormat}` cross the binder. Verified by tests + a security review (no host `BitmapFactory`/`ImageDecoder`/ZXing on source bytes).

## Tests
- JVM/Robolectric: importer composite/degrade/confirm paths (incl. confirm-hook exception contract + opt-in default), storage round-trip + v6→v7 migration, core arm-set lock.
- On-device (`CompositeImportInstrumentedTest`, kernel isolation half): authored + compiles; runs under `connectedAndroidTest`. Full import+**render** e2e tracked consumer-side as `wlt-yjn5.1`.
- All affected-module checks (tests + detekt + ktlint + lint) green locally.

## Review responses
- Untested confirm-hook exception contract → locked with tests (cancellation propagates; other throws degrade).
- Extraction-on-every-image + silent composite default → made extraction **opt-in** (null default skips it entirely).
- ByteArray referential equality → no change (matches existing Image/Pdf arms).
- Instrumented-test temp-PNG leak → unlink-after-open (leak-free).

## Docs
ADR 0005 amended with the 2026-06-17 composite addendum (C1–C5 + telemetry discipline + tests-pinning table).