### PR TITLE
ci: ignore Kotlin/AGP minor bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,11 +14,18 @@ updates:
     # passes-android is the trust-claim repo. Major-version bumps to AGP, Kotlin,
     # AndroidX core, SQLCipher, BouncyCastle, and Compose all warrant manual review;
     # let dependabot handle minor/patch and surface majors as separate PRs.
+    #
+    # Kotlin and AGP additionally ignore MINOR bumps: walt-android composite-builds
+    # this repo, and Gradle runs one AGP and one Kotlin metadata version per build —
+    # so those two move in lockstep with the consumer, by hand, never from a bot PR.
+    # Patch bumps stay automatic; they are metadata- and plugin-compatible.
     ignore:
       - dependency-name: "com.android.tools.build:gradle"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "org.jetbrains.kotlin:*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
       - dependency-name: "androidx.core:core-ktx"
         update-types: ["version-update:semver-major"]
       - dependency-name: "net.zetetic:sqlcipher-android"


### PR DESCRIPTION
## Why

walt-android composite-builds this repo (`includeBuild` in its `settings.gradle.kts`). Gradle runs **one** AGP and **one** Kotlin metadata version per build invocation, so a Kotlin or AGP minor bump landed here alone puts the kernel ahead of the consumer, which pins `agp = "9.0.1"` / `kotlin = "2.3.21"`. The version catalog already states the intent: *"matches walt-android consumer to avoid drift."*

Dependabot has been re-proposing the same unmergeable Kotlin 2.4.10 bump for weeks (#180, and again grouped as #191). Kotlin 2.4 also carries a Compose-compiler stability-inference change (`b/522127447`), which is exactly the kind of thing that wants a coordinated bump, not a bot merge.

## What

Adds `version-update:semver-minor` to the existing `ignore` entries for `com.android.tools.build:gradle` and `org.jetbrains.kotlin:*`.

- **Patch** bumps (2.3.21 → 2.3.22) stay automatic — metadata- and plugin-compatible.
- **Minor/major** bumps become manual, done in lockstep with walt-android.

#180 and #191 are closed as part of this; the config is what keeps them from coming back.