### PR TITLE
feat(barcode)!: add AZTEC + PDF417 to the decode roster (wpass-pl7.1)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -324,10 +324,18 @@ the audited `Docked | HostedTypeRow` choice, pinned by
 **C3. Input hygiene at the create boundary.** `passes-core` validates
 `ScannableCardCreateInput` for: per-format length caps (Code128 ~80 chars,
 EAN-13 / UPC-A fixed-length with checksum, QR per-version cap with a
-conservative ~2000-char ceiling), per-format charset rules (EAN-13 / UPC-A
-numeric only, Code39 limited alphanumeric, Code128 the printable ASCII subset),
-and Unicode Cf (Format) / Cc (Control) codepoint rejection in both `payload`
-and `label`. The Cf/Cc rejection mirrors the discipline that
+conservative ~2000-char ceiling, PDF417 ~800 chars, Aztec ~1500 chars),
+per-format charset rules (EAN-13 / UPC-A numeric only, Code39 limited
+alphanumeric, Code128 the printable ASCII subset; QR, PDF417 and Aztec are
+byte-capable and admit any character), and Unicode Cf (Format) / Cc (Control)
+codepoint rejection in both `payload` and `label`. The Cf/Cc rejection runs
+before the per-format rules, so it covers the byte-capable formats too.
+
+The PDF417 and Aztec caps (`wpass-pl7.1`) were set to hold at any plausible
+error-correction level, because the level itself is not pinned until the writer
+arms land in `wpass-pl7.6`. That bead must re-derive them against its own pin:
+a cap the validator accepts but the encoder cannot fit converts a clean
+`InvalidPayload(TooLong)` rejection into a blank render. The Cf/Cc rejection mirrors the discipline that
 `FieldLinkScanner.kt:67` and the PDF document-label path already enforce.
 
 **C4. Create-time URI-scheme preview for QR.** When the user creates a QR
@@ -338,6 +346,16 @@ match (or a "looks URI-shaped but unrecognized scheme" fallback) raises the
 walt-android-side confirmation dialog before the row is persisted. The user
 must explicitly confirm "yes, this QR is meant to encode an actionable URI."
 Pattern source: `B3UrlConfirmSheet` in `passes-ui/src/main/kotlin/.../SecuritySheets.kt`.
+
+**C4 forward obligation (`wpass-pl7.6`).** PDF417 and Aztec are byte-capable and
+can carry the same actionable URIs, so this gate must widen to them when they
+become creatable. It is not a gap today: `wpass-pl7.1` added them to the *decode*
+roster only, and the encoder refuses both with
+`EncoderFailureReason.FormatNotEncodable`, so no such card can be created or
+rendered in this build. The gate trigger is `QrPayloadKind`-scoped
+(`requiresCreateConfirmation()` takes no format), which is what makes widening a
+deliberate edit rather than something the compiler would have surfaced — hence
+recording it here.
 
 **C5. ZXing-JVM as encoder only; no runtime decoding of untrusted bytes.**
 The kernel uses `com.google.zxing:core` (Apache 2.0, pure JVM) exclusively to
@@ -501,8 +519,10 @@ fast (<50ms for typical payloads) but degrades visibly at the upper end.
 **Mitigation.** C3: per-format payload caps codified in `passes-core` and
 returned as `InvalidPayload(TooLong)` before the encoder runs. Conservative
 ceilings: Code128 80 chars, EAN-13 / UPC-A fixed by format, Code39 80 chars,
-QR ~2000 chars. The 2000-char QR ceiling sits well below format max but well
-above any realistic library / loyalty / URL payload.
+QR ~2000 chars, PDF417 800 chars, Aztec 1500 chars. Every ceiling sits well
+below its format max but well above any realistic library / loyalty / URL
+payload — for the two 2D additions the sizing case is a boarding pass, whose
+IATA BCBP string runs ~60 characters per leg.
 
 **Status.** Mitigated by hard caps. Caps are enforced in `passes-core` (first
 line) and `passes-storage` (second line, as a row-level constraint, defense
@@ -530,6 +550,11 @@ are no longer informational: apply the same 30-day cadence to decoder CVEs that
 are reachable from `decodeYPlane` / `BarcodeImageDecoder`. The blast radius of a
 *static*-path decoder bug is contained to the isolated process (C5 amendment),
 which lowers severity but does not remove the upgrade obligation.
+
+**Widened by `wpass-pl7.1`.** The reachable decoder set grew from five
+symbologies to seven: `AztecReader` and `PDF417Reader`, with their own
+detector and error-correction code, are now invoked on both decode paths.
+Advisories against either are in scope for the same 30-day cadence.
 
 **Status.** Mitigated by surface reduction (C5) and a stated cadence; the
 upgrade-cadence bead is the follow-up artifact.
@@ -695,6 +720,24 @@ system, neither of which existed for the type-it-yourself ScannableCard:
 - **Transient camera stills are swept** to one-at-most in the consumer's cache
   (`wlt-noq5`); the persisted image lives only in SQLCipher (Threats 7, 8
   inherited).
+- **The symbology allowlist bounds both sub-threats.** `DECODE_HINTS` pins
+  `POSSIBLE_FORMATS` to exactly the `ScannableFormat` roster, so a hostile image
+  can only reach the parsers for symbologies Walt actually renders, and the
+  reader has correspondingly fewer candidate interpretations to confuse. The
+  allowlist is the reason both risks scale with roster size rather than with
+  ZXing's full format list.
+
+**Roster growth is a deliberate re-weighting of this threat (`wpass-pl7.1`).**
+Adding PDF417 and Aztec widens the reachable parser surface by two symbologies
+and gives the reader two more candidate interpretations of an ambiguous region.
+Accepted because the alternative was worse: without them an imported
+boarding-pass screenshot — the single most-reported import — decodes to nothing
+at any input scale, and the user gets no scannable code at all. DataMatrix stays
+out for exactly this reason, having no reported need to pay for. The misread
+half of the risk is bounded as above: decode is not the trust boundary, the
+consumer's `confirmBarcode(payload, format)` gate is, and it is
+format-agnostic — it fires for every decoded symbology, including the two new
+ones, and preserves the decoded format verbatim rather than normalising it.
 
 The image-codec RCE class is the kernel's to contain (isolated process); the
 manual-snap "system camera, never CameraX `ImageCapture`" rule and the
@@ -775,7 +818,7 @@ can trace back here.
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
 | C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb`'s wallet-row pins (`scannableCardRowTileHasExactlyFourUserVisibleParameters`, `rowTileDoesNotRenderTrustCaption`, `rowTileRendersFormatSubtitle`) were removed with the concession and the composable in `wpass-80y.4`; `wpass-gv6` adds `scannableCardScreenHasExactlyFiveUserVisibleParameters` (four at the time; `wpass-80y.1`'s `faceTint` bumped it) + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged`; `wpass-80y.5` pins the shared tint gate with `passes-ui-core`'s `FaceTintTest` plus `fullyTransparentTintFallsBackToTheDefaultFace` (scannable face and ink resolution, via `facePaint`) and `…DefaultFrame` (document arm composes intact) |
-| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests)             |
+| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests); `wpass-pl7.1` adds the PDF417 / Aztec cap and byte-capable-charset cases (`pdf417TooLong`, `aztecTooLong`, `pdf417AndAztecHappyPathAcceptsUtf8`, `aztecAcceptsABoardingPassLengthPayload`) |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration). C5 amendment (wpass-7rv): the original "decoder not in dependency closure" build assertion no longer holds — decode confinement is pinned instead by the isolated-decode tests (`BarcodeDecodeServiceInstrumentedTest`, `YPlaneFrameDecodeTest`) and, consumer-side, by walt-android `CompositeImportInstrumentedTest` (no host-process decode of source bytes) + `CameraScanSecurityGuardTest` (no CameraX `ImageCapture` in `src/main`) |
 | C6      | `wpass-lzi.2` (schema snapshot — no `secret`/`hmac`/`totp` fields permitted) |

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -349,13 +349,21 @@ Pattern source: `B3UrlConfirmSheet` in `passes-ui/src/main/kotlin/.../SecuritySh
 
 **C4 forward obligation (`wpass-pl7.6`).** PDF417 and Aztec are byte-capable and
 can carry the same actionable URIs, so this gate must widen to them when they
-become creatable. It is not a gap today: `wpass-pl7.1` added them to the *decode*
-roster only, and the encoder refuses both with
-`EncoderFailureReason.FormatNotEncodable`, so no such card can be created or
-rendered in this build. The gate trigger is `QrPayloadKind`-scoped
-(`requiresCreateConfirmation()` takes no format), which is what makes widening a
-deliberate edit rather than something the compiler would have surfaced — hence
-recording it here.
+become creatable. It is not a gap today, and the reason is enforcement rather
+than convention: `wpass-pl7.1` added them to the *decode* roster only, and
+`ScannableCardInputValidator` returns
+`ScannableCardCreateResult.UnsupportedFormat` for both, so no such card can be
+minted, persisted, or rendered in this build. The refusal lives at the kernel
+choke point on purpose — consumers build their format pickers from
+`ScannableFormat.entries` (walt-android's `CreateScannableCardScreen` does), so
+a roster addition would otherwise surface as a selectable chip that nobody
+decided to offer. `ScannableFormatConstraints.decodeOnly` is the single set both
+the validator and the encoder read, so the two cannot drift.
+
+The gate trigger itself is `QrPayloadKind`-scoped (`requiresCreateConfirmation()`
+takes no format argument), so widening it is a deliberate edit that no compiler
+error will prompt — which is why it is recorded here and on `wpass-pl7.6`'s
+acceptance rather than left to be noticed.
 
 **C5. ZXing-JVM as encoder only; no runtime decoding of untrusted bytes.**
 The kernel uses `com.google.zxing:core` (Apache 2.0, pure JVM) exclusively to

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -329,14 +329,15 @@ per-format charset rules (EAN-13 / UPC-A numeric only, Code39 limited
 alphanumeric, Code128 the printable ASCII subset; QR, PDF417 and Aztec are
 byte-capable and admit any character), and Unicode Cf (Format) / Cc (Control)
 codepoint rejection in both `payload` and `label`. The Cf/Cc rejection runs
-before the per-format rules, so it covers the byte-capable formats too.
+before the per-format rules, so it covers the byte-capable formats too, and
+mirrors the discipline that `FieldLinkScanner.kt:67` and the PDF document-label
+path already enforce.
 
 The PDF417 and Aztec caps (`wpass-pl7.1`) were set to hold at any plausible
 error-correction level, because the level itself is not pinned until the writer
 arms land in `wpass-pl7.6`. That bead must re-derive them against its own pin:
 a cap the validator accepts but the encoder cannot fit converts a clean
-`InvalidPayload(TooLong)` rejection into a blank render. The Cf/Cc rejection mirrors the discipline that
-`FieldLinkScanner.kt:67` and the PDF document-label path already enforce.
+`InvalidPayload(TooLong)` rejection into a blank render.
 
 **C4. Create-time URI-scheme preview for QR.** When the user creates a QR
 ScannableCard, `passes-core`'s URI-scheme classifier inspects the payload
@@ -826,7 +827,7 @@ can trace back here.
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
 | C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb`'s wallet-row pins (`scannableCardRowTileHasExactlyFourUserVisibleParameters`, `rowTileDoesNotRenderTrustCaption`, `rowTileRendersFormatSubtitle`) were removed with the concession and the composable in `wpass-80y.4`; `wpass-gv6` adds `scannableCardScreenHasExactlyFiveUserVisibleParameters` (four at the time; `wpass-80y.1`'s `faceTint` bumped it) + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged`; `wpass-80y.5` pins the shared tint gate with `passes-ui-core`'s `FaceTintTest` plus `fullyTransparentTintFallsBackToTheDefaultFace` (scannable face and ink resolution, via `facePaint`) and `…DefaultFrame` (document arm composes intact) |
-| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests); `wpass-pl7.1` adds the PDF417 / Aztec cap and byte-capable-charset cases (`pdf417TooLong`, `aztecTooLong`, `pdf417AndAztecHappyPathAcceptsUtf8`, `aztecAcceptsABoardingPassLengthPayload`) |
+| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests); `wpass-pl7.1` pins the decode-only refusal at the create boundary (`decodeOnlyFormatsAreRefusedAtTheCreateBoundary`, `decodeOnlyRefusalOutranksPayloadAndLabelProblems`, `isCreatableAgreesWithWhatTheValidatorAccepts`, and `createWithADecodeOnlyFormatIsRejectedAndPersistsNothing` end-to-end in `passes-storage`) plus the PDF417 / Aztec cap and byte-capable-charset rules in `ScannableFormatConstraintsTest` |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration). C5 amendment (wpass-7rv): the original "decoder not in dependency closure" build assertion no longer holds — decode confinement is pinned instead by the isolated-decode tests (`BarcodeDecodeServiceInstrumentedTest`, `YPlaneFrameDecodeTest`) and, consumer-side, by walt-android `CompositeImportInstrumentedTest` (no host-process decode of source bytes) + `CameraScanSecurityGuardTest` (no CameraX `ImageCapture` in `src/main`) |
 | C6      | `wpass-lzi.2` (schema snapshot — no `secret`/`hmac`/`totp` fields permitted) |

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -60,7 +60,11 @@ public fun decodeLuminance(source: LuminanceSource): BarcodeDecodeResult {
     }
 }
 
-/** The symbology allowlist: ZXing format → the [ScannableFormat] Walt renders. */
+/**
+ * The symbology allowlist: ZXing format → the [ScannableFormat] Walt renders. Its width is a
+ * threat-model input (parser surface and misread ambiguity, Threat 14); changing it means
+ * changing `docs/SCANNABLE_CARD_THREAT_MODEL.md` alongside.
+ */
 private val ROSTER_BY_ZXING_FORMAT: Map<BarcodeFormat, ScannableFormat> =
     mapOf(
         BarcodeFormat.CODE_128 to ScannableFormat.Code128,

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -24,8 +24,12 @@ import `is`.walt.passes.core.ScannableFormat
  * fork.
  *
  * Symbology ALLOWLIST, not "decode everything": [DECODE_HINTS] pins the reader to exactly the
- * [ScannableFormat] roster Walt renders. PDF417/Aztec and the rest are deliberately not enabled —
+ * [ScannableFormat] roster Walt renders. DataMatrix and the rest are deliberately not enabled —
  * restricting the reader narrows both the work and the parser surface a hostile image can reach.
+ * PDF417 and Aztec joined the allowlist in wpass-pl7.1: they are the two dominant boarding-pass
+ * and ID symbologies, and without them an imported boarding-pass screenshot is undecodable at
+ * any input scale.
+ *
  * Because the reader can only return a format already in the allowlist, the out-of-roster
  * [DecodeFailureReason.UnsupportedBarcodeFormat] arm is a defensive guard the pinned hints make
  * unreachable in practice; it exists so a later hint change can't silently force an unsupported
@@ -64,6 +68,8 @@ private val ROSTER_BY_ZXING_FORMAT: Map<BarcodeFormat, ScannableFormat> =
         BarcodeFormat.UPC_A to ScannableFormat.UpcA,
         BarcodeFormat.CODE_39 to ScannableFormat.Code39,
         BarcodeFormat.QR_CODE to ScannableFormat.Qr,
+        BarcodeFormat.PDF_417 to ScannableFormat.Pdf417,
+        BarcodeFormat.AZTEC to ScannableFormat.Aztec,
     )
 
 /**

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -24,11 +24,9 @@ import `is`.walt.passes.core.ScannableFormat
  * fork.
  *
  * Symbology ALLOWLIST, not "decode everything": [DECODE_HINTS] pins the reader to exactly the
- * [ScannableFormat] roster Walt renders. DataMatrix and the rest are deliberately not enabled —
- * restricting the reader narrows both the work and the parser surface a hostile image can reach.
- * PDF417 and Aztec joined the allowlist in wpass-pl7.1: they are the two dominant boarding-pass
- * and ID symbologies, and without them an imported boarding-pass screenshot is undecodable at
- * any input scale.
+ * [ScannableFormat] roster. DataMatrix and the rest are deliberately not enabled — restricting
+ * the reader narrows both the work and the parser surface a hostile image can reach. PDF417 and
+ * Aztec joined in wpass-pl7.1, for boarding passes.
  *
  * Because the reader can only return a format already in the allowlist, the out-of-roster
  * [DecodeFailureReason.UnsupportedBarcodeFormat] arm is a defensive guard the pinned hints make

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -59,7 +59,7 @@ public fun decodeLuminance(source: LuminanceSource): BarcodeDecodeResult {
 }
 
 /**
- * The symbology allowlist: ZXing format → the [ScannableFormat] Walt renders. Its width is a
+ * The symbology allowlist: ZXing format → the [ScannableFormat] it maps to. Its width is a
  * threat-model input (parser surface and misread ambiguity, Threat 14); changing it means
  * changing `docs/SCANNABLE_CARD_THREAT_MODEL.md` alongside.
  */

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/YPlaneFrameDecodeTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/YPlaneFrameDecodeTest.kt
@@ -30,7 +30,8 @@ import org.junit.Test
  *    including the boundary where `rowStride == width * pixelStride`;
  *  - **failure arms** — a blank plane (no locatable symbol) and a located-but-ECC-exceeded symbol
  *    both surface as the honest [BarcodeDecodeResult.NoBarcodeFound], never a fabricated payload;
- *  - **allowlist** — a non-roster symbology (PDF417, Aztec) is not decoded;
+ *  - **allowlist** — the 2D roster members (PDF417, Aztec) decode, while a non-roster symbology
+ *    (DataMatrix) does not;
  *  - **geometry preconditions** — the [decodeYPlane] `require` guards reject malformed caller wiring
  *    (non-positive dims, `pixelStride < 1`, `rowStride < width * pixelStride`, undersized buffer)
  *    with [IllegalArgumentException] rather than widening the result surface.
@@ -146,16 +147,23 @@ class YPlaneFrameDecodeTest {
     // --- Allowlist (non-roster symbologies rejected) --------------------------------------------
 
     @Test
-    fun pdf417IsNotDecodedThroughYPlane() {
-        // PDF417 is intentionally absent from the v1 roster, so the pinned POSSIBLE_FORMATS hints
-        // never run a PDF417 decoder: a genuine PDF417 symbol reads as no locatable barcode.
-        assertThat(decodeNonRoster("BOARDING-PASS-PAYLOAD", BarcodeFormat.PDF_417))
-            .isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+    fun pdf417DecodesThroughYPlane() {
+        assertThat(decodeAtSize("WALT-LIVE-PDF417", BarcodeFormat.PDF_417, 600, 300))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-LIVE-PDF417", ScannableFormat.Pdf417))
     }
 
     @Test
-    fun aztecIsNotDecodedThroughYPlane() {
-        assertThat(decodeNonRoster("BOARDING-PASS-PAYLOAD", BarcodeFormat.AZTEC))
+    fun aztecDecodesThroughYPlane() {
+        assertThat(decodeAtSize("WALT-LIVE-AZTEC", BarcodeFormat.AZTEC, 300, 300))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-LIVE-AZTEC", ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun dataMatrixIsNotDecodedThroughYPlane() {
+        // DataMatrix is deliberately out of the roster (wpass-pl7 scope decision), so the pinned
+        // POSSIBLE_FORMATS hints never run a DataMatrix decoder. Rendered at a size the roster
+        // symbologies above decode cleanly at, so the miss is the allowlist and not the scale.
+        assertThat(decodeAtSize("NOT-IN-ROSTER", BarcodeFormat.DATA_MATRIX, 300, 300))
             .isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
     }
 
@@ -275,12 +283,14 @@ class YPlaneFrameDecodeTest {
         return decodeYPlane(interleaved, tight.width, tight.height, rowStride, pixelStride)
     }
 
-    /** Render a non-roster [format] symbol into a tight luminance plane and decode it. */
-    private fun decodeNonRoster(
+    /** Render [format] at the requested size into a tight luminance plane and decode it. */
+    private fun decodeAtSize(
         content: String,
         format: BarcodeFormat,
+        width: Int,
+        height: Int,
     ): BarcodeDecodeResult {
-        val plane = encodeYPlane(content, format, 0, 0, rowPadding = 0)
+        val plane = encodeYPlane(content, format, width, height, rowPadding = 0)
         return decodeYPlane(plane.bytes, plane.width, plane.height, rowStride = plane.width)
     }
 

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/ZxingBarcodeSymbolDecoderTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/ZxingBarcodeSymbolDecoderTest.kt
@@ -17,8 +17,12 @@ import org.junit.Test
  *
  * What these assert:
  *  - every [ScannableFormat] in the roster decodes back to its payload + format faithfully;
- *  - the symbology allowlist holds — a format OUTSIDE the roster (PDF417) is not decoded;
+ *  - the symbology allowlist holds — a format OUTSIDE the roster (DataMatrix) is not decoded;
  *  - a clean image with no symbol is the honest [BarcodeDecodeResult.NoBarcodeFound].
+ *
+ * Fixtures are ENCODED IN-TEST rather than committed as images. That keeps the suite
+ * device-free, and it keeps real boarding-pass payloads — which carry passenger name and PNR
+ * (wpass-pl7) — out of the repository: the 2D cases below use synthetic strings only.
  */
 class ZxingBarcodeSymbolDecoderTest {
     @Test
@@ -64,11 +68,40 @@ class ZxingBarcodeSymbolDecoderTest {
     }
 
     @Test
+    fun pdf417RoundTrips() {
+        val source = encode("WALT-PDF417-CHECK", BarcodeFormat.PDF_417, 600, 300)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-PDF417-CHECK", ScannableFormat.Pdf417))
+    }
+
+    @Test
+    fun aztecRoundTrips() {
+        val source = encode("WALT-AZTEC-CHECK", BarcodeFormat.AZTEC, 300, 300)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode("WALT-AZTEC-CHECK", ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun aztecDecodesAtBcbpPayloadLength() {
+        // The wpass-pl7 repro is an Aztec carrying a ~126-character IATA BCBP string. Shape and
+        // length are what matter to the decoder, so this stands in a synthetic string of the
+        // same size rather than a real boarding pass (those payloads are PII).
+        val payload = "M1WALT/TEST".padEnd(126, 'X')
+        val source = encode(payload, BarcodeFormat.AZTEC, 400, 400)
+
+        assertThat(decodeLuminance(source))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Aztec))
+    }
+
+    @Test
     fun formatOutsideRosterIsNotDecoded() {
-        // PDF417 is intentionally absent from the v1 roster. With POSSIBLE_FORMATS pinned to
-        // the allowlist, the reader never tries a PDF417 decoder, so a genuine PDF417 symbol
-        // reads as no locatable barcode — proving the allowlist, not blind decode-everything.
-        val source = encode("BOARDING-PASS-PAYLOAD", BarcodeFormat.PDF_417, 600, 300)
+        // DataMatrix is deliberately out of the roster (wpass-pl7 scope decision). With
+        // POSSIBLE_FORMATS pinned to the allowlist, the reader never tries a DataMatrix
+        // decoder, so a genuine DataMatrix symbol reads as no locatable barcode — proving the
+        // allowlist, not blind decode-everything.
+        val source = encode("NOT-IN-ROSTER", BarcodeFormat.DATA_MATRIX, 300, 300)
 
         assertThat(decodeLuminance(source)).isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
     }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ScannableFormatWire.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ScannableFormatWire.kt
@@ -22,6 +22,8 @@ internal object ScannableFormatWire {
     const val UPC_A: Int = 2
     const val CODE_39: Int = 3
     const val QR: Int = 4
+    const val PDF_417: Int = 5
+    const val AZTEC: Int = 6
 
     fun encode(format: ScannableFormat): Int =
         when (format) {
@@ -30,6 +32,8 @@ internal object ScannableFormatWire {
             ScannableFormat.UpcA -> UPC_A
             ScannableFormat.Code39 -> CODE_39
             ScannableFormat.Qr -> QR
+            ScannableFormat.Pdf417 -> PDF_417
+            ScannableFormat.Aztec -> AZTEC
         }
 
     fun decode(code: Int): ScannableFormat =
@@ -39,6 +43,8 @@ internal object ScannableFormatWire {
             UPC_A -> ScannableFormat.UpcA
             CODE_39 -> ScannableFormat.Code39
             QR -> ScannableFormat.Qr
+            PDF_417 -> ScannableFormat.Pdf417
+            AZTEC -> ScannableFormat.Aztec
             else -> error("Unknown ScannableFormat wire code: $code")
         }
 }

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ScannableFormatWireSurfaceTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/ScannableFormatWireSurfaceTest.kt
@@ -22,6 +22,8 @@ class ScannableFormatWireSurfaceTest {
                 ScannableFormat.UpcA to ScannableFormatWire.UPC_A,
                 ScannableFormat.Code39 to ScannableFormatWire.CODE_39,
                 ScannableFormat.Qr to ScannableFormatWire.QR,
+                ScannableFormat.Pdf417 to ScannableFormatWire.PDF_417,
+                ScannableFormat.Aztec to ScannableFormatWire.AZTEC,
             )
         for ((format, code) in expected) {
             assertThat(ScannableFormatWire.encode(format)).isEqualTo(code)
@@ -43,6 +45,8 @@ class ScannableFormatWireSurfaceTest {
         assertThat(ScannableFormatWire.UPC_A).isEqualTo(2)
         assertThat(ScannableFormatWire.CODE_39).isEqualTo(3)
         assertThat(ScannableFormatWire.QR).isEqualTo(4)
+        assertThat(ScannableFormatWire.PDF_417).isEqualTo(5)
+        assertThat(ScannableFormatWire.AZTEC).isEqualTo(6)
     }
 
     @Test

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -110,4 +110,17 @@ public sealed interface EncoderFailureReason {
      * switching format.
      */
     public object PayloadTooDense : EncoderFailureReason
+
+    /**
+     * This kernel build has no writer wired for [format], so the symbol cannot be rendered.
+     * The read and write halves of the roster are deliberately out of step for one step:
+     * wpass-pl7.1 taught the decoder Pdf417/Aztec so imported boarding passes stop failing
+     * silently, while the writer arms — whose error-correction and compaction defaults need
+     * their own scan-verified rollout — land in wpass-pl7.6.
+     *
+     * Distinct from [WriterRejected], which means a wired writer looked at this payload and
+     * said no. This arm is about the build, not the input, so retrying with a shorter payload
+     * cannot help. **Temporary:** wpass-pl7.6 removes it once every roster member encodes.
+     */
+    public data class FormatNotEncodable(public val format: ScannableFormat) : EncoderFailureReason
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -113,14 +113,9 @@ public sealed interface EncoderFailureReason {
 
     /**
      * This kernel build has no writer wired for [format], so the symbol cannot be rendered.
-     * The read and write halves of the roster are deliberately out of step for one step:
-     * wpass-pl7.1 taught the decoder Pdf417/Aztec so imported boarding passes stop failing
-     * silently, while the writer arms — whose error-correction and compaction defaults need
-     * their own scan-verified rollout — land in wpass-pl7.6.
-     *
      * Distinct from [WriterRejected], which means a wired writer looked at this payload and
-     * said no. This arm is about the build, not the input, so retrying with a shorter payload
-     * cannot help. **Temporary:** wpass-pl7.6 removes it once every roster member encodes.
+     * said no: this arm is about the build, not the input, so a shorter payload cannot help.
+     * Temporary — wpass-pl7.6 removes it once every roster member encodes.
      */
     public data class FormatNotEncodable(public val format: ScannableFormat) : EncoderFailureReason
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardInputValidator.kt
@@ -10,9 +10,11 @@ package `is`.walt.passes.core
  * tests are deterministic. The validator only judges field content; it does not allocate
  * identity or time.
  *
- * Fail-fast: returns the first violation found. Label trimmed first (a whitespace-only
- * label is empty for users), then payload (trim, empty, bidi/control, length, charset,
- * structural). Both trimmed values land on the resulting [ScannableCard].
+ * Fail-fast: returns the first violation found. Format capability first (it depends on the
+ * build, not on what the user typed, so reporting a charset error for a format that cannot
+ * render either way would misdirect), then label (a whitespace-only label is empty for
+ * users), then payload (trim, empty, bidi/control, length, charset, structural). Both
+ * trimmed values land on the resulting [ScannableCard].
  */
 public object ScannableCardInputValidator {
     /** Display-friendly cap. Long enough for any realistic card name, short enough to render. */
@@ -26,6 +28,14 @@ public object ScannableCardInputValidator {
         id: ScannableCardId,
         createdAt: PassInstant,
     ): ScannableCardCreateResult {
+        // The choke point that keeps a decode-only format from becoming a card nothing can
+        // render. Enforced here rather than left to each consumer's format picker: walt-android
+        // builds its picker from ScannableFormat.entries, so a roster addition would otherwise
+        // appear as a selectable chip with no one having decided it should.
+        if (input.format in ScannableFormatConstraints.decodeOnly) {
+            return ScannableCardCreateResult.UnsupportedFormat(input.format)
+        }
+
         val trimmedLabel = input.label.trim()
         validateLabel(trimmedLabel)?.let { return ScannableCardCreateResult.InvalidLabel(it) }
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -1,7 +1,7 @@
 package `is`.walt.passes.core
 
 /**
- * The barcode formats a [ScannableCard] may render. The v1 roster covers the long tail of
+ * The barcode formats a [ScannableCard] may render. The roster covers the long tail of
  * physical-world cards real users actually hold:
  *
  *  - [Code128] — most modern membership/loyalty cards (alphanumeric, variable length)
@@ -9,9 +9,20 @@ package `is`.walt.passes.core
  *  - [UpcA] — North American retail barcodes (12 numeric digits)
  *  - [Code39] — older institutional cards (alphanumeric, fixed charset)
  *  - [Qr] — modern QR-based loyalty / event / payment cards
+ *  - [Pdf417] — boarding passes, driver's licences, event tickets (stacked 2D)
+ *  - [Aztec] — boarding passes (IATA BCBP) and transit tickets (square 2D)
  *
- * Pdf417 and Aztec are intentionally absent from v1: they are largely vendor-issued
- * (boarding passes, transit) and arrive via PKPASS already.
+ * [Pdf417] and [Aztec] were absent from v1 on the assumption that vendor-issued codes arrive
+ * via PKPASS. wpass-pl7 disproved it: users import boarding passes as SCREENSHOTS, which have
+ * no PKPASS to arrive in, so the code was unreachable at any input scale.
+ *
+ * DataMatrix stays out deliberately — it widens the same surface (encoder, storage, consumer
+ * format pickers) for no reported user need.
+ *
+ * **Read/write asymmetry (transitional).** Every member here decodes today; [Pdf417] and
+ * [Aztec] do NOT yet encode — the writer arms, with their error-correction and compaction
+ * defaults, land in wpass-pl7.6. Until then the encoder reports
+ * [EncoderFailureReason.FormatNotEncodable] for those two.
  *
  * Distinct type from [BarcodeFormat] (the PKPASS-pass barcode enum). The two are
  * deliberately not unified — a verified PKPASS barcode and a user-typed card barcode are
@@ -25,4 +36,6 @@ public enum class ScannableFormat {
     UpcA,
     Code39,
     Qr,
+    Pdf417,
+    Aztec,
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -39,3 +39,18 @@ public enum class ScannableFormat {
     Pdf417,
     Aztec,
 }
+
+/**
+ * Whether a user can create a [ScannableCard] in this format — which is to say whether this
+ * build can render one. False only for the decode-only members ([Pdf417] / [Aztec] until
+ * wpass-pl7.6 wires their writers).
+ *
+ * **Consumers building a format picker must filter on this.** The picker cannot be derived from
+ * [ScannableFormat.entries] alone: [ScannableCardInputValidator] refuses a non-creatable format
+ * with [ScannableCardCreateResult.UnsupportedFormat], so an unfiltered picker offers a choice
+ * whose Save fails on every tap. Exposed rather than left implicit because nothing about adding
+ * a decode-only member breaks a consumer's build — the failure is silent by construction.
+ *
+ * Backed by the same set the validator and encoder read, so the three cannot disagree.
+ */
+public fun ScannableFormat.isCreatable(): Boolean = this !in ScannableFormatConstraints.decodeOnly

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -18,6 +18,8 @@ internal object ScannableFormatConstraints {
             ScannableFormat.Ean13 -> EAN13_LENGTH
             ScannableFormat.UpcA -> UPCA_LENGTH
             ScannableFormat.Qr -> QR_MAX
+            ScannableFormat.Pdf417 -> PDF417_MAX
+            ScannableFormat.Aztec -> AZTEC_MAX
         }
 
     /** Non-null only for fixed-length numeric symbologies (EAN-13, UPC-A). */
@@ -44,7 +46,8 @@ internal object ScannableFormatConstraints {
             ScannableFormat.Code128 -> char.code in PRINTABLE_ASCII_MIN..PRINTABLE_ASCII_MAX
             ScannableFormat.Code39 -> char in CODE39_ALLOWED
             ScannableFormat.Ean13, ScannableFormat.UpcA -> char in '0'..'9'
-            ScannableFormat.Qr -> true
+            // Byte-capable 2D symbologies: any character the payload survives as UTF-8.
+            ScannableFormat.Qr, ScannableFormat.Pdf417, ScannableFormat.Aztec -> true
         }
 
     /**
@@ -59,7 +62,12 @@ internal object ScannableFormatConstraints {
         when (format) {
             ScannableFormat.Ean13 -> validateEan13(payload)
             ScannableFormat.UpcA -> validateUpcA(payload)
-            ScannableFormat.Code128, ScannableFormat.Code39, ScannableFormat.Qr -> null
+            ScannableFormat.Code128,
+            ScannableFormat.Code39,
+            ScannableFormat.Qr,
+            ScannableFormat.Pdf417,
+            ScannableFormat.Aztec,
+            -> null
         }
 
     // Length already enforced by the validator via [requiredLength]; structural check assumes
@@ -132,6 +140,19 @@ internal object ScannableFormatConstraints {
     private const val EAN13_LENGTH = 13
     private const val UPCA_LENGTH = 12
     private const val QR_MAX = 2000
+
+    /**
+     * Soft caps for the two 2D symbologies added in wpass-pl7.1, in characters (same unit as
+     * [QR_MAX]; the byte-exact ceiling is an encoder concern). Both sit well under the spec
+     * maxima at any plausible error-correction level — PDF417 holds ~1,100 bytes and Aztec
+     * ~1,900 at MINIMUM EC, and both shrink as EC rises. wpass-pl7.6 pins the EC defaults; if
+     * it picks anything below PDF417 level 5 or Aztec 23%, re-derive these against that pin.
+     *
+     * A boarding pass is the sizing case that matters and is nowhere near either: an IATA
+     * BCBP payload runs ~60 characters per leg.
+     */
+    private const val PDF417_MAX = 800
+    private const val AZTEC_MAX = 1500
     private const val PRINTABLE_ASCII_MIN = 0x20
     private const val PRINTABLE_ASCII_MAX = 0x7E
 

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -10,6 +10,14 @@ package `is`.walt.passes.core
  * live in [ScannableCardInputValidator] because they apply uniformly across all formats.
  */
 internal object ScannableFormatConstraints {
+    /**
+     * Roster members this build decodes but cannot render: wpass-pl7.1 added them to the decode
+     * allowlist, and the writer arms land in wpass-pl7.6. Read by BOTH the validator (refuses to
+     * mint a card) and the encoder (refuses to encode) so the two cannot drift into a state where
+     * a card is creatable but unrenderable. wpass-pl7.6 empties this set.
+     */
+    val decodeOnly: Set<ScannableFormat> = setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)
+
     /** Soft cap on payload length per symbology. Numeric symbologies use their exact length. */
     fun maxPayloadLength(format: ScannableFormat): Int =
         when (format) {

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -90,7 +90,7 @@ internal object ZxingBarcodeEncoder {
         format: ScannableFormat,
     ): EncoderFailureReason? =
         when {
-            format == ScannableFormat.Pdf417 || format == ScannableFormat.Aztec ->
+            format in ScannableFormatConstraints.decodeOnly ->
                 EncoderFailureReason.FormatNotEncodable(format)
             format == ScannableFormat.Qr &&
                 payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -19,10 +19,16 @@ import com.google.zxing.BarcodeFormat as ZxingFormat
 /**
  * ZXing-backed implementation of the kernel's barcode encoder. Per-format writers
  * (`Code128Writer`, `EAN13Writer`, `UPCAWriter`, `Code39Writer`, `QRCodeWriter`) are used
- * instead of `MultiFormatWriter` so the v1 roster of [ScannableFormat] is enforced at the
+ * instead of `MultiFormatWriter` so the roster of [ScannableFormat] is enforced at the
  * dispatch site: adding a format here is the only path that lets a new symbology reach the
  * encoder. The intermediate `MultiFormatWriter` would silently accept anything ZXing
  * supports, including formats the validator has not been taught to gate.
+ *
+ * **Pdf417 and Aztec decode but do not yet encode.** They joined the decode roster in
+ * wpass-pl7.1 and are refused here as [EncoderFailureReason.FormatNotEncodable] until
+ * wpass-pl7.6 wires `PDF417Writer` / `AztecWriter` with scan-verified EC and compaction
+ * defaults. That gap is why the dispatch is per-format: `MultiFormatWriter` would have
+ * silently emitted an unverified symbol for both the moment the enum grew.
  *
  * Hidden behind [BarcodeEncoder]; this object is package-internal so consumers cannot
  * reach for ZXing types directly.
@@ -45,21 +51,7 @@ internal object ZxingBarcodeEncoder {
         payload: String,
         format: ScannableFormat,
     ): EncodeResult {
-        // Proactive PayloadTooDense check for QR. Gated by the alphanumeric-mode membership
-        // test: a payload that fits QR's numeric or alphanumeric mode has a much larger
-        // capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs
-        // 2,331 bytes), and ZXing's QRCodeWriter auto-selects the densest fitting mode.
-        // Pre-rejecting such payloads against the byte-mode ceiling would over-reject;
-        // instead, for anything outside the alphanumeric set the encoding must use byte
-        // mode and the byte-count check applies. UTF-8 because byte-mode capacity is in
-        // bytes (a payload of "é" × 1500 is 3000 bytes). The "Data too big" message match
-        // in translateFailure stays as belt-and-suspenders for dense alphanumeric/numeric
-        // payloads that still overflow at v40.
-        if (format == ScannableFormat.Qr && payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&
-            payload.toByteArray(Charsets.UTF_8).size > ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M_BYTE_MODE
-        ) {
-            return EncodeResult.Failure(EncoderFailureReason.PayloadTooDense)
-        }
+        refuseBeforeWriter(payload, format)?.let { return EncodeResult.Failure(it) }
         // runCatching absorbs anything ZXing throws — including the plain
         // NullPointerException / ArrayIndexOutOfBoundsException its hand-rolled writers do
         // raise on some edge inputs — and funnels it into EncodeResult.Failure to honor the
@@ -79,6 +71,35 @@ internal object ZxingBarcodeEncoder {
             )
     }
 
+    /**
+     * The two refusals that are decided without running a writer, or null to proceed.
+     *
+     * Pdf417/Aztec are decode-only in this build (see the class KDoc). The QR check is a
+     * proactive [EncoderFailureReason.PayloadTooDense], gated by the alphanumeric-mode
+     * membership test: a payload that fits QR's numeric or alphanumeric mode has a much larger
+     * capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs 2,331
+     * bytes), and ZXing's QRCodeWriter auto-selects the densest fitting mode, so pre-rejecting
+     * such payloads against the byte-mode ceiling would over-reject. Anything outside the
+     * alphanumeric set must use byte mode, where the byte-count check applies — UTF-8 because
+     * byte-mode capacity is in bytes (a payload of "é" × 1500 is 3000 bytes). The "Data too
+     * big" message match in [translateFailure] stays as belt-and-suspenders for dense
+     * alphanumeric/numeric payloads that still overflow at v40.
+     */
+    private fun refuseBeforeWriter(
+        payload: String,
+        format: ScannableFormat,
+    ): EncoderFailureReason? =
+        when {
+            format == ScannableFormat.Pdf417 || format == ScannableFormat.Aztec ->
+                EncoderFailureReason.FormatNotEncodable(format)
+            format == ScannableFormat.Qr &&
+                payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&
+                payload.toByteArray(Charsets.UTF_8).size >
+                ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M_BYTE_MODE ->
+                EncoderFailureReason.PayloadTooDense
+            else -> null
+        }
+
     private fun writeMatrix(
         payload: String,
         format: ScannableFormat,
@@ -93,6 +114,9 @@ internal object ZxingBarcodeEncoder {
                 ScannableFormat.Ean13 -> EAN13Writer().encode(payload, ZxingFormat.EAN_13, 0, 0)
                 ScannableFormat.UpcA -> UPCAWriter().encode(payload, ZxingFormat.UPC_A, 0, 0)
                 ScannableFormat.Qr -> QRCodeWriter().encode(payload, ZxingFormat.QR_CODE, 0, 0, qrHints)
+                // Unreachable: encode() refuses these before dispatching. No payload in the
+                // message — the format name alone is enough to diagnose a lost guard.
+                ScannableFormat.Pdf417, ScannableFormat.Aztec -> error("No writer wired for $format")
             }
         return bitMatrix.toBarcodeMatrix()
     }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -103,11 +103,25 @@ class BarcodeEncoderTest {
         // Locks no-throw AND per-format dispatch correctness in one test. Asserts on
         // WriterRejected.format specifically; PayloadTooDense is not a plausible arm for an
         // empty input (zero bytes can never exceed any ceiling).
-        for (format in ScannableFormat.entries) {
+        for (format in ScannableFormat.entries - notEncodable) {
             val result = BarcodeEncoder.encode("", format)
             val reason = (result as EncodeResult.Failure).reason
             assertThat(reason).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
             assertThat((reason as EncoderFailureReason.WriterRejected).format).isEqualTo(format)
+        }
+    }
+
+    @Test
+    fun decodeOnlyFormatsReportFormatNotEncodable() {
+        // Pdf417/Aztec decode but have no writer until wpass-pl7.6. The refusal must be the
+        // dedicated build-capability arm, not WriterRejected — a consumer that reads
+        // WriterRejected would tell the user to shorten a payload that was never the problem.
+        // Asserted on a valid payload so this cannot pass for the empty-input reason above.
+        for (format in notEncodable) {
+            val result = BarcodeEncoder.encode("WALT-CHECK-1", format)
+
+            assertThat((result as EncodeResult.Failure).reason)
+                .isEqualTo(EncoderFailureReason.FormatNotEncodable(format))
         }
     }
 
@@ -166,6 +180,9 @@ class BarcodeEncoderTest {
         val different = (BarcodeEncoder.encode("XYZ", ScannableFormat.Code128) as EncodeResult.Success).matrix
         assertThat(a).isNotEqualTo(different)
     }
+
+    /** Roster members that decode but do not yet encode; wpass-pl7.6 empties this set. */
+    private val notEncodable = setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)
 
     private fun anyModuleSet(matrix: BarcodeMatrix): Boolean {
         for (y in 0 until matrix.height) {

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -68,6 +68,18 @@ class ScannableCardInputValidatorTest {
     }
 
     @Test
+    fun isCreatableAgreesWithWhatTheValidatorAccepts() {
+        // The predicate consumers filter their format picker on must not drift from the gate it
+        // is meant to predict. Payload validity is irrelevant here: a creatable format with a
+        // bad payload reports InvalidPayload, never UnsupportedFormat.
+        for (format in ScannableFormat.entries) {
+            val refused = validate("WALT-CHECK-1", format) is ScannableCardCreateResult.UnsupportedFormat
+
+            assertThat(format.isCreatable()).isEqualTo(!refused)
+        }
+    }
+
+    @Test
     fun decodeOnlyRefusalOutranksPayloadAndLabelProblems() {
         // The format is unusable regardless of what was typed, so reporting a charset or label
         // error would send the user to fix the wrong field.

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -52,20 +52,29 @@ class ScannableCardInputValidatorTest {
         assertSuccessWithPayload(result, "https://example.org/é/👍")
     }
 
+    // ---- decode-only formats ----
+
     @Test
-    fun pdf417AndAztecHappyPathAcceptsUtf8() {
-        // Both are byte-capable, so they share Qr's "any character" charset rule.
+    fun decodeOnlyFormatsAreRefusedAtTheCreateBoundary() {
+        // Pdf417/Aztec decode but have no writer until wpass-pl7.6, so a card in either would
+        // render as the failure placeholder forever. The validator is the choke point that
+        // stops one being minted — consumers build format pickers from ScannableFormat.entries,
+        // so nothing downstream would otherwise refuse it.
         for (format in setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
-            assertSuccessWithPayload(validate("bag-drop/é/👍", format), "bag-drop/é/👍")
+            val result = validate("WALT-CHECK-1", format)
+
+            assertThat(result).isEqualTo(ScannableCardCreateResult.UnsupportedFormat(format))
         }
     }
 
     @Test
-    fun aztecAcceptsABoardingPassLengthPayload() {
-        // The wpass-pl7 repro decodes to a ~126-character IATA BCBP string. Synthetic stand-in:
-        // real BCBP payloads carry passenger name and PNR and must not enter this repository.
-        val payload = "M1WALT/TEST".padEnd(126, 'X')
-        assertSuccessWithPayload(validate(payload, ScannableFormat.Aztec), payload)
+    fun decodeOnlyRefusalOutranksPayloadAndLabelProblems() {
+        // The format is unusable regardless of what was typed, so reporting a charset or label
+        // error would send the user to fix the wrong field.
+        val result = validateInput("x".repeat(1501), ScannableFormat.Aztec, label = "")
+
+        assertThat(result)
+            .isEqualTo(ScannableCardCreateResult.UnsupportedFormat(ScannableFormat.Aztec))
     }
 
     // ---- length caps ----
@@ -90,22 +99,6 @@ class ScannableCardInputValidatorTest {
     fun qrTooLong() {
         val rejection = expectPayloadRejection("x".repeat(2001), ScannableFormat.Qr)
         assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
-    }
-
-    @Test
-    fun pdf417TooLong() {
-        val rejection = expectPayloadRejection("x".repeat(801), ScannableFormat.Pdf417)
-        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
-        rejection as PayloadRejection.TooLong
-        assertThat(rejection.max).isEqualTo(800)
-    }
-
-    @Test
-    fun aztecTooLong() {
-        val rejection = expectPayloadRejection("x".repeat(1501), ScannableFormat.Aztec)
-        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
-        rejection as PayloadRejection.TooLong
-        assertThat(rejection.max).isEqualTo(1500)
     }
 
     // ---- charset violations ----

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -52,6 +52,22 @@ class ScannableCardInputValidatorTest {
         assertSuccessWithPayload(result, "https://example.org/é/👍")
     }
 
+    @Test
+    fun pdf417AndAztecHappyPathAcceptsUtf8() {
+        // Both are byte-capable, so they share Qr's "any character" charset rule.
+        for (format in setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+            assertSuccessWithPayload(validate("bag-drop/é/👍", format), "bag-drop/é/👍")
+        }
+    }
+
+    @Test
+    fun aztecAcceptsABoardingPassLengthPayload() {
+        // The wpass-pl7 repro decodes to a ~126-character IATA BCBP string. Synthetic stand-in:
+        // real BCBP payloads carry passenger name and PNR and must not enter this repository.
+        val payload = "M1WALT/TEST".padEnd(126, 'X')
+        assertSuccessWithPayload(validate(payload, ScannableFormat.Aztec), payload)
+    }
+
     // ---- length caps ----
 
     @Test
@@ -74,6 +90,22 @@ class ScannableCardInputValidatorTest {
     fun qrTooLong() {
         val rejection = expectPayloadRejection("x".repeat(2001), ScannableFormat.Qr)
         assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+    }
+
+    @Test
+    fun pdf417TooLong() {
+        val rejection = expectPayloadRejection("x".repeat(801), ScannableFormat.Pdf417)
+        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+        rejection as PayloadRejection.TooLong
+        assertThat(rejection.max).isEqualTo(800)
+    }
+
+    @Test
+    fun aztecTooLong() {
+        val rejection = expectPayloadRejection("x".repeat(1501), ScannableFormat.Aztec)
+        assertThat(rejection).isInstanceOf(PayloadRejection.TooLong::class.java)
+        rejection as PayloadRejection.TooLong
+        assertThat(rejection.max).isEqualTo(1500)
     }
 
     // ---- charset violations ----

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardSurfaceTest.kt
@@ -32,6 +32,8 @@ class ScannableCardSurfaceTest {
                 ScannableFormat.UpcA,
                 ScannableFormat.Code39,
                 ScannableFormat.Qr,
+                ScannableFormat.Pdf417,
+                ScannableFormat.Aztec,
             )
         assertThat(allFormats).hasSize(ScannableFormat.entries.size)
     }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
@@ -1,0 +1,71 @@
+package `is`.walt.passes.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavior lock for [ScannableFormatConstraints], the per-symbology charset / length / structural
+ * table. [ScannableCardInputValidatorTest] covers the same rules end-to-end for the formats a card
+ * can actually be minted in; this suite is where the rules for the DECODE-ONLY formats live,
+ * because the validator refuses those before any of them is consulted (wpass-pl7.1).
+ *
+ * When wpass-pl7.6 wires the writers and empties [ScannableFormatConstraints.decodeOnly], the
+ * Pdf417 / Aztec cases below should gain validator-level twins rather than move.
+ */
+class ScannableFormatConstraintsTest {
+    @Test
+    fun decodeOnlyHoldsExactlyTheFormatsWithNoWriter() {
+        assertThat(ScannableFormatConstraints.decodeOnly)
+            .containsExactly(ScannableFormat.Pdf417, ScannableFormat.Aztec)
+    }
+
+    @Test
+    fun everyFormatCarriesItsFrozenLengthCap() {
+        val expected =
+            mapOf(
+                ScannableFormat.Code128 to 80,
+                ScannableFormat.Code39 to 80,
+                ScannableFormat.Ean13 to 13,
+                ScannableFormat.UpcA to 12,
+                ScannableFormat.Qr to 2_000,
+                ScannableFormat.Pdf417 to 800,
+                ScannableFormat.Aztec to 1_500,
+            )
+        for ((format, cap) in expected) {
+            assertThat(ScannableFormatConstraints.maxPayloadLength(format)).isEqualTo(cap)
+        }
+        // Fails closed when a format is added without a cap being chosen for it.
+        assertThat(expected.keys).containsExactlyElementsIn(ScannableFormat.entries)
+    }
+
+    @Test
+    fun theTwoDimensionalFormatsAreVariableLengthAndUnstructured() {
+        for (format in setOf(ScannableFormat.Qr, ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+            assertThat(ScannableFormatConstraints.requiredLength(format)).isNull()
+            assertThat(ScannableFormatConstraints.validateStructural(format, "anything")).isNull()
+        }
+    }
+
+    @Test
+    fun byteCapableFormatsAdmitAnyVisibleCharacter() {
+        // Pdf417 and Aztec share Qr's "any character" rule; the bidi / control screen upstream in
+        // the validator is what excludes the hazardous ones, not this per-format charset.
+        for (format in setOf(ScannableFormat.Qr, ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+            for (char in "bag-drop/é/👍М1") {
+                assertThat(ScannableFormatConstraints.isAllowedChar(format, char)).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun boardingPassLengthPayloadFitsBothTwoDimensionalCaps() {
+        // The wpass-pl7 repro decodes to a ~126-character IATA BCBP string, and a multi-leg pass
+        // is a small multiple of that. Synthetic length only: real BCBP payloads carry passenger
+        // name and PNR and must not enter this repository.
+        val boardingPassLength = 126
+        assertThat(ScannableFormatConstraints.maxPayloadLength(ScannableFormat.Aztec))
+            .isGreaterThan(boardingPassLength * 4)
+        assertThat(ScannableFormatConstraints.maxPayloadLength(ScannableFormat.Pdf417))
+            .isGreaterThan(boardingPassLength * 4)
+    }
+}

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
@@ -50,8 +50,13 @@ class ScannableFormatConstraintsTest {
     fun byteCapableFormatsAdmitAnyVisibleCharacter() {
         // Pdf417 and Aztec share Qr's "any character" rule; the bidi / control screen upstream in
         // the validator is what excludes the hazardous ones, not this per-format charset.
+        // isAllowedChar takes a Char, i.e. a UTF-16 code unit, so an astral codepoint reaches it
+        // as its two surrogates — included deliberately, since that is how an emoji payload
+        // actually arrives.
+        val surrogates = "👍" // U+1F44D, one high + one low surrogate
+        check(surrogates.length == 2)
         for (format in setOf(ScannableFormat.Qr, ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
-            for (char in "bag-drop/é/👍М1") {
+            for (char in "bag-drop/é/М1" + surrogates) {
                 assertThat(ScannableFormatConstraints.isAllowedChar(format, char)).isTrue()
             }
         }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -149,6 +149,34 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
+    fun createWithADecodeOnlyFormatIsRejectedAndPersistsNothing() = runTest {
+        // Aztec decodes but has no writer until wpass-pl7.6. Persisting the row would leave a
+        // card that renders as the failure placeholder forever, so the kernel refuses it here
+        // rather than relying on every consumer's format picker to omit the chip.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "WALT-CHECK-1",
+                format = ScannableFormat.Aztec,
+                label = "Boarding pass",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        assertThat(rejected.reason)
+            .isEqualTo(ScannableCardRejectionReason.UnsupportedFormat(ScannableFormat.Aztec))
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:FormatUnsupported",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
     fun deleteRemovesRowFromObserveFlowAndEmitsDeletedTelemetryAfter() = runTest {
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -285,6 +285,46 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
+    fun updateToADecodeOnlyFormatIsRejectedAndStoredRowIsUnchanged() = runTest {
+        // Edit shares the create gate. Without this the format could be switched to one that
+        // cannot render, turning an existing working card into a blank one.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val seed = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Ean13,
+                label = "seed",
+            ),
+        )
+        check(seed is StorageResult.Success)
+
+        val result = repo.updateScannableCard(
+            seed.value,
+            ScannableCardCreateInput(
+                payload = "5012345678900",
+                format = ScannableFormat.Pdf417,
+                label = "seed",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        assertThat(rejected.reason)
+            .isEqualTo(ScannableCardRejectionReason.UnsupportedFormat(ScannableFormat.Pdf417))
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Ean13",
+            "card-rejected:FormatUnsupported",
+        ).inOrder()
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].format).isEqualTo(ScannableFormat.Ean13)
+    }
+
+    @Test
     fun updateWithControlCharInPayloadIsRejectedAndStoredRowIsUnchanged() = runTest {
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableFormatDiscriminatorTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableFormatDiscriminatorTest.kt
@@ -59,7 +59,8 @@ class ScannableFormatDiscriminatorTest {
         assertThat(lookUp("aztec")).isNull()
     }
 
-    /** Mirrors the store's private cursor lookup; kept in step by the tests above. */
+    // Mirrors SqlCipherScannableCardStore.kt:121. A switch to a throwing valueOf there would
+    // not fail here — the device tests are the only place that catches it.
     private fun lookUp(stored: String): ScannableFormat? =
         ScannableFormat.entries.firstOrNull { it.name == stored }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableFormatDiscriminatorTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableFormatDiscriminatorTest.kt
@@ -1,0 +1,65 @@
+package `is`.walt.passes.storage
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * Pins the on-disk `scannable_cards.format` discriminator contract (wpass-pl7.1).
+ *
+ * `SqlCipherScannableCardStore` writes `format.name` and reads it back with
+ * `ScannableFormat.entries.firstOrNull { it.name == stored }`, dropping the row via
+ * `onMigrationRowDropped(UnknownEnumValue)` when nothing matches. Two properties follow, and
+ * both are asserted here because the store itself needs SQLCipher's native library and so can
+ * only be exercised on a device:
+ *
+ *  - **Names are the discriminator, not ordinals.** Appending Pdf417/Aztec is therefore safe
+ *    for existing rows; RENAMING any member would orphan every row already written under the
+ *    old spelling, which the frozen table below turns into a failing test rather than silent
+ *    data loss.
+ *  - **An unknown discriminator fails safe.** The lookup is total — it returns null instead of
+ *    throwing — so an older build that meets a row written by a newer one drops that single
+ *    row and still lists the rest. This is what makes rolling back a Walt install non-fatal.
+ */
+class ScannableFormatDiscriminatorTest {
+    @Test
+    fun everyFormatPersistsUnderItsFrozenName() {
+        val frozen =
+            mapOf(
+                ScannableFormat.Code128 to "Code128",
+                ScannableFormat.Ean13 to "Ean13",
+                ScannableFormat.UpcA to "UpcA",
+                ScannableFormat.Code39 to "Code39",
+                ScannableFormat.Qr to "Qr",
+                ScannableFormat.Pdf417 to "Pdf417",
+                ScannableFormat.Aztec to "Aztec",
+            )
+        for ((format, discriminator) in frozen) {
+            assertThat(format.name).isEqualTo(discriminator)
+        }
+        // Fails closed when a format is added without being frozen here.
+        assertThat(frozen.keys).containsExactlyElementsIn(ScannableFormat.entries)
+    }
+
+    @Test
+    fun newFormatsResolveFromTheirStoredDiscriminator() {
+        // The round trip a card written by this build takes on the next read.
+        for (format in ScannableFormat.entries) {
+            assertThat(lookUp(format.name)).isEqualTo(format)
+        }
+    }
+
+    @Test
+    fun unknownDiscriminatorResolvesToNullRatherThanThrowing() {
+        // "DataMatrix" stands in for a discriminator a FUTURE build could write: out of scope
+        // for wpass-pl7 but the most plausible next roster member.
+        assertThat(lookUp("DataMatrix")).isNull()
+        assertThat(lookUp("")).isNull()
+        // Case-sensitive: a near-miss spelling must not silently resolve to a real format.
+        assertThat(lookUp("aztec")).isNull()
+    }
+
+    /** Mirrors the store's private cursor lookup; kept in step by the tests above. */
+    private fun lookUp(stored: String): ScannableFormat? =
+        ScannableFormat.entries.firstOrNull { it.name == stored }
+}

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
@@ -117,7 +117,8 @@ public fun CompactCodeView(
  * the tile, they are not a scannability promise at arbitrary sizes.
  */
 private fun ScannableFormat.compactMinSizeDp(): Pair<Int, Int> = when (this) {
-    ScannableFormat.Qr -> 48 to 48
+    ScannableFormat.Qr, ScannableFormat.Aztec -> 48 to 48
+    ScannableFormat.Pdf417 -> 96 to 40
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/CompactCodeView.kt
@@ -42,9 +42,10 @@ import `is`.walt.passes.ui.internal.toMonochromeBitmap
  *    quiet-zone modules at natural size; the fixed white inner padding on top
  *    guarantees a visible quiet zone even when the consumer's tile hugs the code.
  *  - **Sharp modules.** Nearest-neighbor upscale ([FilterQuality.None]), matching
- *    [ScannableCardView]. QR paints [ContentScale.Fit] (square matrix, no
- *    distortion); the 1D symbologies paint [ContentScale.FillBounds] because their
- *    matrices are one module tall and carry no data on the vertical axis.
+ *    [ScannableCardView]. The 2D symbologies paint [ContentScale.Fit] (data on both
+ *    axes, so a non-uniform stretch corrupts the symbol); the 1D symbologies paint
+ *    [ContentScale.FillBounds] because their matrices are one module tall and carry
+ *    no data on the vertical axis.
  *
  * Sizing is the caller's: pass the tile size via [modifier] (the small
  * `defaultMinSize` floor only guards against a collapsed, unscannable render).

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardTile.kt
@@ -191,7 +191,8 @@ private fun Modifier.dashedBorder(
 }
 
 private fun ScannableFormat.previewSize(): Pair<Dp, Dp> = when (this) {
-    ScannableFormat.Qr -> 96.dp to 96.dp
+    ScannableFormat.Qr, ScannableFormat.Aztec -> 96.dp to 96.dp
+    ScannableFormat.Pdf417 -> 132.dp to 56.dp
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -34,13 +34,14 @@ import `is`.walt.passes.ui.internal.toMonochromeBitmap
 /**
  * Renders [card]'s barcode through [BarcodeEncoder] as a 1-bit-per-module bitmap.
  * Minimum on-screen sizes mirror [BarcodeView] so the two barcode surfaces are
- * consistent at gate distance: 240 dp square for QR, 320 dp x 96 dp for the four
- * 1D symbologies. Painted with `FilterQuality.None` so the per-module upscale stays
- * nearest-neighbor and module edges remain sharp.
+ * consistent at gate distance: 240 dp square for the square 2D symbologies,
+ * 320 dp x 96 dp for the 1D ones. Painted with `FilterQuality.None` so the
+ * per-module upscale stays nearest-neighbor and module edges remain sharp.
  *
- * `contentScale` differs per format. QR uses [ContentScale.Fit] because its matrix
- * is square and [ContentScale.FillBounds] would distort it if the slot is non-square.
- * The four 1D symbologies use [ContentScale.FillBounds] because [BarcodeEncoder]
+ * `contentScale` differs per format. The 2D symbologies use [ContentScale.Fit]
+ * because they carry data on both axes, so [ContentScale.FillBounds] would corrupt
+ * the symbol in a slot of the wrong aspect.
+ * The 1D symbologies use [ContentScale.FillBounds] because [BarcodeEncoder]
  * emits their matrices at the symbology's natural minimum — exactly one module tall
  * (see `ZxingBarcodeEncoder.writeMatrix`) — and `Fit` against a ~200:1 painter
  * intrinsic ratio collapses the painted height to a few pixels in a normal-aspect
@@ -148,7 +149,8 @@ private fun BarcodeImage(
 /** Per-symbology min on-screen size in dp. Mirrors [BarcodeView] for gate consistency. */
 private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
     ScannableFormat.Qr, ScannableFormat.Aztec -> 240 to 240
-    // Stacked 2D: as wide as the 1D floor, but taller — its rows carry data.
+    // Taller floor than the 1D row so the stacked rows are not collapsed. Provisional:
+    // wpass-pl7.6 verifies it against the writer's actual aspect ratio.
     ScannableFormat.Pdf417 -> 320 to 120
     ScannableFormat.Code128,
     ScannableFormat.Ean13,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -147,7 +147,9 @@ private fun BarcodeImage(
 
 /** Per-symbology min on-screen size in dp. Mirrors [BarcodeView] for gate consistency. */
 private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
-    ScannableFormat.Qr -> 240 to 240
+    ScannableFormat.Qr, ScannableFormat.Aztec -> 240 to 240
+    // Stacked 2D: as wide as the 1D floor, but taller — its rows carry data.
+    ScannableFormat.Pdf417 -> 320 to 120
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/internal/BarcodeBitmap.kt
@@ -13,13 +13,18 @@ import `is`.walt.passes.core.ScannableFormat
 internal const val BARCODE_RENDER_FAILURE_DESCRIPTION: String = "Barcode failed to render"
 
 /**
- * Per-symbology paint scale shared by ScannableCardView and CompactCodeView. QR uses
- * [ContentScale.Fit] (square matrix; FillBounds would distort in a non-square slot);
- * the 1D symbologies use [ContentScale.FillBounds] because their matrices are one
- * module tall and carry no data on the vertical axis. See ScannableCardView's KDoc.
+ * Per-symbology paint scale shared by ScannableCardView and CompactCodeView. The 2D
+ * symbologies use [ContentScale.Fit] because they carry data on BOTH axes, so a
+ * non-uniform stretch corrupts the symbol — true for Pdf417's stacked rows just as much
+ * as for the square Qr and Aztec matrices, despite Pdf417's wide aspect ratio. The 1D
+ * symbologies use [ContentScale.FillBounds] because their matrices are one module tall
+ * and carry no data on the vertical axis. See ScannableCardView's KDoc.
  */
 internal fun ScannableFormat.barcodeContentScale(): ContentScale = when (this) {
-    ScannableFormat.Qr -> ContentScale.Fit
+    ScannableFormat.Qr,
+    ScannableFormat.Aztec,
+    ScannableFormat.Pdf417,
+    -> ContentScale.Fit
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/PublicApiSurfaceTest.kt
@@ -612,6 +612,8 @@ class PublicApiSurfaceTest {
                 ScannableFormat.Ean13 -> "ean13"
                 ScannableFormat.UpcA -> "upca"
                 ScannableFormat.Code39 -> "code39"
+                ScannableFormat.Pdf417 -> "pdf417"
+                ScannableFormat.Aztec -> "aztec"
             }
         }
         assertThat(sizes.toSet()).containsExactlyElementsIn(


### PR DESCRIPTION
Closes wpass-pl7.1. First child of the wpass-pl7 epic (boarding-pass screenshot support).

## The problem

A boarding-pass screenshot carries an **Aztec** (IATA BCBP) or **PDF417** symbol. Neither was in the decode allowlist, so the code was unreachable at any input scale and an imported boarding pass yielded nothing scannable.

## What this does

Adds both to `ROSTER_BY_ZXING_FORMAT` (which `DECODE_HINTS` derives `POSSIBLE_FORMATS` from) and threads the two new members through the shared model: payload constraints, the binder wire table (codes 5/6), and per-symbology render sizing in `passes-ui`, where both take `ContentScale.Fit` because they carry data on both axes.

**This alone does not fix the reported repro.** The wpass-pl7 probe shows the artifact decodes only at <=1600px, and `decodeLuminance` still makes a single native-resolution attempt. The retry ladder is wpass-pl7.2.

## Read and write are deliberately out of step for one step

The writer arms, with their error-correction and compaction defaults, land in wpass-pl7.6. Until then:

- The encoder refuses both with a new `EncoderFailureReason.FormatNotEncodable` arm, distinct from `WriterRejected` so a consumer does not tell the user to shorten a payload that was never the problem.
- **`ScannableCardInputValidator` refuses both at the create boundary** with the pre-existing `ScannableCardCreateResult.UnsupportedFormat`, which had no producer until now. Without this, a card could be created and persisted in a format that renders as the blank failure placeholder forever.
- **`ScannableFormat.isCreatable()`** is public so consumers can filter their format pickers. walt-android builds its chip row from `ScannableFormat.entries` and derives `canSubmit` from validator errors only, so an unfiltered picker offers a choice whose Save fails on every tap. Nothing about that fails to compile, which is why the predicate is exposed rather than left implicit.

`ScannableFormatConstraints.decodeOnly` is the single set the validator, the encoder, and `isCreatable()` all read, so the three cannot drift. wpass-pl7.6 empties it.

## Security

`docs/SCANNABLE_CARD_THREAT_MODEL.md` is updated rather than left behind - `ScannableFormatConstraints` carries a stated rule that a constraint change requires a doc change.

- **C3** enumerates both caps and marks them provisional until wpass-pl7.6 pins the EC level.
- **Threat 6** records that `AztecReader` and `PDF417Reader` joined the reachable decoder set, so advisories against either fall under the existing 30-day cadence.
- **Threat 14** gets the substantive entry: the allowlist width is what bounds both the hostile-image parser surface and misread ambiguity, so growing it by two symbologies re-weights that threat. Recorded as accepted, with the reasoning and the bound that survives it.
- **C4** gets a forward obligation - the URI-scheme confirmation gate is `QrPayloadKind`-scoped and must widen when these become creatable. On wpass-pl7.6's acceptance.

DataMatrix stays out (wpass-pl7 scope decision) and now serves as the negative case proving the allowlist still holds.

## Testing

Fixtures are encoded in-test from synthetic strings. No real BCBP payload enters the repository - they carry passenger name and PNR.

- Round-trips for both formats through `decodeLuminance` and through the live-camera `decodeYPlane` path.
- An Aztec case at the repro's ~126-character length.
- Create and update both refused end-to-end at the repository level, with telemetry asserted.
- `isCreatable()` pinned against actual validator behavior so the predicate cannot drift from the gate.
- Storage discriminator contract: names not ordinals, and an unknown discriminator resolves to null rather than throwing.

## Follow-ups filed

- **wpass-pl7.3** raised to P1 and sequenced before wpass-pl7.2: the roster growth raises per-frame cost on the live scanner, which is unverified until that bead runs.
- **wpass-pl7.6** acceptance now covers re-deriving the caps against its EC pin, emptying `decodeOnly`, removing `FormatNotEncodable`, and widening the C4 gate.
- **walt-android wlt-l1u5.4** (P1): filter the create-form picker on `isCreatable()`. walt-android composite-builds this kernel from source, so there is no version bump in front of that window.

## Breaking

`ScannableFormat` gains `Pdf417` and `Aztec`; `EncoderFailureReason` gains `FormatNotEncodable`. Exhaustive `when` expressions over either need new arms.
