### PR TITLE
docs: record that colour carries no trust meaning (wpass-80y.3)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -92,18 +92,6 @@ homogeneous-list register and nothing else. A future consumer wanting a wallet
 list that also drops the detail-surface caption is amending this row, not
 filing a refactor.
 
-> **Dormant (wpass-80y, 2026-08-08).** The consumer no longer exercises this
-> concession: the 26.08.08 rules block quoted in the "colour carries no trust
-> meaning" row below says "No previews on list cards", and the redesign removes
-> the code tile, barcode band, image badge and photo thumbnail from every list
-> card face. The concession is not withdrawn - `CompactCodeView` stays, and a
-> host may still render an extracted code at list scale - but it is
-> unexercised, and condition 2's "neutral (never issuer-colored) card surface"
-> is replaced by the class tint that the "colour carries no trust meaning" row
-> grants. Conditions 1 and 3 govern
-> unchanged for any host that takes the concession up again, and the accepted
-> residual risk below applies only while it is exercised.
-
 **C1 / C2 — list-face code render concession (wpass-tjc.2; consumer epic
 wlt-mx2d).** The redesigned wallet list renders a scannable card's — and a
 composite artifact's extracted — ACTUAL code on its list card face, through the
@@ -138,6 +126,19 @@ recipient remains the authority on whether the code is credit-worthy (Threat
 9). A consumer wanting to render a list-face code without the condition-2
 eyebrow taxonomy, or wanting pkpass barcodes at list scale, is amending this
 row, not filing a PR.
+
+> **Dormant (wpass-80y, 2026-08-08).** The consumer no longer exercises this
+> list-face code render concession (the wallet-row concession above is
+> unaffected and stays live): the 26.08.08 rules block quoted in the "colour
+> carries no trust meaning" row below says "No previews on list cards", and the
+> redesign removes the code tile, barcode band, image badge and photo thumbnail
+> from every list card face. The concession is not withdrawn - `CompactCodeView`
+> stays, and a host may still render an extracted code at list scale - but it is
+> unexercised, and condition 2's "neutral (never issuer-colored) card surface"
+> is replaced by the class tint that the "colour carries no trust meaning" row
+> grants. Conditions 1 and 3 govern unchanged for any host that takes the
+> concession up again, and the accepted residual risk above applies only while
+> it is exercised.
 
 **Redesign context — where the C1 list distinction now lives (wpass-tjc.4;
 consumer epic wlt-mx2d).** The redesigned wallet list changes what
@@ -255,7 +256,9 @@ list cards. What is not granted, and would be an amendment rather than a PR:
 deriving a colour from signature status, verification outcome, or issuer
 identity anywhere in the kernel; re-adding a colour field to a kernel artifact
 model or storage table; or a `faceTint` reaching the code panel or the page
-render. See also the still-open `ScannableCardRowTile` accent question
+render. The document-side mirror of this row is ADR 0005 D1.C, which makes the
+same argument for the PDF / image tower and withdraws its neutral-surface rule.
+See also the still-open `ScannableCardRowTile` accent question
 (`wpass-80y.4`), which this row is the precondition for: its leading strip is
 pinned to `unverifiedArtifact.accent` by a rationale ("that would re-create the
 verified-band read at list scale") that premise 1 above no longer supports.

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -92,6 +92,18 @@ homogeneous-list register and nothing else. A future consumer wanting a wallet
 list that also drops the detail-surface caption is amending this row, not
 filing a refactor.
 
+> **Dormant (wpass-80y, 2026-08-08).** The consumer no longer exercises this
+> concession: the 26.08.08 rules block quoted in the "colour carries no trust
+> meaning" row below says "No previews on list cards", and the redesign removes
+> the code tile, barcode band, image badge and photo thumbnail from every list
+> card face. The concession is not withdrawn - `CompactCodeView` stays, and a
+> host may still render an extracted code at list scale - but it is
+> unexercised, and condition 2's "neutral (never issuer-colored) card surface"
+> is replaced by the class tint that the "colour carries no trust meaning" row
+> grants. Conditions 1 and 3 govern
+> unchanged for any host that takes the concession up again, and the accepted
+> residual risk below applies only while it is exercised.
+
 **C1 / C2 — list-face code render concession (wpass-tjc.2; consumer epic
 wlt-mx2d).** The redesigned wallet list renders a scannable card's — and a
 composite artifact's extracted — ACTUAL code on its list card face, through the
@@ -204,7 +216,7 @@ signed pass can wear. It rests on these instead:
 **What this means at the kernel surface.** `ScannableCardScreen(faceTint = …)`
 (wpass-80y.1) and `DocumentView(faceTint = …)` (wpass-80y.2) exist so the
 consumer can tint the card face without reimplementing these surfaces. Both are
-presentation-only and bounded the same way:
+presentation-only, and both are bounded by the same four rules:
 
 - The tint reaches the card face only. The panel behind a code stays
   `SCAN_CODE_PANEL` (literally white in both themes) and the rasterised page /
@@ -225,6 +237,17 @@ presentation-only and bounded the same way:
   (walt-android's `WalletColorRepository`, keyed per wallet entry), so the
   kernel never learns why a colour was chosen and has nothing to leak in
   Threats 7 / 8.
+
+The two surfaces are not identical below those four rules, and the divergence
+is recorded rather than smoothed over: `DocumentView` treats a fully
+transparent tint as "no tint" (`documentFaceIsTinted` gates on
+`isSpecified && alpha > 0f`, pinned by
+`fullyTransparentTintFallsBackToTheDefaultFrame`), while `ScannableCardScreen`
+gates on `isSpecified` alone, so a specified fully transparent tint paints a
+transparent face and derives ink from it. Both KDocs say "pass an opaque
+color", and neither surface can lose its trust caption either way, so this is a
+legibility hazard for a careless consumer rather than a trust-signal hole.
+Aligning the scannable gate with the document one is `wpass-80y.5`.
 
 **Bound of this row.** What is granted is a consumer-chosen face tint on the
 two detail surfaces named above, plus the consumer's freedom to colour its own
@@ -558,7 +581,7 @@ from Walt, Google Wallet, the merchant's own app, or a printed plastic card.
 **Status.** Out of mission. Documented here so future contributors do not
 propose adding it without amending this row.
 
-### 10. Color picker as injection vector — n/a
+### 10. Color picker as injection vector - Out of scope (consumer-side)
 
 **What.** Hostile inputs to a color picker have historically been a vector in
 browser CSS / SVG parsers (named-color injection, `var(--…)` escapes). A
@@ -744,7 +767,7 @@ can trace back here.
 | Control | Pinned by                                  |
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
-| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb` adds `scannableCardRowTileHasExactlyThreeUserVisibleParameters` to pin the wallet-row concession shape, and `rowTileDoesNotRenderTrustCaption` / `rowTileRendersFormatSubtitle` to pin the caption-shift contract; `wpass-gv6` adds `scannableCardScreenHasExactlyFourUserVisibleParameters` + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged` |
+| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb` adds `scannableCardRowTileHasExactlyFourUserVisibleParameters` to pin the wallet-row concession shape, and `rowTileDoesNotRenderTrustCaption` / `rowTileRendersFormatSubtitle` to pin the caption-shift contract; `wpass-gv6` adds `scannableCardScreenHasExactlyFiveUserVisibleParameters` (four at the time; `wpass-80y.1`'s `faceTint` bumped it) + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged` |
 | C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests)             |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration). C5 amendment (wpass-7rv): the original "decoder not in dependency closure" build assertion no longer holds — decode confinement is pinned instead by the isolated-decode tests (`BarcodeDecodeServiceInstrumentedTest`, `YPlaneFrameDecodeTest`) and, consumer-side, by walt-android `CompositeImportInstrumentedTest` (no host-process decode of source bytes) + `CameraScanSecurityGuardTest` (no CameraX `ImageCapture` in `src/main`) |

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -75,7 +75,11 @@ only when, all three of the following hold:
    same neutral token the carousel tile's leading strip uses). Per-card
    user-chosen colour was removed from the kernel (`wpass-q5p`); routing it
    through this strip at list scale would have re-created the trust-conflation
-   risk row 1 names.
+   risk row 1 names. **Under review (`wpass-80y.4`):** that last sentence
+   assumed colour was trust-bearing. The "colour carries no trust meaning" row
+   below removes the premise, so whether this strip may take the item's class
+   tint is now an open contract question, not a settled prohibition. The strip
+   stays on `unverifiedArtifact.accent` until `wpass-80y.4` resolves it.
 3. The detail surface (`ScannableCardScreen`) retains the bottom-docked
    non-suppressible `ScannableCardTrustCaption`. The trust caption shifts from
    list-row to detail-surface only; a user who taps a row to *use* the artifact
@@ -128,6 +132,12 @@ consumer epic wlt-mx2d).** The redesigned wallet list changes what
 distinguishes card classes, and the change is recorded here so the
 verified-band confusion class can be checked against it:
 
+> **Partly superseded (wpass-80y, 2026-08-08).** The first bullet's
+> issuer-colour posture no longer holds: colour is decoupled from the issuer
+> and applied to every artifact class. The second bullet (no verified
+> affordance at list scale) stands and is now load-bearing. See the
+> "colour carries no trust meaning" row below.
+
 - **Issuer `pass.json` colors now drive pkpass list-card faces** (previously
   parsed but unused off the pass front; ADR 0003 D4 addendum). Issuer color
   appears on pkpass cards ONLY: document, scannable, and composite cards keep
@@ -144,6 +154,88 @@ verified-band confusion class can be checked against it:
   `WalletListTest` "no signature dot" invariant extends to every card class
   under `wlt-mx2d` (pin lands with the consumer redesign; until then the
   existing scannable-row invariant holds).
+
+**C1 / C2 - colour carries no trust meaning, for any class (wpass-80y;
+consumer epic wlt-38v8).** The C1 / C2 text above, and the redesign row that
+precedes it, treated colour as trust-adjacent: issuer colour was permitted on
+pkpass cards because it read as pass identity, and forbidden on document,
+scannable, and composite cards because taking it was what would let a
+user-authored artifact present as issuer-signed. The consumer's 26.08.08
+revision removes that premise entirely. Its rules block, verbatim:
+
+> Colour means class. Nothing else. The pass file's backgroundColor is read,
+> never rendered.
+> Card stock is identical in light and dark. No previews on list cards.
+> Expired washes out (#EFEAE3) instead of tinting. Any item is reassignable:
+> Details > Color.
+> No card presents as verified - signature is stated in words, on detail.
+
+Three changes matter to this document. Colour is (a) decoupled from the issuer,
+so every pkpass renders the same class tint regardless of `pass.json`
+`backgroundColor`, which is parsed but not rendered at that surface; (b)
+applied to every artifact class, so documents, scannables and composites now
+carry a tint where the neutral-surface rule previously forbade one; and (c)
+user-reassignable per item from a picker on the detail surface, so any artifact
+can carry any of the seven palette colours.
+
+**The verified-band confusion class is still closed, from different premises.**
+It no longer rests on "a user-created artifact cannot wear the chrome a signed
+pass wears," because with per-item reassignment there is no chrome that only a
+signed pass can wear. It rests on these instead:
+
+1. **No surface presents as verified.** No list card of any class renders a
+   signature affordance, verified band, or pill (the consumer's last one was
+   deleted under `wlt-l9cb`), and no card face carries one at detail scale
+   either. There is no verified visual for a user-created card to imitate -
+   the same structural argument the second "Redesign context" bullet makes,
+   now carrying the load the colour distinction used to share.
+2. **Signature status is stated in words, on the detail surface only.**
+   "Verified - signed by issuer" / "Unverified - unsigned by issuer" /
+   "User provided pass, issuer cannot be verified". Text, not chrome, so it
+   cannot be imitated by a colour choice; `wlt-mx2d.7`'s
+   no-false-forensic-claims rule holds verbatim.
+3. **Colour is uniform per class by default and overridable by the user.** A
+   Bronze PDF or a Teal pkpass is a user preference, and this document says so
+   out loud: it is not a violation, not a spoof, and not something a consumer
+   should guard against. Colour that any user can reassign at will cannot
+   encode provenance even accidentally - which is precisely why it is safe to
+   grant, and precisely why nothing may be inferred from it.
+
+**What this means at the kernel surface.** `ScannableCardScreen(faceTint = …)`
+(wpass-80y.1) and `DocumentView(faceTint = …)` (wpass-80y.2) exist so the
+consumer can tint the card face without reimplementing these surfaces. Both are
+presentation-only and bounded the same way:
+
+- The tint reaches the card face only. The panel behind a code stays
+  `SCAN_CODE_PANEL` (literally white in both themes) and the rasterised page /
+  decoded image render identically tinted or not. Real content stays
+  theme-independent and scannable; the unchanged-posture claim in C5 / Threat 14
+  is untouched.
+- Neither parameter can suppress the barcode, the payload readback, or the
+  trust caption. `faceTint` is not a second route to the C2 bypass that the
+  `HostedTypeRow` concession audits: the caption placement is still the only
+  audited carrier-of-provenance choice.
+- Ink on a tinted face is derived from the tint's luminance (`inkOn`), pinned
+  at ≥ 4.5:1. Legibility of the in-words provenance signal cannot be tuned away
+  by a hostile or careless tint - which is what keeps premise 2 above true for
+  an arbitrary consumer colour.
+- **The kernel stores no colour.** `wpass-q5p` removed `ScannableCard.color`,
+  `ScannableColor` and the storage column; no `Document` arm has ever carried
+  one. They stay removed. Which colour an item carries is consumer state
+  (walt-android's `WalletColorRepository`, keyed per wallet entry), so the
+  kernel never learns why a colour was chosen and has nothing to leak in
+  Threats 7 / 8.
+
+**Bound of this row.** What is granted is a consumer-chosen face tint on the
+two detail surfaces named above, plus the consumer's freedom to colour its own
+list cards. What is not granted, and would be an amendment rather than a PR:
+deriving a colour from signature status, verification outcome, or issuer
+identity anywhere in the kernel; re-adding a colour field to a kernel artifact
+model or storage table; or a `faceTint` reaching the code panel or the page
+render. See also the still-open `ScannableCardRowTile` accent question
+(`wpass-80y.4`), which this row is the precondition for: its leading strip is
+pinned to `unverifiedArtifact.accent` by a rationale ("that would re-create the
+verified-band read at list scale") that premise 1 above no longer supports.
 
 **C2 — host "Pass type" row concession (detail surface).** A consumer (Walt,
 `wlt-3cer`) consolidates the provenance signal into a single "Pass type" row
@@ -303,11 +395,12 @@ risk are in the C2 "Pass type" row concession subsection above.
 
 **Status.** Mitigated structurally, with the detail-surface layer reducible to a
 host "Pass type" row under the bounded `HostedTypeRow` concession (C1 list-level
-distinction then carries the load). Under the `wlt-mx2d` redesign the
-list-level distinction is carried per the "Redesign context" row above: neutral
-surface + class eyebrow on non-pass cards, issuer color on pkpass cards only,
-and no verified affordance on any list card. This is the load-bearing concern
-of the entire epic; every downstream child must trace back to this row.
+distinction then carries the load). Under the `wlt-38v8` colour system the
+list-level distinction is carried per the "colour carries no trust meaning" row
+above: a class tint that any user can reassign, a class eyebrow, and no verified
+affordance on any card of any class - colour distinguishes nothing on its own
+and is not relied on to. This is the load-bearing concern of the entire epic;
+every downstream child must trace back to this row.
 
 ### 2. Hostile URI payload encoded into a QR that another device auto-acts on — Spoofing / Elevation of privilege
 
@@ -475,10 +568,20 @@ unexpected.
 **Mitigation.** The kernel no longer exposes a per-card user colour at all
 (`wpass-q5p` removed `ScannableCard.color` and `ScannableColor`). With no
 colour field on the artifact, the kernel has no colour parsing or storage
-surface to attack, and the consumer's create flow no longer presents a colour
-picker.
+surface to attack.
 
-**Status.** Removed at the kernel; no parsing surface remains.
+**Updated by wpass-80y.** A colour picker exists again, but consumer-side: Walt
+persists per-item overrides in its own `WalletColorRepository` and passes the
+result to `ScannableCardScreen(faceTint)` / `DocumentView(faceTint)` as an
+already-constructed Compose `Color`. The kernel parses no colour string, stores
+no colour, and validates none - a `Color` is an opaque packed value with no
+parse step to attack, and nothing the kernel does with it (paint the face,
+derive ink from its luminance) branches on its value beyond contrast. Picker
+input hygiene is the consumer's, filed under `wlt-38v8`; a hostile value can at
+worst produce an ugly card, since ink contrast is derived and pinned.
+
+**Status.** No parsing or storage surface at the kernel; picker and persistence
+are consumer-side.
 
 ### 11. Future TOTP / HMAC-OATH secret leakage — Explicit non-feature
 
@@ -604,6 +707,12 @@ threat row above.
   feature, file separately.
 - **No "Verified" or "Trusted" badge on any ScannableCardTile** under any
   combination of consumer theming. C2 forbids it.
+- **No colour-derived trust signal anywhere in the kernel.** No surface may pick
+  or vary a colour from signature status, verification outcome, or issuer
+  identity, and no kernel artifact model or storage table may carry a colour
+  field. Colour enters the kernel only as a consumer-supplied `faceTint` on the
+  two detail surfaces, and nothing may be inferred from it. Re-opens the
+  "colour carries no trust meaning" row.
 - **No server-side validation of payloads against merchant APIs.** Re-opens
   row 9 and adds an entirely new key-custody / network surface.
 - **No TOTP / HMAC-OATH / rotating-secret support.** Re-opens row 11.
@@ -635,7 +744,7 @@ can trace back here.
 | Control | Pinned by                                  |
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
-| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb` adds `scannableCardRowTileHasExactlyThreeUserVisibleParameters` to pin the wallet-row concession shape, and `rowTileDoesNotRenderTrustCaption` / `rowTileRendersFormatSubtitle` to pin the caption-shift contract; `wpass-gv6` adds `scannableCardScreenHasExactlyFourUserVisibleParameters` + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer` |
+| C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb` adds `scannableCardRowTileHasExactlyThreeUserVisibleParameters` to pin the wallet-row concession shape, and `rowTileDoesNotRenderTrustCaption` / `rowTileRendersFormatSubtitle` to pin the caption-shift contract; `wpass-gv6` adds `scannableCardScreenHasExactlyFourUserVisibleParameters` + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged` |
 | C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests)             |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration). C5 amendment (wpass-7rv): the original "decoder not in dependency closure" build assertion no longer holds — decode confinement is pinned instead by the isolated-decode tests (`BarcodeDecodeServiceInstrumentedTest`, `YPlaneFrameDecodeTest`) and, consumer-side, by walt-android `CompositeImportInstrumentedTest` (no host-process decode of source bytes) + `CameraScanSecurityGuardTest` (no CameraX `ImageCapture` in `src/main`) |

--- a/docs/adr/0003-passes-ui-theming.md
+++ b/docs/adr/0003-passes-ui-theming.md
@@ -353,4 +353,4 @@ What changes and what does not:
 |-------|----------------------------------------------------------------------------------------------|
 | Ink on a tinted face clears WCAG AA | `ScannableCardTrustSurfaceTest.inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase` (both palette rows, the luminance extremes, and the mid-tones a 0.5 flip gets wrong) |
 | A tint cannot suppress a trust-claim surface | `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` + its dark-tint twin; `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint` |
-| The security-sheet family takes no tint | `ComposableSurfaceLockTest.b3UrlConfirmSheetHasExactlySixUserVisibleParameters` + the `phoneConfirmSheet…` / `emailConfirmSheet…` twins (six params, none of them a color) |
+| The security-sheet family takes no tint | `ComposableSurfaceLockTest.b3UrlConfirmSheetHasExactlySixUserVisibleParameters` + the `phoneConfirmSheet…` / `emailConfirmSheet…` twins. These are count locks: adding a tint breaks the count, but swapping one of the six for a color would not. The enumerations in each test's comment are what a reviewer reads against |

--- a/docs/adr/0003-passes-ui-theming.md
+++ b/docs/adr/0003-passes-ui-theming.md
@@ -302,3 +302,46 @@ The D4 boundaries are otherwise unchanged, and two are load-bearing:
   renders on any list card; the trust ladder stays on detail surfaces. The
   security-sheet family and other off-pass surfaces remain issuer-color-free
   exactly as D4 records.
+
+> **Superseded (wpass-80y, 2026-08-08).** The extension of D4 to the wallet-list
+> pass card face is withdrawn - the consumer no longer renders issuer color at
+> list scale. The two load-bearing boundaries above survive in stronger form:
+> color now functions as neither issuer identity nor class signal anywhere, and
+> off-pass surfaces stay issuer-color-free. See the addendum below.
+
+## Addendum 2026-08-08: Card color is class-based and user-assigned, not issuer-derived
+
+Tracks: kernel `wpass-80y.3` (this addendum), `wpass-80y.1` (the
+`ScannableCardScreen` tint). Consumer epic: walt-android `wlt-38v8`.
+
+The consumer's 26.08.08 revision decouples card color from the issuer: "Colour
+means class. Nothing else. The pass file's backgroundColor is read, never
+rendered." Every pkpass renders the same class tint regardless of `pass.json`,
+every other artifact class gets its own class tint, and the user can reassign
+any item's color from a picker on the detail surface. This reverses the
+2026-07-18 addendum above, which had extended D4's issuer-color override onto
+the wallet-list pass card face.
+
+What changes and what does not:
+
+- **D4 itself is unchanged.** `Pass.colors` still overrides the theme on the
+  kernel pass surface (`PassFront`) and nowhere else. What is withdrawn is the
+  2026-07-18 *extension* of that override to the consumer's list card face,
+  along with its contrast guard and white-issuer hairline special case. A
+  consumer that renders its own card faces is free to ignore `PassColors`; a
+  consumer that composes `PassFront` still gets D4's behavior.
+- **Colors reach kernel surfaces as consumer-supplied tints.**
+  `ScannableCardScreen(faceTint)` (`wpass-80y.1`) and `DocumentView(faceTint)`
+  (`wpass-80y.2`) take an already-constructed `Color`. The kernel stores none,
+  parses none, and infers nothing from one. Ink on a tinted face is derived from
+  the tint's luminance (`inkOn`), pinned at ≥ 4.5:1, so an arbitrary consumer
+  color cannot render the in-words trust text illegible - the theming analogue
+  of D5's "trust-claim composables have no off switch."
+- **The security-sheet family is untouched.** `B3UrlConfirmSheet`,
+  `PhoneConfirmSheet` and `EmailConfirmSheet` read `MaterialTheme.colorScheme`
+  and `LocalPassesSemantics` only. They take no tint parameter and must not: the
+  "adversarial pass darkens cancel button into invisibility" attack D4 names
+  applies verbatim to a user- or consumer-chosen color.
+- **Color carries no trust meaning.** Recorded in full in
+  `SCANNABLE_CARD_THREAT_MODEL.md` ("colour carries no trust meaning") and
+  ADR 0005 D1.C; this addendum is the theming-side pointer to them.

--- a/docs/adr/0003-passes-ui-theming.md
+++ b/docs/adr/0003-passes-ui-theming.md
@@ -312,7 +312,8 @@ The D4 boundaries are otherwise unchanged, and two are load-bearing:
 ## Addendum 2026-08-08: Card color is class-based and user-assigned, not issuer-derived
 
 Tracks: kernel `wpass-80y.3` (this addendum), `wpass-80y.1` (the
-`ScannableCardScreen` tint). Consumer epic: walt-android `wlt-38v8`.
+`ScannableCardScreen` tint), `wpass-80y.2` (the `DocumentView` tint, in
+`passes-document-ui`). Consumer epic: walt-android `wlt-38v8`.
 
 The consumer's 26.08.08 revision decouples card color from the issuer: "Colour
 means class. Nothing else. The pass file's backgroundColor is read, never
@@ -345,3 +346,11 @@ What changes and what does not:
 - **Color carries no trust meaning.** Recorded in full in
   `SCANNABLE_CARD_THREAT_MODEL.md` ("colour carries no trust meaning") and
   ADR 0005 D1.C; this addendum is the theming-side pointer to them.
+
+### Tests pinning this addendum
+
+| Claim | Test                                                                                       |
+|-------|----------------------------------------------------------------------------------------------|
+| Ink on a tinted face clears WCAG AA | `ScannableCardTrustSurfaceTest.inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase` (both palette rows, the luminance extremes, and the mid-tones a 0.5 flip gets wrong) |
+| A tint cannot suppress a trust-claim surface | `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` + its dark-tint twin; `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint` |
+| The security-sheet family takes no tint | `ComposableSurfaceLockTest.b3UrlConfirmSheetHasExactlySixUserVisibleParameters` + the `phoneConfirmSheet…` / `emailConfirmSheet…` twins (six params, none of them a color) |

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -21,7 +21,7 @@ A new `PassDocument` data class lives alongside `Pass`. Documents have no `PassT
 
 A separate `documents` table is added to the existing `walt_passes.db` SQLCipher database (schema v1 to v2). Same database key, same backup-exclusion rules, same irreversible-delete contract.
 
-A separate "Documents" lane appears below the passes list in `passes-ui`. Users see passes and documents as related-but-distinct concepts.
+A separate "Documents" lane appears below the passes list in `passes-ui`. Users see passes and documents as related-but-distinct concepts. (Amended by [D1.L](#d1l-consumers-may-render-documents-inline-in-a-unified-wallet-list): a consumer may instead render documents inline in a unified list, under stated conditions. [D1.C](#d1c-colour-carries-no-trust-meaning-documents-take-a-class-tint) amends the neutral-surface rule that later addenda attached to this row.)
 
 Rationale: the trust contract differs structurally. Mixing PDFs into the `Pass` model would put a "Verified" pill API path within reach of code that should never offer it. Sibling separation moves that risk from "policed at every call site forever" to "physically impossible."
 
@@ -944,3 +944,98 @@ What this addendum records is the presentation posture:
 - The composite code-on-card-face posture is recorded as a C1/C2 concession
   in `SCANNABLE_CARD_THREAT_MODEL.md` ("list-face code render"); this
   addendum and that row cross-reference each other deliberately.
+
+> **Partly superseded (wpass-80y, 2026-08-08).** Documents now take a class
+> tint rather than staying neutral, and list cards carry no content preview.
+> The no-verified-affordance and detail-surface-provenance postures stand. See
+> the D1 addendum below.
+
+## Addendum 2026-08-08: D1 - colour is not a trust signal; documents may render inline
+
+Tracks: kernel `wpass-80y.3` (this addendum), `wpass-80y.2` (the `faceTint`
+parameter). Cross-repo consumers: walt-android `wlt-38v8` (colour system),
+`wlt-o72.6` (inline document rows, held open since 2026-05-14 for this text).
+
+Two long-standing UI expressions of D1 are amended here. Both are presentation;
+the D1 contract they were expressing - a document is a structural sibling of a
+`Pass`, with no `PassType`, no `SignatureStatus`, and no path to a "Verified"
+pill - is untouched by either, and is what D1 actually protects.
+
+### D1.C Colour carries no trust meaning; documents take a class tint
+
+D1 gave documents a separate lane, and the 2026-07-18 list-surface addendum gave
+them neutral card faces, because at the time colour *was* the issuer signal:
+letting a user-provided document take issuer colour would have let it present as
+an issuer-signed pass. The consumer's 26.08.08 revision decouples colour from
+the issuer entirely - "Colour means class. Nothing else. The pass file's
+backgroundColor is read, never rendered." - and applies a class tint to every
+artifact class, user-reassignable per item. The neutral-surface rule loses its
+premise and is withdrawn for documents.
+
+What replaces it as the argument that a document cannot present as verified:
+
+1. No document surface, at list or detail scale, renders a signature affordance
+   or verified indicator - D5 has always been "PDF signatures are not verified
+   and no signed indicator is surfaced", so the document tower has no
+   verified-vs-unverified ladder for a colour to imitate in the first place.
+2. Provenance is stated in words on the detail surface: the non-suppressible
+   `DocumentTrustCaption` (D5, Z.4 / Z.8), or the host "Pass type" row under the
+   audited D5.T concession. Text, not chrome.
+3. Colour is a per-class default that the user can reassign at will, so it
+   cannot encode provenance even accidentally. A Bronze PDF is a user
+   preference and is explicitly not a violation.
+
+The kernel's part is `DocumentView(faceTint = …)` (`wpass-80y.2`), which exists
+so the consumer tints the document detail surface instead of reimplementing it.
+Bounded deliberately: the tint reaches the frame only - the rasterised page and
+the decoded image are real content and render identically tinted or not, and
+identically in light and dark - and it cannot suppress the trust caption or
+change the render request. D2 / D3 / D4 are untouched: no new render, decode, or
+extraction surface. No `Document` arm carries a colour field and none may be
+added; which colour an item carries is consumer state
+(walt-android's `WalletColorRepository`). Deriving a colour from signature
+status, verification outcome, or issuer identity anywhere in the kernel is an
+amendment to this row, not a PR. The mirror row for scannable cards is
+"colour carries no trust meaning" in `SCANNABLE_CARD_THREAT_MODEL.md`; the two
+cross-reference each other deliberately.
+
+### D1.L Consumers may render documents inline in a unified wallet list
+
+D1's stated UI expression - "A separate 'Documents' lane appears below the
+passes list in `passes-ui`" - has been inaccurate for walt-android since
+`wlt-o72.1` (2026-05-14), which replaced `DocumentsLane` with inline
+`DocumentSummaryRow` entries interleaved with passes in one list. That
+divergence is recorded consumer-side in walt-android
+`docs/decisions-and-learnings.md`; this row is the kernel-side amendment
+`wlt-o72.6` was holding for, and it generalises rather than blessing one
+consumer.
+
+A consumer MAY render documents inline in a unified wallet list, or in a
+separate lane, provided:
+
+1. **The sibling data-model contract holds.** The merge is render-time only.
+   A document row is built from `DocumentRow` / `PdfDocument` (or the image /
+   composite arms), never by widening it into a `Pass` or a shared supertype
+   with one. No `PassType`, no `SignatureStatus`, no verified-pill path.
+2. **The row carries no signature or verified affordance**, and none can be
+   themed onto it - D5 forbids a signed indicator for documents at every
+   surface, and the unified list is where a document sits closest to a pkpass.
+3. **Detail-surface provenance is unchanged**: the docked non-suppressible
+   caption, or the host "Pass type" row under D5.T. Dropping `DocumentsLane`
+   drops its list-level caption, so the detail surface is where the in-words
+   signal lives - the same shift the C1 / C2 wallet-row concession records for
+   scannable cards.
+
+`DocumentsLane` remains in `passes-document-ui` and remains the recommended
+surface for a host that wants the kernel to carry the list-level presentation;
+it is no longer the only conforming one. A consumer that renders documents
+inline AND drops the detail-surface provenance signal without a "Pass type" row
+is amending D5.T, not filing a PR.
+
+### Tests pinning this addendum
+
+| Decision | Test                                                                                          |
+|----------|-------------------------------------------------------------------------------------------------|
+| D1.C     | `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm`; `faceTintLeavesThePageRenderRequestUnchanged` (tint reaches the frame, not the render); `fullyTransparentTintFallsBackToTheDefaultFrame` |
+| D1.C     | `DocumentSurfaceLockTest.documentViewHasExactlyElevenUserVisibleParameters` (the tint is the audited 11th param; no colour field on any `Document` arm) |
+| D1.L     | Consumer-side: walt-android's wallet-list tests (no signature affordance on a document row; render-time merge only). The kernel cannot verify a consumer's list at runtime - same posture as D5.T. |

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -21,7 +21,7 @@ A new `PassDocument` data class lives alongside `Pass`. Documents have no `PassT
 
 A separate `documents` table is added to the existing `walt_passes.db` SQLCipher database (schema v1 to v2). Same database key, same backup-exclusion rules, same irreversible-delete contract.
 
-A separate "Documents" lane appears below the passes list in `passes-ui`. Users see passes and documents as related-but-distinct concepts. (Amended by [D1.L](#d1l-consumers-may-render-documents-inline-in-a-unified-wallet-list): a consumer may instead render documents inline in a unified list, under stated conditions. [D1.C](#d1c-colour-carries-no-trust-meaning-documents-take-a-class-tint) amends the neutral-surface rule that later addenda attached to this row.)
+A separate "Documents" lane appears below the passes list in `passes-ui`. Users see passes and documents as related-but-distinct concepts. (Amended by [D1.L](#d1l-consumers-may-render-documents-inline-in-a-unified-wallet-list): a consumer may instead render documents inline in a unified list, under stated conditions. [D1.C](#d1c-color-carries-no-trust-meaning-documents-take-a-class-tint) amends the neutral-surface rule that later addenda attached to this row.)
 
 Rationale: the trust contract differs structurally. Mixing PDFs into the `Pass` model would put a "Verified" pill API path within reach of code that should never offer it. Sibling separation moves that risk from "policed at every call site forever" to "physically impossible."
 
@@ -885,7 +885,8 @@ contract, and what it deliberately gives up versus docked D5:
   `showCaption: Boolean`: the placement is the audited carrier-of-provenance
   choice, pinned by `documentViewTrustCaptionParamIsThePlacementType`. The param
   count lock moves from 9 to 10
-  (`documentViewHasExactlyTenUserVisibleParameters`), superseding the 9-param
+  (`documentViewHasExactlyElevenUserVisibleParameters`; 10 at the time, bumped
+  to 11 when `wpass-80y.2` added `faceTint`), superseding the 9-param
   assertion in the prior (composite) addendum.
 
 **Why this is bounded.** D5 already accepts all PDFs as `Provenance.UserProvided`
@@ -914,7 +915,7 @@ zoom level" guarantees stand verbatim.
 
 | Decision | Test                                                                                                  |
 |----------|-------------------------------------------------------------------------------------------------------|
-| D5.T     | `DocumentSurfaceLockTest.documentViewHasExactlyTenUserVisibleParameters` + `documentViewTrustCaptionParamIsThePlacementType` (placement is the audited choice, not a Boolean) |
+| D5.T     | `DocumentSurfaceLockTest.documentViewHasExactlyElevenUserVisibleParameters` + `documentViewTrustCaptionParamIsThePlacementType` (placement is the audited choice, not a Boolean) |
 | D5.T     | `DocumentTrustSurfaceTest.documentViewHostedTypeRowOmitsKernelCaption` (HostedTypeRow renders no kernel caption); `documentTrustCaptionRendersTheVerbatimTrustText` (the docked-mode caption still renders verbatim) |
 | Consumer | walt-android `wlt-3cer`: the details section renders a "Pass type" row enumerating the artifact class |
 | Scope    | `FullScreenDocumentView` shape lock unchanged (7 params); Z.8 full-screen caption tests stay green |
@@ -950,10 +951,10 @@ What this addendum records is the presentation posture:
 > The no-verified-affordance and detail-surface-provenance postures stand. See
 > the D1 addendum below.
 
-## Addendum 2026-08-08: D1 - colour is not a trust signal; documents may render inline
+## Addendum 2026-08-08: D1 - color is not a trust signal; documents may render inline
 
 Tracks: kernel `wpass-80y.3` (this addendum), `wpass-80y.2` (the `faceTint`
-parameter). Cross-repo consumers: walt-android `wlt-38v8` (colour system),
+parameter). Cross-repo consumers: walt-android `wlt-38v8` (color system),
 `wlt-o72.6` (inline document rows, held open since 2026-05-14 for this text).
 
 Two long-standing UI expressions of D1 are amended here. Both are presentation;
@@ -961,12 +962,12 @@ the D1 contract they were expressing - a document is a structural sibling of a
 `Pass`, with no `PassType`, no `SignatureStatus`, and no path to a "Verified"
 pill - is untouched by either, and is what D1 actually protects.
 
-### D1.C Colour carries no trust meaning; documents take a class tint
+### D1.C Color carries no trust meaning; documents take a class tint
 
 D1 gave documents a separate lane, and the 2026-07-18 list-surface addendum gave
-them neutral card faces, because at the time colour *was* the issuer signal:
-letting a user-provided document take issuer colour would have let it present as
-an issuer-signed pass. The consumer's 26.08.08 revision decouples colour from
+them neutral card faces, because at the time color *was* the issuer signal:
+letting a user-provided document take issuer color would have let it present as
+an issuer-signed pass. The consumer's 26.08.08 revision decouples color from
 the issuer entirely - "Colour means class. Nothing else. The pass file's
 backgroundColor is read, never rendered." - and applies a class tint to every
 artifact class, user-reassignable per item. The neutral-surface rule loses its
@@ -977,11 +978,11 @@ What replaces it as the argument that a document cannot present as verified:
 1. No document surface, at list or detail scale, renders a signature affordance
    or verified indicator - D5 has always been "PDF signatures are not verified
    and no signed indicator is surfaced", so the document tower has no
-   verified-vs-unverified ladder for a colour to imitate in the first place.
+   verified-vs-unverified ladder for a color to imitate in the first place.
 2. Provenance is stated in words on the detail surface: the non-suppressible
    `DocumentTrustCaption` (D5, Z.4 / Z.8), or the host "Pass type" row under the
    audited D5.T concession. Text, not chrome.
-3. Colour is a per-class default that the user can reassign at will, so it
+3. Color is a per-class default that the user can reassign at will, so it
    cannot encode provenance even accidentally. A Bronze PDF is a user
    preference and is explicitly not a violation.
 
@@ -991,9 +992,9 @@ Bounded deliberately: the tint reaches the frame only - the rasterised page and
 the decoded image are real content and render identically tinted or not, and
 identically in light and dark - and it cannot suppress the trust caption or
 change the render request. D2 / D3 / D4 are untouched: no new render, decode, or
-extraction surface. No `Document` arm carries a colour field and none may be
-added; which colour an item carries is consumer state
-(walt-android's `WalletColorRepository`). Deriving a colour from signature
+extraction surface. No `Document` arm carries a color field and none may be
+added; which color an item carries is consumer state
+(walt-android's `WalletColorRepository`). Deriving a color from signature
 status, verification outcome, or issuer identity anywhere in the kernel is an
 amendment to this row, not a PR. The mirror row for scannable cards is
 "colour carries no trust meaning" in `SCANNABLE_CARD_THREAT_MODEL.md`; the two
@@ -1037,5 +1038,5 @@ is amending D5.T, not filing a PR.
 | Decision | Test                                                                                          |
 |----------|-------------------------------------------------------------------------------------------------|
 | D1.C     | `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm`; `faceTintLeavesThePageRenderRequestUnchanged` (tint reaches the frame, not the render); `fullyTransparentTintFallsBackToTheDefaultFrame` |
-| D1.C     | `DocumentSurfaceLockTest.documentViewHasExactlyElevenUserVisibleParameters` (the tint is the audited 11th param; no colour field on any `Document` arm) |
+| D1.C     | `DocumentSurfaceLockTest.documentViewHasExactlyElevenUserVisibleParameters` (the tint is the audited 11th param; no color field on any `Document` arm) |
 | D1.L     | Consumer-side: walt-android's wallet-list tests (no signature affordance on a document row; render-time merge only). The kernel cannot verify a consumer's list at runtime - same posture as D5.T. |

--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -884,10 +884,10 @@ contract, and what it deliberately gives up versus docked D5:
 - `TrustCaptionPlacement` is `Docked | HostedTypeRow`. There is no
   `showCaption: Boolean`: the placement is the audited carrier-of-provenance
   choice, pinned by `documentViewTrustCaptionParamIsThePlacementType`. The param
-  count lock moves from 9 to 10
-  (`documentViewHasExactlyElevenUserVisibleParameters`; 10 at the time, bumped
-  to 11 when `wpass-80y.2` added `faceTint`), superseding the 9-param
-  assertion in the prior (composite) addendum.
+  count lock moves from 9 to 10, superseding the 9-param assertion in the prior
+  (composite) addendum. The lock is now
+  `documentViewHasExactlyElevenUserVisibleParameters`, having gone to 11 when
+  `wpass-80y.2` added `faceTint`.
 
 **Why this is bounded.** D5 already accepts all PDFs as `Provenance.UserProvided`
 and never shows a "verified" signal; the document tower has no verified-vs-

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -42,11 +42,16 @@ class ComposableSurfaceLockTest {
 
     @Test
     fun phoneConfirmSheetHasExactlySixUserVisibleParameters() {
+        // (intent, passType, telemetry, onConfirm, onDismiss, emphasisStyle) — same shape
+        // as B3UrlConfirmSheet. No color/tint parameter: ADR 0003 D4 keeps the sheets on
+        // the host theme so no pass- or consumer-chosen color can dim the cancel button.
         assertUserVisibleParamCount("SecuritySheetsKt", "PhoneConfirmSheet", expected = 6)
     }
 
     @Test
     fun emailConfirmSheetHasExactlySixUserVisibleParameters() {
+        // (intent, passType, telemetry, onConfirm, onDismiss, emphasisStyle) — same shape
+        // and the same no-color rule as the phone sheet above.
         assertUserVisibleParamCount("SecuritySheetsKt", "EmailConfirmSheet", expected = 6)
     }
 

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/ComposableSurfaceLockTest.kt
@@ -183,7 +183,7 @@ class ComposableSurfaceLockTest {
         // SCANNABLE_CARD_THREAT_MODEL.md. The strong type (not a Boolean) is pinned by
         // scannableCardScreenTrustCaptionParamIsThePlacementType. `faceTint` (wpass-80y.1)
         // colors the card face only — it cannot reach the code panel, which is pinned to
-        // literal white by codePanelIsLiterallyWhiteNotAThemeTokenOrTheTint. Adding a SIXTH
+        // literal white by codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint. A SIXTH
         // parameter — e.g. a per-element `showBarcode` / `showPayloadCaption` suppressor, or
         // a panel-color override — would breach the surface contract; review the threat
         // model before changing this number.


### PR DESCRIPTION
Kernel companion to walt-android `wlt-38v8`. Docs only; no code changes.

The 26.08.08 design revision decouples card colour from the issuer: colour means class, every artifact class gets a tint, and any item is user-reassignable from the detail surface. Three kernel docs encoded the opposite.

## `SCANNABLE_CARD_THREAT_MODEL.md`

New C1/C2 row, **colour carries no trust meaning**. The verified-band confusion class stays closed, from new premises:

1. No surface presents as verified, at list or detail scale.
2. Signature status is stated in words, on the detail surface only.
3. Colour is a per-class default the user can reassign, so it cannot encode provenance even accidentally - and this is said out loud, so a Bronze PDF is not read as a violation.

The row also bounds what `faceTint` grants (face only; cannot suppress barcode, payload readback, or trust caption; ink contrast derived and pinned; the kernel stores no colour) and what would need an amendment (colour derived from signature status, a colour field back on a kernel model, a tint reaching the code panel or page render).

Other edits in the same file:

- The wallet-row concession's condition 2 is marked **under review by `wpass-80y.4`** - its prohibition rested on the premise this PR removes, so `.4` can now decide it on the merits. The strip stays neutral until then.
- Threat 10 (colour picker as injection vector) updated: a picker exists again, consumer-side; the kernel takes a constructed `Color`, so there is no parse step to attack.
- Threat 1 status and the `wlt-mx2d` redesign row updated / marked partly superseded.
- Test matrix picks up the `wpass-80y.1` / `.2` tint pins.

## ADR 0005

New D1 addendum, two rows:

- **D1.C** withdraws the neutral-surface rule for documents and states the replacement argument (D5 never surfaced a signed indicator, so there is no ladder for a colour to imitate).
- **D1.L** is the amendment `wlt-o72.6` has been holding open since 2026-05-14: consumers MAY render documents inline in a unified wallet list, provided the sibling data-model contract holds, the row carries no verified affordance, and detail-surface provenance is unchanged.

## ADR 0003

The 2026-07-18 "issuer colors extend to the wallet-list pass card face" addendum is superseded. D4 itself is untouched - `PassFront` still applies `Pass.colors` on the pass surface - and the security-sheet family still takes no tint and must not.

Closes `wpass-80y.3`. Unblocks `wpass-80y.4`.