### PR TITLE
fix(passes-core): accept signedAttrs signed in wire order (wpass-x70)

### DIFF
--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
@@ -1,6 +1,5 @@
-// Each verification step is its own named private helper so the policy mapping in the
-// docblock below reads as a sequence; splitting the file would scatter one security
-// boundary across two.
+// One security boundary, one file: each verification step is a named private helper so
+// the policy mapping in the docblock below reads as a sequence.
 @file:Suppress("TooManyFunctions")
 
 package `is`.walt.passes.core.internal
@@ -15,6 +14,7 @@ import org.bouncycastle.asn1.ASN1Sequence
 import org.bouncycastle.asn1.ASN1Set
 import org.bouncycastle.asn1.ASN1TaggedObject
 import org.bouncycastle.asn1.DLSet
+import org.bouncycastle.asn1.cms.Attribute
 import org.bouncycastle.asn1.cms.CMSAttributes
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
@@ -75,11 +75,11 @@ import java.security.cert.X509Certificate
  *     [SignatureStatus.SelfSigned] / [SignatureStatus.CertChainIncomplete] (lenient,
  *     default) or [TamperReason.SignatureCryptoFailure] (strict).
  *
- * **Constant-time digest comparison.** `SignerInformation.verify` delegates digest
- * comparison to [java.security.MessageDigest.isEqual] internally (BC verifies via
- * the JCE Signature object, which uses the constant-time comparator), so we do not
- * re-roll our own. The manifest-vs-signature math is the only digest comparison
- * happening here; the per-file SHA-1 chain lives in [verifyManifest].
+ * **Constant-time digest comparison.** `SignerInformation.verify` compares the signed
+ * `messageDigest` attribute with [java.security.MessageDigest.isEqual] internally. The
+ * wire-order fallback in [verifiesOverWireEncodedAttributes] re-does that one
+ * comparison and uses the same comparator. The per-file SHA-1 chain lives in
+ * [verifyManifest].
  *
  * **No revocation checking.** [PKIXBuilderParameters.isRevocationEnabled] is set to
  * `false`. Revocation requires either an out-of-band CRL fetch (network) or an
@@ -245,7 +245,12 @@ private fun verifyMath(
             false
         }
     if (derVerified) return true
-    return verifiesOverWireEncodedAttributes(signer, leafHolder, signatureBytes, manifestBytes)
+    // Fail closed, and keep the taxonomy stable: an exception raised only inside the
+    // fallback must not turn the DER path's ManifestSignatureMismatch verdict into
+    // SignatureCryptoFailure at the outer runCatching.
+    return runCatching {
+        verifiesOverWireEncodedAttributes(signer, leafHolder, signatureBytes, manifestBytes)
+    }.getOrDefault(false)
 }
 
 /**
@@ -276,8 +281,14 @@ private fun verifyMath(
  * Together those are precisely the check OpenSSL performs. Any real modification to the
  * manifest or to the attributes still fails.
  *
- * Fails closed: any structural surprise (absent attributes, missing digest, multi-signer
- * envelope, indefinite-length BER) returns `false` and the caller reports tampering.
+ * Both halves read the *same* [WireSignedAttributes], parsed once — the digest checked
+ * in (1) is lifted out of the very bytes verified in (2), so no disagreement between
+ * BouncyCastle's parse and ours can satisfy one check with a structure the other never
+ * saw.
+ *
+ * Fails closed: any structural surprise (absent attributes, missing or repeated digest
+ * attribute, multi-signer envelope, indefinite-length BER) returns `false`, as does any
+ * exception, and the caller reports tampering.
  */
 @Suppress("ReturnCount")
 private fun verifiesOverWireEncodedAttributes(
@@ -286,17 +297,11 @@ private fun verifiesOverWireEncodedAttributes(
     signatureBytes: ByteArray,
     manifestBytes: ByteArray,
 ): Boolean {
-    val signedAttrs = signer.signedAttributes ?: return false
-    val declaredDigest =
-        (
-            signedAttrs.get(CMSAttributes.messageDigest)
-                ?.attributeValues?.firstOrNull() as? ASN1OctetString
-        )?.octets ?: return false
+    val wire = wireEncodedSignedAttributes(signatureBytes) ?: return false
     val actualDigest =
         MessageDigest.getInstance(signer.digestAlgOID, BC_PROVIDER).digest(manifestBytes)
-    if (!MessageDigest.isEqual(declaredDigest, actualDigest)) return false
+    if (!MessageDigest.isEqual(wire.messageDigest, actualDigest)) return false
 
-    val wireAttrs = wireEncodedSignedAttributes(signatureBytes) ?: return false
     val signerInfo = signer.toASN1Structure()
     val signatureName =
         DefaultCMSSignatureAlgorithmNameGenerator()
@@ -304,10 +309,19 @@ private fun verifiesOverWireEncodedAttributes(
     val leaf = JcaX509CertificateConverter().setProvider(BC_PROVIDER).getCertificate(leafHolder)
     return Signature.getInstance(signatureName, BC_PROVIDER).run {
         initVerify(leaf.publicKey)
-        update(wireAttrs)
+        update(wire.encoded)
         verify(signer.signature)
     }
 }
+
+/**
+ * The signed attributes as the signer encoded them, together with the `messageDigest`
+ * value lifted out of that same encoding.
+ */
+private class WireSignedAttributes(
+    val encoded: ByteArray,
+    val messageDigest: ByteArray,
+)
 
 /**
  * Re-reads the `[0] IMPLICIT SignedAttributes` of the sole SignerInfo straight out of
@@ -315,24 +329,47 @@ private fun verifiesOverWireEncodedAttributes(
  * [ASN1Encoding.DL] is what keeps that order — [ASN1Encoding.DER] would re-sort and
  * reproduce the very bytes the caller already tried.
  *
- * Returns `null` on anything other than a single-signer, definite-length envelope,
- * matching the single-signer trust claim documented on [firstSignerWithCert].
+ * Returns `null` on anything other than a single-signer, definite-length envelope
+ * carrying exactly one single-valued `messageDigest` attribute. The single-signer floor
+ * matches the trust claim documented on [firstSignerWithCert]; the single-attribute
+ * floor is what lets the caller treat [WireSignedAttributes.messageDigest] as *the*
+ * digest the signature commits to rather than a first-match guess.
  */
 @Suppress("ReturnCount")
-private fun wireEncodedSignedAttributes(signatureBytes: ByteArray): ByteArray? {
+private fun wireEncodedSignedAttributes(signatureBytes: ByteArray): WireSignedAttributes? {
     val contentInfo =
         ASN1InputStream(signatureBytes).use { it.readObject() } as? ASN1Sequence ?: return null
+    if (contentInfo.size() < 2) return null
     val signedData =
         (contentInfo.getObjectAt(1) as? ASN1TaggedObject)
             ?.baseObject?.toASN1Primitive() as? ASN1Sequence ?: return null
     // signerInfos is the final field of SignedData, after the optional [0]/[1] sets.
+    if (signedData.size() == 0) return null
     val signerInfos = signedData.getObjectAt(signedData.size() - 1) as? ASN1Set ?: return null
     if (signerInfos.size() != 1) return null
     val signerInfo = signerInfos.getObjectAt(0) as? ASN1Sequence ?: return null
+    if (signerInfo.size() <= SIGNED_ATTRS_INDEX) return null
     val tagged = signerInfo.getObjectAt(SIGNED_ATTRS_INDEX) as? ASN1TaggedObject ?: return null
     if (tagged.tagNo != 0) return null
     val attrs = ASN1Set.getInstance(tagged, false)
-    return runCatching { DLSet(attrs.toArray()).getEncoded(ASN1Encoding.DL) }.getOrNull()
+    val messageDigest = soleMessageDigestValue(attrs) ?: return null
+    return WireSignedAttributes(DLSet(attrs.toArray()).getEncoded(ASN1Encoding.DL), messageDigest)
+}
+
+/**
+ * The one `messageDigest` attribute's one value, or `null` if the set holds a non-
+ * attribute element, no `messageDigest`, more than one, or one carrying anything but a
+ * single OCTET STRING. BouncyCastle enforces the same shape via
+ * `getSingleValuedSignedAttribute`; re-stating it here keeps the fallback's guarantee
+ * from resting on where BC happens to place that check.
+ */
+@Suppress("ReturnCount")
+private fun soleMessageDigestValue(attrs: ASN1Set): ByteArray? {
+    val parsed =
+        attrs.toArray().map { runCatching { Attribute.getInstance(it) }.getOrNull() ?: return null }
+    val values = parsed.singleOrNull { it.attrType == CMSAttributes.messageDigest }?.attrValues
+    if (values == null || values.size() != 1) return null
+    return (values.getObjectAt(0) as? ASN1OctetString)?.octets
 }
 
 /** SignerInfo ::= SEQUENCE { version, sid, digestAlgorithm, [0] signedAttrs, ... }. */

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/SignatureVerifier.kt
@@ -1,19 +1,35 @@
+// Each verification step is its own named private helper so the policy mapping in the
+// docblock below reads as a sequence; splitting the file would scatter one security
+// boundary across two.
+@file:Suppress("TooManyFunctions")
+
 package `is`.walt.passes.core.internal
 
 import `is`.walt.passes.core.ParserConfig
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.TamperReason
+import org.bouncycastle.asn1.ASN1Encoding
+import org.bouncycastle.asn1.ASN1InputStream
+import org.bouncycastle.asn1.ASN1OctetString
+import org.bouncycastle.asn1.ASN1Sequence
+import org.bouncycastle.asn1.ASN1Set
+import org.bouncycastle.asn1.ASN1TaggedObject
+import org.bouncycastle.asn1.DLSet
+import org.bouncycastle.asn1.cms.CMSAttributes
 import org.bouncycastle.cert.X509CertificateHolder
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cms.CMSProcessableByteArray
 import org.bouncycastle.cms.CMSSignedData
 import org.bouncycastle.cms.CMSSignerDigestMismatchException
+import org.bouncycastle.cms.DefaultCMSSignatureAlgorithmNameGenerator
 import org.bouncycastle.cms.SignerId
 import org.bouncycastle.cms.SignerInformation
 import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.Selector
 import org.bouncycastle.util.Store
+import java.security.MessageDigest
+import java.security.Signature
 import java.security.cert.CertPathBuilder
 import java.security.cert.CertStore
 import java.security.cert.CollectionCertStoreParameters
@@ -41,8 +57,9 @@ import java.security.cert.X509Certificate
  *
  *  1. CMS structurally well-formed and the signed math evaluates against
  *     `manifestBytes` to "doesn't match" — either [SignerInformation.verify] returns
- *     `false` or BC raises [CMSSignerDigestMismatchException]. → [Failed]
- *     ([TamperReason.ManifestSignatureMismatch]).
+ *     `false` or BC raises [CMSSignerDigestMismatchException] — **and** the
+ *     wire-order fallback in [verifiesOverWireEncodedAttributes] also fails. →
+ *     [Failed] ([TamperReason.ManifestSignatureMismatch]).
  *  2. CMS structurally malformed, an unexpected BouncyCastle exception, or any
  *     cryptographic operation fails outside the digest-mismatch path. → [Failed]
  *     ([TamperReason.SignatureCryptoFailure]). The outer `runCatching` is the
@@ -140,15 +157,17 @@ private fun verifyAndClassify(
     val signerCert =
         firstSignerWithCert(signedData)
             ?: return SignatureVerifyResult.Failed(TamperReason.SignerCertificateMissing)
-    return finalizeVerification(signerCert, signedData, ctx)
+    return finalizeVerification(signerCert, signedData, signatureBytes, manifestBytes, ctx)
 }
 
 private fun finalizeVerification(
     signerCert: SignerWithHolder,
     signedData: CMSSignedData,
+    signatureBytes: ByteArray,
+    manifestBytes: ByteArray,
     ctx: VerifyContext,
 ): SignatureVerifyResult {
-    if (!verifyMath(signerCert.signer, signerCert.holder)) {
+    if (!verifyMath(signerCert.signer, signerCert.holder, signatureBytes, manifestBytes)) {
         return SignatureVerifyResult.Failed(TamperReason.ManifestSignatureMismatch)
     }
     val converter = JcaX509CertificateConverter().setProvider(BC_PROVIDER)
@@ -209,20 +228,115 @@ private fun firstSignerWithCert(signedData: CMSSignedData): SignerWithHolder? {
 private fun verifyMath(
     signer: SignerInformation,
     leafHolder: X509CertificateHolder,
+    signatureBytes: ByteArray,
+    manifestBytes: ByteArray,
 ): Boolean {
     val verifier =
         JcaSimpleSignerInfoVerifierBuilder()
             .setProvider(BC_PROVIDER)
             .build(leafHolder)
-    return try {
-        signer.verify(verifier)
-    } catch (_: CMSSignerDigestMismatchException) {
-        // BC raises this when the signed digest attribute doesn't match the recomputed
-        // digest of `manifestBytes`. That is exactly the mismatch arm; collapsing it
-        // back to a boolean keeps the policy mapping above readable.
-        false
+    val derVerified =
+        try {
+            signer.verify(verifier)
+        } catch (_: CMSSignerDigestMismatchException) {
+            // BC raises this when the signed digest attribute doesn't match the recomputed
+            // digest of `manifestBytes`. That is exactly the mismatch arm; collapsing it
+            // back to a boolean keeps the policy mapping above readable.
+            false
+        }
+    if (derVerified) return true
+    return verifiesOverWireEncodedAttributes(signer, leafHolder, signatureBytes, manifestBytes)
+}
+
+/**
+ * Fallback for signers that computed the signature over the `SignedAttributes` SET in
+ * the element order it appears on the wire rather than in sorted DER order.
+ *
+ * DER requires a SET OF to be sorted by the ascending byte order of its members'
+ * encodings, and [SignerInformation.verify] re-encodes with [ASN1Encoding.DER] before
+ * hashing — so it sorts. Real-world issuers exist whose tooling signs the unsorted
+ * order (observed: `contentType`, `messageDigest`, `signingTime`, whose lengths
+ * 0x18 / 0x23 / 0x1c are not ascending). BC then hashes different bytes than the
+ * signer did and reports a mismatch on a perfectly sound pass. OpenSSL, Apple Wallet
+ * and Google Wallet all verify over the bytes as received, which is why only this
+ * kernel rejected those passes as [TamperReason.ManifestSignatureMismatch].
+ *
+ * **This does not weaken the trust claim.** The DER path is still tried first, and this
+ * fallback independently re-establishes both halves of the CMS binding:
+ *
+ *  1. the `messageDigest` signed attribute must equal the digest of `manifestBytes`
+ *     under the signer's own digest algorithm, compared with the constant-time
+ *     [MessageDigest.isEqual]. This check is what makes bypassing
+ *     [SignerInformation.verify] safe: BC normally enforces it, and without re-doing it
+ *     here a tampered `manifest.json` would still carry an intact attribute signature
+ *     and slip through.
+ *  2. the signature must verify, under the leaf's public key, over the exact attribute
+ *     bytes as they appear in the archive.
+ *
+ * Together those are precisely the check OpenSSL performs. Any real modification to the
+ * manifest or to the attributes still fails.
+ *
+ * Fails closed: any structural surprise (absent attributes, missing digest, multi-signer
+ * envelope, indefinite-length BER) returns `false` and the caller reports tampering.
+ */
+@Suppress("ReturnCount")
+private fun verifiesOverWireEncodedAttributes(
+    signer: SignerInformation,
+    leafHolder: X509CertificateHolder,
+    signatureBytes: ByteArray,
+    manifestBytes: ByteArray,
+): Boolean {
+    val signedAttrs = signer.signedAttributes ?: return false
+    val declaredDigest =
+        (
+            signedAttrs.get(CMSAttributes.messageDigest)
+                ?.attributeValues?.firstOrNull() as? ASN1OctetString
+        )?.octets ?: return false
+    val actualDigest =
+        MessageDigest.getInstance(signer.digestAlgOID, BC_PROVIDER).digest(manifestBytes)
+    if (!MessageDigest.isEqual(declaredDigest, actualDigest)) return false
+
+    val wireAttrs = wireEncodedSignedAttributes(signatureBytes) ?: return false
+    val signerInfo = signer.toASN1Structure()
+    val signatureName =
+        DefaultCMSSignatureAlgorithmNameGenerator()
+            .getSignatureName(signerInfo.digestAlgorithm, signerInfo.digestEncryptionAlgorithm)
+    val leaf = JcaX509CertificateConverter().setProvider(BC_PROVIDER).getCertificate(leafHolder)
+    return Signature.getInstance(signatureName, BC_PROVIDER).run {
+        initVerify(leaf.publicKey)
+        update(wireAttrs)
+        verify(signer.signature)
     }
 }
+
+/**
+ * Re-reads the `[0] IMPLICIT SignedAttributes` of the sole SignerInfo straight out of
+ * the CMS blob and re-tags it as a SET, preserving the parsed element order.
+ * [ASN1Encoding.DL] is what keeps that order — [ASN1Encoding.DER] would re-sort and
+ * reproduce the very bytes the caller already tried.
+ *
+ * Returns `null` on anything other than a single-signer, definite-length envelope,
+ * matching the single-signer trust claim documented on [firstSignerWithCert].
+ */
+@Suppress("ReturnCount")
+private fun wireEncodedSignedAttributes(signatureBytes: ByteArray): ByteArray? {
+    val contentInfo =
+        ASN1InputStream(signatureBytes).use { it.readObject() } as? ASN1Sequence ?: return null
+    val signedData =
+        (contentInfo.getObjectAt(1) as? ASN1TaggedObject)
+            ?.baseObject?.toASN1Primitive() as? ASN1Sequence ?: return null
+    // signerInfos is the final field of SignedData, after the optional [0]/[1] sets.
+    val signerInfos = signedData.getObjectAt(signedData.size() - 1) as? ASN1Set ?: return null
+    if (signerInfos.size() != 1) return null
+    val signerInfo = signerInfos.getObjectAt(0) as? ASN1Sequence ?: return null
+    val tagged = signerInfo.getObjectAt(SIGNED_ATTRS_INDEX) as? ASN1TaggedObject ?: return null
+    if (tagged.tagNo != 0) return null
+    val attrs = ASN1Set.getInstance(tagged, false)
+    return runCatching { DLSet(attrs.toArray()).getEncoded(ASN1Encoding.DL) }.getOrNull()
+}
+
+/** SignerInfo ::= SEQUENCE { version, sid, digestAlgorithm, [0] signedAttrs, ... }. */
+private const val SIGNED_ATTRS_INDEX = 3
 
 private fun collectIncludedCerts(
     signedData: CMSSignedData,

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
@@ -518,6 +518,42 @@ class SignatureVerifierTest {
         assertFailed(result, TamperReason.ManifestSignatureMismatch)
     }
 
+    /**
+     * Pins the single-signer floor the fallback documents. Both signatures here are
+     * genuine, so nothing but that guard stops the verifier from accepting the envelope
+     * off its first SignerInfo while silently ignoring the second.
+     */
+    @Test
+    fun wireOrderFallbackRejectsMultiSignerEnvelope() {
+        val key = newRsaKeyPair()
+        val leaf = selfSignedCertificate(key, "CN=Self")
+        val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature = cmsWithTwoUnsortedSigners(manifest, leaf, key.private, listOf(leaf))
+
+        val result = runWithFakeAnchor(signature, manifest, ParserConfig())
+
+        assertThat(result).isInstanceOf(SignatureVerifyResult.Failed::class.java)
+    }
+
+    /**
+     * Two `messageDigest` attributes leave "which digest did the signer commit to?"
+     * ambiguous, so no answer may be picked. Asserts only that the pass is rejected: BC
+     * throws on the ambiguity before the fallback is reached, so which of the two
+     * [TamperReason] arms wins is BC's internal ordering, not this kernel's policy.
+     */
+    @Test
+    fun duplicateMessageDigestAttributeIsRejected() {
+        val key = newRsaKeyPair()
+        val leaf = selfSignedCertificate(key, "CN=Self")
+        val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature =
+            cmsWithDuplicateMessageDigestAttribute(manifest, leaf, key.private, listOf(leaf))
+
+        val result = runWithFakeAnchor(signature, manifest, ParserConfig())
+
+        assertThat(result).isInstanceOf(SignatureVerifyResult.Failed::class.java)
+    }
+
     private fun runWithFakeAnchor(
         signature: ByteArray,
         manifest: ByteArray,

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/SignatureVerifierTest.kt
@@ -5,6 +5,10 @@ import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.ParserConfig
 import `is`.walt.passes.core.SignatureStatus
 import `is`.walt.passes.core.TamperReason
+import org.bouncycastle.cert.X509CertificateHolder
+import org.bouncycastle.cms.CMSProcessableByteArray
+import org.bouncycastle.cms.CMSSignedData
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.BeforeClass
 import org.junit.Test
@@ -415,6 +419,103 @@ class SignatureVerifierTest {
             )
 
         assertOk(result, SignatureStatus.AppleVerified)
+    }
+
+    /**
+     * Control for the three tests below: proves the fixture really does reproduce the
+     * wpass-x70 wire shape. Stock BouncyCastle re-encodes the attributes as sorted DER
+     * and so reports a mismatch on this sound envelope — if this ever starts passing,
+     * BC changed and the fallback's regression tests would be silently vacuous.
+     */
+    @Test
+    fun unsortedSignedAttrsFixtureIsRejectedByStockBouncyCastle() {
+        val key = newRsaKeyPair()
+        val leaf = selfSignedCertificate(key, "CN=Unsorted Attrs")
+        val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature =
+            cmsDetachedSignatureWithUnsortedSignedAttrs(manifest, leaf, key.private, listOf(leaf))
+
+        val signedData = CMSSignedData(CMSProcessableByteArray(manifest), signature)
+        val signer = signedData.signerInfos.signers.first()
+        val verifier =
+            JcaSimpleSignerInfoVerifierBuilder()
+                .setProvider(BouncyCastleProvider())
+                .build(X509CertificateHolder(leaf.encoded))
+
+        assertThat(signer.verify(verifier)).isFalse()
+    }
+
+    /**
+     * wpass-x70. Real issuers sign the SignedAttributes SET in wire order rather than
+     * sorted DER order; Apple Wallet, Google Wallet and OpenSSL all accept those passes.
+     * The verifier must too, instead of accusing the user's pass of being tampered.
+     */
+    @Test
+    fun signedAttrsInWireOrderStillVerify() {
+        val rootKey = newRsaKeyPair()
+        val rootCert = selfSignedCertificate(rootKey, "CN=Test Apple Root")
+        val leafKey = newRsaKeyPair()
+        val leafCert = signLeafCertificate(leafKey.public, rootKey, rootCert, "CN=Test Apple Leaf")
+        val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature =
+            cmsDetachedSignatureWithUnsortedSignedAttrs(
+                manifest,
+                leafCert,
+                leafKey.private,
+                listOf(leafCert, rootCert),
+            )
+
+        val result =
+            verifySignatureAgainstAnchorsForTesting(
+                signatureBytes = signature,
+                manifestBytes = manifest,
+                config = ParserConfig(),
+                trustAnchors = setOf(TrustAnchor(rootCert, null)),
+                knownIntermediates = emptySet(),
+            )
+
+        assertOk(result, SignatureStatus.AppleVerified)
+    }
+
+    /**
+     * The security-critical half of wpass-x70. The fallback bypasses
+     * [org.bouncycastle.cms.SignerInformation.verify], which is what normally binds the
+     * signed `messageDigest` attribute to the content — so the fallback re-checks that
+     * binding itself. Without that check a tampered manifest would sail through, since
+     * the signature over the untouched attributes stays perfectly valid.
+     */
+    @Test
+    fun wireOrderFallbackStillRejectsTamperedManifest() {
+        val key = newRsaKeyPair()
+        val leaf = selfSignedCertificate(key, "CN=Self")
+        val original = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature =
+            cmsDetachedSignatureWithUnsortedSignedAttrs(original, leaf, key.private, listOf(leaf))
+        val tampered = original.copyOf().also { it[1] = 0x20 }
+
+        val result = runWithFakeAnchor(signature, tampered, ParserConfig())
+
+        assertFailed(result, TamperReason.ManifestSignatureMismatch)
+    }
+
+    /** A wire-order envelope signed by a key other than the named leaf must still fail. */
+    @Test
+    fun wireOrderFallbackRejectsSignatureFromWrongKey() {
+        val realKey = newRsaKeyPair()
+        val leaf = selfSignedCertificate(realKey, "CN=Self")
+        val impostorKey = newRsaKeyPair()
+        val manifest = "{\"pass.json\":\"abcd\"}".toByteArray()
+        val signature =
+            cmsDetachedSignatureWithUnsortedSignedAttrs(
+                manifest,
+                leaf,
+                impostorKey.private,
+                listOf(leaf),
+            )
+
+        val result = runWithFakeAnchor(signature, manifest, ParserConfig())
+
+        assertFailed(result, TamperReason.ManifestSignatureMismatch)
     }
 
     private fun runWithFakeAnchor(

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
@@ -1,9 +1,26 @@
 package `is`.walt.passes.core.internal
 
+import org.bouncycastle.asn1.ASN1Encodable
+import org.bouncycastle.asn1.ASN1Encoding
+import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.DERNull
+import org.bouncycastle.asn1.DEROctetString
+import org.bouncycastle.asn1.DERSet
+import org.bouncycastle.asn1.DLSequence
+import org.bouncycastle.asn1.DLSet
+import org.bouncycastle.asn1.DLTaggedObject
+import org.bouncycastle.asn1.cms.Attribute
+import org.bouncycastle.asn1.cms.CMSAttributes
+import org.bouncycastle.asn1.cms.CMSObjectIdentifiers
+import org.bouncycastle.asn1.cms.IssuerAndSerialNumber
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import org.bouncycastle.asn1.x509.BasicConstraints
+import org.bouncycastle.asn1.x509.Certificate
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier
+import org.bouncycastle.asn1.x509.Time
 import org.bouncycastle.cert.jcajce.JcaCertStore
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils
@@ -17,9 +34,11 @@ import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder
 import java.math.BigInteger
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.Security
+import java.security.Signature
 import java.security.cert.X509Certificate
 import java.util.Date
 
@@ -166,6 +185,89 @@ internal fun cmsDetachedSignatureWithSki(
         }
     return gen.generate(CMSProcessableByteArray(content), false).encoded
 }
+
+/**
+ * Detached CMS blob whose `SignedAttributes` are signed — and encoded — in the order
+ * `contentType`, `messageDigest`, `signingTime`, which is **not** DER-sorted (their
+ * encodings run 0x18, 0x23, 0x1c; DER SET OF requires ascending 0x18, 0x1c, 0x23).
+ *
+ * This reproduces the wire shape of real issuers whose signing tooling emits the
+ * natural insertion order rather than the sorted one. [CMSSignedDataGenerator] cannot
+ * produce it — it always emits sorted DER — so the envelope is assembled by hand and
+ * serialized with [ASN1Encoding.DL], which preserves element order where DER would
+ * re-sort it. [DLTaggedObject] rather than `DERTaggedObject` for the same reason: the
+ * DER flavor re-encodes its base object and would silently sort the set back.
+ *
+ * SHA-1 digest with a plain `rsaEncryption` signature algorithm mirrors the observed
+ * real-world envelopes.
+ */
+internal fun cmsDetachedSignatureWithUnsortedSignedAttrs(
+    content: ByteArray,
+    signerCert: X509Certificate,
+    signerKey: PrivateKey,
+    includedCerts: List<X509Certificate>,
+): ByteArray {
+    ensureBouncyCastleProvider()
+    val sha1 = AlgorithmIdentifier(ASN1ObjectIdentifier(SHA1_OID), DERNull.INSTANCE)
+    val digest = MessageDigest.getInstance("SHA-1").digest(content)
+
+    // Deliberately NOT sorted — this is the whole point of the fixture.
+    val attrs =
+        DLSet(
+            arrayOf(
+                Attribute(CMSAttributes.contentType, DERSet(CMSObjectIdentifiers.data)),
+                Attribute(CMSAttributes.messageDigest, DERSet(DEROctetString(digest))),
+                Attribute(CMSAttributes.signingTime, DERSet(Time(Date()))),
+            ),
+        )
+
+    val signature =
+        Signature.getInstance("SHA1withRSA", BC_PROVIDER_NAME).run {
+            initSign(signerKey)
+            update(attrs.getEncoded(ASN1Encoding.DL))
+            sign()
+        }
+
+    val signerInfo =
+        DLSequence(
+            arrayOf(
+                ASN1Integer(1L),
+                IssuerAndSerialNumber(
+                    X500Name(signerCert.issuerX500Principal.name),
+                    signerCert.serialNumber,
+                ),
+                sha1,
+                DLTaggedObject(false, 0, attrs),
+                AlgorithmIdentifier(ASN1ObjectIdentifier(RSA_ENCRYPTION_OID), DERNull.INSTANCE),
+                DEROctetString(signature),
+            ),
+        )
+
+    val signedData =
+        DLSequence(
+            arrayOf(
+                ASN1Integer(1L),
+                DLSet(arrayOf<ASN1Encodable>(sha1)),
+                DLSequence(arrayOf<ASN1Encodable>(CMSObjectIdentifiers.data)),
+                DLTaggedObject(
+                    false,
+                    0,
+                    DLSet(includedCerts.map { Certificate.getInstance(it.encoded) }.toTypedArray()),
+                ),
+                DLSet(arrayOf<ASN1Encodable>(signerInfo)),
+            ),
+        )
+
+    return DLSequence(
+        arrayOf(
+            CMSObjectIdentifiers.signedData,
+            DLTaggedObject(true, 0, signedData),
+        ),
+    ).getEncoded(ASN1Encoding.DL)
+}
+
+private const val SHA1_OID = "1.3.14.3.2.26"
+private const val RSA_ENCRYPTION_OID = "1.2.840.113549.1.1.1"
 
 /**
  * Pulls the 20-byte SubjectKeyIdentifier extension value out of [cert]. Both

--- a/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/internal/TestCryptoSupport.kt
@@ -206,19 +206,64 @@ internal fun cmsDetachedSignatureWithUnsortedSignedAttrs(
     signerCert: X509Certificate,
     signerKey: PrivateKey,
     includedCerts: List<X509Certificate>,
-): ByteArray {
+): ByteArray =
+    unsortedSignedAttrsEnvelope(
+        includedCerts,
+        listOf(unsortedSignedAttrsSignerInfo(content, signerCert, signerKey)),
+    )
+
+/**
+ * As [cmsDetachedSignatureWithUnsortedSignedAttrs], but with two SignerInfos, both
+ * genuinely signed. The verifier claims to handle single-signer envelopes only, so this
+ * must fail closed rather than verify off the first signer.
+ */
+internal fun cmsWithTwoUnsortedSigners(
+    content: ByteArray,
+    signerCert: X509Certificate,
+    signerKey: PrivateKey,
+    includedCerts: List<X509Certificate>,
+): ByteArray =
+    unsortedSignedAttrsEnvelope(
+        includedCerts,
+        List(2) { unsortedSignedAttrsSignerInfo(content, signerCert, signerKey) },
+    )
+
+/**
+ * As [cmsDetachedSignatureWithUnsortedSignedAttrs], but carrying the `messageDigest`
+ * attribute twice. Both copies are correct and inside the signature, so the envelope is
+ * cryptographically sound — it is the ambiguity itself that must be rejected, since
+ * "which digest did the signer commit to?" has no single answer.
+ */
+internal fun cmsWithDuplicateMessageDigestAttribute(
+    content: ByteArray,
+    signerCert: X509Certificate,
+    signerKey: PrivateKey,
+    includedCerts: List<X509Certificate>,
+): ByteArray =
+    unsortedSignedAttrsEnvelope(
+        includedCerts,
+        listOf(unsortedSignedAttrsSignerInfo(content, signerCert, signerKey, duplicateDigest = true)),
+    )
+
+private fun unsortedSignedAttrsSignerInfo(
+    content: ByteArray,
+    signerCert: X509Certificate,
+    signerKey: PrivateKey,
+    duplicateDigest: Boolean = false,
+): DLSequence {
     ensureBouncyCastleProvider()
-    val sha1 = AlgorithmIdentifier(ASN1ObjectIdentifier(SHA1_OID), DERNull.INSTANCE)
     val digest = MessageDigest.getInstance("SHA-1").digest(content)
+    val messageDigest = Attribute(CMSAttributes.messageDigest, DERSet(DEROctetString(digest)))
 
     // Deliberately NOT sorted — this is the whole point of the fixture.
     val attrs =
         DLSet(
-            arrayOf(
+            listOfNotNull(
                 Attribute(CMSAttributes.contentType, DERSet(CMSObjectIdentifiers.data)),
-                Attribute(CMSAttributes.messageDigest, DERSet(DEROctetString(digest))),
+                messageDigest,
+                messageDigest.takeIf { duplicateDigest },
                 Attribute(CMSAttributes.signingTime, DERSet(Time(Date()))),
-            ),
+            ).toTypedArray(),
         )
 
     val signature =
@@ -228,33 +273,37 @@ internal fun cmsDetachedSignatureWithUnsortedSignedAttrs(
             sign()
         }
 
-    val signerInfo =
-        DLSequence(
-            arrayOf(
-                ASN1Integer(1L),
-                IssuerAndSerialNumber(
-                    X500Name(signerCert.issuerX500Principal.name),
-                    signerCert.serialNumber,
-                ),
-                sha1,
-                DLTaggedObject(false, 0, attrs),
-                AlgorithmIdentifier(ASN1ObjectIdentifier(RSA_ENCRYPTION_OID), DERNull.INSTANCE),
-                DEROctetString(signature),
+    return DLSequence(
+        arrayOf(
+            ASN1Integer(1L),
+            IssuerAndSerialNumber(
+                X500Name(signerCert.issuerX500Principal.name),
+                signerCert.serialNumber,
             ),
-        )
+            SHA1_ALG_ID,
+            DLTaggedObject(false, 0, attrs),
+            AlgorithmIdentifier(ASN1ObjectIdentifier(RSA_ENCRYPTION_OID), DERNull.INSTANCE),
+            DEROctetString(signature),
+        ),
+    )
+}
 
+private fun unsortedSignedAttrsEnvelope(
+    includedCerts: List<X509Certificate>,
+    signerInfos: List<DLSequence>,
+): ByteArray {
     val signedData =
         DLSequence(
             arrayOf(
                 ASN1Integer(1L),
-                DLSet(arrayOf<ASN1Encodable>(sha1)),
+                DLSet(arrayOf<ASN1Encodable>(SHA1_ALG_ID)),
                 DLSequence(arrayOf<ASN1Encodable>(CMSObjectIdentifiers.data)),
                 DLTaggedObject(
                     false,
                     0,
                     DLSet(includedCerts.map { Certificate.getInstance(it.encoded) }.toTypedArray()),
                 ),
-                DLSet(arrayOf<ASN1Encodable>(signerInfo)),
+                DLSet(signerInfos.toTypedArray<ASN1Encodable>()),
             ),
         )
 
@@ -268,6 +317,7 @@ internal fun cmsDetachedSignatureWithUnsortedSignedAttrs(
 
 private const val SHA1_OID = "1.3.14.3.2.26"
 private const val RSA_ENCRYPTION_OID = "1.2.840.113549.1.1.1"
+private val SHA1_ALG_ID = AlgorithmIdentifier(ASN1ObjectIdentifier(SHA1_OID), DERNull.INSTANCE)
 
 /**
  * Pulls the 20-byte SubjectKeyIdentifier extension value out of [cert]. Both


### PR DESCRIPTION
Fixes #176.

## The bug

Real-world pkpasses that verify in Apple Wallet, Google Wallet, FossWallet and OpenSSL were rejected as `ParseResult.Tampered(ManifestSignatureMismatch)` — Walt accused a cryptographically sound pass of being tampered with.

Some issuers sign the CMS `SignedAttributes` SET in the element order it appears on the wire, which is not DER-sorted (observed: `contentType` 0x18, `messageDigest` 0x23, `signingTime` 0x1c; DER requires ascending 0x18, 0x1c, 0x23). `SignerInformation.verify` re-encodes with `ASN1Encoding.DER`, which sorts, then hashes different bytes than the signer did:

```
SHA1(wire order) = b58870852561242b2cc2d02b1c348583259f3e78  <- signed digest
SHA1(sorted DER) = d8bf5aa9b2cc97115340943f8be9e1a9fc750277  <- what BC hashed
```

Reproduced on JVM with a real Deutschlandticket signed by `pass.de.digital-h.ride`, the same issuer as #176.

**Not** the EKU/purpose hypothesis in the issue. PKIX path building with the bundled Apple anchors succeeds for this leaf inside its validity window, Apple pass EKU and all. The reporter's `unsuitable certificate purpose` is OpenSSL's own `X509_PURPOSE` S/MIME check, which this kernel never performs — and under the lenient default `ParserConfig` a chain failure yields `CertChainIncomplete`, never `Tampered`, so no chain issue could have produced that alert.

## The fix

`verifyMath` falls back to verifying over the original wire encoding when the DER attempt fails. The DER path is still tried first.

This does not weaken the trust claim. The fallback independently re-establishes both halves of the CMS binding: the `messageDigest` attribute must equal the digest of `manifestBytes` (constant-time compare), and the signature must verify under the leaf's key over the exact attribute bytes as received. That is the check OpenSSL performs. Re-doing the digest check is load-bearing rather than belt-and-braces: bypassing `SignerInformation.verify` also bypasses BC's own enforcement of it, and a tampered manifest otherwise keeps a perfectly valid signature over its untouched attributes.

Verified against the real reported pass: `Tampered(ManifestSignatureMismatch)` -> `Success(CertChainIncomplete)`. It reads `CertChainIncomplete` rather than `AppleVerified` only because that sample's leaf expired 2026-04-24; a current pass from the same issuer chains to the bundled Apple root.

## Why the fallback is safe to reach

Verified against BouncyCastle 1.84 bytecode. `verifyMath` catches *only* `CMSSignerDigestMismatchException`; every other `CMSException` propagates to `SignatureCryptoFailure`. `SignerInformation.doVerify` runs `verifyContentTypeAttributeValue`, `verifyAlgorithmIdentifierProtectionAttribute` (RFC 6211), `verifyMessageDigestAttribute` and `verifyCounterSignatureAttribute` — all throwing plain `CMSException` — *before* `contentVerifier.verify()`. So the fallback is reachable only after those checks have already passed; they are inherited as preconditions, not dropped.

There is also no parser differential: BC's `SignedData` picks `signerInfos` as the last untagged element and its `SignerInfo` reads `signedAttrs` at index 3, exactly as the hand parse does. Where the two could diverge, the hand parse returns `null` — the difference only ever runs in the fail-closed direction.

## Hardening from review (second commit)

No change to which passes verify.

1. **The fallback could throw.** `MessageDigest.getInstance` on an attacker-chosen digest OID, the leaf conversion, `Signature.getInstance/initVerify/verify`, and an out-of-range `getObjectAt(3)` all escaped to the outer `runCatching`, which relabelled the DER path's `ManifestSignatureMismatch` verdict as `SignatureCryptoFailure`. Fallback exceptions now fold to `false`, so the fallback can only confirm the stricter path's rejection. ASN.1 indices are bounds-checked, making "fails closed" structural rather than exception-dependent.
2. **Two independent parses unified.** The `messageDigest` came from BC's `AttributeTable` while the signature covered our own re-parse. Not exploitable, but the argument required reasoning about BC internals. Both now come from one `WireSignedAttributes`, so the digest checked is lifted out of the exact bytes verified.
3. **`soleMessageDigestValue`** requires exactly one `messageDigest` attribute carrying exactly one `OCTET STRING`, rather than taking the first match. BC enforces the same shape and throws before the fallback is reachable, so this is defense-in-depth against that ordering changing.

## Tests

- `unsortedSignedAttrsFixtureIsRejectedByStockBouncyCastle` — control proving the fixture really reproduces the wire shape. Without it the regression tests would go vacuous if BC ever changed.
- `signedAttrsInWireOrderStillVerify` — the fix works.
- `wireOrderFallbackStillRejectsTamperedManifest` — the security-critical direction.
- `wireOrderFallbackRejectsSignatureFromWrongKey` — impostor key still fails.
- `wireOrderFallbackRejectsMultiSignerEnvelope` — pins the documented single-signer floor. Mutation-tested: deleting the `signerInfos.size() != 1` guard makes this envelope verify and the test fails.
- `duplicateMessageDigestAttributeIsRejected` — asserts rejection only, since BC throws on the ambiguity before the fallback is reached.

`CMSSignedDataGenerator` cannot emit unsorted attributes, so the fixture envelope is assembled by hand and serialized with `ASN1Encoding.DL`.

## Known limitations

- RSASSA-PSS parameters are not propagated in the fallback's `Signature.getInstance`. This causes false negatives only, and Apple uses PKCS#1 v1.5.
- No digest-algorithm allowlist was added; the DER path has the same freedom, so that is a separate policy decision.
- Field data turned up that this issuer chains through WWDR G4, which is not bundled (only G3 and G6). Path building still works because the issuer ships G4 in the envelope. Filed as `wpass-f5e`.

Reported-by: @abdu-frh