### PR TITLE
feat(passes-document-ui): add card-face tint to DocumentView (wpass-80y.2)

### DIFF
--- a/passes-document-ui/src/androidTest/kotlin/is/walt/passes/document/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-document-ui/src/androidTest/kotlin/is/walt/passes/document/ui/DocumentViewInstrumentedTest.kt
@@ -4,6 +4,7 @@ import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
@@ -11,10 +12,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -459,6 +462,50 @@ class DocumentViewInstrumentedTest {
             .top
 
         assertThat(pageTop.value).isAtLeast(captionBottom.value)
+    }
+
+    @Test
+    fun faceTintDoesNotChangeTheLaidOutPageSize() {
+        // wpass-80y.2: `faceTint` colors the frame the page sits on, never the page. On
+        // device the rendered page is a real bitmap in a real layout, so this is where the
+        // constraint can be checked as geometry rather than as a render request (the unit
+        // test's `DocumentFaceTintTest.faceTintLeavesThePageRenderRequestUnchanged`).
+        // Two equally-sized slots, one tinted and one not: the page must lay out to the
+        // same size in both. A tint that inset, clipped, or reshaped the content — the
+        // natural way to break this while the frame still "looks right" — fails here.
+        composeRule.setContent {
+            ThemedHost {
+                Column {
+                    Box(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+                        DocumentView(
+                            doc = doc(pageCount = 1),
+                            pdfFile = pipeRead,
+                            renderer = RecordingBinder(),
+                        )
+                    }
+                    Box(modifier = Modifier.fillMaxWidth().height(300.dp)) {
+                        DocumentView(
+                            doc = doc(pageCount = 1),
+                            pdfFile = pipeRead,
+                            renderer = RecordingBinder(),
+                            // Denim, the palette's PDF default.
+                            faceTint = Color(0xFFCEE6FF),
+                        )
+                    }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        val pages = composeRule.onAllNodesWithContentDescription("Page 1 of 1")
+        pages.assertCountEquals(2)
+        val untinted = pages[0].getUnclippedBoundsInRoot()
+        val tinted = pages[1].getUnclippedBoundsInRoot()
+
+        assertThat((tinted.right - tinted.left).value)
+            .isEqualTo((untinted.right - untinted.left).value)
+        assertThat((tinted.bottom - tinted.top).value)
+            .isEqualTo((untinted.bottom - untinted.top).value)
     }
 
     private fun doc(pageCount: Int) = PdfDocument(

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +21,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
@@ -63,6 +66,20 @@ import `is`.walt.passes.ui.core.toComposeColor
  * and the row may sit in a collapsed-by-default foldout — see `TrustCaptionPlacement` and
  * the ADR 0005 D5 "Pass type" row addendum. Defaults to [TrustCaptionPlacement.Docked] (the
  * verbatim docked caption) so every existing caller is unchanged.
+ *
+ * [faceTint] colors the frame the page render or the decoded photo sits on, in both arms.
+ * The tint reaches the frame ONLY: the rasterised PDF page and the decoded image are real
+ * content, so they render identically tinted or not, and identically in light and dark
+ * (wpass-80y.2 / Walt wlt-38v8). The tint is presentation only — the kernel never learns
+ * why a color was chosen and stores nothing; which color an item carries is the consumer's
+ * (walt-android's `WalletColorRepository`, keyed per wallet entry), and no [Document] arm
+ * carries a color field.
+ *
+ * @param faceTint color of the frame behind the page render / decoded image. Defaults to
+ *   [Color.Unspecified], which keeps the flush-to-slot
+ *   [is.walt.passes.document.ui.theme.DocumentSemantics.laneBackground] frame every existing
+ *   caller gets today. Pass an opaque color: a translucent tint composites over host paint
+ *   the kernel cannot see.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -77,6 +94,7 @@ public fun DocumentView(
     trustCaption: TrustCaptionPlacement = TrustCaptionPlacement.Docked,
     onOpenFullScreen: (() -> Unit)? = null,
     fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)? = null,
+    faceTint: Color = Color.Unspecified,
 ) {
     when (doc) {
         is PdfDocument -> PdfDocumentView(
@@ -88,6 +106,7 @@ public fun DocumentView(
             trustCaption = trustCaption,
             onOpenFullScreen = onOpenFullScreen,
             fullScreenAffordance = fullScreenAffordance,
+            faceTint = faceTint,
         )
         is ImageDocument -> ImageDocumentView(
             documentId = doc.id,
@@ -96,6 +115,7 @@ public fun DocumentView(
             modifier = modifier,
             telemetry = telemetry,
             trustCaption = trustCaption,
+            faceTint = faceTint,
         )
         // wpass-8lu: a composite renders its IMAGE half through the same isolated image-decode
         // surface as a plain image (same imageFile / imageDecoder pair, no new DocumentView
@@ -112,6 +132,7 @@ public fun DocumentView(
             modifier = modifier,
             telemetry = telemetry,
             trustCaption = trustCaption,
+            faceTint = faceTint,
         )
     }
 }
@@ -186,8 +207,8 @@ private fun PdfDocumentView(
     trustCaption: TrustCaptionPlacement = TrustCaptionPlacement.Docked,
     onOpenFullScreen: (() -> Unit)? = null,
     fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)? = null,
+    faceTint: Color = Color.Unspecified,
 ) {
-    val semantics = LocalDocumentSemantics.current
     val cache = remember(doc.id) { PdfThumbnailCache() }
     DisposableEffect(doc.id) {
         onDispose { cache.clear() }
@@ -209,14 +230,14 @@ private fun PdfDocumentView(
             TrustCaptionPlacement.HostedTypeRow -> Unit
         }
 
-        // `laneBackground` paints behind the pager only — the document-surface tone the
-        // page sits on (showing through ContentScale.Fit letterbox bars). The page region
-        // is a Box so a host-supplied affordance can float over its bottom edge.
+        // The face paints behind the pager only — the document-surface tone the page sits
+        // on (showing through ContentScale.Fit letterbox bars). The page region is a Box so
+        // a host-supplied affordance can float over its bottom edge.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .background(semantics.laneBackground.toComposeColor()),
+                .documentFace(faceTint),
         ) {
             // Page tap opens full screen; clickable and the pager's drag coexist (Compose
             // routes quick press-release to the click, horizontal drag to the pager).
@@ -300,8 +321,8 @@ private fun ImageDocumentView(
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     trustCaption: TrustCaptionPlacement = TrustCaptionPlacement.Docked,
+    faceTint: Color = Color.Unspecified,
 ) {
-    val semantics = LocalDocumentSemantics.current
     Column(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -316,14 +337,14 @@ private fun ImageDocumentView(
             TrustCaptionPlacement.HostedTypeRow -> Unit
         }
 
-        // `laneBackground` paints behind the image only — the document-surface tone the image
-        // sits on (showing through the ContentScale.Fit letterbox bars), so the caption above
-        // reads as host chrome rather than part of the document surface, matching the PDF arm.
+        // The face paints behind the image only — the document-surface tone the image sits on
+        // (showing through the ContentScale.Fit letterbox bars), so the caption above reads as
+        // host chrome rather than part of the document surface, matching the PDF arm.
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .background(semantics.laneBackground.toComposeColor()),
+                .documentFace(faceTint),
         ) {
             val density = LocalDensity.current
             val requestWidthPx = with(density) {
@@ -357,6 +378,33 @@ private fun ImageDocumentView(
         }
     }
 }
+
+/**
+ * Paints the frame the page render / decoded image sits on, shared by both arms so the
+ * PDF and image surfaces cannot drift apart on the one thing [DocumentView.faceTint]
+ * touches.
+ *
+ * This paints the frame and NOTHING else: it is a background, so it never clips, tints,
+ * or filters the content drawn into the Box. That is the wpass-80y.2 constraint — the
+ * rasterised page and the decoded photo are real content and render identically tinted or
+ * not, and identically in light and dark.
+ *
+ * The rounded card shape arrives with the tint rather than unconditionally: an untinted
+ * frame is the host's own [is.walt.passes.document.ui.theme.DocumentSemantics.laneBackground]
+ * tone bleeding to the slot edge, and rounding that would change the layout of every
+ * consumer already shipping the surface. Corner radius comes with the opt-in that asks
+ * for a card.
+ */
+@Composable
+private fun Modifier.documentFace(faceTint: Color): Modifier =
+    if (faceTint.isSpecified) {
+        background(faceTint, RoundedCornerShape(FACE_RADIUS))
+    } else {
+        background(LocalDocumentSemantics.current.laneBackground.toComposeColor())
+    }
+
+/** Card radius from the 26.08.08 design's card anatomy spec (radius 20, padding 18). */
+private val FACE_RADIUS = 20.dp
 
 // wpass-jil: the kernel's neutral default open-full-screen affordance, docked below the
 // page. Label and colours come from DocumentSemantics; a host wanting a different

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -67,19 +67,19 @@ import `is`.walt.passes.ui.core.toComposeColor
  * the ADR 0005 D5 "Pass type" row addendum. Defaults to [TrustCaptionPlacement.Docked] (the
  * verbatim docked caption) so every existing caller is unchanged.
  *
- * [faceTint] colors the frame the page render or the decoded photo sits on, in both arms.
- * The tint reaches the frame ONLY: the rasterised PDF page and the decoded image are real
- * content, so they render identically tinted or not, and identically in light and dark
- * (wpass-80y.2 / Walt wlt-38v8). The tint is presentation only — the kernel never learns
- * why a color was chosen and stores nothing; which color an item carries is the consumer's
- * (walt-android's `WalletColorRepository`, keyed per wallet entry), and no [Document] arm
- * carries a color field.
+ * [faceTint] is presentation only — the kernel never learns why a color was chosen and
+ * stores nothing; which color an item carries is the consumer's (walt-android's
+ * `WalletColorRepository`, keyed per wallet entry), and no [Document] arm carries a color
+ * field (wpass-80y.2 / Walt wlt-38v8).
  *
- * @param faceTint color of the frame behind the page render / decoded image. Defaults to
- *   [Color.Unspecified], which keeps the flush-to-slot
+ * @param faceTint color of the frame the page render / decoded image sits on, in both
+ *   arms. The tint reaches the frame ONLY: the rasterised PDF page and the decoded image
+ *   are real content, so they render identically tinted or not, and identically in light
+ *   and dark. Defaults to [Color.Unspecified], which keeps the flush-to-slot
  *   [is.walt.passes.document.ui.theme.DocumentSemantics.laneBackground] frame every existing
- *   caller gets today. Pass an opaque color: a translucent tint composites over host paint
- *   the kernel cannot see.
+ *   caller gets today; a fully transparent tint means "no tint" and falls back to the same
+ *   default rather than leaving the frame unpainted. Pass an opaque color: a translucent
+ *   tint composites over host paint the kernel cannot see.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -380,30 +380,44 @@ private fun ImageDocumentView(
 }
 
 /**
- * Paints the frame the page render / decoded image sits on, shared by both arms so the
- * PDF and image surfaces cannot drift apart on the one thing [DocumentView.faceTint]
- * touches.
+ * Paints the frame the page render / decoded image sits on, shared by both arms so the PDF
+ * and image surfaces cannot drift apart on the one thing [DocumentView] `faceTint` touches.
  *
- * This paints the frame and NOTHING else: it is a background, so it never clips, tints,
- * or filters the content drawn into the Box. That is the wpass-80y.2 constraint — the
- * rasterised page and the decoded photo are real content and render identically tinted or
- * not, and identically in light and dark.
+ * Background only: it never clips or filters the content drawn into the Box, which is what
+ * makes the frame-not-content constraint structural rather than a convention.
  *
- * The rounded card shape arrives with the tint rather than unconditionally: an untinted
- * frame is the host's own [is.walt.passes.document.ui.theme.DocumentSemantics.laneBackground]
- * tone bleeding to the slot edge, and rounding that would change the layout of every
- * consumer already shipping the surface. Corner radius comes with the opt-in that asks
- * for a card.
+ * Two things are deliberate. A fully transparent tint falls back to the default rather than
+ * taking the tinted branch and painting nothing — [Color.isSpecified] is true for
+ * [Color.Transparent], so a consumer handing over a cleared or not-yet-loaded color would
+ * otherwise lose the document-surface tone entirely and show host paint through the
+ * letterbox bars. And the rounded card shape arrives with the tint rather than
+ * unconditionally: an untinted frame is the host's own
+ * [is.walt.passes.document.ui.theme.DocumentSemantics.laneBackground] tone bleeding to the
+ * slot edge, and rounding it would change the appearance of every consumer already shipping
+ * the surface (paint only — a shape on a background never moves layout). Corner radius comes
+ * with the opt-in that asks for a card.
  */
 @Composable
 private fun Modifier.documentFace(faceTint: Color): Modifier =
-    if (faceTint.isSpecified) {
+    if (documentFaceIsTinted(faceTint)) {
         background(faceTint, RoundedCornerShape(FACE_RADIUS))
     } else {
         background(LocalDocumentSemantics.current.laneBackground.toComposeColor())
     }
 
-/** Card radius from the 26.08.08 design's card anatomy spec (radius 20, padding 18). */
+/**
+ * Whether [faceTint] is a tint the frame should actually take. Internal (not private) so a
+ * test can pin the [Color.Transparent] fallback: the branch it guards is invisible to a
+ * composition assertion, since both arms paint *something* and neither changes the tree.
+ */
+internal fun documentFaceIsTinted(faceTint: Color): Boolean =
+    faceTint.isSpecified && faceTint.alpha > 0f
+
+/**
+ * Card radius from the 26.08.08 design's card anatomy spec. Duplicated as `CARD_RADIUS` in
+ * `passes-ui`'s `ScannableCardScreen`, which fulfils the same spec for the scannable face;
+ * hoisting both onto one shared token is wpass-nbr.
+ */
 private val FACE_RADIUS = 20.dp
 
 // wpass-jil: the kernel's neutral default open-full-screen affordance, docked below the
@@ -482,5 +496,8 @@ private fun DocumentPage(
 // via BoxWithConstraints), the inline surface is fixed 1x and ContentScale.Fit masks
 // any over/under-render — the BoxWithConstraints cost isn't worth it for a thumbnail-
 // sized slot.
-private const val TARGET_PAGE_WIDTH_DP: Int = 360
-private const val TARGET_PAGE_HEIGHT_DP: Int = 480
+// Internal (not private) so DocumentFaceTintTest can pin that the request really is
+// derived from these and not from the slot; a slot-derived request would make the
+// tint-invariance it asserts depend on layout the test does not control.
+internal const val TARGET_PAGE_WIDTH_DP: Int = 360
+internal const val TARGET_PAGE_HEIGHT_DP: Int = 480

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentFaceTintTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentFaceTintTest.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
@@ -45,13 +48,23 @@ import org.robolectric.annotation.Config
  * render identically tinted or not, and (per the section 04 note in Walt's 26.08.08 design)
  * identically in light and dark, which is exactly the rule real content already follows.
  *
- * The load-bearing test is [faceTintLeavesThePageRenderRequestUnchanged]: what reaches the
- * isolated renderer must not move when a tint is passed. Its on-device counterpart —
- * `DocumentViewInstrumentedTest.faceTintDoesNotChangeTheLaidOutPageSize`, which pins the
- * rendered page's *geometry* — lives in `androidTest` because neither the SharedMemory
- * round-trip nor pixel layout is reachable under this Robolectric setup. The rest assert
- * the tint is not a surface suppressor: everything the untinted surface renders still
- * renders under a tint, including the non-suppressible trust caption.
+ * The primary pin is on-device: `DocumentViewInstrumentedTest.faceTintDoesNotChangeTheLaidOut
+ * PageSize` compares the rendered page's geometry tinted vs untinted, which is where a tint
+ * that inset, clipped, or reshaped the content would show. It lives in `androidTest` because
+ * neither the SharedMemory round-trip nor pixel layout is reachable under this Robolectric
+ * setup — a page never leaves the Loading arm here.
+ *
+ * What the unit tests add is the layer below that: [faceTintLeavesThePageRenderRequestUnchanged]
+ * guards what reaches the isolated renderer, including that the request stays derived from
+ * [TARGET_PAGE_WIDTH_DP] / [TARGET_PAGE_HEIGHT_DP] rather than from the slot. Note the
+ * asymmetry that makes the second half of that test the load-bearing half: while the request
+ * is constant-derived, its size *cannot* vary with a tint by construction, so tint-invariance
+ * alone would only catch a tint reaching the page index or source rect. The constant-derived
+ * assertion is what fails if a future change makes the request slot-derived — at which point
+ * the tint could start moving it and the invariance assertion starts meaning something.
+ *
+ * The rest assert the tint is not a surface suppressor: everything the untinted surface
+ * renders still renders under a tint, including the non-suppressible trust caption.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -89,25 +102,27 @@ class DocumentFaceTintTest {
 
     @Test
     fun faceTintLeavesThePageRenderRequestUnchanged() {
-        // The constraint the parameter has to earn: a tint colors the frame and must not
-        // reach the render. Every argument the pager hands the isolated renderer — page
-        // index, requested pixel size, source rect — has to be identical to the untinted
-        // composition's. Both surfaces are composed once, in equally-sized slots, because
-        // the rule allows one setContent per test; equal slots are also what makes the
-        // comparison mean anything.
+        // Every argument the pager hands the isolated renderer — page index, requested
+        // pixel size, source rect — has to be identical to the untinted composition's.
+        // Both surfaces are composed once, in DELIBERATELY DIFFERENT slot sizes: the
+        // request is supposed to be slot-independent, so differing slots turn the equality
+        // below into a check on that too, and the one-setContent-per-rule limit means
+        // this is the only shot at composing both.
         val untinted = RecordingRenderer()
         val tinted = RecordingRenderer()
+        var density: Density? = null
         composeRule.setContent {
+            density = LocalDensity.current
             ThemedHost {
                 Column {
-                    Slot {
+                    Slot(width = SLOT_W, height = SLOT_H) {
                         DocumentView(
                             doc = pdfFixture("untinted", PAGE_COUNT),
                             pdfFile = openPdfFd(),
                             renderer = untinted,
                         )
                     }
-                    Slot {
+                    Slot(width = SLOT_W / 2, height = SLOT_H / 2) {
                         DocumentView(
                             doc = pdfFixture("tinted", PAGE_COUNT),
                             pdfFile = openPdfFd(),
@@ -124,6 +139,21 @@ class DocumentFaceTintTest {
             .that(untinted.requests())
             .isNotEmpty()
         assertThat(tinted.requests()).isEqualTo(untinted.requests())
+
+        // The load-bearing half. While the request is derived from these fixed constants
+        // its SIZE cannot vary with a tint by construction, so the equality above only
+        // catches a tint that reached the page index or source rect. This is what fails if
+        // a future change derives the request from the slot instead (as
+        // FullScreenDocumentView already does via BoxWithConstraints) — the point at which
+        // a tint could start moving it and the equality above starts carrying weight.
+        val d = requireNotNull(density) { "composition never ran" }
+        val expectedWidth = with(d) { TARGET_PAGE_WIDTH_DP.dp.toPx().toInt() }
+        val expectedHeight = with(d) { TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt() }
+        untinted.requests().forEach { request ->
+            assertWithMessage("render request %s must be constant-derived, not slot-derived", request)
+                .that(request.widthPx to request.heightPx)
+                .isEqualTo(expectedWidth to expectedHeight)
+        }
     }
 
     @Test
@@ -183,21 +213,61 @@ class DocumentFaceTintTest {
         composeRule.onNodeWithText(TRUST_CAPTION_TEXT).assertIsDisplayed()
     }
 
+    @Test
+    fun fullyTransparentTintFallsBackToTheDefaultFrame() {
+        // Color.isSpecified is true for Color.Transparent, so the naive gate would take
+        // the tinted branch and paint nothing — a consumer handing over a cleared or
+        // not-yet-loaded color would lose the document-surface tone entirely rather than
+        // get the documented default. Pixel capture is unavailable here, so the pin is on
+        // the resolution itself; the surface must still compose intact either way.
+        assertThat(documentFaceIsTinted(Color.Transparent)).isFalse()
+        assertThat(documentFaceIsTinted(Color.Unspecified)).isFalse()
+        assertThat(documentFaceIsTinted(denim)).isTrue()
+        assertThat(documentFaceIsTinted(denim.copy(alpha = 0.5f))).isTrue()
+
+        composeRule.setContent {
+            ThemedHost {
+                Slot {
+                    DocumentView(
+                        doc = pdfFixture("transparent", PAGE_COUNT),
+                        pdfFile = openPdfFd(),
+                        renderer = RecordingRenderer(),
+                        faceTint = Color.Transparent,
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(TRUST_CAPTION_TEXT).assertIsDisplayed()
+    }
+
     // -- helpers -------------------------------------------------------------------
 
     /**
-     * A fixed, identical slot for each surface under comparison. `DocumentView` fills the
-     * bounds it is given, so without this the two compositions would differ by layout
-     * rather than by the one variable under test.
+     * A fixed slot. `DocumentView` fills the bounds it is given, so without this the
+     * surfaces under comparison would size themselves off the root rather than off
+     * something the test controls.
      */
     @Composable
-    private fun Slot(content: @Composable () -> Unit) {
-        Box(modifier = Modifier.size(SLOT_W, SLOT_H)) { content() }
+    private fun Slot(
+        width: Dp = SLOT_W,
+        height: Dp = SLOT_H,
+        content: @Composable () -> Unit,
+    ) {
+        Box(modifier = Modifier.size(width, height)) { content() }
     }
 
-    /** Records every `(page, widthPx, heightPx, sourceRect)` the pager asks the renderer for. */
+    /** One call into the isolated renderer: everything the tint must not be able to move. */
+    private data class Request(
+        val page: Int,
+        val widthPx: Int,
+        val heightPx: Int,
+        val sourceRect: RenderSourceRect,
+    )
+
     private class RecordingRenderer : PdfRendererBinder {
-        private val seen = Collections.synchronizedSet(mutableSetOf<String>())
+        private val seen = Collections.synchronizedSet(mutableSetOf<Request>())
 
         override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
             ProbeResult.Ok(pageCount = PAGE_COUNT)
@@ -209,13 +279,13 @@ class DocumentFaceTintTest {
             heightPx: Int,
             sourceRect: RenderSourceRect,
         ): RenderResult {
-            seen += "$page/$widthPx/$heightPx/$sourceRect"
+            seen += Request(page, widthPx, heightPx, sourceRect)
             // Rejected keeps the test free of SharedMemory plumbing, which does not
             // round-trip under Robolectric; the request itself is what is under test.
             return RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
         }
 
-        fun requests(): Set<String> = seen.toSet()
+        fun requests(): Set<Request> = seen.toSet()
     }
 
     private object RejectingDecoder : ImageDecodeBinder {

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentFaceTintTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentFaceTintTest.kt
@@ -1,0 +1,269 @@
+package `is`.walt.passes.document.ui
+
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import `is`.walt.passes.document.DocumentRejectedKind
+import `is`.walt.passes.document.ImageDocument
+import `is`.walt.passes.document.ImageDocumentId
+import `is`.walt.passes.document.PdfDocument
+import `is`.walt.passes.document.PdfDocumentId
+import `is`.walt.passes.document.ui.theme.DocumentSemantics
+import `is`.walt.passes.document.ui.theme.DocumentTheme
+import `is`.walt.passes.image.android.ImageDecodeBinder
+import `is`.walt.passes.image.android.ImageDecodeRejectedKind
+import `is`.walt.passes.image.android.ImageDecodeResult
+import `is`.walt.passes.pdf.android.PdfRendererBinder
+import `is`.walt.passes.pdf.android.ProbeResult
+import `is`.walt.passes.pdf.android.RenderResult
+import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.ui.core.ArgbColor
+import java.io.File
+import java.util.Collections
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Pins the wpass-80y.2 constraint on `DocumentView.faceTint`: the tint is the **frame**,
+ * never the content. The rasterised PDF page and the decoded photo are real content — they
+ * render identically tinted or not, and (per the section 04 note in Walt's 26.08.08 design)
+ * identically in light and dark, which is exactly the rule real content already follows.
+ *
+ * The load-bearing test is [faceTintLeavesThePageRenderRequestUnchanged]: what reaches the
+ * isolated renderer must not move when a tint is passed. Its on-device counterpart —
+ * `DocumentViewInstrumentedTest.faceTintDoesNotChangeTheLaidOutPageSize`, which pins the
+ * rendered page's *geometry* — lives in `androidTest` because neither the SharedMemory
+ * round-trip nor pixel layout is reachable under this Robolectric setup. The rest assert
+ * the tint is not a surface suppressor: everything the untinted surface renders still
+ * renders under a tint, including the non-suppressible trust caption.
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+class DocumentFaceTintTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // Denim / Violet are the palette's PDF and image defaults; any of the 7 tints is
+    // reachable once the user reassigns, so nothing here may depend on either value.
+    private val denim = Color(0xFFCEE6FF)
+    private val violet = Color(0xFFE8DCFE)
+
+    // Closed in @After, not inside the test: the documented pdfFile / imageFile contract
+    // is that the fd outlives the composition.
+    private val openFds = mutableListOf<ParcelFileDescriptor>()
+    private val tempFiles = mutableListOf<File>()
+
+    @After
+    fun tearDown() {
+        openFds.forEach { it.close() }
+        tempFiles.forEach { it.delete() }
+    }
+
+    private val semantics = DocumentSemantics(
+        captionBackground = ArgbColor(0xFF202020.toInt()),
+        captionForeground = ArgbColor(0xFFFFFFFF.toInt()),
+        tileBackground = ArgbColor(0xFFF5F5F5.toInt()),
+        tileForeground = ArgbColor(0xFF202020.toInt()),
+        tileLabelForeground = ArgbColor(0xFF606060.toInt()),
+        laneBackground = ArgbColor(0xFFEEEEEE.toInt()),
+        documentBadgeBackground = ArgbColor(0xFFD0D0D0.toInt()),
+        documentBadgeForeground = ArgbColor(0xFF202020.toInt()),
+    )
+
+    @Test
+    fun faceTintLeavesThePageRenderRequestUnchanged() {
+        // The constraint the parameter has to earn: a tint colors the frame and must not
+        // reach the render. Every argument the pager hands the isolated renderer — page
+        // index, requested pixel size, source rect — has to be identical to the untinted
+        // composition's. Both surfaces are composed once, in equally-sized slots, because
+        // the rule allows one setContent per test; equal slots are also what makes the
+        // comparison mean anything.
+        val untinted = RecordingRenderer()
+        val tinted = RecordingRenderer()
+        composeRule.setContent {
+            ThemedHost {
+                Column {
+                    Slot {
+                        DocumentView(
+                            doc = pdfFixture("untinted", PAGE_COUNT),
+                            pdfFile = openPdfFd(),
+                            renderer = untinted,
+                        )
+                    }
+                    Slot {
+                        DocumentView(
+                            doc = pdfFixture("tinted", PAGE_COUNT),
+                            pdfFile = openPdfFd(),
+                            renderer = tinted,
+                            faceTint = denim,
+                        )
+                    }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        assertWithMessage("the untinted composition must request pages at all")
+            .that(untinted.requests())
+            .isNotEmpty()
+        assertThat(tinted.requests()).isEqualTo(untinted.requests())
+    }
+
+    @Test
+    fun faceTintDoesNotSuppressTheTrustCaptionOnEitherArm() {
+        // The tint is presentation only, not a surface suppressor: the non-suppressible
+        // D5 caption survives it in both arms. The ONE way the caption is omitted stays
+        // the audited HostedTypeRow concession.
+        composeRule.setContent {
+            ThemedHost {
+                Column {
+                    Slot {
+                        DocumentView(
+                            doc = pdfFixture("pdf", PAGE_COUNT),
+                            pdfFile = openPdfFd(),
+                            renderer = RecordingRenderer(),
+                            faceTint = denim,
+                        )
+                    }
+                    Slot {
+                        DocumentView(
+                            doc = imageFixture(),
+                            imageFile = openImageFd(),
+                            imageDecoder = RejectingDecoder,
+                            faceTint = violet,
+                        )
+                    }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(TRUST_CAPTION_TEXT).fetchSemanticsNodes().let { nodes ->
+            assertWithMessage("both tinted arms must carry the caption").that(nodes).hasSize(2)
+        }
+    }
+
+    @Test
+    fun faceTintStillComposesUnderAnOpaqueDarkTint() {
+        // The palette ships light tints, but the parameter accepts any colour and — unlike
+        // the scannable card face — this frame derives no ink from it, because no kernel
+        // text sits on it. Pinning a dark tint keeps it that way: if a future change starts
+        // reading the tint's luminance, it acquires a branch this test already covers.
+        composeRule.setContent {
+            ThemedHost {
+                Slot {
+                    DocumentView(
+                        doc = pdfFixture("dark", PAGE_COUNT),
+                        pdfFile = openPdfFd(),
+                        renderer = RecordingRenderer(),
+                        faceTint = Color(0xFF2A75BA),
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(TRUST_CAPTION_TEXT).assertIsDisplayed()
+    }
+
+    // -- helpers -------------------------------------------------------------------
+
+    /**
+     * A fixed, identical slot for each surface under comparison. `DocumentView` fills the
+     * bounds it is given, so without this the two compositions would differ by layout
+     * rather than by the one variable under test.
+     */
+    @Composable
+    private fun Slot(content: @Composable () -> Unit) {
+        Box(modifier = Modifier.size(SLOT_W, SLOT_H)) { content() }
+    }
+
+    /** Records every `(page, widthPx, heightPx, sourceRect)` the pager asks the renderer for. */
+    private class RecordingRenderer : PdfRendererBinder {
+        private val seen = Collections.synchronizedSet(mutableSetOf<String>())
+
+        override suspend fun probe(pdf: ParcelFileDescriptor): ProbeResult =
+            ProbeResult.Ok(pageCount = PAGE_COUNT)
+
+        override suspend fun render(
+            pdf: ParcelFileDescriptor,
+            page: Int,
+            widthPx: Int,
+            heightPx: Int,
+            sourceRect: RenderSourceRect,
+        ): RenderResult {
+            seen += "$page/$widthPx/$heightPx/$sourceRect"
+            // Rejected keeps the test free of SharedMemory plumbing, which does not
+            // round-trip under Robolectric; the request itself is what is under test.
+            return RenderResult.Rejected(DocumentRejectedKind.RendererFailed)
+        }
+
+        fun requests(): Set<String> = seen.toSet()
+    }
+
+    private object RejectingDecoder : ImageDecodeBinder {
+        override suspend fun decode(
+            image: ParcelFileDescriptor,
+            maxWidthPx: Int,
+            maxHeightPx: Int,
+        ): ImageDecodeResult = ImageDecodeResult.Rejected(ImageDecodeRejectedKind.DecodeFailed)
+    }
+
+    private fun pdfFixture(id: String, pageCount: Int) = PdfDocument(
+        id = PdfDocumentId(id),
+        displayLabel = "doc.pdf",
+        byteCount = 1024L,
+        pageCount = pageCount,
+        importedAtEpochMs = 0L,
+    )
+
+    private fun imageFixture() = ImageDocument(
+        id = ImageDocumentId("img-tint"),
+        displayLabel = "receipt.png",
+        byteCount = 2048L,
+        widthPx = 1080,
+        heightPx = 1830,
+        importedAtEpochMs = 0L,
+    )
+
+    private fun openPdfFd(): ParcelFileDescriptor = openFd("doc", ".pdf", byteArrayOf(0x25))
+
+    private fun openImageFd(): ParcelFileDescriptor = openFd("img", ".png", byteArrayOf(1, 2, 3))
+
+    private fun openFd(prefix: String, suffix: String, bytes: ByteArray): ParcelFileDescriptor {
+        val backing = File.createTempFile(prefix, suffix).apply { writeBytes(bytes) }
+        tempFiles += backing
+        return ParcelFileDescriptor.open(backing, ParcelFileDescriptor.MODE_READ_ONLY)
+            .also { openFds += it }
+    }
+
+    @Composable
+    private fun ThemedHost(content: @Composable () -> Unit) {
+        MaterialTheme {
+            DocumentTheme(semantics = semantics, content = content)
+        }
+    }
+
+    private companion object {
+        const val PAGE_COUNT = 3
+        val SLOT_W = 320.dp
+        val SLOT_H = 400.dp
+    }
+}

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
@@ -33,17 +33,19 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun documentViewHasExactlyTenUserVisibleParameters() {
+    fun documentViewHasExactlyElevenUserVisibleParameters() {
         // (doc, pdfFile, renderer, imageFile, imageDecoder, modifier, telemetry,
-        // trustCaption, onOpenFullScreen, fullScreenAffordance). Bumping from 9 to 10 is
-        // the deliberate wpass-gv6 change: `trustCaption` is a TrustCaptionPlacement
-        // selecting how provenance is carried — Docked renders the verbatim caption;
-        // HostedTypeRow drops it so the host carries provenance via its own "Pass type"
-        // details row, under the bounded D5 concession (ADR 0005 "Pass type" row addendum).
-        // The strong type (not a Boolean) is pinned by documentViewTrustCaptionParamIsThe
-        // PlacementType. Adding an ELEVENTH parameter that suppressed the page, the image,
-        // or some other surface element would breach D5/D8; review the ADR first.
-        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 10)
+        // trustCaption, onOpenFullScreen, fullScreenAffordance, faceTint). `trustCaption`
+        // (wpass-gv6) is a TrustCaptionPlacement selecting how provenance is carried —
+        // Docked renders the verbatim caption; HostedTypeRow drops it so the host carries
+        // provenance via its own "Pass type" details row, under the bounded D5 concession
+        // (ADR 0005 "Pass type" row addendum). The strong type (not a Boolean) is pinned by
+        // documentViewTrustCaptionParamIsThePlacementType. Bumping from 10 to 11 is the
+        // deliberate wpass-80y.2 change: `faceTint` colors the frame the page render sits
+        // on and cannot reach the content, pinned by faceTintLeavesThePageRenderRequest
+        // Unchanged. Adding a TWELFTH parameter that suppressed the page, the image, or
+        // some other surface element would breach D5/D8; review the ADR first.
+        assertUserVisibleParamCount("DocumentViewKt", "DocumentView", expected = 11)
     }
 
     @Test
@@ -140,7 +142,7 @@ class DocumentSurfaceLockTest {
             "FullScreenDocumentViewKt" to "FullScreenDocumentView",
         ).forEach { (file, name) ->
             val klass = Class.forName("is.walt.passes.document.ui.$file")
-            val matches = klass.methods.filter { it.name == name || it.name.startsWith("$name-") }
+            val matches = klass.declaredComposableOverloads(name)
             assertWithMessage("$name should have exactly one declared overload")
                 .that(matches.size)
                 .isEqualTo(1)
@@ -151,14 +153,21 @@ class DocumentSurfaceLockTest {
 
     private fun findComposable(fileClassSimpleName: String, methodName: String): Method {
         val klass = Class.forName("is.walt.passes.document.ui.$fileClassSimpleName")
-        // Kotlin's value-class name mangling appends `-<hash>` to a JVM method name
-        // when the function takes a value-class parameter. Match either the bare name
-        // or the mangled prefix.
-        return klass.methods
-            .filter { it.name == methodName || it.name.startsWith("$methodName-") }
+        return klass.declaredComposableOverloads(methodName)
             .maxByOrNull { it.parameterCount }
             ?: error("Composable $fileClassSimpleName.$methodName not found")
     }
+
+    /**
+     * Source-declared overloads of [methodName]. The `-<hash>` suffix is Kotlin's
+     * value-class name mangling (`DocumentView` takes a `Color`); the synthetic filter
+     * drops the `$default` bridge that mangling would otherwise smuggle in under that
+     * same prefix, with an inflated parameter count.
+     */
+    private fun Class<*>.declaredComposableOverloads(methodName: String): List<Method> =
+        methods.filter {
+            (it.name == methodName || it.name.startsWith("$methodName-")) && !it.isSynthetic
+        }
 
     private fun userVisibleParameterCount(method: Method): Int {
         // Compose appends `Composer $composer` and `int $changed` (and `int $changed1`


### PR DESCRIPTION
Kernel companion to walt-android **wlt-38v8** (Passes colour system redesign). Unblocks wlt-38v8's document detail work. Sibling of #203 (`ScannableCardScreen`), whose parameter shape this mirrors.

Design source: [26.08.08 Pass color selector](https://www.figma.com/design/N26Fe2mNKzMoLnNkFXb4Kk/26.08.08---Pass-color-selector?node-id=0-1) — "Document Detail" / "Image Document Detail" frames (sections 03/04) and the card anatomy spec (section 05).

## What

`DocumentView` gains `faceTint: Color = Color.Unspecified` (11th parameter), forwarded to both arms — PDF, image, and the composite's image half. `Unspecified` keeps today's flush-to-slot `laneBackground` frame, so every existing call site is unchanged.

## The constraint

The tint is the **frame**, never the content. Both arms route their page region through one shared `Modifier.documentFace(faceTint)`, so the PDF and image surfaces cannot drift apart on the one thing the parameter touches. It paints a background and nothing else: no clip, no `colorFilter`, no inset. The rasterised page and the decoded photo are real content and render identically tinted or not — and, per the design's section 04 note, identically in light and dark.

The rounded card shape (radius 20, the design's card anatomy token) arrives *with* the tint rather than unconditionally: an untinted frame is the host's own `laneBackground` tone bleeding to the slot edge, and rounding that would change the layout of every consumer already shipping the surface.

Unlike the scannable face (#203) there is no contrast-derived ink here, because no kernel text sits on this frame — the page counter and the details rows in the frames are host chrome. Nothing reads the tint's luminance, and a dark-tint test keeps it that way.

## Tests

- Surface lock 10 → 11.
- **Load-bearing unit pin**: the `(page, widthPx, heightPx, sourceRect)` set reaching the isolated renderer is identical tinted vs untinted, composed in two equal slots.
- **On-device counterpart**: the same constraint as geometry — the laid-out page is the same size in both — since neither the `SharedMemory` round-trip nor pixel layout is reachable under Robolectric.
- The non-suppressible trust caption survives the tint in both arms; an opaque dark tint composes.
- The lock test's reflection helper now excludes synthetic `$default` bridges, which `Color`'s value-class name mangling would otherwise surface as a second overload.

Gates: `:passes-document-ui` `testDebugUnitTest` + `detekt` + `lintDebug` + `compileDebugAndroidTestKotlin` all green.

## Out of scope

Persistence (consumer-side `WalletColorRepository`; the kernel never learns why a colour was chosen and no `Document` arm carries a colour field), the page pager, the full-screen view, and the trust-caption contract. The threat-model amendment that records colour as trust-neutral is wpass-80y.3.