### PR TITLE
docs: publish APK signing fingerprint and verify steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ Pre-alpha. Architecture and design phase. No releases yet.
 - Manual entry, QR-scan import (deferred to v2).
 - Lock screen integration (deferred to v1.5).
 
+## Verifying a downloaded APK
+
+Every Walt Android build is signed with the same key, so its SHA-256
+signing-certificate fingerprint is stable across releases. The canonical
+download is [walt.is/releases](https://walt.is/releases); this fingerprint is
+published here as a second, independent source so it can be cross-checked
+against the website rather than trusted on the website's word alone.
+
+**SHA-256 signing fingerprint:**
+
+```
+6C:8D:50:53:EB:9D:0A:4A:84:72:CA:7D:92:F2:52:9E:FB:A9:4C:24:E4:90:1D:99:D1:6B:B8:5A:79:34:64:99
+```
+
+Before installing a directly downloaded APK, run `apksigner` (from the Android
+SDK build-tools) against the file and confirm the printed certificate digest
+matches the value above:
+
+```
+apksigner verify --print-certs --min-sdk-version 24 walt-<version>.apk
+```
+
+If the digests do not match, do not install the file.
+
 ## Security policy
 
 See [`SECURITY.md`](SECURITY.md) for vulnerability disclosure.

--- a/README.md
+++ b/README.md
@@ -54,27 +54,38 @@ Pre-alpha. Architecture and design phase. No releases yet.
 
 ## Verifying a downloaded APK
 
+> These steps apply to the shipped Walt Android app, downloadable once releases
+> ship. This repository's own library modules are still pre-alpha (see Status).
+
 Every Walt Android build is signed with the same key, so its SHA-256
 signing-certificate fingerprint is stable across releases. The canonical
 download is [walt.is/releases](https://walt.is/releases); this fingerprint is
 published here as a second, independent source so it can be cross-checked
 against the website rather than trusted on the website's word alone.
 
-**SHA-256 signing fingerprint:**
+**SHA-256 signing-certificate fingerprint**, as printed by `apksigner`
+(lowercase, no colons):
+
+```
+6c8d5053eb9d0a4a8472ca7d92f2529efba94c24e4901d99d16bb85a79346499
+```
+
+The same value in `keytool` / Play Console format (uppercase, colon-separated):
 
 ```
 6C:8D:50:53:EB:9D:0A:4A:84:72:CA:7D:92:F2:52:9E:FB:A9:4C:24:E4:90:1D:99:D1:6B:B8:5A:79:34:64:99
 ```
 
 Before installing a directly downloaded APK, run `apksigner` (from the Android
-SDK build-tools) against the file and confirm the printed certificate digest
-matches the value above:
+SDK build-tools) against the file:
 
 ```
-apksigner verify --print-certs --min-sdk-version 24 walt-<version>.apk
+apksigner verify --print-certs walt-<version>.apk
 ```
 
-If the digests do not match, do not install the file.
+The APK is genuine only if **both** hold: the command exits successfully (the
+signature is valid) and the printed `certificate SHA-256 digest` matches the
+apksigner fingerprint above. If either check fails, do not install the file.
 
 ## Security policy
 


### PR DESCRIPTION
Adds a **Verifying a downloaded APK** section to the README.

## Why
The signing fingerprint is currently published only on walt.is/releases — the same origin as the APK download. A fingerprint co-located with the binary it vouches for can't defend against compromise of that origin. Publishing it here gives users a second, independent source to cross-check.

## What
- SHA-256 signing-certificate fingerprint (per-key, stable across releases), shown in **both** apksigner format (lowercase/no-colon) and keytool/Play Console format (uppercase/colon)
- `apksigner verify --print-certs` command, with a do-not-install warning if the check fails
- Genuine = command succeeds (signature valid) **and** digest matches
- Scope note: steps apply to the shipped app, not this repo's pre-alpha modules

## Fingerprint verification (review item)
The published value was verified **byte-for-byte against a release-signed APK** (`walt-0.1.12.apk`, same key):
```
Signer #1 certificate SHA-256 digest: 6c8d5053eb9d0a4a8472ca7d92f2529efba94c24e4901d99d16bb85a79346499
Signer #1 certificate DN: CN=Cole Bittel, O=Embedded Engineering ApS, C=DK
```
Matches the published fingerprint. `apksigner verify` exits 0.

## Review responses
- **Format mismatch** — fixed: now published in apksigner's lowercase/no-colon form (plus keytool form).
- **`--min-sdk-version 24`** — dropped. Verified the claimed failure does **not** occur (the APK is v3-only/minSdk 28; `--min-sdk-version 24` still verifies, exit 0), but the flag is unnecessary so it's removed and apksigner now infers the floor.
- **"No releases yet" tension** — addressed with a scope note (the line refers to this repo's library modules, not the shipped app).

Companion: walt-app/walt-signup#166.
