### PR TITLE
passes-document-ui: adjacent-page prefetch for the PDF pager (wpass-tjc.3)

### DIFF
--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -226,11 +226,8 @@ private fun PdfDocumentView(
                     if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
                 }
                 .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
-            // beyondViewportPageCount = 1: the adjacent page composes (and rasterises
-            // into the cache) before it enters the viewport, so a swipe or a consumer
-            // peek layout reveals a ready page, not a blank sliver (wpass-tjc.3). One
-            // page each side keeps at most 3 live pages, inside the cache window of
-            // DEFAULT_PAGE_WINDOW (5).
+            // Adjacent page rasterises ahead of the viewport so a swipe or peek reveals a
+            // ready page (wpass-tjc.3); up to 4 live pages mid-swipe, inside DEFAULT_PAGE_WINDOW.
             HorizontalPager(
                 state = pagerState,
                 modifier = pagerModifier,

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -226,7 +226,16 @@ private fun PdfDocumentView(
                     if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
                 }
                 .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
-            HorizontalPager(state = pagerState, modifier = pagerModifier) { page ->
+            // beyondViewportPageCount = 1: the adjacent page composes (and rasterises
+            // into the cache) before it enters the viewport, so a swipe or a consumer
+            // peek layout reveals a ready page, not a blank sliver (wpass-tjc.3). One
+            // page each side keeps at most 3 live pages, inside the cache window of
+            // DEFAULT_PAGE_WINDOW (5).
+            HorizontalPager(
+                state = pagerState,
+                modifier = pagerModifier,
+                beyondViewportPageCount = 1,
+            ) { page ->
                 DocumentPage(
                     document = doc,
                     pageIndex = page,

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
@@ -102,6 +102,9 @@ public fun FullScreenDocumentView(
             dock = { DocumentTrustCaption() },
             modifier = Modifier.fillMaxSize(),
         ) {
+            // Deliberately no beyondViewportPageCount here (unlike DocumentView's inline
+            // pager): full-screen rasters are far larger and the peek redesign does not
+            // apply to this surface (wpass-tjc.3).
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize(),

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/PdfThumbnail.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/PdfThumbnail.kt
@@ -80,8 +80,15 @@ internal data class CachedPage(val bitmap: Bitmap, val pageAspect: Float)
 
 /**
  * Compose-friendly facade over the isolated-process PDF renderer for **single-page
- * thumbnails**. Use this from a list-row composable to drive an asynchronously
+ * renders**. Use this from a list-row composable to drive an asynchronously
  * rendered page-N bitmap with correct lifetime, cancellation, and cache discipline.
+ *
+ * This is also the blessed paged-access path for pager surfaces (wpass-tjc.3;
+ * consumer epic wlt-mx2d): [page] selects any index, so a pager composes one call
+ * per visible page — plus the adjacent page for a peek/prefetch — against a shared
+ * [cache], and only that window is ever rasterised ([DEFAULT_PAGE_WINDOW] pages;
+ * never the whole document). `DocumentView`'s inline pager is the reference
+ * consumer of exactly this pattern.
  *
  * Lifecycle guarantees this facade owns so consumers do not have to reimplement:
  *

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/PdfThumbnail.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/PdfThumbnail.kt
@@ -40,9 +40,9 @@ public sealed interface PdfThumbnailState {
 
 /**
  * The cache's default size: how many recently-rendered pages to retain per consumer.
- * Sized so the `HorizontalPager` in `DocumentView` can keep the current page plus
- * `±2` adjacent pages hot during a swipe without recycling a bitmap that is still
- * being painted.
+ * The `HorizontalPager` in `DocumentView` composes the current page ±1
+ * (`beyondViewportPageCount = 1`), up to 4 live pages mid-swipe; 5 keeps a margin so
+ * a still-painted bitmap is never recycled by an eviction.
  */
 public const val DEFAULT_PAGE_WINDOW: Int = 5
 

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentViewPagerPrefetchTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentViewPagerPrefetchTest.kt
@@ -1,0 +1,101 @@
+package `is`.walt.passes.document.ui
+
+import android.os.ParcelFileDescriptor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.document.DocumentRejectedKind
+import `is`.walt.passes.document.PdfDocument
+import `is`.walt.passes.document.PdfDocumentId
+import `is`.walt.passes.document.ui.theme.DocumentSemantics
+import `is`.walt.passes.document.ui.theme.DocumentTheme
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.ProbeResult
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.ui.core.ArgbColor
+import java.io.File
+import java.util.Collections
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the pager's adjacent-page prefetch (wpass-tjc.3): the PDF arm composes the
+ * next page beyond the viewport (`beyondViewportPageCount = 1`), so its render is
+ * requested while page 0 is on screen — the peek/next swipe reveals a ready page.
+ * Equally load-bearing: pages past the window are NOT requested, pinning the
+ * "never the whole document rasterised" claim.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DocumentViewPagerPrefetchTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val semantics = DocumentSemantics(
+        captionBackground = ArgbColor(0xFF202020.toInt()),
+        captionForeground = ArgbColor(0xFFFFFFFF.toInt()),
+        tileBackground = ArgbColor(0xFFF5F5F5.toInt()),
+        tileForeground = ArgbColor(0xFF202020.toInt()),
+        tileLabelForeground = ArgbColor(0xFF606060.toInt()),
+        laneBackground = ArgbColor(0xFFEEEEEE.toInt()),
+        documentBadgeBackground = ArgbColor(0xFFD0D0D0.toInt()),
+        documentBadgeForeground = ArgbColor(0xFF202020.toInt()),
+    )
+
+    @Test
+    fun pdfPagerRequestsCurrentAndAdjacentPageButNotTheRest() {
+        val requestedPages = Collections.synchronizedSet(mutableSetOf<Int>())
+        val recordingRenderer = object : PdfRendererBinder {
+            override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
+                ProbeResult.Ok(pageCount = 5)
+
+            override suspend fun render(
+                pdf: ParcelFileDescriptor,
+                page: Int,
+                widthPx: Int,
+                heightPx: Int,
+                sourceRect: RenderSourceRect,
+            ): RenderResult {
+                requestedPages += page
+                // Rejected keeps the test free of SharedMemory plumbing; the page
+                // request itself is the behavior under test.
+                return RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+            }
+        }
+        val doc = PdfDocument(
+            id = PdfDocumentId("doc-1"),
+            displayLabel = "doc.pdf",
+            byteCount = 1024L,
+            pageCount = 5,
+            importedAtEpochMs = 0L,
+        )
+        val file = File.createTempFile("doc", ".pdf").apply { writeBytes(byteArrayOf(0x25)) }
+        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        try {
+            composeRule.setContent {
+                ThemedHost {
+                    DocumentView(doc = doc, pdfFile = pfd, renderer = recordingRenderer)
+                }
+            }
+            composeRule.waitForIdle()
+
+            assertThat(requestedPages).containsExactly(0, 1)
+        } finally {
+            pfd.close()
+            file.delete()
+        }
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme {
+            DocumentTheme(semantics = semantics, content = content)
+        }
+    }
+}

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentViewPagerPrefetchTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentViewPagerPrefetchTest.kt
@@ -18,6 +18,7 @@ import `is`.walt.passes.pdf.android.RenderSourceRect
 import `is`.walt.passes.ui.core.ArgbColor
 import java.io.File
 import java.util.Collections
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,6 +37,17 @@ class DocumentViewPagerPrefetchTest {
 
     @get:Rule
     val composeRule = createComposeRule()
+
+    // Closed in @After, not inside the test: the documented pdfFile contract is that
+    // the fd outlives the composition.
+    private var pfd: ParcelFileDescriptor? = null
+    private var file: File? = null
+
+    @After
+    fun tearDown() {
+        pfd?.close()
+        file?.delete()
+    }
 
     private val semantics = DocumentSemantics(
         captionBackground = ArgbColor(0xFF202020.toInt()),
@@ -75,21 +87,19 @@ class DocumentViewPagerPrefetchTest {
             pageCount = 5,
             importedAtEpochMs = 0L,
         )
-        val file = File.createTempFile("doc", ".pdf").apply { writeBytes(byteArrayOf(0x25)) }
-        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-        try {
-            composeRule.setContent {
-                ThemedHost {
-                    DocumentView(doc = doc, pdfFile = pfd, renderer = recordingRenderer)
-                }
-            }
-            composeRule.waitForIdle()
+        val backing = File.createTempFile("doc", ".pdf").apply { writeBytes(byteArrayOf(0x25)) }
+        file = backing
+        val fd = ParcelFileDescriptor.open(backing, ParcelFileDescriptor.MODE_READ_ONLY)
+        pfd = fd
 
-            assertThat(requestedPages).containsExactly(0, 1)
-        } finally {
-            pfd.close()
-            file.delete()
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(doc = doc, pdfFile = fd, renderer = recordingRenderer)
+            }
         }
+        composeRule.waitForIdle()
+
+        assertThat(requestedPages).containsExactly(0, 1)
     }
 
     @Composable


### PR DESCRIPTION
## Summary

Kernel side of the redesign's paged PDF detail with next-page peek (wpass-tjc.3, consumer wlt-mx2d.8). Verification outcome: the paged-access surface already supports the pager — `PdfRendererBinder.render` takes an arbitrary page index, `rememberPdfThumbnail` is the public page-indexed, cache-disciplined, cancellation-safe facade, and only the LRU window is ever rasterized (never the whole document). Its KDoc now names the pager pattern as blessed for consumers.

The one real gap was compose-ahead: the inline pager rendered a page only once visible, so a peek would reveal a blank sliver. `beyondViewportPageCount = 1` rasterizes the adjacent page ahead of the viewport (up to 4 live pages mid-swipe, inside the cache window of 5). The full-screen pager deliberately does not prefetch (far larger rasters; the peek redesign does not apply there) and now says so.

A mutation-verified Robolectric test pins both directions: page 1 is requested while page 0 is shown, and pages 2-4 are never requested, locking the never-whole-document claim.

## Testing

- `:passes-document-ui:testDebugUnitTest` (new `DocumentViewPagerPrefetchTest`; full module suite green)
- `:passes-document-ui:detekt`, `:passes-document-ui:lintDebug`