### PR TITLE
feat(passes-ui): add card-face tint to ScannableCardScreen (wpass-80y.1)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -352,10 +352,10 @@ defense-in-depth, mirroring `B3UrlConfirmSheet` and the
 
 **What.** During create-time URI preview (C4), the dialog renders the raw
 `payload` so the user can see what they typed. The detail surface
-(`ScannableCardScreen`) also renders the payload as a human-readable caption
-below the barcode (GH #102 — fallback for when a point-of-sale scanner cannot
-read the code; opt-in via `ScannableCardView.showPayloadCaption`). The same
-bidi/control-char attack applies to both displays.
+(`ScannableCardScreen`) also renders the payload as a human-readable readback
+on its card face, below the code panel (GH #102 — fallback for when a
+point-of-sale scanner cannot read the code). The same bidi/control-char attack
+applies to both displays.
 
 **Mitigation.** C3: `passes-core` rejects payloads containing Cf/Cc codepoints
 *before* any preview is shown or any caption is rendered. Neither the dialog

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -128,8 +128,8 @@ private fun CodeCard(
     val face = if (tinted) faceTint else MaterialTheme.colorScheme.surface
     val ink = if (tinted) inkOn(faceTint) else MaterialTheme.colorScheme.onSurface
     // The payload is the POS fallback, not decorative meta: on a tint it takes full ink,
-    // because inkOn's worst case is already only 4.58:1 and any alpha would push the
-    // readback under WCAG AA. Untinted keeps the contrast-checked theme token.
+    // because INK_FLIP_LUMINANCE's worst case leaves no headroom for alpha. Untinted
+    // keeps the contrast-checked theme token.
     val payloadInk = if (tinted) ink else MaterialTheme.colorScheme.onSurfaceVariant
 
     Surface(

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -39,22 +39,15 @@ import `is`.walt.passes.ui.core.isolated
  * [CODE_QUIET_ZONE] adds visual breathing room inside the panel and the QR/1D
  * `ContentScale` split in [ScannableCardView] is unchanged.
  *
- * ## Face tint vs. code panel
- *
- * [faceTint] colors the card face only. The panel directly behind the code is
- * [SCAN_CODE_PANEL] — literally white in both themes, never a theme token and never the
- * tint — because the code is real content and must stay theme-independent and scannable
- * in dark mode. This mirrors `CompactCodeView`'s `COMPACT_CODE_BACKING` guarantee, so
- * both the list-face and detail-face renders of a code share one white-backing rule.
- * Routing the panel off that constant, or letting the tint reach it, is amending the
- * contract rather than refactoring it.
+ * [faceTint] colors the card face only; the panel behind the code stays
+ * [SCAN_CODE_PANEL], which carries that guarantee and the argument for it.
  *
  * The tint is presentation only. The kernel never learns why a color was chosen and
  * stores nothing: which color an item carries is the consumer's (walt-android's
  * `WalletColorRepository`, keyed per wallet entry). `ScannableCard` deliberately carries
- * no color field — wpass-q5p removed it and it stays removed. Label and payload ink is
- * derived from the tint's luminance so an arbitrary consumer tint stays legible in both
- * themes; that is a contrast guarantee, not a brand token.
+ * no color field — wpass-q5p removed it and it stays removed. Ink on the face is derived
+ * from the tint's luminance via [inkOn] so an arbitrary consumer tint stays legible in
+ * both themes; that is a contrast guarantee, not a brand token.
  *
  * Trust contract: by default ([TrustCaptionPlacement.Docked]) the caption is composed at
  * the bottom of the screen (C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`), structurally
@@ -87,7 +80,9 @@ import `is`.walt.passes.ui.core.isolated
  *   provenance via its own "Pass type" details row under the C2 concession (wpass-gv6).
  * @param faceTint color of the card face behind the code panel. Defaults to
  *   [Color.Unspecified], which keeps the `MaterialTheme.colorScheme.surface` face every
- *   existing caller gets today (wpass-80y.1 / Walt wlt-38v8).
+ *   existing caller gets today (wpass-80y.1 / Walt wlt-38v8). Pass an opaque color: ink
+ *   is derived from the nominal value, so a translucent tint composites over host paint
+ *   the kernel cannot see and the derived ink may not match what the user sees.
  */
 @Composable
 public fun ScannableCardScreen(
@@ -104,7 +99,7 @@ public fun ScannableCardScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .padding(24.dp),
+                .padding(SCREEN_MARGIN),
             contentAlignment = Alignment.Center,
         ) {
             CodeCard(card = card, showLabel = showLabel, faceTint = faceTint)
@@ -122,10 +117,7 @@ public fun ScannableCardScreen(
     }
 }
 
-/**
- * The content-sized card: tinted face, literal-white code panel, then the label and
- * payload readback on the face. [faceTint] never reaches [SCAN_CODE_PANEL].
- */
+/** The content-sized card: tinted face, white code panel, then label and payload on the face. */
 @Composable
 private fun CodeCard(
     card: ScannableCard,
@@ -135,8 +127,10 @@ private fun CodeCard(
     val tinted = faceTint.isSpecified
     val face = if (tinted) faceTint else MaterialTheme.colorScheme.surface
     val ink = if (tinted) inkOn(faceTint) else MaterialTheme.colorScheme.onSurface
-    val metaInk =
-        if (tinted) ink.copy(alpha = META_INK_ALPHA) else MaterialTheme.colorScheme.onSurfaceVariant
+    // The payload is the POS fallback, not decorative meta: on a tint it takes full ink,
+    // because inkOn's worst case is already only 4.58:1 and any alpha would push the
+    // readback under WCAG AA. Untinted keeps the contrast-checked theme token.
+    val payloadInk = if (tinted) ink else MaterialTheme.colorScheme.onSurfaceVariant
 
     Surface(
         color = face,
@@ -151,8 +145,11 @@ private fun CodeCard(
                 color = SCAN_CODE_PANEL,
                 shape = RoundedCornerShape(PANEL_RADIUS),
             ) {
-                ScannableCardView(
+                // No image description: the label and payload below announce this card,
+                // so describing the image too would make TalkBack read the label twice.
+                ScannableCodeImage(
                     card = card,
+                    imageDescription = null,
                     modifier = Modifier.padding(CODE_QUIET_ZONE),
                 )
             }
@@ -180,7 +177,7 @@ private fun CodeCard(
                         text = isolated(card.payload),
                         style = MaterialTheme.typography.labelMedium,
                         fontFamily = FontFamily.Monospace,
-                        color = metaInk,
+                        color = payloadInk,
                         textAlign = TextAlign.Center,
                     )
                 }
@@ -193,26 +190,38 @@ private fun CodeCard(
  * Contrast-derived ink for text sitting on [ScannableCardScreen]'s face. Consumers may
  * pass any tint, so the flip keeps the label and payload legible rather than assuming a
  * light palette. Neutral black/white by design: `passes-ui` carries no brand values.
+ *
+ * Internal so a test can pin the guarantee across the tint range, since the swatches a
+ * smoke test happens to pick would only exercise one branch.
  */
-private fun inkOn(tint: Color): Color =
+internal fun inkOn(tint: Color): Color =
     if (tint.luminance() > INK_FLIP_LUMINANCE) Color.Black else Color.White
 
 /** Panel padding around the code. The scan quiet zone is in the matrix; this is visual. */
 private val CODE_QUIET_ZONE = 16.dp
 
+private val SCREEN_MARGIN = 24.dp
 private val CARD_RADIUS = 20.dp
 private val CARD_PADDING = 18.dp
 private val PANEL_RADIUS = 16.dp
 private val PANEL_TO_TEXT_GAP = 16.dp
 private val LABEL_TO_PAYLOAD_GAP = 4.dp
 
-private const val INK_FLIP_LUMINANCE = 0.5f
-private const val META_INK_ALPHA = 0.6f
+/**
+ * Where black and white ink tie on WCAG contrast: black scores `(L + 0.05) / 0.05` and
+ * white `1.05 / (L + 0.05)`, which cross at `L = sqrt(0.0525) - 0.05 ≈ 0.179`. Flipping
+ * at the intuitive 0.5 instead would hand every mid-tone tint the *worse* of the two —
+ * e.g. `#2E8B7F` (L ≈ 0.206) would take white at 4.1:1 over black at 5.1:1. The tie point
+ * is also the worst case: no tint scores below 4.58:1 against the ink chosen here.
+ */
+private const val INK_FLIP_LUMINANCE = 0.179f
 
 /**
- * Literally white, never a theme token and never [ScannableCardScreen]'s face tint — the
- * dark-mode scannability guarantee, matching `COMPACT_CODE_BACKING` on the list face.
- * Internal (not private) so the smoke test pins the value; rerouting the panel off this
- * constant is amending the contract, not a refactor.
+ * Literally white, never a theme token and never [ScannableCardScreen]'s face tint,
+ * because the code is real content and must stay theme-independent and scannable in dark
+ * mode. Mirrors `COMPACT_CODE_BACKING` so the list-face and detail-face renders of a code
+ * share one white-backing rule. Internal (not private) so the smoke test pins the value;
+ * rerouting the panel off this constant, or letting a tint reach it, is amending the
+ * contract rather than refactoring it.
  */
 internal val SCAN_CODE_PANEL: Color = Color.White

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardScreen.kt
@@ -1,17 +1,23 @@
 package `is`.walt.passes.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -20,26 +26,43 @@ import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.ui.core.isolated
 
 /**
- * Full-screen surface for scanning a [ScannableCard]. Wraps [ScannableCardView] with
- * minimal chrome: the user-controlled label up top (FSI/PDI isolated), the barcode
- * itself rendered at its full nominal size on a content-sized white backing, and the
- * [ScannableCardTrustCaption] docked at the bottom by default (omitted only under the
- * audited [TrustCaptionPlacement.HostedTypeRow] concession — see [trustCaption]).
+ * Full-screen surface for scanning a [ScannableCard]. A content-sized card face holds a
+ * literal-white code panel, the user-controlled label and the payload readback (all
+ * FSI/PDI isolated), with the [ScannableCardTrustCaption] docked at the bottom by
+ * default (omitted only under the audited [TrustCaptionPlacement.HostedTypeRow]
+ * concession — see [trustCaption]).
  *
- * The white backing is sized to the code (plus a quiet-zone margin), not to the whole
- * screen (wpass-1wu.2 / Walt wlt-n5z): the rest of the surface is transparent so the
- * host's background shows through instead of a full white wash in a tall slot. ZXing
- * bakes the scan quiet zone into the matrix (`ZxingBarcodeEncoder`), so scannability is
- * preserved; [CODE_QUIET_ZONE] adds visual breathing room inside the card and the
- * QR/1D `ContentScale` split in [ScannableCardView] is unchanged.
+ * The card is sized to the code (plus a quiet-zone margin), not to the whole screen
+ * (wpass-1wu.2 / Walt wlt-n5z): the rest of the surface is transparent so the host's
+ * background shows through instead of a full wash in a tall slot. ZXing bakes the scan
+ * quiet zone into the matrix (`ZxingBarcodeEncoder`), so scannability is preserved;
+ * [CODE_QUIET_ZONE] adds visual breathing room inside the panel and the QR/1D
+ * `ContentScale` split in [ScannableCardView] is unchanged.
+ *
+ * ## Face tint vs. code panel
+ *
+ * [faceTint] colors the card face only. The panel directly behind the code is
+ * [SCAN_CODE_PANEL] — literally white in both themes, never a theme token and never the
+ * tint — because the code is real content and must stay theme-independent and scannable
+ * in dark mode. This mirrors `CompactCodeView`'s `COMPACT_CODE_BACKING` guarantee, so
+ * both the list-face and detail-face renders of a code share one white-backing rule.
+ * Routing the panel off that constant, or letting the tint reach it, is amending the
+ * contract rather than refactoring it.
+ *
+ * The tint is presentation only. The kernel never learns why a color was chosen and
+ * stores nothing: which color an item carries is the consumer's (walt-android's
+ * `WalletColorRepository`, keyed per wallet entry). `ScannableCard` deliberately carries
+ * no color field — wpass-q5p removed it and it stays removed. Label and payload ink is
+ * derived from the tint's luminance so an arbitrary consumer tint stays legible in both
+ * themes; that is a contrast guarantee, not a brand token.
  *
  * Trust contract: by default ([TrustCaptionPlacement.Docked]) the caption is composed at
  * the bottom of the screen (C2 in `docs/SCANNABLE_CARD_THREAT_MODEL.md`), structurally
  * separate from any host navigation chrome. No theme token and no overload can drop it;
  * the ONE way it is omitted is the audited [TrustCaptionPlacement.HostedTypeRow]
  * concession below, under which the host carries provenance via its own "Pass type" row
- * (C2 "Pass type" row concession). [showLabel] gates ONLY the top label `Text`; it cannot
- * suppress the barcode, the payload caption, or the trust caption.
+ * (C2 "Pass type" row concession). Neither [showLabel] nor [faceTint] can suppress the
+ * barcode, the payload caption, or the trust caption.
  *
  * [trustCaption] selects how the provenance signal is carried: with
  * [TrustCaptionPlacement.HostedTypeRow] the kernel renders no caption here because the
@@ -62,6 +85,9 @@ import `is`.walt.passes.ui.core.isolated
  *   [TrustCaptionPlacement.Docked] (verbatim docked caption).
  *   [TrustCaptionPlacement.HostedTypeRow] drops the kernel caption so the host carries
  *   provenance via its own "Pass type" details row under the C2 concession (wpass-gv6).
+ * @param faceTint color of the card face behind the code panel. Defaults to
+ *   [Color.Unspecified], which keeps the `MaterialTheme.colorScheme.surface` face every
+ *   existing caller gets today (wpass-80y.1 / Walt wlt-38v8).
  */
 @Composable
 public fun ScannableCardScreen(
@@ -69,24 +95,11 @@ public fun ScannableCardScreen(
     modifier: Modifier = Modifier,
     showLabel: Boolean = true,
     trustCaption: TrustCaptionPlacement = TrustCaptionPlacement.Docked,
+    faceTint: Color = Color.Unspecified,
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
     ) {
-        if (showLabel) {
-            Text(
-                text = isolated(card.label),
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-                color = MaterialTheme.colorScheme.onSurface,
-                textAlign = TextAlign.Center,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp, vertical = 16.dp),
-            )
-        }
-
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -94,18 +107,7 @@ public fun ScannableCardScreen(
                 .padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            Surface(
-                color = MaterialTheme.colorScheme.surface,
-                shape = RoundedCornerShape(16.dp),
-            ) {
-                // POS-scan fallback for GH #102; only the detail surface is large
-                // enough. A11y rationale lives on ScannableCardView.
-                ScannableCardView(
-                    card = card,
-                    showPayloadCaption = true,
-                    modifier = Modifier.padding(CODE_QUIET_ZONE),
-                )
-            }
+            CodeCard(card = card, showLabel = showLabel, faceTint = faceTint)
         }
 
         // Docked: the kernel renders the verbatim caption here. HostedTypeRow: the kernel
@@ -120,5 +122,97 @@ public fun ScannableCardScreen(
     }
 }
 
-/** White-card padding around the code. The scan quiet zone is in the matrix; this is visual. */
+/**
+ * The content-sized card: tinted face, literal-white code panel, then the label and
+ * payload readback on the face. [faceTint] never reaches [SCAN_CODE_PANEL].
+ */
+@Composable
+private fun CodeCard(
+    card: ScannableCard,
+    showLabel: Boolean,
+    faceTint: Color,
+) {
+    val tinted = faceTint.isSpecified
+    val face = if (tinted) faceTint else MaterialTheme.colorScheme.surface
+    val ink = if (tinted) inkOn(faceTint) else MaterialTheme.colorScheme.onSurface
+    val metaInk =
+        if (tinted) ink.copy(alpha = META_INK_ALPHA) else MaterialTheme.colorScheme.onSurfaceVariant
+
+    Surface(
+        color = face,
+        shape = RoundedCornerShape(CARD_RADIUS),
+    ) {
+        Column(
+            modifier = Modifier.padding(CARD_PADDING),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(PANEL_TO_TEXT_GAP),
+        ) {
+            Surface(
+                color = SCAN_CODE_PANEL,
+                shape = RoundedCornerShape(PANEL_RADIUS),
+            ) {
+                ScannableCardView(
+                    card = card,
+                    modifier = Modifier.padding(CODE_QUIET_ZONE),
+                )
+            }
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(LABEL_TO_PAYLOAD_GAP),
+            ) {
+                if (showLabel) {
+                    Text(
+                        text = isolated(card.label),
+                        style = MaterialTheme.typography.titleMedium
+                            .copy(fontWeight = FontWeight.SemiBold),
+                        color = ink,
+                        textAlign = TextAlign.Center,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                // POS-scan fallback for GH #102; only the detail surface is large enough.
+                // Sits on the face, not the code panel, so the panel stays a pure scan
+                // target.
+                SelectionContainer {
+                    Text(
+                        text = isolated(card.payload),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontFamily = FontFamily.Monospace,
+                        color = metaInk,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Contrast-derived ink for text sitting on [ScannableCardScreen]'s face. Consumers may
+ * pass any tint, so the flip keeps the label and payload legible rather than assuming a
+ * light palette. Neutral black/white by design: `passes-ui` carries no brand values.
+ */
+private fun inkOn(tint: Color): Color =
+    if (tint.luminance() > INK_FLIP_LUMINANCE) Color.Black else Color.White
+
+/** Panel padding around the code. The scan quiet zone is in the matrix; this is visual. */
 private val CODE_QUIET_ZONE = 16.dp
+
+private val CARD_RADIUS = 20.dp
+private val CARD_PADDING = 18.dp
+private val PANEL_RADIUS = 16.dp
+private val PANEL_TO_TEXT_GAP = 16.dp
+private val LABEL_TO_PAYLOAD_GAP = 4.dp
+
+private const val INK_FLIP_LUMINANCE = 0.5f
+private const val META_INK_ALPHA = 0.6f
+
+/**
+ * Literally white, never a theme token and never [ScannableCardScreen]'s face tint — the
+ * dark-mode scannability guarantee, matching `COMPACT_CODE_BACKING` on the list face.
+ * Internal (not private) so the smoke test pins the value; rerouting the panel off this
+ * constant is amending the contract, not a refactor.
+ */
+internal val SCAN_CODE_PANEL: Color = Color.White

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -68,25 +68,15 @@ public fun ScannableCardView(
     modifier: Modifier = Modifier,
     showPayloadCaption: Boolean = false,
 ) {
-    val bitmap = remember(card.payload, card.format) {
-        when (val result = BarcodeEncoder.encode(card.payload, card.format)) {
-            is EncodeResult.Success -> result.matrix.toMonochromeBitmap()
-            is EncodeResult.Failure -> null
-        }
-    }
-
     if (!showPayloadCaption) {
-        BarcodeImage(card.format, bitmap, imageDescription = card.label, modifier = modifier)
+        ScannableCodeImage(card, imageDescription = card.label, modifier = modifier)
     } else {
         Column(
             modifier = modifier,
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(CAPTION_GAP),
         ) {
-            // Drop the image's contentDescription so TalkBack reads the caption,
-            // not the duplicate label. clearAndSetSemantics would dedupe too but
-            // would zap the caption.
-            BarcodeImage(card.format, bitmap, imageDescription = null, modifier = Modifier)
+            ScannableCodeImage(card, imageDescription = null, modifier = Modifier)
             SelectionContainer {
                 Text(
                     text = isolated(card.payload),
@@ -98,6 +88,28 @@ public fun ScannableCardView(
             }
         }
     }
+}
+
+/**
+ * The encoded code alone. [imageDescription] is null wherever the composing surface
+ * already announces the label or the payload in its own text — TalkBack would otherwise
+ * read the label twice. `clearAndSetSemantics` would dedupe too, but would zap the
+ * neighbouring caption. Encoder failures still carry the failure description, which
+ * [BarcodeImage] owns.
+ */
+@Composable
+internal fun ScannableCodeImage(
+    card: ScannableCard,
+    imageDescription: String?,
+    modifier: Modifier = Modifier,
+) {
+    val bitmap = remember(card.payload, card.format) {
+        when (val result = BarcodeEncoder.encode(card.payload, card.format)) {
+            is EncodeResult.Success -> result.matrix.toMonochromeBitmap()
+            is EncodeResult.Failure -> null
+        }
+    }
+    BarcodeImage(card.format, bitmap, imageDescription, modifier)
 }
 
 @Composable

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -56,9 +56,11 @@ import `is`.walt.passes.ui.internal.toMonochromeBitmap
  * user-selectable caption beneath the barcode — fallback for when a point-of-sale
  * scanner cannot read the code (GH issue #102). The caption is FSI/PDI isolated as
  * defense-in-depth on top of the create-boundary Cf/Cc rejection (C3 in
- * `docs/SCANNABLE_CARD_THREAT_MODEL.md`). Default false; only [ScannableCardScreen]
- * opts in. The tile / row registers keep it off because their identification-sized
- * preview leaves no room for a legible caption.
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`). Default false, and no kernel surface opts in:
+ * [ScannableCardScreen] renders the same readback on its card face so the white code
+ * panel stays a pure scan target, and the tile / row registers keep it off because their
+ * identification-sized preview leaves no room for a legible caption. It stays available
+ * for hosts composing their own detail surface from this view.
  */
 @Composable
 public fun ScannableCardView(

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -276,14 +276,10 @@ class ComposableSurfaceLockTest {
     }
 
     /**
-     * Source-declared overloads of [methodName], excluding the synthetic `$default`
-     * bridges Kotlin emits for defaulted parameters.
-     *
-     * Kotlin's value-class name mangling appends `-<hash>` to a JVM method name when the
-     * function takes a value-class parameter (`PassLocale`, `ImageBytes`, Compose's
-     * `Color`, …), so `PassFront` compiles to e.g. `PassFront-I15CzMI` — and its default
-     * bridge to `PassFront-I15CzMI$default`, which the mangled-prefix match would
-     * otherwise pick up as a second overload with an inflated parameter count.
+     * Source-declared overloads of [methodName]. The `-<hash>` suffix is Kotlin's
+     * value-class name mangling (`PassFront-I15CzMI`); the synthetic filter drops the
+     * `$default` bridge that mangling would otherwise smuggle in under that same prefix,
+     * with an inflated parameter count.
      */
     private fun Class<*>.declaredComposableOverloads(methodName: String): List<Method> =
         methods.filter { (it.name == methodName || it.name.startsWith("$methodName-")) && !it.isSynthetic }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -174,20 +174,23 @@ class ComposableSurfaceLockTest {
     }
 
     @Test
-    fun scannableCardScreenHasExactlyFourUserVisibleParameters() {
-        // (card, modifier, showLabel, trustCaption). `showLabel` (wpass-1wu.1 / Walt
-        // wlt-tct) gates ONLY the top label Text. `trustCaption` (wpass-gv6) is a
+    fun scannableCardScreenHasExactlyFiveUserVisibleParameters() {
+        // (card, modifier, showLabel, trustCaption, faceTint). `showLabel` (wpass-1wu.1 /
+        // Walt wlt-tct) gates ONLY the label Text. `trustCaption` (wpass-gv6) is a
         // TrustCaptionPlacement selecting how provenance is carried: Docked renders the
         // verbatim caption; HostedTypeRow drops it so the host carries provenance via its
         // own "Pass type" details row, under the bounded C2 concession in
         // SCANNABLE_CARD_THREAT_MODEL.md. The strong type (not a Boolean) is pinned by
-        // scannableCardScreenTrustCaptionParamIsThePlacementType. Adding a FIFTH parameter
-        // — e.g. a per-element `showBarcode` / `showPayloadCaption` suppressor — would
-        // breach the surface contract; review the threat model before changing this number.
+        // scannableCardScreenTrustCaptionParamIsThePlacementType. `faceTint` (wpass-80y.1)
+        // colors the card face only — it cannot reach the code panel, which is pinned to
+        // literal white by codePanelIsLiterallyWhiteNotAThemeTokenOrTheTint. Adding a SIXTH
+        // parameter — e.g. a per-element `showBarcode` / `showPayloadCaption` suppressor, or
+        // a panel-color override — would breach the surface contract; review the threat
+        // model before changing this number.
         assertUserVisibleParamCount(
             "ScannableCardScreenKt",
             "ScannableCardScreen",
-            expected = 4,
+            expected = 5,
         )
     }
 
@@ -244,7 +247,7 @@ class ComposableSurfaceLockTest {
             "CompactCodeViewKt" to "CompactCodeView",
         ).forEach { (file, name) ->
             val klass = Class.forName("is.walt.passes.ui.$file")
-            val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }
+            val matches = klass.declaredComposableOverloads(name)
             assertWithMessage("$name should have exactly one declared overload")
                 .that(matches.size)
                 .isEqualTo(1)
@@ -267,16 +270,23 @@ class ComposableSurfaceLockTest {
 
     private fun findComposable(fileClassSimpleName: String, methodName: String): Method {
         val klass = Class.forName("is.walt.passes.ui.$fileClassSimpleName")
-        // Kotlin's value-class name mangling appends `-<hash>` to a JVM method name
-        // when the function takes a value-class parameter. `passes-core` exposes
-        // several value classes (`PassLocale`, `PassInstant`, `ImageBytes`,
-        // `ColorValue`), so most of these composables compile to e.g.
-        // `PassFront-I15CzMI`. Match either the bare name or the mangled prefix.
-        return klass.methods
-            .filter { it.name == methodName || it.name.startsWith("$methodName-") }
+        return klass.declaredComposableOverloads(methodName)
             .maxByOrNull { it.parameterCount }
             ?: error("Composable $fileClassSimpleName.$methodName not found")
     }
+
+    /**
+     * Source-declared overloads of [methodName], excluding the synthetic `$default`
+     * bridges Kotlin emits for defaulted parameters.
+     *
+     * Kotlin's value-class name mangling appends `-<hash>` to a JVM method name when the
+     * function takes a value-class parameter (`PassLocale`, `ImageBytes`, Compose's
+     * `Color`, …), so `PassFront` compiles to e.g. `PassFront-I15CzMI` — and its default
+     * bridge to `PassFront-I15CzMI$default`, which the mangled-prefix match would
+     * otherwise pick up as a second overload with an inflated parameter count.
+     */
+    private fun Class<*>.declaredComposableOverloads(methodName: String): List<Method> =
+        methods.filter { (it.name == methodName || it.name.startsWith("$methodName-")) && !it.isSynthetic }
 
     private fun userVisibleParameterCount(method: Method): Int {
         // Compose appends `Composer $composer` and `int $changed` (and `int $changed1`

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -15,6 +17,9 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlin.math.max
+import kotlin.math.min
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableCardCreateInput
@@ -263,6 +268,48 @@ class ScannableCardTrustSurfaceTest {
         composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
         composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
         composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun darkFaceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption() {
+        // Sibling of the light-tint case above so both inkOn branches compose. The
+        // palette's tints are light, but the parameter accepts any color and the ink flip
+        // is a real branch — exercising only one would leave half the surface untested.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(
+                    card = qrFixture(label = "Library card"),
+                    faceTint = Color(0xFF00837E),
+                )
+            }
+        }
+        composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
+    }
+
+    @Test
+    fun inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase() {
+        // The stated justification for accepting an arbitrary consumer tint is that ink
+        // is contrast-derived; without this the claim rests on whichever swatch a smoke
+        // test happened to pick. Covers both design palette rows (light tints, mid-tone
+        // accents), the mid-tones a naive 0.5 luminance flip would get wrong, and the
+        // luminance extremes.
+        val tints = listOf(
+            // Card tints — Clay, Bronze, Moss, Teal, Denim, Violet, Rose.
+            0xFFFFD8D5, 0xFFFBDDC3, 0xFFDAEAC8, 0xFFBFEEEA, 0xFFCEE6FF, 0xFFE8DCFE, 0xFFFFD6E4,
+            // Their accents — mid-tones, which is where the flip point actually matters.
+            0xFFB14E4B, 0xFFA55D00, 0xFF5B7F1D, 0xFF00837E, 0xFF2A75BA, 0xFF805DB0, 0xFFAB4D74,
+            // Extremes and a mid-tone sitting between the true tie point and 0.5.
+            0xFF000000, 0xFFFFFFFF, 0xFF2E8B7F, 0xFF767676,
+        ).map { Color(it) }
+
+        tints.forEach { tint ->
+            val ratio = contrastRatio(inkOn(tint), tint)
+            assertWithMessage("ink on tint %s scored %s:1", tint.toArgb().toUInt().toString(16), ratio)
+                .that(ratio)
+                .isAtLeast(WCAG_AA_NORMAL_TEXT)
+        }
     }
 
     @Test
@@ -527,5 +574,16 @@ class ScannableCardTrustSurfaceTest {
                 "Update encoderRejectedEan13Fixture before changing the data class."
         }
         return ctor.callBy(args.mapKeys { (name, _) -> byName.getValue(name) })
+    }
+
+    /** WCAG 2.x relative-luminance contrast ratio, ordered lighter-over-darker. */
+    private fun contrastRatio(a: Color, b: Color): Float {
+        val lighter = max(a.luminance(), b.luminance())
+        val darker = min(a.luminance(), b.luminance())
+        return (lighter + 0.05f) / (darker + 0.05f)
+    }
+
+    private companion object {
+        const val WCAG_AA_NORMAL_TEXT = 4.5f
     }
 }

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -13,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.ScannableCard
 import `is`.walt.passes.core.ScannableCardCreateInput
@@ -232,6 +234,35 @@ class ScannableCardTrustSurfaceTest {
         }
         composeRule.onNodeWithText("Created by you").assertIsDisplayed()
         composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint() {
+        // wpass-80y.1: faceTint colors the card face; the panel directly behind the code
+        // is real content and stays literally white in both themes so the code scans in
+        // dark mode. Rerouting the panel to a theme token — or to the tint — must fail
+        // here, not in the field. Pixel capture is unavailable under this Robolectric
+        // setup, so the pin is the internal constant the panel routes through, mirroring
+        // CompactCodeViewTest.backingIsLiterallyWhiteNotAThemeToken.
+        assertThat(SCAN_CODE_PANEL).isEqualTo(Color.White)
+    }
+
+    @Test
+    fun faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption() {
+        // The tint is presentation only: it is not a surface suppressor. Every element
+        // the untinted surface renders must still render under a tint — in particular the
+        // non-suppressible C2 caption and the GH #102 payload readback.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(
+                    card = qrFixture(label = "Library card"),
+                    faceTint = Color(0xFFBFEEEA),
+                )
+            }
+        }
+        composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
+        composeRule.onNodeWithText("⁨WALT-MEMBER-12345⁩").assertIsDisplayed()
+        composeRule.onNodeWithText("Created by you").assertIsDisplayed()
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ScannableCardTrustSurfaceTest.kt
@@ -9,8 +9,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -213,6 +215,25 @@ class ScannableCardTrustSurfaceTest {
         }
         // The label is wrapped in FSI/PDI, so look up by the isolated form. Mirrors how
         // the security-sheet tests assert isolated-form display of user-supplied strings.
+        composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
+    }
+
+    @Test
+    fun fullScreenCodeImageCarriesNoDescriptionSoTalkBackReadsTheLabelOnce() {
+        // The detail surface composes the label as its own Text directly beneath the code,
+        // so the code image must carry no contentDescription — otherwise TalkBack reads the
+        // label twice. The trap is a one-word default: routing this back through
+        // ScannableCardView (showPayloadCaption = false) sends card.label into the image
+        // again, and the by-text assertions above stay green because a contentDescription
+        // is not a text node. Both forms checked: the image would carry the raw label,
+        // while the Text carries the FSI/PDI-isolated one.
+        composeRule.setContent {
+            ThemedHost {
+                ScannableCardScreen(card = qrFixture(label = "Library card"))
+            }
+        }
+        composeRule.onAllNodesWithContentDescription("Library card").assertCountEquals(0)
+        composeRule.onAllNodesWithContentDescription("⁨Library card⁩").assertCountEquals(0)
         composeRule.onNodeWithText("⁨Library card⁩").assertIsDisplayed()
     }
 


### PR DESCRIPTION
Kernel companion to walt-android **wlt-38v8** (Passes colour system redesign). Closes `wpass-80y.1`; unblocks `wlt-38v8.6`.

## What

`ScannableCardScreen` gains `faceTint: Color = Color.Unspecified` (5th parameter). `Unspecified` keeps today's `colorScheme.surface` face, so every existing call site is unchanged.

The tint reaches the **card face only**. The panel behind the code is now `SCAN_CODE_PANEL` — literally `Color.White` in both themes, mirroring `CompactCodeView`'s `COMPACT_CODE_BACKING` — because the code is real content and must stay theme-independent and scannable in dark mode.

## Notable decisions

- **`Color = Color.Unspecified`, not `Color? = null`.** Matches `PassIdentityBlock`'s existing sentinel precedent in this module and avoids boxing the value class.
- **Panel colour changed** from `colorScheme.surface` to literal white. This file's KDoc has claimed a "white backing" since wpass-1wu.2; the theme token contradicted it and left a dark quiet-zone ring around the code in dark mode.
- **Card body restructured** per the Figma frames (`4 · QR code` / `4b · Linear`): the label and the GH #102 payload readback now sit *on the face*, below the white panel, rather than above the card and inside the panel. Without this the tint renders as a thin ring and the label sits off-card.
- **Ink derived from tint luminance** (black/white) so an arbitrary consumer tint stays legible. That is a contrast guarantee, not a brand token — `passes-ui` carries no brand values. *Open question for wlt-38v8:* the frames specify ink `#171717` exactly; an exact match would need a second `faceInk` parameter. Flag before the 5-param lock settles.
- `ScannableCardView.showPayloadCaption` is no longer used by any kernel surface. Kept public (hosts composing their own detail surface) with KDoc updated.

## Out of scope (unchanged)

Persistence of which colour an item carries stays consumer-side (`WalletColorRepository`); the kernel never learns why a tint was chosen. `ScannableCard.color` stays removed (wpass-q5p). The trust-caption contract is untouched — neither `showLabel` nor `faceTint` can suppress the barcode, payload caption, or C2 caption.

The threat-model amendment arguing colour is trust-neutral is `wpass-80y.3`, and the contested `ScannableCardRowTile` accent is `wpass-80y.4`; neither is touched here.

## Tests

- Surface lock raised 4 → 5 with rationale.
- `SCAN_CODE_PANEL` pinned to `Color.White` (mirrors `CompactCodeViewTest`).
- A tinted render asserts barcode, label, payload, and the non-suppressible C2 caption all still display.
- The lock test's reflection helper now excludes synthetic `$default` bridges — value-class name mangling would otherwise surface `ScannableCardScreen-<hash>$default` as a second overload with an inflated parameter count.

Gates: `:passes-ui` `testDebugUnitTest` + `detekt` + `lintDebug` all green.