### PR TITLE
deps: align Kotlin to consumer (2.2.21 → 2.3.21)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.0.1"
-kotlin = "2.2.21"
+kotlin = "2.3.21"
 kotlinxSerialization = "1.11.0"
 kotlinxCoroutines = "1.11.0"
 junit = "4.13.2"


### PR DESCRIPTION
Aligns this repo's Kotlin to the consumer instead of overshooting it.

## Why
- walt-android (the toolchain source of truth per the version-catalog comment, "matches walt-android consumer to avoid drift") is on **Kotlin 2.3.21**.
- This repo had drifted **behind** at 2.2.21.
- Dependabot #142 proposed **2.4.0**, which would push this repo **ahead** of the consumer and re-introduce drift in the other direction. Closed #142 in favor of this.

## What
- `kotlin = "2.2.21"` → `"2.3.21"`.
- The `kotlin` key drives the Compose compiler plugin, serialization plugin, `kotlin-reflect`, and the Kotlin Gradle plugins in lockstep (`version.ref = "kotlin"`), so the whole Kotlin toolchain moves together. AGP (9.0.1), detekt (1.23.8), and ktlint (12.1.1) already match the consumer.

## Follow-up (not in this PR)
- The consumer also moved Compose BOM `2026.01.00` → `2026.06.00`. This repo is still on `2026.01.00`; a separate alignment may be warranted.

## CI note
The #142 red-X was the flaky `FieldLinkScannerTest.phoneScanCompletesQuicklyOnPathologicalInput` wall-clock timing test (and a corrupted emulator-SDK download), not a Kotlin incompatibility. Expect a possible re-run here.

https://claude.ai/code/session_01VgedtvVaboKPh5EDuxnR1b