### PR TITLE
bd: disable auto-export git staging

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -52,3 +52,5 @@
 # - linear.api-key
 # - github.org
 # - github.repo
+
+export.git-add: false


### PR DESCRIPTION
`.beads/issues.jsonl` is gitignored (`.gitignore:20`, added by the `bd init` commit `9d63f0b`), so bd's auto-export `git add` step failed on every write command:

```
Warning: auto-export: git add failed: ...
The following paths are ignored by one of your .gitignore files: .beads/issues.jsonl
```

Reproducible on a clean `main`; unrelated to worktrees. No data was ever at risk - the export itself succeeded every time, only the staging step failed.

`export.git-add: false` turns off just the staging attempt. Auto-export still runs, so `.beads/issues.jsonl` stays fresh locally for `bv`/grep.

Committing this rather than leaving it local so it applies in every worktree and clone, matching the committed ignore rule that causes the failure.