### PR TITLE
passes-storage: align updateDocumentLabel with pass rename semantics (wpass-tjc.1)

### DIFF
--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -107,7 +107,9 @@ public interface PassRepository {
      * Defense in depth (ADR 0005 D7): rejects documents whose size exceeds
      * [DocumentBounds.MAX_BYTES] with [DocumentStorageRejectedKind.OversizedAtStorage], and
      * labels longer than [DocumentBounds.MAX_LABEL_CHARS] with
-     * [DocumentStorageRejectedKind.LabelTooLongAtStorage]. For a [DocumentInsert.Pdf] it
+     * [DocumentStorageRejectedKind.LabelTooLongAtStorage]. The label is normalized like
+     * [updateDocumentLabel] — trimmed, blank folding to the empty string — and the cap is
+     * measured against the trimmed value, so both paths writing the label column agree. For a [DocumentInsert.Pdf] it
      * additionally rejects page counts exceeding [DocumentBounds.MAX_PAGES] with
      * [DocumentStorageRejectedKind.TooManyPagesAtStorage]; the page cap does not apply to
      * images, which are a single page. The upstream import path already enforces the size
@@ -132,8 +134,7 @@ public interface PassRepository {
      * trailing whitespace before storage (internal whitespace preserved), and a label
      * that is blank after trimming is stored as the empty string — the document label
      * column is non-null with no fallback identity, so empty is its cleared state
-     * (consumers render a placeholder). The same "invisible label" defense in depth
-     * applies here as on the pass side: an all-whitespace rename cannot land verbatim.
+     * (consumers render a placeholder).
      *
      * Mirrors [insertDocument]'s label cap, measured against the trimmed value: rejects
      * labels longer than [DocumentBounds.MAX_LABEL_CHARS] with

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -124,14 +124,24 @@ public interface PassRepository {
     ): StorageResult<DocumentRecordId>
 
     /**
-     * Updates the display label of an existing document row. Mirrors [insertDocument]'s
-     * label cap: rejects labels longer than [DocumentBounds.MAX_LABEL_CHARS] with
+     * Updates the display label of an existing document row. Applies to every document
+     * kind — PDF, image, and composite rows share one `documents` table, and the update
+     * touches only `display_label`; kind-specific columns are preserved.
+     *
+     * Normalization mirrors [updatePassUserLabel]: [label] is trimmed of leading and
+     * trailing whitespace before storage (internal whitespace preserved), and a label
+     * that is blank after trimming is stored as the empty string — the document label
+     * column is non-null with no fallback identity, so empty is its cleared state
+     * (consumers render a placeholder). The same "invisible label" defense in depth
+     * applies here as on the pass side: an all-whitespace rename cannot land verbatim.
+     *
+     * Mirrors [insertDocument]'s label cap, measured against the trimmed value: rejects
+     * labels longer than [DocumentBounds.MAX_LABEL_CHARS] with
      * [StorageError.DocumentRejected] carrying
      * [DocumentStorageRejectedKind.LabelTooLongAtStorage], and no row is touched. The cap
      * is checked before the row is loaded, so an over-long label against an unknown
      * [id] surfaces as [StorageError.DocumentRejected], not
-     * [StorageError.IntegrityViolation]. Empty and blank labels are accepted, matching
-     * [insertDocument]'s behavior.
+     * [StorageError.IntegrityViolation].
      *
      * Returns [StorageError.IntegrityViolation] if no row matches [id] (and the label
      * passed the cap). On success, the row's `imported_at_epoch_ms` is unchanged

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -205,11 +205,15 @@ public class SqlCipherPassRepository internal constructor(
         id: DocumentRecordId,
         label: String,
     ): StorageResult<Unit> = runIo {
-        if (label.length > DocumentBounds.MAX_LABEL_CHARS) {
+        // Normalize like updatePassUserLabel: trim, then measure the cap against the
+        // trimmed value. Blank-after-trim folds to "" — the non-null column has no
+        // fallback identity to clear to, so empty IS the cleared state.
+        val normalized = label.trim()
+        if (normalized.length > DocumentBounds.MAX_LABEL_CHARS) {
             return@runIo rejectDocument(DocumentStorageRejectedKind.LabelTooLongAtStorage)
         }
         val matched = writeMutex.withLock {
-            val ok = documentStore.updateLabel(id, label)
+            val ok = documentStore.updateLabel(id, normalized)
             if (ok) _documents.value = documentStore.listRows()
             ok
         }

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -169,14 +169,18 @@ public class SqlCipherPassRepository internal constructor(
         val barcodePayload = (insert as? DocumentInsert.BarcodedImage)?.barcodePayload
         val barcodeFormat = (insert as? DocumentInsert.BarcodedImage)?.barcodeFormat
 
-        rejectionKindOrNull(insert, byteCount)?.let { kind ->
+        // Same label normalization as updateDocumentLabel, so both paths writing
+        // display_label agree (an all-whitespace label cannot land at import either).
+        val label = insert.label.trim()
+
+        rejectionKindOrNull(insert, label, byteCount)?.let { kind ->
             return@runIo rejectDocument(kind)
         }
 
         val outcome = writeMutex.withLock {
             val o = documentStore.insert(
                 DocumentInsertRequest(
-                    displayLabel = insert.label,
+                    displayLabel = label,
                     bytes = insert.bytes,
                     format = format,
                     pageCount = pageCount,
@@ -205,9 +209,8 @@ public class SqlCipherPassRepository internal constructor(
         id: DocumentRecordId,
         label: String,
     ): StorageResult<Unit> = runIo {
-        // Normalize like updatePassUserLabel: trim, then measure the cap against the
-        // trimmed value. Blank-after-trim folds to "" — the non-null column has no
-        // fallback identity to clear to, so empty IS the cleared state.
+        // Normalize like updatePassUserLabel: trim, measure the cap against the trimmed
+        // value. Blank folds to "" (see the contract KDoc).
         val normalized = label.trim()
         if (normalized.length > DocumentBounds.MAX_LABEL_CHARS) {
             return@runIo rejectDocument(DocumentStorageRejectedKind.LabelTooLongAtStorage)
@@ -385,17 +388,19 @@ public class SqlCipherPassRepository internal constructor(
 
     /**
      * Returns the storage-side rejection kind for an insert, or null if all caps pass.
-     * Checked in order: size, page count (PDF only), label length. The page cap is skipped
-     * for the image arm, which is a single page and cannot exceed it.
+     * Checked in order: size, page count (PDF only), label length ([label] is the
+     * trimmed value). The page cap is skipped for the image arm, which is a single page
+     * and cannot exceed it.
      */
     private fun rejectionKindOrNull(
         insert: DocumentInsert,
+        label: String,
         byteCount: Long,
     ): DocumentStorageRejectedKind? = when {
         byteCount > DocumentBounds.MAX_BYTES -> DocumentStorageRejectedKind.OversizedAtStorage
         insert is DocumentInsert.Pdf && insert.pageCount > DocumentBounds.MAX_PAGES ->
             DocumentStorageRejectedKind.TooManyPagesAtStorage
-        insert.label.length > DocumentBounds.MAX_LABEL_CHARS ->
+        label.length > DocumentBounds.MAX_LABEL_CHARS ->
             DocumentStorageRejectedKind.LabelTooLongAtStorage
         else -> null
     }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -347,6 +347,48 @@ class DocumentRepositoryTest {
     }
 
     @Test
+    fun updateLabelOverCapAgainstUnknownIdIsRejectedBeforeRowLookup() = runTest {
+        val telemetry = RecordingGuard()
+        val repo = repo(FakeDocumentStore(), telemetry)
+
+        val tooLongAfterTrim = "  " + "a".repeat(DocumentBounds.MAX_LABEL_CHARS + 1) + "  "
+        val result = repo.updateDocumentLabel(DocumentRecordId(404L), tooLongAfterTrim)
+
+        check(result is StorageResult.Failure)
+        val err = result.error as StorageError.DocumentRejected
+        assertThat(err.kind).isEqualTo(DocumentStorageRejectedKind.LabelTooLongAtStorage)
+        // Cap precedence: rejected before the row lookup, so no IntegrityViolation event.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "doc-rejected:LabelTooLongAtStorage",
+        ).inOrder()
+    }
+
+    @Test
+    fun insertTrimsLabelAndFoldsBlankToEmptyMatchingUpdate() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+
+        val trimmed = repo.insertDocument(
+            label = "  boarding pass  ",
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(trimmed is StorageResult.Success)
+        val blank = repo.insertDocument(
+            label = "   ",
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(blank is StorageResult.Success)
+
+        val labelsById = repo.observeDocuments().first().associate { it.id to it.displayLabel }
+        assertThat(labelsById[trimmed.value]).isEqualTo("boarding pass")
+        assertThat(labelsById[blank.value]).isEqualTo("")
+    }
+
+    @Test
     fun updateLabelOnImageRowPreservesKindColumns() = runTest {
         val repo = repo(FakeDocumentStore(), RecordingGuard())
         val insert = repo.insertDocument(
@@ -642,9 +684,6 @@ class DocumentRepositoryTest {
     }
 
     /**
-     * Pass-side store stub: the document tests do not exercise pass-side code paths.
-     */
-    /**
      * Scannable-card store stub: the document tests do not exercise scannable-card paths.
      */
     private object NoOpScannableCardStore : ScannableCardStore {
@@ -658,6 +697,9 @@ class DocumentRepositoryTest {
         override fun close() = Unit
     }
 
+    /**
+     * Pass-side store stub: the document tests do not exercise pass-side code paths.
+     */
     private object NoOpPassStore : PassStore {
         override fun listSummaries(): List<PassSummary> = emptyList()
         override fun loadById(id: PassRecordId): StoredPass? = null

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/DocumentRepositoryTest.kt
@@ -305,7 +305,7 @@ class DocumentRepositoryTest {
     }
 
     @Test
-    fun updateLabelAcceptsEmptyAndBlankToMatchInsertDocument() = runTest {
+    fun updateLabelTrimsEdgesAndFoldsBlankToEmpty() = runTest {
         val repo = repo(FakeDocumentStore(), RecordingGuard())
         val insert = repo.insertDocument(
             label = "seed",
@@ -316,10 +316,86 @@ class DocumentRepositoryTest {
         check(insert is StorageResult.Success)
         val id = insert.value
 
+        // Edges trimmed, internal whitespace preserved (mirrors updatePassUserLabel).
+        check(repo.updateDocumentLabel(id, "  My Boarding Pass  ") is StorageResult.Success)
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("My Boarding Pass")
+
+        // Blank-after-trim folds to "" — the non-null column's cleared state.
         check(repo.updateDocumentLabel(id, "") is StorageResult.Success)
         assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("")
         check(repo.updateDocumentLabel(id, "   ") is StorageResult.Success)
-        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("   ")
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo("")
+    }
+
+    @Test
+    fun updateLabelMeasuresCapAgainstTrimmedValue() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+        val insert = repo.insertDocument(
+            label = "seed",
+            pdfBytes = ByteArray(1),
+            pageCount = 1,
+            thumbnailBytes = ByteArray(0),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        val maxLabel = "a".repeat(DocumentBounds.MAX_LABEL_CHARS)
+        val padded = "  $maxLabel  "
+        check(padded.length > DocumentBounds.MAX_LABEL_CHARS)
+        check(repo.updateDocumentLabel(id, padded) is StorageResult.Success)
+        assertThat(repo.observeDocuments().first()[0].displayLabel).isEqualTo(maxLabel)
+    }
+
+    @Test
+    fun updateLabelOnImageRowPreservesKindColumns() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+        val insert = repo.insertDocument(
+            DocumentInsert.Image(
+                label = "photo.png",
+                bytes = ByteArray(16),
+                thumbnailBytes = ByteArray(4),
+                format = DocumentFormat.Png,
+                widthPx = 640,
+                heightPx = 480,
+            ),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        check(repo.updateDocumentLabel(id, "Gym membership") is StorageResult.Success)
+
+        val row = repo.observeDocuments().first().single()
+        assertThat(row.displayLabel).isEqualTo("Gym membership")
+        assertThat(row.format).isEqualTo(DocumentFormat.Png)
+        assertThat(row.widthPx).isEqualTo(640)
+        assertThat(row.heightPx).isEqualTo(480)
+    }
+
+    @Test
+    fun updateLabelOnCompositeRowPreservesBarcodeColumns() = runTest {
+        val repo = repo(FakeDocumentStore(), RecordingGuard())
+        val insert = repo.insertDocument(
+            DocumentInsert.BarcodedImage(
+                label = "ticket.jpg",
+                bytes = ByteArray(16),
+                thumbnailBytes = ByteArray(4),
+                format = DocumentFormat.Jpeg,
+                widthPx = 800,
+                heightPx = 600,
+                barcodePayload = "PAYLOAD-123",
+                barcodeFormat = ScannableFormat.Qr,
+            ),
+        )
+        check(insert is StorageResult.Success)
+        val id = insert.value
+
+        check(repo.updateDocumentLabel(id, "Concert ticket") is StorageResult.Success)
+
+        val row = repo.observeDocuments().first().single()
+        assertThat(row.displayLabel).isEqualTo("Concert ticket")
+        assertThat(row.format).isEqualTo(DocumentFormat.Jpeg)
+        assertThat(row.barcodePayload).isEqualTo("PAYLOAD-123")
+        assertThat(row.barcodeFormat).isEqualTo(ScannableFormat.Qr)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Kernel side of the redesign's Name row (wpass-tjc.1, consumer wlt-mx2d.6). The document rename API itself landed with wpass-hhq (#109); this PR closes the remaining gaps:

- `updateDocumentLabel` now mirrors `updatePassUserLabel` normalization: labels are trimmed of leading/trailing whitespace (internal preserved), a blank-after-trim label folds to the empty string (the non-null column's cleared state), and the `MAX_LABEL_CHARS` cap is measured against the trimmed value. Same "invisible label" defense in depth as the pass side.
- `insertDocument` applies the identical normalization, so both paths writing `display_label` agree.
- Contract coverage for rename on image and composite rows (kind-specific columns preserved), the trim/blank-fold semantics, and the cap-before-row-lookup precedence against an unknown id.

Consumer impact: none in practice — walt-android's `EditableTitleRow` already trims and blocks empty saves before calling `DocumentRenamer`; this moves the guarantee into the kernel where the trust claim lives.

## Testing

- `:passes-storage:testDebugUnitTest` (22/22 in `DocumentRepositoryTest`, full module suite green)
- `:passes-storage:detekt`, `:passes-storage:lintDebug`