### PR TITLE
docs: record redesigned list-surface posture (wpass-tjc.4)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -131,7 +131,8 @@ verified-band confusion class can be checked against it:
 - **Issuer `pass.json` colors now drive pkpass list-card faces** (previously
   parsed but unused off the pass front; ADR 0003 D4 addendum). Issuer color
   appears on pkpass cards ONLY: document, scannable, and composite cards keep
-  the neutral surface + class eyebrow of condition 2 above. A white issuer card
+  the neutral surface + class eyebrow posture of condition 2 above (document
+  eyebrows "PDF" / "IMAGE" per the ADR 0005 list-surface addendum). A white issuer card
   is distinguished from the wallet background by a hairline, not by tinting —
   color never becomes the class signal.
 - **No list card of any class carries a signature or verified affordance.** The
@@ -139,7 +140,12 @@ verified-band confusion class can be checked against it:
   surfaces. The verified-band confusion class is therefore structurally absent
   at list scale: there is no verified visual for a user-created card to
   imitate, which is a stronger posture than the per-row distinguisher
-  accounting the original C1/C2 text assumed. A consumer (Walt,
+  accounting the original C1/C2 text assumed. Pinned consumer-side: the
+  `WalletListTest` "no signature dot" invariant extends to every card class
+  under `wlt-mx2d` (pin lands with the consumer redesign; until then the
+  existing scannable-row invariant holds).
+
+**C2 — host "Pass type" row concession (detail surface).** A consumer (Walt,
 `wlt-3cer`) consolidates the provenance signal into a single "Pass type" row
 inside its own host-rendered details section — values *Image / Scanned / Pkpass
 / PDF / "Image, Scanned"* across artifact classes — rather than carrying it as
@@ -297,8 +303,11 @@ risk are in the C2 "Pass type" row concession subsection above.
 
 **Status.** Mitigated structurally, with the detail-surface layer reducible to a
 host "Pass type" row under the bounded `HostedTypeRow` concession (C1 list-level
-distinction then carries the load). This is the load-bearing concern of the
-entire epic; every downstream child must trace back to this row.
+distinction then carries the load). Under the `wlt-mx2d` redesign the
+list-level distinction is carried per the "Redesign context" row above: neutral
+surface + class eyebrow on non-pass cards, issuer color on pkpass cards only,
+and no verified affordance on any list card. This is the load-bearing concern
+of the entire epic; every downstream child must trace back to this row.
 
 ### 2. Hostile URI payload encoded into a QR that another device auto-acts on — Spoofing / Elevation of privilege
 

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -123,7 +123,23 @@ recipient remains the authority on whether the code is credit-worthy (Threat
 eyebrow taxonomy, or wanting pkpass barcodes at list scale, is amending this
 row, not filing a PR.
 
-**C2 — host "Pass type" row concession (detail surface).** A consumer (Walt,
+**Redesign context — where the C1 list distinction now lives (wpass-tjc.4;
+consumer epic wlt-mx2d).** The redesigned wallet list changes what
+distinguishes card classes, and the change is recorded here so the
+verified-band confusion class can be checked against it:
+
+- **Issuer `pass.json` colors now drive pkpass list-card faces** (previously
+  parsed but unused off the pass front; ADR 0003 D4 addendum). Issuer color
+  appears on pkpass cards ONLY: document, scannable, and composite cards keep
+  the neutral surface + class eyebrow of condition 2 above. A white issuer card
+  is distinguished from the wallet background by a hairline, not by tinting —
+  color never becomes the class signal.
+- **No list card of any class carries a signature or verified affordance.** The
+  trust ladder (signature badge, trust captions) lives exclusively on detail
+  surfaces. The verified-band confusion class is therefore structurally absent
+  at list scale: there is no verified visual for a user-created card to
+  imitate, which is a stronger posture than the per-row distinguisher
+  accounting the original C1/C2 text assumed. A consumer (Walt,
 `wlt-3cer`) consolidates the provenance signal into a single "Pass type" row
 inside its own host-rendered details section — values *Image / Scanned / Pkpass
 / PDF / "Image, Scanned"* across artifact classes — rather than carrying it as

--- a/docs/adr/0003-passes-ui-theming.md
+++ b/docs/adr/0003-passes-ui-theming.md
@@ -277,3 +277,28 @@ Rationale, restated from the storage precedent:
   `contentDescription: String?` (where applicable) and the implementation bead
   must pass non-null content descriptions for the trust badge, expired pill,
   and barcode altText. Accessibility-test coverage is a follow-on.
+
+## Addendum 2026-07-18: Issuer colors extend to the wallet-list pass card face
+
+Tracks: kernel `wpass-tjc.4`; consumer epic `wlt-mx2d` (wallet redesign).
+
+D4 scoped issuer colors to "the pass surface itself" and made the host theme
+authoritative for wallet-list chrome; in practice the parsed `PassColors` went
+unused at list scale. The redesigned wallet list renders each pkpass as an
+Apple-Wallet-style card whose face is a miniature pass surface, and D4's
+override now extends to it: `pass.json` `backgroundColor` drives the card
+face, `foregroundColor` / `labelColor` drive its text under the consumer's
+contrast guard, with the category accent as fallback. A white issuer card is
+distinguished from the wallet background by a hairline, not by tinting.
+
+The D4 boundaries are otherwise unchanged, and two are load-bearing:
+
+- **Only pkpass cards take issuer color.** Document, scannable, and composite
+  list cards stay neutral with the class named in the eyebrow — see the
+  "list-face code render" and "redesign context" rows in
+  `SCANNABLE_CARD_THREAT_MODEL.md`. Issuer color functions as pass identity,
+  never as the artifact-class signal.
+- **Color is presentation, not trust.** No signature or verified affordance
+  renders on any list card; the trust ladder stays on detail surfaces. The
+  security-sheet family and other off-pass surfaces remain issuer-color-free
+  exactly as D4 records.

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -918,3 +918,29 @@ zoom level" guarantees stand verbatim.
 | D5.T     | `DocumentTrustSurfaceTest.documentViewHostedTypeRowOmitsKernelCaption` (HostedTypeRow renders no kernel caption); `documentTrustCaptionRendersTheVerbatimTrustText` (the docked-mode caption still renders verbatim) |
 | Consumer | walt-android `wlt-3cer`: the details section renders a "Pass type" row enumerating the artifact class |
 | Scope    | `FullScreenDocumentView` shape lock unchanged (7 params); Z.8 full-screen caption tests stay green |
+
+## Addendum 2026-07-18: List-surface presentation — content-true previews on neutral cards
+
+Tracks: kernel `wpass-tjc.4`; consumer epic `wlt-mx2d` (wallet redesign).
+
+Walt's redesigned wallet list presents documents as neutral cards with
+content-true previews rendered inline on the card face: a PDF card shows its
+page-0 thumbnail, an image card its photo thumbnail, and a composite card its
+EXTRACTED code (via `passes-ui`'s `CompactCodeView`; the kept image reduces to
+a small corner badge, with the full image behind the detail surface).
+
+Nothing here is mechanically new: previews come from the existing
+Walt-produced rasters (stored thumbnails / `rememberPdfThumbnail`), so no new
+render, decode, or extraction surface is introduced (D2/D3/D4 unchanged).
+What this addendum records is the presentation posture:
+
+- List cards are neutral surfaces with the artifact class named in the
+  eyebrow ("PDF" / "IMAGE" / "IMAGE, QR CODE"); they never take issuer color
+  (ADR 0003 D4 addendum) and carry no verified affordance of any kind.
+- Detail-surface trust posture is unchanged: the non-suppressible caption
+  (D5, Z.4/Z.8) and the audited `HostedTypeRow` concession (D5.T) stand
+  verbatim. The list preview adds no caption of its own — provenance stays a
+  detail-surface signal, exactly as the D5.T addendum records.
+- The composite code-on-card-face posture is recorded as a C1/C2 concession
+  in `SCANNABLE_CARD_THREAT_MODEL.md` ("list-face code render"); this
+  addendum and that row cross-reference each other deliberately.


### PR DESCRIPTION
## Summary

Doc-only amendments for the wallet redesign (wpass-tjc.4; consumer epic wlt-mx2d):

- **ADR 0003, D4 addendum**: issuer `pass.json` colors extend to the pkpass wallet-list card face (previously parsed but unused at list scale). The card face is consumer-composed (wlt-mx2d.3 owns it and the contrast guard) fed by kernel-parsed `PassColors`; white issuer cards are distinguished by a hairline, not tinting. Only pkpass cards take issuer color; color is presentation, not trust.
- **ADR 0005, list-surface addendum**: neutral document cards render content-true previews inline (page-0 thumbnail / photo / extracted code via `CompactCodeView`) from existing Walt-produced rasters — no new render or extraction surface; detail-surface trust captions and the HostedTypeRow posture stand verbatim.
- **SCANNABLE_CARD_THREAT_MODEL, redesign-context row**: records where the C1 list distinction now lives (class eyebrows on neutral surfaces; issuer color on pkpass only) and confirms the verified-band confusion class stays structurally absent — no list card of any class carries a signature or verified affordance. Threat 1's Status points at the row.

The scannable/composite list-face code concession itself landed with wpass-tjc.2 (PR #185); the C5 composite amendment (wlt-ixlf / wpass-7rv) was already landed. Unbiased review blocker (an accidentally absorbed C2 concession heading) fixed; cross-references and pins named per review.