### PR TITLE
passes-ui: CompactCodeView, blessed row-scale code render for list card faces (wpass-tjc.2)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -66,9 +66,10 @@ only when, all three of the following hold:
 
 1. The row owns no signature dot or other verified-pass affordance. Pinned at
    the kernel surface by `ComposableSurfaceLockTest.scannableCardRowTileHas
-   ExactlyThreeUserVisibleParameters` (count: 3 — `card`, `onClick`, `modifier`;
-   no `showSignatureBadge`, no `leadingIcon`) and at the consumer (walt-android)
-   by `WalletListTest`'s "no scannable-card row owns a signature dot" invariant.
+   ExactlyFourUserVisibleParameters` (count: 4 — `card`, `onClick`, `modifier`,
+   `leadingSlot` (a visual hook only, wpass-2a2); no `showSignatureBadge`) and
+   at the consumer (walt-android) by `WalletListTest`'s "no scannable-card row
+   owns a signature dot" invariant.
 2. The row owns no coloured leading strip styled to read as a verified-pass
    band. The kernel surface uses the `unverifiedArtifact.accent` token (the
    same neutral token the carousel tile's leading strip uses). Per-card
@@ -86,6 +87,41 @@ in their own lane; `ScannableCardRowTile` is the alternative for the
 homogeneous-list register and nothing else. A future consumer wanting a wallet
 list that also drops the detail-surface caption is amending this row, not
 filing a refactor.
+
+**C1 / C2 — list-face code render concession (wpass-tjc.2; consumer epic
+wlt-mx2d).** The redesigned wallet list renders a scannable card's — and a
+composite artifact's extracted — ACTUAL code on its list card face, through the
+kernel's `CompactCodeView` (`(payload, format)` only). This goes one step past
+the wallet-row concession above: its condition 3 reasoned that "a user who taps
+a row to *use* the artifact still sees 'Created by you' before the scan target
+renders," and a code usable at a reader straight from the list means the user
+may never tap through at all. That shift is recorded here, and it is permitted
+strictly when all three of the following hold:
+
+1. The kernel render stays mechanism-only. No label, eyebrow, caption, or
+   signature affordance can be composed inside `CompactCodeView`; the shape is
+   pinned by `ComposableSurfaceLockTest.compactCodeViewHasExactlyFourUser
+   VisibleParameters` (count: 4 — `payload`, `format`, `modifier`,
+   `contentDescription`) and by its no-overload lock.
+2. The consumer card carries the C1 class distinction structurally: a neutral
+   (never issuer-colored) card surface with the artifact class named in the
+   eyebrow ("QR CODE" / "CODE 128" / "IMAGE, QR CODE"), and no verified
+   affordance of any kind on any list card. Only user-created codes render at
+   list scale — the payload is user-authored, not a trust signal. Signed pkpass
+   barcodes stay detail-surface-only; a pass card face never renders its code
+   in the list.
+3. Detail-surface provenance is unchanged: the bottom-docked caption by
+   default, or the audited `HostedTypeRow` carrier under the concession below.
+
+**Accepted residual risk.** A user who scans straight from the list never meets
+the in-words provenance signal for that use. This is judged bounded for the
+same reasons as the foldout placement below: the artifact is the user's own
+creation, the list-level class distinction (condition 2) is still in view at
+the moment of scanning, and Walt is a display device, not an issuer — the POS /
+recipient remains the authority on whether the code is credit-worthy (Threat
+9). A consumer wanting to render a list-face code without the condition-2
+eyebrow taxonomy, or wanting pkpass barcodes at list scale, is amending this
+row, not filing a PR.
 
 **C2 — host "Pass type" row concession (detail surface).** A consumer (Walt,
 `wlt-3cer`) consolidates the provenance signal into a single "Pass type" row

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
@@ -1,0 +1,134 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import `is`.walt.passes.core.BarcodeEncoder
+import `is`.walt.passes.core.EncodeResult
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.internal.toMonochromeBitmap
+
+/**
+ * Row-scale code render for wallet-list card faces (wpass-tjc.2; consumer epic
+ * wlt-mx2d). Where [ScannableCardView] enforces gate-distance minimum sizes for the
+ * detail surface, this surface renders the same `(payload, format)` pair compactly —
+ * the redesign's neutral list cards show a scannable's or composite's ACTUAL code on
+ * the card face (a ~90 dp QR tile, or a full-width 1D band), so the code is usable at
+ * a reader straight from the list.
+ *
+ * The blessed-path guarantees, so consumers do not hand-roll them per card face:
+ *
+ *  - **White backing, both themes.** The backing is literally [Color.White], never a
+ *    theme surface token, so the code scans in dark mode (spec board: "barcode
+ *    tiles/thumbnails stay light"). Consumers clip the outer shape via [modifier];
+ *    the backing itself is not optional.
+ *  - **Quiet zones.** The [BarcodeEncoder] matrix already carries each symbology's
+ *    quiet-zone modules at natural size; the fixed white inner padding on top
+ *    guarantees a visible quiet zone even when the consumer's tile hugs the code.
+ *  - **Sharp modules.** Nearest-neighbor upscale ([FilterQuality.None]), matching
+ *    [ScannableCardView]. QR paints [ContentScale.Fit] (square matrix, no
+ *    distortion); the 1D symbologies paint [ContentScale.FillBounds] because their
+ *    matrices are one module tall and carry no data on the vertical axis.
+ *
+ * Sizing is the caller's: pass the tile size via [modifier] (the small
+ * `defaultMinSize` floor only guards against a collapsed, unscannable render).
+ * Encoder failures render as a same-sized white tile with a TalkBack-readable
+ * "Barcode failed to render" description instead of throwing, mirroring
+ * [ScannableCardView].
+ *
+ * ## Trust posture
+ *
+ * This is mechanism, not chrome: no label, no eyebrow, no trust caption, no
+ * signature affordance can be composed here. The C1/C2 list-surface distinctions
+ * (class eyebrow, neutral card surface — see `docs/SCANNABLE_CARD_THREAT_MODEL.md`
+ * and the wpass-pnb / wpass-2a2 [ScannableCardRowTile] lineage) stay on the
+ * consumer's card, and kernel trust captions stay on detail surfaces. C5 posture is
+ * unchanged: this path only re-renders through the kernel's encoder-only
+ * [BarcodeEncoder]; it adds no decode surface. [contentDescription] exists because
+ * the code is usually the card face's dominant visual: the consumer passes its
+ * merged card description (or null when a parent node already carries it).
+ */
+@Composable
+public fun CompactCodeView(
+    payload: String,
+    format: ScannableFormat,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+) {
+    val bitmap = remember(payload, format) {
+        when (val result = BarcodeEncoder.encode(payload, format)) {
+            is EncodeResult.Success -> result.matrix.toMonochromeBitmap()
+            is EncodeResult.Failure -> null
+        }
+    }
+    val (minWidthDp, minHeightDp) = format.compactMinSizeDp()
+
+    Box(
+        modifier = modifier
+            .defaultMinSize(minWidth = minWidthDp.dp, minHeight = minHeightDp.dp)
+            .background(Color.White),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (bitmap != null) {
+            Image(
+                painter = BitmapPainter(
+                    image = bitmap.asImageBitmap(),
+                    filterQuality = FilterQuality.None,
+                ),
+                contentDescription = contentDescription,
+                contentScale = format.compactContentScale(),
+                modifier = Modifier
+                    .matchParentSize()
+                    .padding(QUIET_ZONE_PADDING),
+            )
+        } else {
+            // Same-sized failure placeholder; silent blank rectangles are the worst
+            // a11y failure mode. Wording matches ScannableCardView's placeholder.
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .semantics { this.contentDescription = "Barcode failed to render" },
+            )
+        }
+    }
+}
+
+/**
+ * Row-scale floors, deliberately below [ScannableCardView]'s gate-distance minimums:
+ * they only prevent a degenerate collapsed render when the caller forgets to size
+ * the tile, they are not a scannability promise at arbitrary sizes.
+ */
+private fun ScannableFormat.compactMinSizeDp(): Pair<Int, Int> = when (this) {
+    ScannableFormat.Qr -> 48 to 48
+    ScannableFormat.Code128,
+    ScannableFormat.Ean13,
+    ScannableFormat.UpcA,
+    ScannableFormat.Code39,
+    -> 96 to 32
+}
+
+/** Same QR-vs-1D split as ScannableCardView; see that KDoc for the rationale. */
+private fun ScannableFormat.compactContentScale(): ContentScale = when (this) {
+    ScannableFormat.Qr -> ContentScale.Fit
+    ScannableFormat.Code128,
+    ScannableFormat.Ean13,
+    ScannableFormat.UpcA,
+    ScannableFormat.Code39,
+    -> ContentScale.FillBounds
+}
+
+private val QUIET_ZONE_PADDING = 8.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.BarcodeEncoder
 import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.ui.internal.BARCODE_RENDER_FAILURE_DESCRIPTION
+import `is`.walt.passes.ui.internal.barcodeContentScale
 import `is`.walt.passes.ui.internal.toMonochromeBitmap
 
 /**
@@ -48,7 +50,10 @@ import `is`.walt.passes.ui.internal.toMonochromeBitmap
  * `defaultMinSize` floor only guards against a collapsed, unscannable render).
  * Encoder failures render as a same-sized white tile with a TalkBack-readable
  * "Barcode failed to render" description instead of throwing, mirroring
- * [ScannableCardView].
+ * [ScannableCardView]. Encoding runs synchronously in composition (`remember`),
+ * the same trade [ScannableCardView] makes: for validated list-scale payloads the
+ * ZXing writers are sub-millisecond, and a card face renders one code. A consumer
+ * observing jank on pathological lists owns the async wrapping.
  *
  * ## Trust posture
  *
@@ -80,7 +85,7 @@ public fun CompactCodeView(
     Box(
         modifier = modifier
             .defaultMinSize(minWidth = minWidthDp.dp, minHeight = minHeightDp.dp)
-            .background(Color.White),
+            .background(COMPACT_CODE_BACKING),
         contentAlignment = Alignment.Center,
     ) {
         if (bitmap != null) {
@@ -90,7 +95,7 @@ public fun CompactCodeView(
                     filterQuality = FilterQuality.None,
                 ),
                 contentDescription = contentDescription,
-                contentScale = format.compactContentScale(),
+                contentScale = format.barcodeContentScale(),
                 modifier = Modifier
                     .matchParentSize()
                     .padding(QUIET_ZONE_PADDING),
@@ -101,7 +106,7 @@ public fun CompactCodeView(
             Box(
                 modifier = Modifier
                     .matchParentSize()
-                    .semantics { this.contentDescription = "Barcode failed to render" },
+                    .semantics { this.contentDescription = BARCODE_RENDER_FAILURE_DESCRIPTION },
             )
         }
     }
@@ -121,14 +126,11 @@ private fun ScannableFormat.compactMinSizeDp(): Pair<Int, Int> = when (this) {
     -> 96 to 32
 }
 
-/** Same QR-vs-1D split as ScannableCardView; see that KDoc for the rationale. */
-private fun ScannableFormat.compactContentScale(): ContentScale = when (this) {
-    ScannableFormat.Qr -> ContentScale.Fit
-    ScannableFormat.Code128,
-    ScannableFormat.Ean13,
-    ScannableFormat.UpcA,
-    ScannableFormat.Code39,
-    -> ContentScale.FillBounds
-}
-
 private val QUIET_ZONE_PADDING = 8.dp
+
+/**
+ * Literally white, never a theme surface token — the dark-mode scannability guarantee.
+ * Internal (not private) so the smoke test pins the value; rerouting the backing off
+ * this constant is amending the blessed-path contract, not a refactor.
+ */
+internal val COMPACT_CODE_BACKING: Color = Color.White

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -1,7 +1,6 @@
 package `is`.walt.passes.ui
 
 import android.graphics.Bitmap
-import android.graphics.Color as AndroidColor
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,11 +23,11 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.BarcodeEncoder
-import `is`.walt.passes.core.BarcodeMatrix
 import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.ui.core.isolated
+import `is`.walt.passes.ui.internal.toMonochromeBitmap
 
 /**
  * Renders [card]'s barcode through [BarcodeEncoder] as a 1-bit-per-module bitmap.
@@ -148,21 +147,6 @@ private fun ScannableFormat.contentScale(): ContentScale = when (this) {
     ScannableFormat.UpcA,
     ScannableFormat.Code39,
     -> ContentScale.FillBounds
-}
-
-/**
- * Paints a [BarcodeMatrix] into a matrix-sized ARGB_8888 bitmap. Compose scales to
- * the final dp container nearest-neighbor via `BitmapPainter(filterQuality = None)`.
- */
-private fun BarcodeMatrix.toMonochromeBitmap(): Bitmap {
-    val pixels = IntArray(width * height)
-    for (y in 0 until height) {
-        val rowOffset = y * width
-        for (x in 0 until width) {
-            pixels[rowOffset + x] = if (isSet(x, y)) AndroidColor.BLACK else AndroidColor.WHITE
-        }
-    }
-    return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
 }
 
 private val CAPTION_GAP = 12.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -27,6 +27,8 @@ import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.ui.core.isolated
+import `is`.walt.passes.ui.internal.BARCODE_RENDER_FAILURE_DESCRIPTION
+import `is`.walt.passes.ui.internal.barcodeContentScale
 import `is`.walt.passes.ui.internal.toMonochromeBitmap
 
 /**
@@ -111,7 +113,7 @@ private fun BarcodeImage(
                 filterQuality = FilterQuality.None,
             ),
             contentDescription = imageDescription,
-            contentScale = format.contentScale(),
+            contentScale = format.barcodeContentScale(),
             modifier = modifier.defaultMinSize(
                 minWidth = minWidthDp.dp,
                 minHeight = minHeightDp.dp,
@@ -124,7 +126,7 @@ private fun BarcodeImage(
         Spacer(
             modifier = modifier
                 .defaultMinSize(minWidth = minWidthDp.dp, minHeight = minHeightDp.dp)
-                .semantics { contentDescription = "Barcode failed to render" },
+                .semantics { contentDescription = BARCODE_RENDER_FAILURE_DESCRIPTION },
         )
     }
 }
@@ -137,16 +139,6 @@ private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
     ScannableFormat.UpcA,
     ScannableFormat.Code39,
     -> 320 to 96
-}
-
-/** Per-symbology paint scale. See ScannableCardView KDoc for the QR-vs-1D split. */
-private fun ScannableFormat.contentScale(): ContentScale = when (this) {
-    ScannableFormat.Qr -> ContentScale.Fit
-    ScannableFormat.Code128,
-    ScannableFormat.Ean13,
-    ScannableFormat.UpcA,
-    ScannableFormat.Code39,
-    -> ContentScale.FillBounds
 }
 
 private val CAPTION_GAP = 12.dp

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
@@ -1,0 +1,22 @@
+package `is`.walt.passes.ui.internal
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import `is`.walt.passes.core.BarcodeMatrix
+
+/**
+ * Paints a [BarcodeMatrix] into a matrix-sized ARGB_8888 bitmap. Compose scales to
+ * the final dp container nearest-neighbor via `BitmapPainter(filterQuality = None)`.
+ * Shared by [ScannableCardView][`is`.walt.passes.ui.ScannableCardView] and
+ * [CompactCodeView][`is`.walt.passes.ui.CompactCodeView].
+ */
+internal fun BarcodeMatrix.toMonochromeBitmap(): Bitmap {
+    val pixels = IntArray(width * height)
+    for (y in 0 until height) {
+        val rowOffset = y * width
+        for (x in 0 until width) {
+            pixels[rowOffset + x] = if (isSet(x, y)) AndroidColor.BLACK else AndroidColor.WHITE
+        }
+    }
+    return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
@@ -2,7 +2,30 @@ package `is`.walt.passes.ui.internal
 
 import android.graphics.Bitmap
 import android.graphics.Color as AndroidColor
+import androidx.compose.ui.layout.ContentScale
 import `is`.walt.passes.core.BarcodeMatrix
+import `is`.walt.passes.core.ScannableFormat
+
+/**
+ * Failure-placeholder wording shared by ScannableCardView and CompactCodeView; both
+ * surfaces' tests pin the literal, this constant keeps the two from drifting.
+ */
+internal const val BARCODE_RENDER_FAILURE_DESCRIPTION: String = "Barcode failed to render"
+
+/**
+ * Per-symbology paint scale shared by ScannableCardView and CompactCodeView. QR uses
+ * [ContentScale.Fit] (square matrix; FillBounds would distort in a non-square slot);
+ * the 1D symbologies use [ContentScale.FillBounds] because their matrices are one
+ * module tall and carry no data on the vertical axis. See ScannableCardView's KDoc.
+ */
+internal fun ScannableFormat.barcodeContentScale(): ContentScale = when (this) {
+    ScannableFormat.Qr -> ContentScale.Fit
+    ScannableFormat.Code128,
+    ScannableFormat.Ean13,
+    ScannableFormat.UpcA,
+    ScannableFormat.Code39,
+    -> ContentScale.FillBounds
+}
 
 /**
  * Paints a [BarcodeMatrix] into a matrix-sized ARGB_8888 bitmap. Compose scales to

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/CompactCodeViewTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/CompactCodeViewTest.kt
@@ -2,11 +2,13 @@ package `is`.walt.passes.ui
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.ScannableFormat
 import org.junit.Rule
 import org.junit.Test
@@ -54,6 +56,15 @@ class CompactCodeViewTest {
             )
         }
         composeRule.onNodeWithContentDescription("Library card, Code 128").assertIsDisplayed()
+    }
+
+    @Test
+    fun backingIsLiterallyWhiteNotAThemeToken() {
+        // The white backing is a blessed-path guarantee (dark-mode scannability); a
+        // refactor to a theme surface token must fail here, not in the field. Pixel
+        // capture is unavailable under this Robolectric setup, so the pin is the
+        // internal constant the backing modifier routes through.
+        assertThat(COMPACT_CODE_BACKING).isEqualTo(Color.White)
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/CompactCodeViewTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/CompactCodeViewTest.kt
@@ -1,0 +1,72 @@
+package `is`.walt.passes.ui
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-backed Compose smoke tests for [CompactCodeView] (wpass-tjc.2). Locks
+ * the two behavioral contracts that matter at list scale:
+ *
+ *  1. A valid `(payload, format)` renders an image node carrying the caller-supplied
+ *     [contentDescription] — the card face's dominant visual stays TalkBack-reachable.
+ *  2. An encoder rejection renders the same-sized placeholder with the literal
+ *     "Barcode failed to render" description (shared wording with [ScannableCardView])
+ *     instead of throwing — a malformed payload cannot crash the wallet list.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class CompactCodeViewTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun validQrPayloadRendersImageWithCallerDescription() {
+        composeRule.setContent {
+            CompactCodeView(
+                payload = "LOCKER-0042",
+                format = ScannableFormat.Qr,
+                modifier = Modifier.size(90.dp),
+                contentDescription = "Locker code, QR code",
+            )
+        }
+        composeRule.onNodeWithContentDescription("Locker code, QR code").assertIsDisplayed()
+    }
+
+    @Test
+    fun validCode128PayloadRendersImageWithCallerDescription() {
+        composeRule.setContent {
+            CompactCodeView(
+                payload = "21000456782",
+                format = ScannableFormat.Code128,
+                modifier = Modifier.size(width = 280.dp, height = 56.dp),
+                contentDescription = "Library card, Code 128",
+            )
+        }
+        composeRule.onNodeWithContentDescription("Library card, Code 128").assertIsDisplayed()
+    }
+
+    @Test
+    fun encoderRejectionRendersFailurePlaceholderNotCrash() {
+        composeRule.setContent {
+            // EAN-13 requires 12-13 digits; "12" is rejected by the writer, exercising
+            // the EncodeResult.Failure arm.
+            CompactCodeView(
+                payload = "12",
+                format = ScannableFormat.Ean13,
+                modifier = Modifier.size(width = 280.dp, height = 56.dp),
+            )
+        }
+        composeRule.onNodeWithContentDescription("Barcode failed to render").assertIsDisplayed()
+    }
+}

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -217,6 +217,16 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
+    fun compactCodeViewHasExactlyFourUserVisibleParameters() {
+        // (payload, format, modifier, contentDescription). The compact list-face code
+        // render (wpass-tjc.2) is mechanism only: no label, eyebrow, caption, or
+        // signature-affordance parameter may appear here — the C1/C2 list-surface
+        // distinctions live on the consumer's card and kernel trust captions stay on
+        // detail surfaces. Review the threat model before changing this number.
+        assertUserVisibleParamCount("CompactCodeViewKt", "CompactCodeView", expected = 4)
+    }
+
+    @Test
     fun scannableCardSurfacesHaveNoOverloads() {
         // The caption non-suppressibility rule extends to overloads: a future
         // contributor cannot quietly add `ScannableCardTile(..., showCaption: Boolean)`
@@ -229,6 +239,9 @@ class ComposableSurfaceLockTest {
             "ScannableCardTileKt" to "ScannableCardTile",
             "ScannableCardScreenKt" to "ScannableCardScreen",
             "ScannableCardRowTileKt" to "ScannableCardRowTile",
+            // Compact list-face render (wpass-tjc.2): an overload adding chrome would
+            // dilute the mechanism-only shape its param-count lock pins.
+            "CompactCodeViewKt" to "CompactCodeView",
         ).forEach { (file, name) ->
             val klass = Class.forName("is.walt.passes.ui.$file")
             val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }


### PR DESCRIPTION
## Summary

Kernel side of the redesign's neutral list-card faces (wpass-tjc.2, consumer wlt-mx2d.4): scannable cards and composites render their ACTUAL code on the wallet-list card face (a ~90 dp QR tile, or a full-width 1D band on a white tile). `CompactCodeView` is the blessed compact path:

- Takes `(payload, format)` so both scannable cards and composite documents (extracted code) use one surface.
- Guarantees a literally-white backing in both themes (dark-mode scannability; pinned by test via an internal constant), quiet-zone padding on top of the encoder matrix's own quiet-zone modules, and nearest-neighbor module upscale with the same QR-vs-1D `ContentScale` split as `ScannableCardView`.
- Mechanism only: no label / eyebrow / caption / signature affordance can be composed here; param count 4 and no-overloads pinned in `ComposableSurfaceLockTest`.
- C5 posture unchanged: renders through the encoder-only `BarcodeEncoder`; adds no decode surface.

The threat model gains a recorded C1/C2 "list-face code render" concession: the wallet-row concession's condition 3 reasoned a user taps through to the detail surface before scanning, and a list-usable code voids that assumption. The amendment states the three conditions (mechanism-only kernel shape, consumer card carries the class eyebrow + neutral surface, detail-surface provenance unchanged) and the accepted residual risk. Also fixes the doc's stale RowTile param-count reference (3 -> 4, stale since wpass-2a2).

Shared helpers (`toMonochromeBitmap`, failure wording, content scale) are extracted to `is.walt.passes.ui.internal` instead of duplicated.

## Testing

- `:passes-ui:testDebugUnitTest` (4 new smoke tests incl. genuine encoder-rejection arm; surface locks extended; full module suite green)
- `:passes-ui:detekt`, `:passes-ui:lintDebug`