### PR TITLE
ci: correct action pin comments to the exact tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Gradle managed devices launch a real Android emulator under /dev/kvm. The
       # ubuntu-latest runner image has KVM available, but the runner user is not in
@@ -92,7 +92,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK 17
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: "17"
           distribution: "temurin"
@@ -149,7 +149,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
Comment-only. Dependabot moves the pinned SHA but leaves the trailing comment alone when the original was a bare major, so two pins were misdescribing themselves:

- `actions/checkout@3d3c42e5…` read `# v6` after #189 moved it to **v7.0.1**
- `actions/setup-java@b6effb05…` read `# v5` after #197 moved it to **v5.7.0**

Both SHAs verified against the upstream tag refs. Now written as the exact tag, matching the `setup-gradle` / `upload-artifact` / `dependency-review-action` pins already in the file.

This repo exists so people can read it and trust what they read. A pin comment that names a version the SHA is not is a small lie in exactly the file a reviewer checks first.

Closes `wpass-q7h`.