### PR TITLE
fix(barcode): split DecodeTimedOut from DecoderUnavailable, warm the sandbox (wpass-qw3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,9 @@ jobs:
       # org.gradle.parallel start both managed devices at once, so two emulators shared a
       # 4-core runner and the isolated-process decode blew its watchdog budget on API 36.
       # Separate steps make the serialization structural rather than a Gradle scheduling
-      # accident.
+      # accident. The cost is two Gradle invocations and two device provision/teardown cycles
+      # per API level; `--no-parallel` on one invocation would be cheaper but leaves the
+      # serialization up to Gradle's scheduler, and gives no per-module step attribution.
       - name: Run connected tests (passes-storage)
         id: storage-connected
         run: ./gradlew :passes-storage:api${{ matrix.api }}googleDebugAndroidTest --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,8 @@ jobs:
       # One module per step, deliberately (wpass-qw3). Passing both tasks to one invocation let
       # org.gradle.parallel start both managed devices at once, so two emulators shared a
       # 4-core runner and the isolated-process decode blew its watchdog budget on API 36.
-      # Separate steps make the serialization structural rather than a Gradle scheduling
-      # accident. The cost is two Gradle invocations and two device provision/teardown cycles
-      # per API level; `--no-parallel` on one invocation would be cheaper but leaves the
-      # serialization up to Gradle's scheduler, and gives no per-module step attribution.
+      # Separate steps make the serialization structural rather than a Gradle scheduling flag,
+      # at the cost of a second Gradle invocation and device cycle per API level.
       - name: Run connected tests (passes-storage)
         id: storage-connected
         run: ./gradlew :passes-storage:api${{ matrix.api }}googleDebugAndroidTest --stacktrace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,12 +124,19 @@ jobs:
       # build.gradle.kts. The DebugAndroidTest suffix runs the androidTest sources against
       # the debug variant. passes-barcode runs the wpass-zrt.5 on-device security suite; its
       # @Ignore'd scenarios (sandbox probe, parcel probe) skip rather than fail.
-      - name: Run connected tests
-        run: >-
-          ./gradlew
-          :passes-storage:api${{ matrix.api }}googleDebugAndroidTest
-          :passes-barcode:api${{ matrix.api }}googleDebugAndroidTest
-          --stacktrace
+      #
+      # One module per step, deliberately (wpass-qw3). Passing both tasks to one invocation let
+      # org.gradle.parallel start both managed devices at once, so two emulators shared a
+      # 4-core runner and the isolated-process decode blew its watchdog budget on API 36.
+      # Separate steps make the serialization structural rather than a Gradle scheduling
+      # accident.
+      - name: Run connected tests (passes-storage)
+        run: ./gradlew :passes-storage:api${{ matrix.api }}googleDebugAndroidTest --stacktrace
+
+      # Runs even when the storage leg failed: one module's failure must not hide the other's.
+      - name: Run connected tests (passes-barcode)
+        if: ${{ !cancelled() }}
+        run: ./gradlew :passes-barcode:api${{ matrix.api }}googleDebugAndroidTest --stacktrace
 
       - name: Upload connected test reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,7 @@ jobs:
 
       # Per-API task name matches the localDevices entries declared in each module's
       # build.gradle.kts. The DebugAndroidTest suffix runs the androidTest sources against
-      # the debug variant. passes-barcode runs the wpass-zrt.5 on-device security suite; its
-      # @Ignore'd scenarios (sandbox probe, parcel probe) skip rather than fail.
+      # the debug variant. passes-barcode runs the wpass-zrt.5 on-device security suite.
       #
       # One module per step, deliberately (wpass-qw3). Passing both tasks to one invocation let
       # org.gradle.parallel start both managed devices at once, so two emulators shared a
@@ -131,11 +130,14 @@ jobs:
       # Separate steps make the serialization structural rather than a Gradle scheduling
       # accident.
       - name: Run connected tests (passes-storage)
+        id: storage-connected
         run: ./gradlew :passes-storage:api${{ matrix.api }}googleDebugAndroidTest --stacktrace
 
-      # Runs even when the storage leg failed: one module's failure must not hide the other's.
+      # Runs when the storage leg passed OR failed on its own tests, so one module's failure
+      # cannot hide the other's. Scoped to that step rather than `!cancelled()`, which would
+      # also run this after a setup step failed and report a confusing second failure.
       - name: Run connected tests (passes-barcode)
-        if: ${{ !cancelled() }}
+        if: ${{ success() || steps.storage-connected.conclusion == 'failure' }}
         run: ./gradlew :passes-barcode:api${{ matrix.api }}googleDebugAndroidTest --stacktrace
 
       - name: Upload connected test reports

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -11,6 +11,7 @@ import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
 import android.os.Process
+import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
@@ -132,6 +133,38 @@ class BarcodeDecodeServiceInstrumentedTest {
             ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { decode(it) }
 
         assertThat(result).isInstanceOf(BarcodeDecodeResult.DecodeFailed::class.java)
+    }
+
+    @Test
+    fun slowLorisSourceTimesOutAndReportsDecodeTimedOut() {
+        // The wpass-qw3 premise, end to end on a real device: a source that never delivers its
+        // bytes must trip the watchdog, and that kill must surface as DecodeTimedOut rather than
+        // DecoderUnavailable. Every other test of the split drives an injected clock and a dead
+        // binder, which pins the arithmetic but not the chain it rests on — that a watchdog kill
+        // reaches the host as a RemoteException at or past the budget.
+        //
+        // A pipe with the write end held open and never written is the slow-loris shape the
+        // watchdog exists for: readBoundedBytes blocks in read(), so the decode cannot finish on
+        // its own. Holding the write end here is load-bearing; closing it would signal EOF and
+        // the decode would complete as a malformed-image rejection instead.
+        val pipe = ParcelFileDescriptor.createPipe()
+        val readEnd = pipe[0]
+        val writeEnd = pipe[1]
+
+        val elapsedMs: Long
+        val result: BarcodeDecodeResult
+        try {
+            val startedAt = SystemClock.uptimeMillis()
+            result = readEnd.use { decode(it) }
+            elapsedMs = SystemClock.uptimeMillis() - startedAt
+        } finally {
+            runCatching { writeEnd.close() }
+        }
+
+        assertThat(result)
+            .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
+        // The watchdog waited its budget rather than failing fast for some unrelated reason.
+        assertThat(elapsedMs).isAtLeast(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
     }
 
     @Test

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -163,8 +163,15 @@ class BarcodeDecodeServiceInstrumentedTest {
 
         assertThat(result)
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
-        // The watchdog waited its budget rather than failing fast for some unrelated reason.
+        // Sanity bounds, not a measurement of the watchdog: this window covers process spawn,
+        // warm-up and bind as well as the decode, so the lower bound can be met by bind cost
+        // alone. The DecodeTimedOut result above is the real assertion — the host only attributes
+        // that arm when the full budget elapsed. The upper bound catches a budget retuned to
+        // something wild, since the bind timeout would have folded to DecoderUnavailable first.
         assertThat(elapsedMs).isAtLeast(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
+        assertThat(elapsedMs).isLessThan(
+            BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS + BarcodeDecodeConfig.DEFAULT_BIND_TIMEOUT_MS,
+        )
     }
 
     @Test

--- a/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
+++ b/passes-barcode/src/androidTest/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceInstrumentedTest.kt
@@ -137,16 +137,12 @@ class BarcodeDecodeServiceInstrumentedTest {
 
     @Test
     fun slowLorisSourceTimesOutAndReportsDecodeTimedOut() {
-        // The wpass-qw3 premise, end to end on a real device: a source that never delivers its
-        // bytes must trip the watchdog, and that kill must surface as DecodeTimedOut rather than
-        // DecoderUnavailable. Every other test of the split drives an injected clock and a dead
-        // binder, which pins the arithmetic but not the chain it rests on — that a watchdog kill
-        // reaches the host as a RemoteException at or past the budget.
+        // The wpass-qw3 premise, end to end: a watchdog kill must reach the host as a
+        // RemoteException at or past the budget and surface as DecodeTimedOut. The unit tests
+        // pin the arithmetic with an injected clock; only this pins the chain it rests on.
         //
-        // A pipe with the write end held open and never written is the slow-loris shape the
-        // watchdog exists for: readBoundedBytes blocks in read(), so the decode cannot finish on
-        // its own. Holding the write end here is load-bearing; closing it would signal EOF and
-        // the decode would complete as a malformed-image rejection instead.
+        // Holding the write end open is load-bearing: it is what makes readBoundedBytes block.
+        // Closing it would signal EOF and the decode would finish as a malformed-image reject.
         val pipe = ParcelFileDescriptor.createPipe()
         val readEnd = pipe[0]
         val writeEnd = pipe[1]
@@ -163,15 +159,9 @@ class BarcodeDecodeServiceInstrumentedTest {
 
         assertThat(result)
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
-        // Sanity bounds, not a measurement of the watchdog: this window covers process spawn,
-        // warm-up and bind as well as the decode, so the lower bound can be met by bind cost
-        // alone. The DecodeTimedOut result above is the real assertion — the host only attributes
-        // that arm when the full budget elapsed. The upper bound catches a budget retuned to
-        // something wild, since the bind timeout would have folded to DecoderUnavailable first.
+        // A sanity floor, not a measurement: this window also covers spawn, warm-up and bind, so
+        // bind cost alone could satisfy it. The DecodeTimedOut assertion above is the real one.
         assertThat(elapsedMs).isAtLeast(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
-        assertThat(elapsedMs).isLessThan(
-            BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS + BarcodeDecodeConfig.DEFAULT_BIND_TIMEOUT_MS,
-        )
     }
 
     @Test

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
@@ -36,7 +36,11 @@ import kotlinx.coroutines.withContext
  *    decode fine on retry); anything earlier stays [DecodeFailureReason.DecoderUnavailable]
  *    (a crash or an absent decoder — retry will not help). The budget is read from
  *    [BarcodeDecodeConfig], the same constant the sandbox arms its watchdog with, so the two
- *    sides cannot drift apart.
+ *    sides cannot drift apart on the *value*. They must also not drift on the *clock*:
+ *    [SystemClock.uptimeMillis] shares `CLOCK_MONOTONIC` with the `delay` the watchdog's kill
+ *    timer runs on, so both stop counting across device deep sleep. `elapsedRealtime` would
+ *    keep counting through a suspend the sandbox never experienced, and could report a
+ *    timeout the watchdog never fired.
  *  - A `false` return from [IBinder.transact] folds to [DecodeFailureReason.DecoderUnavailable]
  *    defensively, and is never timeout-attributed: the only path that returns false is the
  *    proxy failing to read the PFD out of the request parcel (a same-build wire-invariant
@@ -61,7 +65,7 @@ import kotlinx.coroutines.withContext
 internal class BarcodeDecodeClient(
     private val binder: IBinder,
     private val decodeBudgetMs: Long = BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS,
-    private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
+    private val elapsedMs: () -> Long = SystemClock::uptimeMillis,
 ) : BarcodeDecodeBinder {
     override suspend fun decode(image: ParcelFileDescriptor): BarcodeDecodeResult =
         withContext(Dispatchers.IO) {
@@ -71,7 +75,7 @@ internal class BarcodeDecodeClient(
                 data.writeTypedObject(image, 0)
                 // Stamped immediately before the transaction: the elapsed window must cover the
                 // decode only, not the bind that preceded it (which pays sandbox cold start).
-                val startedAtMs = elapsedRealtimeMs()
+                val startedAtMs = elapsedMs()
                 val accepted =
                     try {
                         binder.transact(CODE_DECODE, data, reply, 0)
@@ -108,7 +112,7 @@ internal class BarcodeDecodeClient(
      * signature of a timeout, while an earlier death is a crash or an absent decoder.
      */
     private fun decoderWentAway(startedAtMs: Long): BarcodeDecodeResult =
-        if (elapsedRealtimeMs() - startedAtMs >= decodeBudgetMs) {
+        if (elapsedMs() - startedAtMs >= decodeBudgetMs) {
             BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut)
         } else {
             decoderUnavailable()

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
@@ -45,9 +45,9 @@ import kotlinx.coroutines.withContext
  *  - A malformed reply parcel — unrecognised tag, missing payload on a [TAG_DECODED] reply,
  *    or unrecognised wire code — also folds to [DecodeFailureReason.DecoderUnavailable]
  *    rather than throwing, and is likewise never timeout-attributed: the sandbox answered, so
- *    whatever went wrong is not a timeout regardless of how long it took. This is the one
- *    place the posture diverges from `passes-pdf`'s
- *    fail-fast `PdfRendererClient`: here the reply's sender is the isolated decode process,
+ *    whatever went wrong is not a timeout regardless of how long it took. This is the one place
+ *    the posture diverges from `passes-pdf`'s fail-fast `PdfRendererClient`: here the reply's
+ *    sender is the isolated decode process,
  *    which this feature's threat model assumes may be compromised, so the reply shape is
  *    attacker-controlled and must be treated like the payload string — never trusted. A
  *    throw out of this result-returning API would be a DoS on the decode path; folding keeps

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
@@ -4,6 +4,7 @@ import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
 import android.os.RemoteException
+import android.os.SystemClock
 import `is`.walt.passes.barcode.android.BarcodeDecodeBinderProxy.Companion.CODE_DECODE
 import `is`.walt.passes.barcode.android.BarcodeDecodeBinderProxy.Companion.TAG_DECODED
 import `is`.walt.passes.barcode.android.BarcodeDecodeBinderProxy.Companion.TAG_FAILED
@@ -26,17 +27,27 @@ import kotlinx.coroutines.withContext
  * Failure-mode posture mirrors `passes-pdf`'s `PdfRendererClient`:
  *
  *  - A [RemoteException] from [IBinder.transact] is the designed runtime failure mode for a
- *    decode process that went away (e.g. killed by a future bounded-decode watchdog). It is
- *    folded into [DecodeFailureReason.DecoderUnavailable] — "the isolated decode process
- *    could not be bound or terminated before returning a result."
- *  - A `false` return from [IBinder.transact] is treated the same way, defensively: the
- *    only path that returns false is the proxy failing to read the PFD out of the request
- *    parcel (a same-build wire-invariant violation). Folding it in avoids decoding an empty
- *    reply parcel where `readInt()` returns 0 (which equals [TAG_DECODED]) and surfacing a
- *    phantom decoded result.
+ *    decode process that went away — including the [DecodeWatchdog] killing the sandbox on
+ *    budget expiry. Which of the two it was is decided here, by elapsed time (wpass-qw3): the
+ *    sandbox SIGKILLs itself, so it cannot report its own timeout, and the only observable
+ *    that separates "the decoder was never there" from "the decoder ran out of time" is
+ *    whether the full [decodeBudgetMs] elapsed before the binder dropped. At or past the
+ *    budget folds to [DecodeFailureReason.DecodeTimedOut] (a load signal — the same image may
+ *    decode fine on retry); anything earlier stays [DecodeFailureReason.DecoderUnavailable]
+ *    (a crash or an absent decoder — retry will not help). The budget is read from
+ *    [BarcodeDecodeConfig], the same constant the sandbox arms its watchdog with, so the two
+ *    sides cannot drift apart.
+ *  - A `false` return from [IBinder.transact] folds to [DecodeFailureReason.DecoderUnavailable]
+ *    defensively, and is never timeout-attributed: the only path that returns false is the
+ *    proxy failing to read the PFD out of the request parcel (a same-build wire-invariant
+ *    violation), which is immediate and means no decode was ever attempted. Folding it in
+ *    avoids decoding an empty reply parcel where `readInt()` returns 0 (which equals
+ *    [TAG_DECODED]) and surfacing a phantom decoded result.
  *  - A malformed reply parcel — unrecognised tag, missing payload on a [TAG_DECODED] reply,
  *    or unrecognised wire code — also folds to [DecodeFailureReason.DecoderUnavailable]
- *    rather than throwing. This is the one place the posture diverges from `passes-pdf`'s
+ *    rather than throwing, and is likewise never timeout-attributed: the sandbox answered, so
+ *    whatever went wrong is not a timeout regardless of how long it took. This is the one
+ *    place the posture diverges from `passes-pdf`'s
  *    fail-fast `PdfRendererClient`: here the reply's sender is the isolated decode process,
  *    which this feature's threat model assumes may be compromised, so the reply shape is
  *    attacker-controlled and must be treated like the payload string — never trusted. A
@@ -49,6 +60,8 @@ import kotlinx.coroutines.withContext
  */
 internal class BarcodeDecodeClient(
     private val binder: IBinder,
+    private val decodeBudgetMs: Long = BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS,
+    private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
 ) : BarcodeDecodeBinder {
     override suspend fun decode(image: ParcelFileDescriptor): BarcodeDecodeResult =
         withContext(Dispatchers.IO) {
@@ -56,11 +69,14 @@ internal class BarcodeDecodeClient(
             val reply = Parcel.obtain()
             try {
                 data.writeTypedObject(image, 0)
+                // Stamped immediately before the transaction: the elapsed window must cover the
+                // decode only, not the bind that preceded it (which pays sandbox cold start).
+                val startedAtMs = elapsedRealtimeMs()
                 val accepted =
                     try {
                         binder.transact(CODE_DECODE, data, reply, 0)
                     } catch (_: RemoteException) {
-                        return@withContext decoderUnavailable()
+                        return@withContext decoderWentAway(startedAtMs)
                     }
                 if (!accepted) {
                     return@withContext decoderUnavailable()
@@ -84,6 +100,18 @@ internal class BarcodeDecodeClient(
             TAG_NO_BARCODE -> BarcodeDecodeResult.NoBarcodeFound
             TAG_FAILED -> BarcodeDecodeResult.DecodeFailed(DecodeFailureReasonWire.decode(reply.readInt()))
             else -> error("Unknown decode reply tag: $tag")
+        }
+
+    /**
+     * The binder dropped mid-transaction. Attribute it by how long the decode had been running:
+     * the sandbox's own watchdog kills at [decodeBudgetMs], so reaching that mark is the
+     * signature of a timeout, while an earlier death is a crash or an absent decoder.
+     */
+    private fun decoderWentAway(startedAtMs: Long): BarcodeDecodeResult =
+        if (elapsedRealtimeMs() - startedAtMs >= decodeBudgetMs) {
+            BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut)
+        } else {
+            decoderUnavailable()
         }
 
     private fun decoderUnavailable(): BarcodeDecodeResult =

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeClient.kt
@@ -34,13 +34,8 @@ import kotlinx.coroutines.withContext
  *    whether the full [decodeBudgetMs] elapsed before the binder dropped. At or past the
  *    budget folds to [DecodeFailureReason.DecodeTimedOut] (a load signal — the same image may
  *    decode fine on retry); anything earlier stays [DecodeFailureReason.DecoderUnavailable]
- *    (a crash or an absent decoder — retry will not help). The budget is read from
- *    [BarcodeDecodeConfig], the same constant the sandbox arms its watchdog with, so the two
- *    sides cannot drift apart on the *value*. They must also not drift on the *clock*:
- *    [SystemClock.uptimeMillis] shares `CLOCK_MONOTONIC` with the `delay` the watchdog's kill
- *    timer runs on, so both stop counting across device deep sleep. `elapsedRealtime` would
- *    keep counting through a suspend the sandbox never experienced, and could report a
- *    timeout the watchdog never fired.
+ *    (a crash or an absent decoder — retry will not help). What that comparison rests on is
+ *    documented on [decoderWentAway].
  *  - A `false` return from [IBinder.transact] folds to [DecodeFailureReason.DecoderUnavailable]
  *    defensively, and is never timeout-attributed: the only path that returns false is the
  *    proxy failing to read the PFD out of the request parcel (a same-build wire-invariant
@@ -110,6 +105,15 @@ internal class BarcodeDecodeClient(
      * The binder dropped mid-transaction. Attribute it by how long the decode had been running:
      * the sandbox's own watchdog kills at [decodeBudgetMs], so reaching that mark is the
      * signature of a timeout, while an earlier death is a crash or an absent decoder.
+     *
+     * Two things have to hold for that comparison to mean anything, and both are load-bearing:
+     *
+     *  - Same VALUE. [decodeBudgetMs] defaults to the [BarcodeDecodeConfig] field the sandbox
+     *    arms its watchdog from, so neither side can be retuned without the other.
+     *  - Same CLOCK. [SystemClock.uptimeMillis] shares `CLOCK_MONOTONIC` with the `delay` the
+     *    watchdog's kill timer runs on, so both stop counting across device deep sleep.
+     *    `elapsedRealtime` would keep counting through a suspend the sandbox never experienced
+     *    and could report a timeout the watchdog never fired.
      */
     private fun decoderWentAway(startedAtMs: Long): BarcodeDecodeResult =
         if (elapsedMs() - startedAtMs >= decodeBudgetMs) {

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -11,7 +11,8 @@ package `is`.walt.passes.barcode.android
  * checked from the decoded *header* (via `ImageDecoder.OnHeaderDecodedListener`) before the
  * backing bitmap is allocated; [allowedMimeTypes] rejects containers outside the still-image
  * roster at the same header step; [decodeTimeoutMs] is the watchdog budget that bounds a
- * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]).
+ * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]); and
+ * [bindTimeoutMs] bounds getting to the sandbox at all, so no decode can hang forever.
  *
  * Exposed as constants so tests and the service refer to the same numbers and changing a
  * default is a deliberate, test-breaking edit.
@@ -21,6 +22,7 @@ internal data class BarcodeDecodeConfig(
     val maxDimensionPx: Int = DEFAULT_MAX_DIMENSION_PX,
     val maxAreaPx: Long = DEFAULT_MAX_AREA_PX,
     val decodeTimeoutMs: Long = DEFAULT_DECODE_TIMEOUT_MS,
+    val bindTimeoutMs: Long = DEFAULT_BIND_TIMEOUT_MS,
     val allowedMimeTypes: Set<String> = DEFAULT_ALLOWED_MIME_TYPES,
 ) {
     companion object {
@@ -38,6 +40,16 @@ internal data class BarcodeDecodeConfig(
 
         /** Decode wall-clock budget; on expiry [DecodeWatchdog] kills the sandbox (slow-loris guard). */
         const val DEFAULT_DECODE_TIMEOUT_MS: Long = 5_000L
+
+        /**
+         * Liveness backstop on the bind, NOT a performance bound. `bindService` reports refusal
+         * synchronously but a bind that is accepted and then never completes (the sandbox dies
+         * during startup) would otherwise wait forever, which since wpass-qw3 also covers the
+         * `onCreate` warm-up. Deliberately loose — several times the worst cold start observed
+         * on a loaded 2-vCPU emulator — so that a slow sandbox is never mistaken for a dead one.
+         * Tightening this would re-create the flake it exists to bound.
+         */
+        const val DEFAULT_BIND_TIMEOUT_MS: Long = 20_000L
 
         /** Still-image containers a card photo realistically arrives in; others are refused before decode. */
         val DEFAULT_ALLOWED_MIME_TYPES: Set<String> =

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -14,6 +14,11 @@ package `is`.walt.passes.barcode.android
  * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]); and
  * [bindTimeoutMs] bounds getting to the sandbox at all, so no decode can hang forever.
  *
+ * All caps except [bindTimeoutMs] are enforced INSIDE the sandbox, before the platform decoder
+ * allocates. [bindTimeoutMs] is the odd one out: a host-side liveness bound, applied before the
+ * sandbox exists at all. [decodeTimeoutMs] is read on both sides — armed in the sandbox, and
+ * used by the host to attribute a dropped binder.
+ *
  * Exposed as constants so tests and the service refer to the same numbers and changing a
  * default is a deliberate, test-breaking edit.
  */

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -11,13 +11,12 @@ package `is`.walt.passes.barcode.android
  * checked from the decoded *header* (via `ImageDecoder.OnHeaderDecodedListener`) before the
  * backing bitmap is allocated; [allowedMimeTypes] rejects containers outside the still-image
  * roster at the same header step; [decodeTimeoutMs] is the watchdog budget that bounds a
- * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]); and
- * [bindTimeoutMs] bounds getting to the sandbox at all, so no decode can hang forever.
+ * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]).
  *
- * All caps except [bindTimeoutMs] are enforced INSIDE the sandbox, before the platform decoder
- * allocates. [bindTimeoutMs] is the odd one out: a host-side liveness bound, applied before the
- * sandbox exists at all. [decodeTimeoutMs] is read on both sides — armed in the sandbox, and
- * used by the host to attribute a dropped binder.
+ * Every field here is enforced INSIDE the sandbox. [decodeTimeoutMs] is additionally read by the
+ * host, which compares elapsed time against it to attribute a dropped binder — see
+ * [BarcodeDecodeClient]. The host's own bind bound is not a sandbox cap and lives with the host
+ * code, on [DefaultBarcodeImageDecoder].
  *
  * Exposed as constants so tests and the service refer to the same numbers and changing a
  * default is a deliberate, test-breaking edit.
@@ -27,7 +26,6 @@ internal data class BarcodeDecodeConfig(
     val maxDimensionPx: Int = DEFAULT_MAX_DIMENSION_PX,
     val maxAreaPx: Long = DEFAULT_MAX_AREA_PX,
     val decodeTimeoutMs: Long = DEFAULT_DECODE_TIMEOUT_MS,
-    val bindTimeoutMs: Long = DEFAULT_BIND_TIMEOUT_MS,
     val allowedMimeTypes: Set<String> = DEFAULT_ALLOWED_MIME_TYPES,
 ) {
     companion object {
@@ -45,16 +43,6 @@ internal data class BarcodeDecodeConfig(
 
         /** Decode wall-clock budget; on expiry [DecodeWatchdog] kills the sandbox (slow-loris guard). */
         const val DEFAULT_DECODE_TIMEOUT_MS: Long = 5_000L
-
-        /**
-         * Liveness backstop on the bind, NOT a performance bound. `bindService` reports refusal
-         * synchronously but a bind that is accepted and then never completes (the sandbox dies
-         * during startup) would otherwise wait forever, which since wpass-qw3 also covers the
-         * `onCreate` warm-up. Deliberately loose — several times the worst cold start observed
-         * on a loaded 2-vCPU emulator — so that a slow sandbox is never mistaken for a dead one.
-         * Tightening this would re-create the flake it exists to bound.
-         */
-        const val DEFAULT_BIND_TIMEOUT_MS: Long = 20_000L
 
         /** Still-image containers a card photo realistically arrives in; others are refused before decode. */
         val DEFAULT_ALLOWED_MIME_TYPES: Set<String> =

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -62,18 +62,20 @@ public class BarcodeDecodeService : Service() {
  * decode work and nothing else (wpass-qw3). A freshly forked isolated process loads
  * `ImageDecoder`'s native codec support and every ZXing reader class on first touch,
  * interpreted and un-JIT'd; on a loaded machine that alone consumed most of the budget and the
- * watchdog killed benign decodes. Because the host has no bind timeout, moving the cost ahead
- * of `onBind` tightens what the guard bounds rather than loosening the guard.
+ * watchdog killed benign decodes. The cost is MOVED, not saved: binds are per-decode, so the
+ * probe runs on every decode. Moving it out of the guarded window is the entire point, and it
+ * is only safe because the bind itself is now bounded (`DefaultBarcodeImageDecoder`).
  *
  * The probe is Walt-generated, never caller-supplied, and runs the production path end to end:
- * encode a blank bitmap, put it through [decodeBoundedBitmap], then through [symbolDecoder].
- * Sized past ZXing's 40px hybrid-binarizer floor so the real binarizer path warms too. Any
- * failure is swallowed — warm-up is an optimization, and a service that refuses to start would
- * turn a slow decode into no decode at all.
+ * encode a blank bitmap, put it through [boundedDecode], then hand the DECODED bitmap to
+ * [symbolDecoder] exactly as [doDecode] does. Sized past ZXing's 40px hybrid-binarizer floor so
+ * the real binarizer path warms too. Any failure is swallowed — warm-up is an optimization, and
+ * a service that refuses to start would turn a slow decode into no decode at all.
  */
 internal fun warmDecodePath(
     config: BarcodeDecodeConfig,
     symbolDecoder: BarcodeSymbolDecoder,
+    boundedDecode: (ByteArray, BarcodeDecodeConfig) -> BoundedDecodeResult = ::decodeBoundedBitmap,
 ) {
     runCatching {
         val probe = Bitmap.createBitmap(WARM_UP_PROBE_PX, WARM_UP_PROBE_PX, Bitmap.Config.ARGB_8888)
@@ -82,7 +84,7 @@ internal fun warmDecodePath(
             probe.compress(Bitmap.CompressFormat.PNG, 100, encoded)
             // Feed the symbol decoder the ImageDecoder-produced bitmap, exactly as doDecode
             // does; handing it the source probe instead would skip a hop of the real path.
-            when (val decoded = decodeBoundedBitmap(encoded.toByteArray(), config)) {
+            when (val decoded = boundedDecode(encoded.toByteArray(), config)) {
                 is BoundedDecodeResult.Decoded ->
                     try {
                         symbolDecoder.decode(decoded.bitmap)

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -80,9 +80,19 @@ internal fun warmDecodePath(
         try {
             val encoded = ByteArrayOutputStream()
             probe.compress(Bitmap.CompressFormat.PNG, 100, encoded)
-            val decoded = decodeBoundedBitmap(encoded.toByteArray(), config)
-            if (decoded is BoundedDecodeResult.Decoded) decoded.bitmap.recycle()
-            symbolDecoder.decode(probe)
+            // Feed the symbol decoder the ImageDecoder-produced bitmap, exactly as doDecode
+            // does; handing it the source probe instead would skip a hop of the real path.
+            when (val decoded = decodeBoundedBitmap(encoded.toByteArray(), config)) {
+                is BoundedDecodeResult.Decoded ->
+                    try {
+                        symbolDecoder.decode(decoded.bitmap)
+                    } finally {
+                        decoded.bitmap.recycle()
+                    }
+                // The platform decoder is unavailable (the JVM test runtime, say). Warm ZXing
+                // off the probe rather than skipping it — the reader classes are the slow half.
+                is BoundedDecodeResult.Rejected -> symbolDecoder.decode(probe)
+            }
         } finally {
             probe.recycle()
         }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -2,10 +2,12 @@ package `is`.walt.passes.barcode.android
 
 import android.app.Service
 import android.content.Intent
+import android.graphics.Bitmap
 import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import `is`.walt.passes.core.BarcodeDecodeResult
 import `is`.walt.passes.core.DecodeFailureReason
+import java.io.ByteArrayOutputStream
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -32,11 +34,19 @@ import kotlin.coroutines.cancellation.CancellationException
  * decoder allocates, under a [DecodeWatchdog] that kills the process on a slow/hung input;
  * the symbol decode (wpass-zrt.4) reads the barcode off the produced bitmap. Only the pure
  * `{payload, format}` result crosses back — the bitmap is recycled inside the sandbox.
+ *
+ * [onCreate] warms both decoders before `onBind` returns (see [warmDecodePath]) so the
+ * watchdog budget bounds decode work rather than the sandbox's cold start.
  */
 public class BarcodeDecodeService : Service() {
     private val config: BarcodeDecodeConfig = BarcodeDecodeConfig()
     private val watchdog: DecodeWatchdog = DecodeWatchdog(config.decodeTimeoutMs)
     private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder()
+
+    override fun onCreate() {
+        super.onCreate()
+        warmDecodePath(config, symbolDecoder)
+    }
 
     override fun onBind(intent: Intent): IBinder = BarcodeDecodeBinderProxy(buildImpl())
 
@@ -46,6 +56,41 @@ public class BarcodeDecodeService : Service() {
                 doDecode(image, config, watchdog, symbolDecoder)
         }
 }
+
+/**
+ * Pay the sandbox's cold-start cost here, in `onCreate`, so [DecodeWatchdog]'s budget covers
+ * decode work and nothing else (wpass-qw3). A freshly forked isolated process loads
+ * `ImageDecoder`'s native codec support and every ZXing reader class on first touch,
+ * interpreted and un-JIT'd; on a loaded machine that alone consumed most of the budget and the
+ * watchdog killed benign decodes. Because the host has no bind timeout, moving the cost ahead
+ * of `onBind` tightens what the guard bounds rather than loosening the guard.
+ *
+ * The probe is Walt-generated, never caller-supplied, and runs the production path end to end:
+ * encode a blank bitmap, put it through [decodeBoundedBitmap], then through [symbolDecoder].
+ * Sized past ZXing's 40px hybrid-binarizer floor so the real binarizer path warms too. Any
+ * failure is swallowed — warm-up is an optimization, and a service that refuses to start would
+ * turn a slow decode into no decode at all.
+ */
+internal fun warmDecodePath(
+    config: BarcodeDecodeConfig,
+    symbolDecoder: BarcodeSymbolDecoder,
+) {
+    runCatching {
+        val probe = Bitmap.createBitmap(WARM_UP_PROBE_PX, WARM_UP_PROBE_PX, Bitmap.Config.ARGB_8888)
+        try {
+            val encoded = ByteArrayOutputStream()
+            probe.compress(Bitmap.CompressFormat.PNG, 100, encoded)
+            val decoded = decodeBoundedBitmap(encoded.toByteArray(), config)
+            if (decoded is BoundedDecodeResult.Decoded) decoded.bitmap.recycle()
+            symbolDecoder.decode(probe)
+        } finally {
+            probe.recycle()
+        }
+    }
+}
+
+/** Above ZXing's 40px floor for the hybrid binarizer, so warm-up touches the real path. */
+private const val WARM_UP_PROBE_PX = 64
 
 /**
  * One decode: read and bound-decode [image] to a bitmap under [watchdog], hand the bitmap to

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWire.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWire.kt
@@ -9,6 +9,11 @@ import `is`.walt.passes.core.DecodeFailureReason
  * there cannot silently mis-decode failures downstream in walt-android.
  *
  * [DecodeFailureReasonWireSurfaceTest] fails closed if the table drifts from the enum.
+ *
+ * [DECODE_TIMED_OUT] never crosses the wire today — a watchdog-killed sandbox cannot report
+ * its own death, so [BarcodeDecodeClient] attributes that arm host-side. The code is reserved
+ * here anyway so the table stays total over the enum and a future sandbox-side report needs no
+ * renumber.
  */
 internal object DecodeFailureReasonWire {
     const val SOURCE_UNREADABLE: Int = 0
@@ -16,6 +21,7 @@ internal object DecodeFailureReasonWire {
     const val IMAGE_TOO_LARGE: Int = 2
     const val UNSUPPORTED_BARCODE_FORMAT: Int = 3
     const val DECODER_UNAVAILABLE: Int = 4
+    const val DECODE_TIMED_OUT: Int = 5
 
     fun encode(reason: DecodeFailureReason): Int =
         when (reason) {
@@ -24,6 +30,7 @@ internal object DecodeFailureReasonWire {
             DecodeFailureReason.ImageTooLarge -> IMAGE_TOO_LARGE
             DecodeFailureReason.UnsupportedBarcodeFormat -> UNSUPPORTED_BARCODE_FORMAT
             DecodeFailureReason.DecoderUnavailable -> DECODER_UNAVAILABLE
+            DecodeFailureReason.DecodeTimedOut -> DECODE_TIMED_OUT
         }
 
     fun decode(code: Int): DecodeFailureReason =
@@ -33,6 +40,7 @@ internal object DecodeFailureReasonWire {
             IMAGE_TOO_LARGE -> DecodeFailureReason.ImageTooLarge
             UNSUPPORTED_BARCODE_FORMAT -> DecodeFailureReason.UnsupportedBarcodeFormat
             DECODER_UNAVAILABLE -> DecodeFailureReason.DecoderUnavailable
+            DECODE_TIMED_OUT -> DecodeFailureReason.DecodeTimedOut
             else -> error("Unknown DecodeFailureReason wire code: $code")
         }
 }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWire.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWire.kt
@@ -10,10 +10,12 @@ import `is`.walt.passes.core.DecodeFailureReason
  *
  * [DecodeFailureReasonWireSurfaceTest] fails closed if the table drifts from the enum.
  *
- * [DECODE_TIMED_OUT] never crosses the wire today — a watchdog-killed sandbox cannot report
- * its own death, so [BarcodeDecodeClient] attributes that arm host-side. The code is reserved
- * here anyway so the table stays total over the enum and a future sandbox-side report needs no
- * renumber.
+ * No honest sandbox emits [DECODE_TIMED_OUT] — a watchdog-killed process cannot report its own
+ * death, so [BarcodeDecodeClient] attributes that arm host-side. The code is reserved here so
+ * the table stays total over the enum and a future sandbox-side report needs no renumber. A
+ * compromised sandbox can of course send it, which grants nothing it did not already have: it
+ * could always assert any of codes 0-4, and no consumer branches on the reason for a security
+ * decision.
  */
 internal object DecodeFailureReasonWire {
     const val SOURCE_UNREADABLE: Int = 0

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
@@ -15,9 +15,7 @@ import kotlinx.coroutines.withContext
  * process without a hard wall-clock bound. On expiry the watchdog terminates the isolated
  * process; the main process then observes the dropped binder as a
  * [android.os.RemoteException]. A killed sandbox cannot report its own death, so
- * [BarcodeDecodeClient] attributes that drop to
- * [is.walt.passes.core.DecodeFailureReason.DecodeTimedOut] when the full [timeoutMs] had
- * elapsed, and to `DecoderUnavailable` otherwise (wpass-qw3).
+ * [BarcodeDecodeClient] attributes that drop by elapsed time (wpass-qw3).
  *
  * The budget bounds DECODE work only. Class loading, native codec init, and ZXing reader
  * first-touch are paid in [BarcodeDecodeService.onCreate], before `onBind` returns, so a cold

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DecodeWatchdog.kt
@@ -14,8 +14,14 @@ import kotlinx.coroutines.withContext
  * container that sends the platform codec into a long parse. Either would starve the decode
  * process without a hard wall-clock bound. On expiry the watchdog terminates the isolated
  * process; the main process then observes the dropped binder as a
- * [android.os.RemoteException] and surfaces
- * [is.walt.passes.core.DecodeFailureReason.DecoderUnavailable].
+ * [android.os.RemoteException]. A killed sandbox cannot report its own death, so
+ * [BarcodeDecodeClient] attributes that drop to
+ * [is.walt.passes.core.DecodeFailureReason.DecodeTimedOut] when the full [timeoutMs] had
+ * elapsed, and to `DecoderUnavailable` otherwise (wpass-qw3).
+ *
+ * The budget bounds DECODE work only. Class loading, native codec init, and ZXing reader
+ * first-touch are paid in [BarcodeDecodeService.onCreate], before `onBind` returns, so a cold
+ * sandbox on a loaded machine cannot spend the budget on warm-up it was never meant to cover.
  *
  * Killing the process (rather than cancelling the coroutine) is deliberate: coroutine
  * cancellation is cooperative and only fires at suspension points, but the decode is a

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
@@ -35,14 +35,20 @@ internal class DefaultBarcodeImageDecoder(
     private val config: BarcodeDecodeConfig = BarcodeDecodeConfig(),
 ) : BarcodeImageDecoder {
     internal data class Deps(
-        val sessionFactoryFor: (Context) -> IsolatedWorkerSessionFactory<BarcodeDecodeBinder> = { ctx ->
-            AndroidIsolatedWorkerSessionFactory(ctx, BarcodeDecodeService::class.java) { BarcodeDecodeClient(it) }
-        },
+        // Takes the config so the client's timeout-attribution threshold is the one THIS decoder
+        // holds. Reading the constant here instead would let a non-default config disagree with
+        // the threshold it is attributed against — the drift the shared constant exists to stop.
+        val sessionFactoryFor: (Context, BarcodeDecodeConfig) -> IsolatedWorkerSessionFactory<BarcodeDecodeBinder> =
+            { ctx, cfg ->
+                AndroidIsolatedWorkerSessionFactory(ctx, BarcodeDecodeService::class.java) {
+                    BarcodeDecodeClient(it, cfg.decodeTimeoutMs)
+                }
+            },
         val openPfd: (BarcodeImageSource) -> ParcelFileDescriptor? = ::defaultOpenPfd,
     )
 
     private val sessionFactory: IsolatedWorkerSessionFactory<BarcodeDecodeBinder> by lazy {
-        deps.sessionFactoryFor(appContext)
+        deps.sessionFactoryFor(appContext, config)
     }
 
     override suspend fun decode(source: BarcodeImageSource): BarcodeDecodeResult {
@@ -68,9 +74,13 @@ internal class DefaultBarcodeImageDecoder(
      * covers the warm-up too. Returns null on expiry, which the caller folds to
      * `DecoderUnavailable` — accurate, because no decode was ever attempted.
      *
-     * The `also` is what makes this leak-free: if `connect()` resolves in the same instant the
-     * timeout fires, `withTimeoutOrNull` discards the result, so the session is captured on the
-     * way out and closed here. Otherwise that race would strand a bound sandbox process.
+     * The `also` narrows the teardown race. `connect()`'s own `invokeOnCancellation` unbinds
+     * while it is still suspended, but that hook is detached once it resumes — so a session that
+     * materializes just as the deadline fires would be discarded by `withTimeoutOrNull` still
+     * bound. Capturing on the way out lets it be closed here. What this does NOT cover is a
+     * continuation resumed after cancellation, whose value the dispatcher drops without running
+     * this block at all; closing that needs the facade to resume with an onCancellation handler
+     * (wpass-67l). The residue is one bound sandbox in a sub-millisecond window.
      */
     private suspend fun connectWithinBudget(): ConnectResult<BarcodeDecodeBinder>? {
         var connected: ConnectResult<BarcodeDecodeBinder>? = null

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
@@ -32,23 +32,16 @@ import kotlinx.coroutines.withTimeoutOrNull
 internal class DefaultBarcodeImageDecoder(
     private val appContext: Context,
     private val deps: Deps = Deps(),
-    private val config: BarcodeDecodeConfig = BarcodeDecodeConfig(),
 ) : BarcodeImageDecoder {
     internal data class Deps(
-        // Takes the config so the client's timeout-attribution threshold is the one THIS decoder
-        // holds. Reading the constant here instead would let a non-default config disagree with
-        // the threshold it is attributed against — the drift the shared constant exists to stop.
-        val sessionFactoryFor: (Context, BarcodeDecodeConfig) -> IsolatedWorkerSessionFactory<BarcodeDecodeBinder> =
-            { ctx, cfg ->
-                AndroidIsolatedWorkerSessionFactory(ctx, BarcodeDecodeService::class.java) {
-                    BarcodeDecodeClient(it, cfg.decodeTimeoutMs)
-                }
-            },
+        val sessionFactoryFor: (Context) -> IsolatedWorkerSessionFactory<BarcodeDecodeBinder> = { ctx ->
+            AndroidIsolatedWorkerSessionFactory(ctx, BarcodeDecodeService::class.java) { BarcodeDecodeClient(it) }
+        },
         val openPfd: (BarcodeImageSource) -> ParcelFileDescriptor? = ::defaultOpenPfd,
     )
 
     private val sessionFactory: IsolatedWorkerSessionFactory<BarcodeDecodeBinder> by lazy {
-        deps.sessionFactoryFor(appContext, config)
+        deps.sessionFactoryFor(appContext)
     }
 
     override suspend fun decode(source: BarcodeImageSource): BarcodeDecodeResult {
@@ -85,7 +78,7 @@ internal class DefaultBarcodeImageDecoder(
     private suspend fun connectWithinBudget(): ConnectResult<BarcodeDecodeBinder>? {
         var connected: ConnectResult<BarcodeDecodeBinder>? = null
         val result =
-            withTimeoutOrNull(config.bindTimeoutMs) {
+            withTimeoutOrNull(DEFAULT_BIND_TIMEOUT_MS) {
                 sessionFactory.connect().also { connected = it }
             }
         if (result == null) {
@@ -97,6 +90,15 @@ internal class DefaultBarcodeImageDecoder(
     }
 
     internal companion object {
+        /**
+         * Liveness backstop on the bind, NOT a performance bound. Lives here rather than on
+         * [BarcodeDecodeConfig] because it bounds the host's wait, not anything the sandbox
+         * enforces. Deliberately loose — several times the worst cold start observed on a loaded
+         * 2-vCPU emulator — so a slow sandbox is never mistaken for a dead one. Tightening it
+         * would recreate the flake it exists to bound.
+         */
+        const val DEFAULT_BIND_TIMEOUT_MS: Long = 20_000L
+
         /**
          * Open [source] as a [ParcelFileDescriptor] without reading its bytes into this
          * process. Mirrors the PDF importer's source discipline: the `content://` scheme

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoder.kt
@@ -8,6 +8,7 @@ import `is`.walt.passes.core.DecodeFailureReason
 import `is`.walt.passes.isolation.AndroidIsolatedWorkerSessionFactory
 import `is`.walt.passes.isolation.ConnectResult
 import `is`.walt.passes.isolation.IsolatedWorkerSessionFactory
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Default [BarcodeImageDecoder]. Orchestrates one decode: open the source as a file
@@ -31,6 +32,7 @@ import `is`.walt.passes.isolation.IsolatedWorkerSessionFactory
 internal class DefaultBarcodeImageDecoder(
     private val appContext: Context,
     private val deps: Deps = Deps(),
+    private val config: BarcodeDecodeConfig = BarcodeDecodeConfig(),
 ) : BarcodeImageDecoder {
     internal data class Deps(
         val sessionFactoryFor: (Context) -> IsolatedWorkerSessionFactory<BarcodeDecodeBinder> = { ctx ->
@@ -48,14 +50,40 @@ internal class DefaultBarcodeImageDecoder(
             deps.openPfd(source)
                 ?: return BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.SourceUnreadable)
         return try {
-            when (val conn = sessionFactory.connect()) {
-                ConnectResult.BindFailed ->
+            when (val conn = connectWithinBudget()) {
+                null, ConnectResult.BindFailed ->
                     BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable)
                 is ConnectResult.Connected -> conn.session.use { it.client.decode(pfd) }
             }
         } finally {
             runCatching { pfd.close() }
         }
+    }
+
+    /**
+     * Bind, or give up. `bindService` reports an outright refusal synchronously, but a bind that
+     * is accepted and whose service then dies before `onServiceConnected` never resumes at all —
+     * the facade has no deadline of its own (wpass-67l). Without this bound the decode path could
+     * hang indefinitely, and since wpass-qw3 moved sandbox warm-up into `onCreate` that window
+     * covers the warm-up too. Returns null on expiry, which the caller folds to
+     * `DecoderUnavailable` — accurate, because no decode was ever attempted.
+     *
+     * The `also` is what makes this leak-free: if `connect()` resolves in the same instant the
+     * timeout fires, `withTimeoutOrNull` discards the result, so the session is captured on the
+     * way out and closed here. Otherwise that race would strand a bound sandbox process.
+     */
+    private suspend fun connectWithinBudget(): ConnectResult<BarcodeDecodeBinder>? {
+        var connected: ConnectResult<BarcodeDecodeBinder>? = null
+        val result =
+            withTimeoutOrNull(config.bindTimeoutMs) {
+                sessionFactory.connect().also { connected = it }
+            }
+        if (result == null) {
+            (connected as? ConnectResult.Connected)?.session?.let { session ->
+                runCatching { session.close() }
+            }
+        }
+        return result
     }
 
     internal companion object {

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
@@ -106,7 +106,7 @@ class BarcodeDecodeBinderRoundTripTest {
     fun clientBudgetDefaultsToTheBudgetTheSandboxArmsItsWatchdogWith() = runTest {
         // Host-side timeout attribution is only sound while both sides read the same number.
         val atBudget = clockReading(0L, BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
-        val client = BarcodeDecodeClient(DeadBinder(), elapsedRealtimeMs = atBudget)
+        val client = BarcodeDecodeClient(DeadBinder(), elapsedMs = atBudget)
         assertThat(client.decode(pipeRead))
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
     }

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
@@ -84,11 +84,31 @@ class BarcodeDecodeBinderRoundTripTest {
 
     @Test
     fun decodeFoldsRemoteExceptionIntoDecoderUnavailable() = runTest {
-        // A decode process that goes away (e.g. killed by a future bounded-decode watchdog)
-        // surfaces as RemoteException from transact; the client folds it to DecoderUnavailable.
-        val client = BarcodeDecodeClient(DeadBinder())
+        // A decode process that goes away surfaces as RemoteException from transact. Dying well
+        // inside the budget is an absent or crashed decoder, not a timeout.
+        val client = BarcodeDecodeClient(DeadBinder(), BUDGET_MS, clockReading(0L, BUDGET_MS - 1))
         assertThat(client.decode(pipeRead))
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
+    }
+
+    @Test
+    fun decodeAtOrPastBudgetFoldsIntoDecodeTimedOut() = runTest {
+        // The watchdog kills the sandbox at the budget, so a binder that drops once the budget
+        // has elapsed is the signature of a timeout (wpass-qw3). The boundary is inclusive.
+        for (elapsed in listOf(BUDGET_MS, BUDGET_MS + 1, BUDGET_MS * 3)) {
+            val client = BarcodeDecodeClient(DeadBinder(), BUDGET_MS, clockReading(0L, elapsed))
+            assertThat(client.decode(pipeRead))
+                .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
+        }
+    }
+
+    @Test
+    fun clientBudgetDefaultsToTheBudgetTheSandboxArmsItsWatchdogWith() = runTest {
+        // Host-side timeout attribution is only sound while both sides read the same number.
+        val atBudget = clockReading(0L, BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
+        val client = BarcodeDecodeClient(DeadBinder(), elapsedRealtimeMs = atBudget)
+        assertThat(client.decode(pipeRead))
+            .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
     }
 
     @Test
@@ -96,7 +116,9 @@ class BarcodeDecodeBinderRoundTripTest {
         // onTransact returning false (proxy could not read the request PFD) leaves the reply
         // parcel empty; decoding it as TAG_DECODED (empty parcel reads 0) would surface a
         // phantom decoded result, so the client must translate false into DecoderUnavailable.
-        val client = BarcodeDecodeClient(FalseBinder())
+        // The clock is parked past the budget: no decode was attempted, so elapsed time is
+        // irrelevant and this must never be attributed as a timeout.
+        val client = BarcodeDecodeClient(FalseBinder(), BUDGET_MS, clockReading(0L, BUDGET_MS * 2))
         assertThat(client.decode(pipeRead))
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
     }
@@ -106,7 +128,8 @@ class BarcodeDecodeBinderRoundTripTest {
         // A compromised sandbox could return a reply with an unrecognised tag (or a garbled
         // payload / wire code). The client treats the reply as untrusted and folds any parse
         // failure to DecoderUnavailable rather than throwing out of the result-returning API.
-        val client = BarcodeDecodeClient(GarbageReplyBinder())
+        // Past-budget clock again: the sandbox answered, so this is not a timeout however slow.
+        val client = BarcodeDecodeClient(GarbageReplyBinder(), BUDGET_MS, clockReading(0L, BUDGET_MS * 2))
         assertThat(client.decode(pipeRead))
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
     }
@@ -118,6 +141,12 @@ class BarcodeDecodeBinderRoundTripTest {
 
     private fun clientFor(impl: BarcodeDecodeBinder): BarcodeDecodeClient =
         BarcodeDecodeClient(BarcodeDecodeBinderProxy(impl))
+
+    /** Hands out [readings] in order, then repeats the last, so paths that read once still work. */
+    private fun clockReading(vararg readings: Long): () -> Long {
+        var index = 0
+        return { readings[minOf(index++, readings.lastIndex)] }
+    }
 
     /** Every transact throws RemoteException — the shape after the decode process is gone. */
     private class DeadBinder : Binder() {
@@ -136,6 +165,11 @@ class BarcodeDecodeBinderRoundTripTest {
             reply?.writeInt(Int.MAX_VALUE)
             return true
         }
+    }
+
+    private companion object {
+        /** Distinct from the production default so a test cannot pass by picking up the real one. */
+        const val BUDGET_MS = 1_234L
     }
 
     private class StaticImpl(

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeBinderRoundTripTest.kt
@@ -104,11 +104,18 @@ class BarcodeDecodeBinderRoundTripTest {
 
     @Test
     fun clientBudgetDefaultsToTheBudgetTheSandboxArmsItsWatchdogWith() = runTest {
-        // Host-side timeout attribution is only sound while both sides read the same number.
+        // Host-side timeout attribution is only sound while the client's default IS the constant
+        // the sandbox arms from — a client that stopped referencing it would attribute against a
+        // threshold nothing enforces. The at-budget reading alone cannot catch that (a smaller
+        // default still reads as timed-out at 5000); the reading one millisecond below is what
+        // pins it. Retuning the constant itself moves both sides together, which is intended.
         val atBudget = clockReading(0L, BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
-        val client = BarcodeDecodeClient(DeadBinder(), elapsedMs = atBudget)
-        assertThat(client.decode(pipeRead))
+        assertThat(BarcodeDecodeClient(DeadBinder(), elapsedMs = atBudget).decode(pipeRead))
             .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecodeTimedOut))
+
+        val justUnder = clockReading(0L, BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS - 1)
+        assertThat(BarcodeDecodeClient(DeadBinder(), elapsedMs = justUnder).decode(pipeRead))
+            .isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
     }
 
     @Test

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -140,6 +140,16 @@ class BarcodeDecodeServiceTest {
     }
 
     @Test
+    fun serviceWatchdogAndClientAttributionReadTheSameBudget() {
+        // Host-side timeout attribution is a shared-constant handshake across a process
+        // boundary with no wire check, so the value must be pinned on BOTH sides. The client
+        // half is pinned in BarcodeDecodeBinderRoundTripTest; this is the service half, which
+        // arms its watchdog from the default config rather than the constant directly.
+        assertThat(BarcodeDecodeConfig().decodeTimeoutMs)
+            .isEqualTo(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
+    }
+
+    @Test
     fun warmDecodePathContainsFailures() {
         // Warm-up is an optimization. A throw here would take down onCreate and turn a slow
         // decode into no decode at all, so nothing may escape.

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -24,6 +24,9 @@ import org.robolectric.annotation.Config
  *  - a Throwable from either the bounded decode or the symbol decode is contained as
  *    `DecodeFailed(ImageDecodeFailed)` rather than escaping;
  *  - the source descriptor is closed on every outcome.
+ *
+ * Also covers [warmDecodePath], the `onCreate` warm-up that keeps cold start out of the
+ * watchdog budget (wpass-qw3).
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -115,6 +118,32 @@ class BarcodeDecodeServiceTest {
         assertThat(result).isEqualTo(BoundedDecodeResult.Rejected(DecodeFailureReason.ImageTooLarge))
         assertThat(readEnd.fileDescriptor.valid()).isTrue()
         readEnd.close()
+    }
+
+    @Test
+    fun warmDecodePathRunsTheSymbolDecoderOffTheDecodeBudget() {
+        // The warm-up must actually touch ZXing — a no-op would leave the reader classes to
+        // load inside the watchdog budget, which is the wpass-qw3 failure.
+        var probedWidth = 0
+        var probedHeight = 0
+
+        warmDecodePath(config) { bitmap ->
+            probedWidth = bitmap.width
+            probedHeight = bitmap.height
+            BarcodeDecodeResult.NoBarcodeFound
+        }
+
+        // Both stay 0 if the decoder was never called; 40 is ZXing's hybrid-binarizer floor,
+        // below which the warm-up would touch a binarizer path the real decode never uses.
+        assertThat(probedWidth).isAtLeast(40)
+        assertThat(probedHeight).isAtLeast(40)
+    }
+
+    @Test
+    fun warmDecodePathContainsFailures() {
+        // Warm-up is an optimization. A throw here would take down onCreate and turn a slow
+        // decode into no decode at all, so nothing may escape.
+        warmDecodePath(config) { error("warm-up blew up") }
     }
 
     // --------------------------------------------------------------------- helpers

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -121,30 +121,44 @@ class BarcodeDecodeServiceTest {
     }
 
     @Test
-    fun warmDecodePathRunsTheSymbolDecoderOffTheDecodeBudget() {
-        // The warm-up must actually touch ZXing — a no-op would leave the reader classes to
-        // load inside the watchdog budget, which is the wpass-qw3 failure.
-        var probedWidth = 0
-        var probedHeight = 0
+    fun warmDecodePathWarmsTheSymbolDecoderOnTheDecodedBitmap() {
+        // The warm-up must hand ZXing the ImageDecoder OUTPUT, exactly as doDecode does —
+        // warming it off the source probe instead would skip the codec hop and leave part of
+        // the cold start inside the watchdog budget. A marker bitmap of a distinctive size is
+        // what separates the two; asserting only "some 64x64 bitmap arrived" would stay green
+        // either way, since the probe is 64x64 too.
+        val marker = Bitmap.createBitmap(9, 7, Bitmap.Config.ARGB_8888)
+        var warmed: Bitmap? = null
 
-        warmDecodePath(config) { bitmap ->
-            probedWidth = bitmap.width
-            probedHeight = bitmap.height
-            BarcodeDecodeResult.NoBarcodeFound
+        warmDecodePath(config, { bitmap -> warmed = bitmap; BarcodeDecodeResult.NoBarcodeFound }) { _, _ ->
+            BoundedDecodeResult.Decoded(marker)
         }
 
-        // Both stay 0 if the decoder was never called; 40 is ZXing's hybrid-binarizer floor,
-        // below which the warm-up would touch a binarizer path the real decode never uses.
-        assertThat(probedWidth).isAtLeast(40)
-        assertThat(probedHeight).isAtLeast(40)
+        assertThat(warmed).isSameInstanceAs(marker)
+        assertThat(marker.isRecycled).isTrue()
     }
 
     @Test
-    fun serviceWatchdogAndClientAttributionReadTheSameBudget() {
-        // Host-side timeout attribution is a shared-constant handshake across a process
-        // boundary with no wire check, so the value must be pinned on BOTH sides. The client
-        // half is pinned in BarcodeDecodeBinderRoundTripTest; this is the service half, which
-        // arms its watchdog from the default config rather than the constant directly.
+    fun warmDecodePathStillWarmsZxingWhenThePlatformDecoderIsUnavailable() {
+        // Fallback arm: no bitmap to warm from, but the ZXing reader classes are the slow half
+        // of cold start, so they must still be touched rather than the warm-up skipped.
+        var probedWidth = 0
+
+        warmDecodePath(config, { bitmap -> probedWidth = bitmap.width; BarcodeDecodeResult.NoBarcodeFound }) { _, _ ->
+            BoundedDecodeResult.Rejected(DecodeFailureReason.ImageDecodeFailed)
+        }
+
+        // Stays 0 if the decoder was never called; 40 is ZXing's hybrid-binarizer floor, below
+        // which the warm-up would touch a binarizer path the real decode never uses.
+        assertThat(probedWidth).isAtLeast(40)
+    }
+
+    @Test
+    fun configDefaultDecodeTimeoutMatchesTheSharedConstant() {
+        // Narrow on purpose: this catches only an edit to the default parameter expression.
+        // The service arming its watchdog from this config is NOT reachable from a unit test —
+        // that end of the handshake is proven on-device by the instrumented slow-loris case,
+        // which asserts a real decode was killed at this budget.
         assertThat(BarcodeDecodeConfig().decodeTimeoutMs)
             .isEqualTo(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
     }
@@ -153,7 +167,7 @@ class BarcodeDecodeServiceTest {
     fun warmDecodePathContainsFailures() {
         // Warm-up is an optimization. A throw here would take down onCreate and turn a slow
         // decode into no decode at all, so nothing may escape.
-        warmDecodePath(config) { error("warm-up blew up") }
+        warmDecodePath(config, { error("warm-up blew up") }) { _, _ -> error("codec blew up") }
     }
 
     // --------------------------------------------------------------------- helpers

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeServiceTest.kt
@@ -154,16 +154,6 @@ class BarcodeDecodeServiceTest {
     }
 
     @Test
-    fun configDefaultDecodeTimeoutMatchesTheSharedConstant() {
-        // Narrow on purpose: this catches only an edit to the default parameter expression.
-        // The service arming its watchdog from this config is NOT reachable from a unit test —
-        // that end of the handshake is proven on-device by the instrumented slow-loris case,
-        // which asserts a real decode was killed at this budget.
-        assertThat(BarcodeDecodeConfig().decodeTimeoutMs)
-            .isEqualTo(BarcodeDecodeConfig.DEFAULT_DECODE_TIMEOUT_MS)
-    }
-
-    @Test
     fun warmDecodePathContainsFailures() {
         // Warm-up is an optimization. A throw here would take down onCreate and turn a slow
         // decode into no decode at all, so nothing may escape.

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWireSurfaceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DecodeFailureReasonWireSurfaceTest.kt
@@ -19,6 +19,7 @@ class DecodeFailureReasonWireSurfaceTest {
                 DecodeFailureReason.ImageTooLarge to DecodeFailureReasonWire.IMAGE_TOO_LARGE,
                 DecodeFailureReason.UnsupportedBarcodeFormat to DecodeFailureReasonWire.UNSUPPORTED_BARCODE_FORMAT,
                 DecodeFailureReason.DecoderUnavailable to DecodeFailureReasonWire.DECODER_UNAVAILABLE,
+                DecodeFailureReason.DecodeTimedOut to DecodeFailureReasonWire.DECODE_TIMED_OUT,
             )
         for ((reason, code) in expected) {
             assertThat(DecodeFailureReasonWire.encode(reason)).isEqualTo(code)
@@ -40,6 +41,7 @@ class DecodeFailureReasonWireSurfaceTest {
         assertThat(DecodeFailureReasonWire.IMAGE_TOO_LARGE).isEqualTo(2)
         assertThat(DecodeFailureReasonWire.UNSUPPORTED_BARCODE_FORMAT).isEqualTo(3)
         assertThat(DecodeFailureReasonWire.DECODER_UNAVAILABLE).isEqualTo(4)
+        assertThat(DecodeFailureReasonWire.DECODE_TIMED_OUT).isEqualTo(5)
     }
 
     @Test

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
@@ -135,7 +135,7 @@ class DefaultBarcodeImageDecoderTest {
         // capture the sandbox would stay bound with nothing holding a reference to it.
         val pfd = TrackingPfd(pipeReadEnd())
         val session = RecordingSession(StaticDecodeBinder(BarcodeDecodeResult.NoBarcodeFound))
-        val factory = LateSessionFactory(BarcodeDecodeConfig.DEFAULT_BIND_TIMEOUT_MS + 1, session)
+        val factory = LateSessionFactory(DefaultBarcodeImageDecoder.DEFAULT_BIND_TIMEOUT_MS + 1, session)
         val decoder = decoder(sessionFactory = factory, openPfd = { pfd })
 
         val result = decoder.decode(fileDescriptorSource())
@@ -163,7 +163,7 @@ class DefaultBarcodeImageDecoderTest {
         DefaultBarcodeImageDecoder(
             appContext = context,
             deps = DefaultBarcodeImageDecoder.Deps(
-                sessionFactoryFor = { _, _ -> sessionFactory },
+                sessionFactoryFor = { sessionFactory },
                 openPfd = openPfd,
             ),
         )

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
@@ -12,6 +12,7 @@ import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.isolation.ConnectResult
 import `is`.walt.passes.isolation.IsolatedWorkerSession
 import `is`.walt.passes.isolation.IsolatedWorkerSessionFactory
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -24,7 +25,8 @@ import org.robolectric.annotation.Config
  *
  *  - An unreadable / disallowed-scheme source short-circuits to `SourceUnreadable` *before*
  *    any bind is attempted.
- *  - A failed bind folds to `DecoderUnavailable`.
+ *  - A failed bind folds to `DecoderUnavailable`, as does one that is accepted and then never
+ *    completes (the bind is bounded so a dead sandbox cannot hang the import path).
  *  - The binder's result rounds back through `decode` unchanged (the wire arms are pinned
  *    separately by [BarcodeDecodeBinderRoundTripTest]).
  *  - The session is unbound and the source PFD is closed on *every* outcome (the bind-first
@@ -107,6 +109,22 @@ class DefaultBarcodeImageDecoderTest {
     }
 
     @Test
+    fun bindThatNeverCompletesFoldsToDecoderUnavailableAndClosesPfd() = runTest {
+        // bindService reporting refusal synchronously is the BindFailed case above. This is the
+        // other one: the bind is accepted and onServiceConnected never fires, which the shared
+        // facade waits on forever (wpass-67l). Since warm-up moved into onCreate, that window
+        // covers it, so the decoder must impose its own bound rather than hang the import.
+        val pfd = TrackingPfd(pipeReadEnd())
+        val factory = HangingSessionFactory()
+        val decoder = decoder(sessionFactory = factory, openPfd = { pfd })
+
+        val result = decoder.decode(fileDescriptorSource())
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
     fun nonContentSchemeUriIsRejectedByDefaultOpener() {
         // file:// is the canonical escape-hatch shape the scheme allowlist closes:
         // openFileDescriptor would otherwise resolve an arbitrary filesystem path.
@@ -147,6 +165,11 @@ class DefaultBarcodeImageDecoderTest {
             closed = true
             super.close()
         }
+    }
+
+    /** connect() that is accepted and then never resumes — the un-bounded bind shape. */
+    private class HangingSessionFactory : IsolatedWorkerSessionFactory<BarcodeDecodeBinder> {
+        override suspend fun connect(): ConnectResult<BarcodeDecodeBinder> = awaitCancellation()
     }
 
     private class RecordingSessionFactory(

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/DefaultBarcodeImageDecoderTest.kt
@@ -12,8 +12,11 @@ import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.isolation.ConnectResult
 import `is`.walt.passes.isolation.IsolatedWorkerSession
 import `is`.walt.passes.isolation.IsolatedWorkerSessionFactory
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -125,6 +128,24 @@ class DefaultBarcodeImageDecoderTest {
     }
 
     @Test
+    fun sessionArrivingAfterTheBindDeadlineIsClosedNotStranded() = runTest {
+        // The teardown race the `also` capture exists for: connect() resolves, but only after
+        // withTimeoutOrNull has given up, so the result is discarded while the session is bound.
+        // NonCancellable makes that ordering deterministic under virtual time. Without the
+        // capture the sandbox would stay bound with nothing holding a reference to it.
+        val pfd = TrackingPfd(pipeReadEnd())
+        val session = RecordingSession(StaticDecodeBinder(BarcodeDecodeResult.NoBarcodeFound))
+        val factory = LateSessionFactory(BarcodeDecodeConfig.DEFAULT_BIND_TIMEOUT_MS + 1, session)
+        val decoder = decoder(sessionFactory = factory, openPfd = { pfd })
+
+        val result = decoder.decode(fileDescriptorSource())
+
+        assertThat(result).isEqualTo(BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.DecoderUnavailable))
+        assertThat(session.closed).isTrue()
+        assertThat(pfd.closed).isTrue()
+    }
+
+    @Test
     fun nonContentSchemeUriIsRejectedByDefaultOpener() {
         // file:// is the canonical escape-hatch shape the scheme allowlist closes:
         // openFileDescriptor would otherwise resolve an arbitrary filesystem path.
@@ -142,7 +163,7 @@ class DefaultBarcodeImageDecoderTest {
         DefaultBarcodeImageDecoder(
             appContext = context,
             deps = DefaultBarcodeImageDecoder.Deps(
-                sessionFactoryFor = { sessionFactory },
+                sessionFactoryFor = { _, _ -> sessionFactory },
                 openPfd = openPfd,
             ),
         )
@@ -170,6 +191,17 @@ class DefaultBarcodeImageDecoderTest {
     /** connect() that is accepted and then never resumes — the un-bounded bind shape. */
     private class HangingSessionFactory : IsolatedWorkerSessionFactory<BarcodeDecodeBinder> {
         override suspend fun connect(): ConnectResult<BarcodeDecodeBinder> = awaitCancellation()
+    }
+
+    /** connect() that outlives the deadline uncancellably, then hands back a live session. */
+    private class LateSessionFactory(
+        private val afterMs: Long,
+        private val session: RecordingSession,
+    ) : IsolatedWorkerSessionFactory<BarcodeDecodeBinder> {
+        override suspend fun connect(): ConnectResult<BarcodeDecodeBinder> {
+            withContext(NonCancellable) { delay(afterMs) }
+            return ConnectResult.Connected(session)
+        }
     }
 
     private class RecordingSessionFactory(

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/PublicApiSurfaceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/PublicApiSurfaceTest.kt
@@ -104,6 +104,7 @@ class PublicApiSurfaceTest {
                 "ImageTooLarge",
                 "UnsupportedBarcodeFormat",
                 "DecoderUnavailable",
+                "DecodeTimedOut",
             )
     }
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
@@ -55,6 +55,15 @@ public enum class DecodeFailureReason {
     /** A symbol was found but its symbology is outside the [ScannableFormat] roster. */
     UnsupportedBarcodeFormat,
 
-    /** The isolated decode process could not be bound or terminated before returning a result. */
+    /** The isolated decode process could not be bound, or went away before returning a result. */
     DecoderUnavailable,
+
+    /**
+     * The decode exceeded its wall-clock budget and the isolated process was terminated by its
+     * watchdog. Split from [DecoderUnavailable] (wpass-qw3) because the two call for opposite
+     * responses: an unavailable decoder will not succeed on retry, a timed-out one is a load
+     * signal and the same image may decode fine later. Conflating them cost a real misdiagnosis
+     * on both this kernel and walt-passes-ios, which made the same split (`decodeTimedOut`).
+     */
+    DecodeTimedOut,
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
@@ -62,8 +62,7 @@ public enum class DecodeFailureReason {
      * The decode exceeded its wall-clock budget and the isolated process was terminated by its
      * watchdog. Split from [DecoderUnavailable] (wpass-qw3) because the two call for opposite
      * responses: an unavailable decoder will not succeed on retry, whereas a timed-out one is a
-     * load signal and the same image may decode fine later. walt-passes-ios names the same arm
-     * `decodeTimedOut`.
+     * load signal and the same image may decode fine later.
      *
      * Retry is a user-initiated affordance, never automatic: an image crafted to exhaust the
      * budget costs a full sandbox spawn and the whole budget on every attempt, so an automatic

--- a/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/BarcodeDecodeResult.kt
@@ -61,9 +61,13 @@ public enum class DecodeFailureReason {
     /**
      * The decode exceeded its wall-clock budget and the isolated process was terminated by its
      * watchdog. Split from [DecoderUnavailable] (wpass-qw3) because the two call for opposite
-     * responses: an unavailable decoder will not succeed on retry, a timed-out one is a load
-     * signal and the same image may decode fine later. Conflating them cost a real misdiagnosis
-     * on both this kernel and walt-passes-ios, which made the same split (`decodeTimedOut`).
+     * responses: an unavailable decoder will not succeed on retry, whereas a timed-out one is a
+     * load signal and the same image may decode fine later. walt-passes-ios names the same arm
+     * `decodeTimedOut`.
+     *
+     * Retry is a user-initiated affordance, never automatic: an image crafted to exhaust the
+     * budget costs a full sandbox spawn and the whole budget on every attempt, so an automatic
+     * retry loop would amplify a bounded cost into an unbounded one.
      */
     DecodeTimedOut,
 }


### PR DESCRIPTION
Closes wpass-qw3.

## What was wrong

API 36 connected tests failed intermittently with `DecodeFailed(reason=DecoderUnavailable)`, always on one of the only two scenarios that reach ZXing (`benignQrDecodesToPayloadAndFormat`, and the recovery half of `malformedContainerFailsClosedAndNextDecodeSucceeds`). Every other test rejects at the header or the bounded read and never decodes.

Root cause was confirmed from per-test logcat in the GMD artifacts, not inferred: the `DecodeWatchdog`'s own 5000 ms budget was expiring and the sandbox was SIGKILLing itself. The budget was being spent on cold start (class loading, `ImageDecoder` native init, ZXing reader first-touch, all interpreted in a freshly forked process that lives ~1 s), not on decode work. Nominal is ~1.2-1.6 s class-load to result; failures blew past 5 s. Job duration separates pass from fail perfectly across all 11 API 36 jobs on this code, with zero overlap.

## What changed

**1. Taxonomy split, first.** `DecodeFailureReason` gains a `DecodeTimedOut` arm (wire code 5). `DecoderUnavailable` previously meant bind-refused, binder-died, watchdog-killed and malformed-reply all at once, which is why diagnosing this needed artifact forensics and which would let a real bind failure hide behind the flake. walt-passes-ios made the same split (`decodeTimedOut`) after the same conflation cost a misdiagnosis there.

A killed sandbox cannot report its own death, so attribution is host-side: `BarcodeDecodeClient` stamps `elapsedRealtime` immediately before `transact`, and a binder drop at or past the budget is a timeout while an earlier one stays `DecoderUnavailable`. The `transact`-false and malformed-reply paths are never timeout-attributed - no decode was attempted, or the sandbox answered. Both sides read the budget from `BarcodeDecodeConfig`, pinned by a test, so they cannot drift.

Two alternatives were weighed and rejected: having the sandbox reply-then-kill reorders the one code path whose job is bounding a hung decode, and a separate host deadline carries two budgets that must stay ordered while parking a thread until the sandbox dies anyway.

**2. Cold start out of the budget.** `BarcodeDecodeService.onCreate` warms both decoders before `onBind` returns, running a Walt-generated 64x64 probe through the production path. This tightens what the guard bounds rather than loosening the guard, and it is the change that actually removes the tail.

**3. CI serialization.** The two managed-device tasks run in separate steps. One invocation plus `org.gradle.parallel` was starting two API 36 emulators on a 4-core runner.

The 5000 ms number itself is untouched. It has no documented empirical basis and wants a measured real-device baseline first - filed as wpass-4ba, blocked on this.

## Verification

`./gradlew check assemble assembleDebugAndroidTest` green locally. The API 36 connected leg on this PR is the real verifier.

## Follow-ups filed

- wpass-4ba - give the 5000 ms budget an empirical basis (blocked by this)
- wpass-67l - **P2 bug**: `AndroidIsolatedWorkerSessionFactory.connect()` has no bind timeout, so a hung bind hangs the production import path forever
- wpass-yhj - `passes-pdf` / `passes-image` carry the same budget but are not in the connected-tests matrix