### PR TITLE
fix(barcode): bounded multi-scale decode ladder (wpass-pl7.2)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -748,6 +748,22 @@ consumer's `confirmBarcode(payload, format)` gate is, and it is
 format-agnostic — it fires for every decoded symbology, including the two new
 ones, and preserves the decoded format verbatim rather than normalising it.
 
+**The scale ladder narrows the decode-cost surface it widens (`wpass-pl7.2`).**
+Roster growth alone did not make the reported screenshot decode: ZXing refuses
+it at the resolution the picker delivers and reads it immediately once the image
+is area-averaged down, so `decodeLuminance` now tries several scales of one
+image instead of one. More attempts per image is more CPU per hostile image, and
+the budget it spends is the same one `DecodeWatchdog` kills the sandbox over — so
+the ladder is bounded at both ends. Every rung caps the longest side, *including
+the largest*, which is the substantive change: decode cost stops scaling with a
+hostile image's area, and the 50 MP canvas the header caps still admit is now
+decoded at roughly 5 MP — measurably cheaper than the single uncapped attempt it
+replaces. A wall-clock budget (`DecodeLadder.budget`, a fraction of
+`decodeTimeoutMs` and checked against it at construction) drops the remaining
+rungs on a device slower than the one the caps were measured on, so the failure
+mode under load is "no barcode found" rather than a killed process. The live
+path keeps its single attempt per frame: its retry is the next frame.
+
 The image-codec RCE class is the kernel's to contain (isolated process); the
 manual-snap "system camera, never CameraX `ImageCapture`" rule and the
 confirmation surfaces are the consumer's, recorded in walt-android

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -11,6 +11,7 @@ import com.google.zxing.common.HybridBinarizer
 import `is`.walt.passes.core.BarcodeDecodeResult
 import `is`.walt.passes.core.DecodeFailureReason
 import `is`.walt.passes.core.ScannableFormat
+import kotlin.time.Duration
 import kotlin.time.TimeSource
 
 /**
@@ -43,7 +44,7 @@ import kotlin.time.TimeSource
  * symbol-like region was found but could not be decoded cleanly, reported honestly as
  * no usable barcode rather than a fabricated payload.
  *
- * One attempt at the source's own resolution is not enough, so [ladder] decides which SCALES of
+ * One attempt at the source's own resolution is not enough, so [ladder] decides which scales of
  * the image are tried and bounds the total spend — see [DecodeLadder] for why the caps make the
  * worst case cheaper rather than dearer. "No locatable symbol" is only reported once every rung
  * has said so.
@@ -54,11 +55,13 @@ public fun decodeLuminance(
 ): BarcodeDecodeResult {
     val started = TimeSource.Monotonic.markNow()
     var luminances: ByteArray? = null
+    var previous: RungCost? = null
 
-    for ((index, rung) in rungSizes(source.width, source.height, ladder).withIndex()) {
-        // The first rung always runs; later ones are dropped once the budget is spent so a slow
-        // device degrades to "no barcode" rather than to a sandbox its caller's watchdog kills.
-        if (index > 0 && started.elapsedNow() >= ladder.budget) break
+    for (rung in rungSizes(source.width, source.height, ladder)) {
+        // The first rung always runs; a later one starts only if it is predicted to finish inside
+        // the budget, so a slow device degrades to "no barcode" rather than to a sandbox its
+        // caller's watchdog kills mid-rung.
+        if (previous != null && !fits(rung, previous, started.elapsedNow(), ladder.budget)) break
 
         val view =
             if (rung.width == source.width && rung.height == source.height) {
@@ -71,10 +74,32 @@ public fun decodeLuminance(
         // Only "no locatable symbol" is worth another rung. A symbol found in a format outside
         // the roster is terminal: the allowlist is a policy statement, and re-reading the same
         // image at another scale until it gives a different answer would blunt it.
+        val rungStarted = TimeSource.Monotonic.markNow()
         val result = decodeOnce(view)
         if (result != BarcodeDecodeResult.NoBarcodeFound) return result
+        previous = RungCost(rung.area, rungStarted.elapsedNow())
     }
     return BarcodeDecodeResult.NoBarcodeFound
+}
+
+/** What the last rung cost, the basis for predicting what the next one will. */
+private class RungCost(val area: Long, val duration: Duration)
+
+/**
+ * Whether [rung] is predicted to complete within [budget], given [elapsed] already spent and what
+ * [previous] cost. ZXing's work is close to linear in pixel count, so the previous rung's measured
+ * cost scaled by the area ratio is a good enough estimate — and being approximate is fine in this
+ * direction: the budget exists to keep the ladder clear of a watchdog set well above it, not to
+ * schedule to the millisecond.
+ */
+private fun fits(
+    rung: RungSize,
+    previous: RungCost,
+    elapsed: Duration,
+    budget: Duration,
+): Boolean {
+    val estimate = previous.duration * (rung.area.toDouble() / previous.area)
+    return elapsed + estimate <= budget
 }
 
 /** One binarize-and-read pass over exactly the pixels [source] presents. */

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/BarcodeSymbolDecode.kt
@@ -11,6 +11,7 @@ import com.google.zxing.common.HybridBinarizer
 import `is`.walt.passes.core.BarcodeDecodeResult
 import `is`.walt.passes.core.DecodeFailureReason
 import `is`.walt.passes.core.ScannableFormat
+import kotlin.time.TimeSource
 
 /**
  * The pure-JVM ZXing symbol decode (wpass-zrt.4): reads a barcode off a [LuminanceSource] and
@@ -41,8 +42,43 @@ import `is`.walt.passes.core.ScannableFormat
  * [BarcodeDecodeResult.NoBarcodeFound]; a [ReaderException] (checksum/format) means a
  * symbol-like region was found but could not be decoded cleanly, reported honestly as
  * no usable barcode rather than a fabricated payload.
+ *
+ * One attempt at the source's own resolution is not enough, so [ladder] decides which SCALES of
+ * the image are tried and bounds the total spend — see [DecodeLadder] for why the caps make the
+ * worst case cheaper rather than dearer. "No locatable symbol" is only reported once every rung
+ * has said so.
  */
-public fun decodeLuminance(source: LuminanceSource): BarcodeDecodeResult {
+public fun decodeLuminance(
+    source: LuminanceSource,
+    ladder: DecodeLadder = DecodeLadder.STILL_IMAGE,
+): BarcodeDecodeResult {
+    val started = TimeSource.Monotonic.markNow()
+    var luminances: ByteArray? = null
+
+    for ((index, rung) in rungSizes(source.width, source.height, ladder).withIndex()) {
+        // The first rung always runs; later ones are dropped once the budget is spent so a slow
+        // device degrades to "no barcode" rather than to a sandbox its caller's watchdog kills.
+        if (index > 0 && started.elapsedNow() >= ladder.budget) break
+
+        val view =
+            if (rung.width == source.width && rung.height == source.height) {
+                source
+            } else {
+                val full = luminances ?: source.matrix.also { luminances = it }
+                scaledTo(full, source.width, source.height, rung.width, rung.height)
+            }
+
+        // Only "no locatable symbol" is worth another rung. A symbol found in a format outside
+        // the roster is terminal: the allowlist is a policy statement, and re-reading the same
+        // image at another scale until it gives a different answer would blunt it.
+        val result = decodeOnce(view)
+        if (result != BarcodeDecodeResult.NoBarcodeFound) return result
+    }
+    return BarcodeDecodeResult.NoBarcodeFound
+}
+
+/** One binarize-and-read pass over exactly the pixels [source] presents. */
+private fun decodeOnce(source: LuminanceSource): BarcodeDecodeResult {
     val binary = BinaryBitmap(HybridBinarizer(source))
     return try {
         val result = MultiFormatReader().decode(binary, DECODE_HINTS)

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/DecodeLadder.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/DecodeLadder.kt
@@ -1,42 +1,59 @@
 package `is`.walt.passes.barcode
 
+import com.google.zxing.GrayscaleLuminanceSource
 import com.google.zxing.LuminanceSource
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 /**
  * How many views of one image [decodeLuminance] is allowed to try, and how long it may spend
- * doing so (wpass-pl7.2). A single full-resolution attempt is NOT enough: the reported
+ * doing so (wpass-pl7.2). A single full-resolution attempt is not enough: the reported
  * boarding-pass screenshot carries a valid Aztec that ZXing refuses at the picker's native
  * resolution and reads immediately once the image is area-averaged down, and the effect is not
  * monotonic in scale — measurement, not intuition, picks [rungsPx].
  *
- * Each rung is a cap on the LONGEST side. A rung whose cap already exceeds the source is the
+ * Each rung is a cap on the longest side. A rung whose cap already exceeds the source is the
  * source itself (no resampling, no cost), so an image smaller than every cap runs exactly one
  * attempt — the pre-ladder behaviour, unchanged, which is what the live-camera path relies on.
  * Rungs producing a size an earlier rung already tried are skipped rather than decoded twice.
  *
  * ### Why the caps bound the work rather than widen it
  * The still-image caller kills its sandbox when a decode overruns (`DecodeWatchdog`, 5s), so a
- * ladder that simply appended attempts to today's native-resolution one would turn slow decodes
+ * ladder that simply appended attempts to the old native-resolution one would turn slow decodes
  * into killed processes. Two properties stop that:
  *  - **Cheap rungs first, and the largest rung is itself capped.** Cost stops scaling with the
- *    source's area: a 50 MP decompression bomb is decoded as ~5 MP, MEASURABLY CHEAPER than
- *    today's single uncapped attempt (see the wpass-pl7.2 figures in NOTES).
- *  - **[budget] bounds the tail.** Rungs after the first are skipped once it is spent, so a
- *    device slower than the one the caps were measured on degrades to "no barcode found"
- *    instead of to a killed sandbox. The first rung always runs — a ladder that could decline
- *    to try at all would be a worse contract than the one it replaces.
+ *    source's area. Measured over a no-barcode input, so every rung runs: a 50 MP canvas (the
+ *    largest the caller's header caps admit) went from 875ms for the old single uncapped attempt
+ *    to 262ms, and the ladder's worst case is now a 16 MP source at 495ms. Host-JVM figures — a
+ *    phone is slower, which is what [budget] is for.
+ *  - **[budget] bounds the tail.** Before starting a rung, its cost is predicted from the
+ *    previous rung's measured cost scaled by the area ratio (decode cost is close to linear in
+ *    pixels), and the rung is skipped if that prediction would not fit. Checking bare elapsed
+ *    time instead would let the dearest rung start at the last instant and overrun by its whole
+ *    duration — precisely the sandbox kill this design exists to avoid. So a device slower than
+ *    the one the caps were measured on degrades to "no barcode found" rather than to a killed
+ *    sandbox.
+ *
+ * The first rung always runs, whatever the budget: a ladder that could decline to look at all
+ * would be a worse contract than the one it replaces. Its cost is bounded by construction
+ * instead — the cheapest rung is first, and every cap is fixed.
  */
-public data class DecodeLadder(
-    val rungsPx: List<Int>,
-    val budget: Duration,
+public class DecodeLadder internal constructor(
+    public val rungsPx: List<Int>,
+    public val budget: Duration,
 ) {
     init {
         require(rungsPx.isNotEmpty()) { "A ladder needs at least one rung." }
         require(rungsPx.all { it > 0 }) { "Rung caps must be positive (was $rungsPx)." }
         require(budget.isPositive()) { "Budget must be positive (was $budget)." }
     }
+
+    /**
+     * The same rungs on a different clock. The only knob a caller outside this module gets: the
+     * budget is the caller's to set (it owns the watchdog the ladder has to finish inside), while
+     * [rungsPx] is measured policy that belongs with the decode it was measured against.
+     */
+    public fun withBudget(budget: Duration): DecodeLadder = DecodeLadder(rungsPx, budget)
 
     public companion object {
         /** A rung that never resamples: decode the source at whatever size it arrives. */
@@ -48,7 +65,7 @@ public data class DecodeLadder(
          *
          * 1600 and 1024 are the two that actually recover the reported repro class — a large
          * symbol carrying screenshot/compression noise, where area-averaging is what makes it
-         * readable. 4000 is the fallback for the opposite shape, a SMALL symbol inside a large
+         * readable. 4000 is the fallback for the opposite shape, a small symbol inside a large
          * photo, which the downscales destroy and which only a near-native view reads; it is
          * capped rather than native so a bomb-sized canvas cannot make this rung unbounded.
          * A 640 rung was measured and dropped: it recovered nothing 1024 had not already.
@@ -57,43 +74,27 @@ public data class DecodeLadder(
 
         /**
          * One attempt at the source's own resolution — the pre-ladder behaviour, kept for the
-         * live-camera path (`decodeYPlane`). A camera frame gets its retries from the NEXT
+         * live-camera path (`decodeYPlane`). A camera frame gets its retries from the next
          * frame, so paying for extra scales per frame would spend the analysis budget the live
          * path is already tight on (wpass-pl7.3) to re-examine an image about to be replaced.
+         *
+         * Its budget is inert and cannot bound that path: a one-rung ladder has no second rung
+         * to skip, and the first always runs. Bounding a live frame's decode is the caller's job.
          */
         public val SINGLE_ATTEMPT: DecodeLadder = DecodeLadder(listOf(NO_CAP), 3.seconds)
     }
 }
 
-/**
- * A read-only view of [luminances] box-filtered down to [width] x [height]. Area-averaging (not
- * point-sampling) is the whole point: it is what suppresses the per-pixel noise that defeats the
- * binarizer at native resolution, and point-sampling a barcode would instead alias thin bars away.
- */
-internal class ScaledLuminanceSource(
-    private val luminances: ByteArray,
-    width: Int,
-    height: Int,
-) : LuminanceSource(width, height) {
-    override fun getRow(
-        y: Int,
-        row: ByteArray?,
-    ): ByteArray {
-        val out = if (row != null && row.size >= width) row else ByteArray(width)
-        luminances.copyInto(out, destinationOffset = 0, startIndex = y * width, endIndex = (y + 1) * width)
-        return out
-    }
-
-    override fun getMatrix(): ByteArray = luminances
-}
-
 /** The pixel size of one rung. */
-internal data class RungSize(val width: Int, val height: Int)
+internal data class RungSize(val width: Int, val height: Int) {
+    /** Long, not Int: the largest rung a 50 MP source can produce still overflows nothing here. */
+    val area: Long get() = width.toLong() * height
+}
 
 /**
  * The distinct sizes [ladder] will actually decode a [sourceWidth] x [sourceHeight] image at, in
  * order. A cap at or above the source's longest side yields the source's own size, so caps that
- * collapse onto each other (and onto the source) are decoded ONCE, not once per rung. Pure and
+ * collapse onto each other (and onto the source) are decoded once, not once per rung. Pure and
  * separated from the decode so the ladder's shape — how many attempts an input costs — is
  * assertable without running ZXing over a fixture.
  */
@@ -121,6 +122,13 @@ internal fun rungSizes(
  * Box-filter the [srcWidth] x [srcHeight] grayscale in [luminances] down to [width] x [height].
  * Takes the already-materialised grayscale rather than a [LuminanceSource] so a multi-rung ladder
  * pays for that conversion once no matter how many rungs it runs.
+ *
+ * Area-averaging, not point-sampling: averaging is what suppresses the per-pixel noise that
+ * defeats the binarizer at native resolution, where point-sampling would instead alias thin bars
+ * away. The result is handed back as ZXing's own [GrayscaleLuminanceSource] rather than a local
+ * subclass, because [LuminanceSource]'s rotate and crop support defaults to false: a hand-rolled
+ * source silently costs `OneDReader` its 90-degree retry, and with it every rotated 1D symbol in
+ * any image large enough for all three rungs to resample (a 12 MP phone photo, say).
  */
 internal fun scaledTo(
     luminances: ByteArray,
@@ -139,7 +147,7 @@ internal fun scaledTo(
             scaled[y * width + x] = meanOf(luminances, srcWidth, left, top, right, bottom)
         }
     }
-    return ScaledLuminanceSource(scaled, width, height)
+    return GrayscaleLuminanceSource(width, height, scaled)
 }
 
 /** The mean luminance of the `[left, right) x [top, bottom)` block of a [srcWidth]-wide image. */

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/DecodeLadder.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/DecodeLadder.kt
@@ -1,0 +1,163 @@
+package `is`.walt.passes.barcode
+
+import com.google.zxing.LuminanceSource
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * How many views of one image [decodeLuminance] is allowed to try, and how long it may spend
+ * doing so (wpass-pl7.2). A single full-resolution attempt is NOT enough: the reported
+ * boarding-pass screenshot carries a valid Aztec that ZXing refuses at the picker's native
+ * resolution and reads immediately once the image is area-averaged down, and the effect is not
+ * monotonic in scale — measurement, not intuition, picks [rungsPx].
+ *
+ * Each rung is a cap on the LONGEST side. A rung whose cap already exceeds the source is the
+ * source itself (no resampling, no cost), so an image smaller than every cap runs exactly one
+ * attempt — the pre-ladder behaviour, unchanged, which is what the live-camera path relies on.
+ * Rungs producing a size an earlier rung already tried are skipped rather than decoded twice.
+ *
+ * ### Why the caps bound the work rather than widen it
+ * The still-image caller kills its sandbox when a decode overruns (`DecodeWatchdog`, 5s), so a
+ * ladder that simply appended attempts to today's native-resolution one would turn slow decodes
+ * into killed processes. Two properties stop that:
+ *  - **Cheap rungs first, and the largest rung is itself capped.** Cost stops scaling with the
+ *    source's area: a 50 MP decompression bomb is decoded as ~5 MP, MEASURABLY CHEAPER than
+ *    today's single uncapped attempt (see the wpass-pl7.2 figures in NOTES).
+ *  - **[budget] bounds the tail.** Rungs after the first are skipped once it is spent, so a
+ *    device slower than the one the caps were measured on degrades to "no barcode found"
+ *    instead of to a killed sandbox. The first rung always runs — a ladder that could decline
+ *    to try at all would be a worse contract than the one it replaces.
+ */
+public data class DecodeLadder(
+    val rungsPx: List<Int>,
+    val budget: Duration,
+) {
+    init {
+        require(rungsPx.isNotEmpty()) { "A ladder needs at least one rung." }
+        require(rungsPx.all { it > 0 }) { "Rung caps must be positive (was $rungsPx)." }
+        require(budget.isPositive()) { "Budget must be positive (was $budget)." }
+    }
+
+    public companion object {
+        /** A rung that never resamples: decode the source at whatever size it arrives. */
+        public const val NO_CAP: Int = Int.MAX_VALUE
+
+        /**
+         * The still-image ladder. Ordered cheapest-first so the common case pays the least and
+         * [budget] drops the dearest rung rather than a cheap one.
+         *
+         * 1600 and 1024 are the two that actually recover the reported repro class — a large
+         * symbol carrying screenshot/compression noise, where area-averaging is what makes it
+         * readable. 4000 is the fallback for the opposite shape, a SMALL symbol inside a large
+         * photo, which the downscales destroy and which only a near-native view reads; it is
+         * capped rather than native so a bomb-sized canvas cannot make this rung unbounded.
+         * A 640 rung was measured and dropped: it recovered nothing 1024 had not already.
+         */
+        public val STILL_IMAGE: DecodeLadder = DecodeLadder(listOf(1600, 1024, 4000), 3.seconds)
+
+        /**
+         * One attempt at the source's own resolution — the pre-ladder behaviour, kept for the
+         * live-camera path (`decodeYPlane`). A camera frame gets its retries from the NEXT
+         * frame, so paying for extra scales per frame would spend the analysis budget the live
+         * path is already tight on (wpass-pl7.3) to re-examine an image about to be replaced.
+         */
+        public val SINGLE_ATTEMPT: DecodeLadder = DecodeLadder(listOf(NO_CAP), 3.seconds)
+    }
+}
+
+/**
+ * A read-only view of [luminances] box-filtered down to [width] x [height]. Area-averaging (not
+ * point-sampling) is the whole point: it is what suppresses the per-pixel noise that defeats the
+ * binarizer at native resolution, and point-sampling a barcode would instead alias thin bars away.
+ */
+internal class ScaledLuminanceSource(
+    private val luminances: ByteArray,
+    width: Int,
+    height: Int,
+) : LuminanceSource(width, height) {
+    override fun getRow(
+        y: Int,
+        row: ByteArray?,
+    ): ByteArray {
+        val out = if (row != null && row.size >= width) row else ByteArray(width)
+        luminances.copyInto(out, destinationOffset = 0, startIndex = y * width, endIndex = (y + 1) * width)
+        return out
+    }
+
+    override fun getMatrix(): ByteArray = luminances
+}
+
+/** The pixel size of one rung. */
+internal data class RungSize(val width: Int, val height: Int)
+
+/**
+ * The distinct sizes [ladder] will actually decode a [sourceWidth] x [sourceHeight] image at, in
+ * order. A cap at or above the source's longest side yields the source's own size, so caps that
+ * collapse onto each other (and onto the source) are decoded ONCE, not once per rung. Pure and
+ * separated from the decode so the ladder's shape — how many attempts an input costs — is
+ * assertable without running ZXing over a fixture.
+ */
+internal fun rungSizes(
+    sourceWidth: Int,
+    sourceHeight: Int,
+    ladder: DecodeLadder,
+): List<RungSize> {
+    val longest = maxOf(sourceWidth, sourceHeight)
+    return ladder.rungsPx
+        .map { capPx ->
+            if (longest <= capPx) {
+                RungSize(sourceWidth, sourceHeight)
+            } else {
+                RungSize(
+                    width = (sourceWidth.toLong() * capPx / longest).toInt().coerceAtLeast(1),
+                    height = (sourceHeight.toLong() * capPx / longest).toInt().coerceAtLeast(1),
+                )
+            }
+        }
+        .distinct()
+}
+
+/**
+ * Box-filter the [srcWidth] x [srcHeight] grayscale in [luminances] down to [width] x [height].
+ * Takes the already-materialised grayscale rather than a [LuminanceSource] so a multi-rung ladder
+ * pays for that conversion once no matter how many rungs it runs.
+ */
+internal fun scaledTo(
+    luminances: ByteArray,
+    srcWidth: Int,
+    srcHeight: Int,
+    width: Int,
+    height: Int,
+): LuminanceSource {
+    val scaled = ByteArray(width * height)
+    for (y in 0 until height) {
+        val top = (y.toLong() * srcHeight / height).toInt()
+        val bottom = maxOf(top + 1, ((y + 1).toLong() * srcHeight / height).toInt())
+        for (x in 0 until width) {
+            val left = (x.toLong() * srcWidth / width).toInt()
+            val right = maxOf(left + 1, ((x + 1).toLong() * srcWidth / width).toInt())
+            scaled[y * width + x] = meanOf(luminances, srcWidth, left, top, right, bottom)
+        }
+    }
+    return ScaledLuminanceSource(scaled, width, height)
+}
+
+/** The mean luminance of the `[left, right) x [top, bottom)` block of a [srcWidth]-wide image. */
+@Suppress("LongParameterList") // A pixel block is six numbers; a holder type would only hide them.
+private fun meanOf(
+    luminances: ByteArray,
+    srcWidth: Int,
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int,
+): Byte {
+    var total = 0
+    for (y in top until bottom) {
+        val rowStart = y * srcWidth
+        for (x in left until right) {
+            total += luminances[rowStart + x].toInt() and 0xFF
+        }
+    }
+    return (total / ((right - left) * (bottom - top))).toByte()
+}

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
@@ -12,9 +12,14 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  * extracts the Y plane from its `ImageProxy` / `ImageAnalysis` frame and passes raw bytes plus the
  * plane geometry in; the module stays KMP-friendly (`ByteArray` + `Int` only). The contract is
  * identical to the static path: the [ScannableFormat][`is`.walt.passes.core.ScannableFormat] roster
- * is enforced (PDF417/Aztec rejected), the payload is returned FAITHFULLY, and the result is only
- * [BarcodeDecodeResult] — `{payload, format}`, `NoBarcodeFound`, or `DecodeFailed`. Nothing here
- * interprets, classifies, or validates the bytes.
+ * is enforced, the payload is returned FAITHFULLY, and the result is only [BarcodeDecodeResult] —
+ * `{payload, format}`, `NoBarcodeFound`, or `DecodeFailed`. Nothing here interprets, classifies, or
+ * validates the bytes.
+ *
+ * ### One attempt per frame
+ * The scale ladder the still-image path runs ([DecodeLadder.STILL_IMAGE]) is deliberately NOT used
+ * here: a live frame's retry is the next frame, so re-decoding this one at further scales would
+ * spend an analysis budget that is already tight (wpass-pl7.3) on an image about to be replaced.
  *
  * ### Stride handling (ZXing #1387)
  * An Android YUV_420_888 Y plane is rarely densely packed. Two HAL realities have to be stripped
@@ -82,7 +87,7 @@ public fun decodeYPlane(
             height,
             reverseHorizontal,
         )
-    return decodeLuminance(source)
+    return decodeLuminance(source, DecodeLadder.SINGLE_ATTEMPT)
 }
 
 /** Collapse a row/pixel-strided Y plane into a dense `width * height` luminance buffer. */

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/DecodeLadderTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/DecodeLadderTest.kt
@@ -1,0 +1,194 @@
+package `is`.walt.passes.barcode
+
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.LuminanceSource
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.aztec.encoder.Encoder
+import com.google.zxing.common.BitMatrix
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The wpass-pl7.2 ladder: [decodeLuminance] tries several SCALES of one image, because a single
+ * attempt at the resolution the picker delivers is measurably not enough.
+ *
+ * Fixtures are SYNTHESISED here rather than committed as images, for the same two reasons as
+ * [ZxingBarcodeSymbolDecoderTest]: the suite stays device-free, and no real boarding pass (whose
+ * payload carries passenger name and PNR) enters the repository. [screenshot] reproduces the
+ * reported repro's SHAPE — a large Aztec carrying per-pixel screenshot/compression noise on a
+ * 1080x2340 phone canvas — which fails at native resolution and reads once area-averaged down.
+ * [photo] is the opposite shape and the reason the ladder keeps a near-native rung: a small
+ * symbol inside a 4000x3000 camera photo, which the downscale rungs destroy.
+ *
+ * Both shapes were found by measurement (the sweep recorded on wpass-pl7.2), not by intuition:
+ * decodability is NOT monotonic in scale, so these fixtures pin the ladder that was measured to
+ * cover both, and any future edit to [DecodeLadder.STILL_IMAGE] has to keep clearing them.
+ */
+class DecodeLadderTest {
+    @Test
+    fun noisyScreenshotFailsAtNativeResolution() {
+        // Establishes that the fixture reproduces the reported defect rather than passing
+        // trivially: this IS the pre-ladder behaviour, and it is what the live path still runs.
+        assertThat(decodeLuminance(screenshot(), DecodeLadder.SINGLE_ATTEMPT))
+            .isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+    }
+
+    @Test
+    fun noisyScreenshotDecodesThroughTheLadder() {
+        assertThat(decodeLuminance(screenshot()))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(PAYLOAD, ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun smallSymbolInALargePhotoSurvivesTheLadder() {
+        // The downscale rungs alone would lose this one; the capped near-native rung is what
+        // keeps the ladder from trading one broken shape for another.
+        assertThat(decodeLuminance(photo()))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(PAYLOAD, ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun ladderStopsAtTheFirstRungThatDecodes() {
+        val counted = CountingSource(screenshot())
+
+        assertThat(decodeLuminance(counted)).isInstanceOf(BarcodeDecodeResult.DecodedBarcode::class.java)
+        // One read, for the downscale the ladder derives its rungs from. The last rung IS the
+        // source, so a ladder that kept climbing after decoding would hand the source itself to
+        // the binarizer and read it a second time.
+        assertThat(counted.matrixReads).isEqualTo(1)
+    }
+
+    @Test
+    fun sourceBelowEveryCapIsDecodedExactlyOnce() {
+        // The live-camera invariant: a 640x480 analysis frame collapses every rung onto the
+        // source, so the ladder cannot silently multiply per-frame cost (wpass-pl7.3).
+        assertThat(rungSizes(640, 480, DecodeLadder.STILL_IMAGE)).containsExactly(RungSize(640, 480))
+    }
+
+    @Test
+    fun rungsArePickedFromTheLongestSideAndKeepAspectRatio() {
+        assertThat(rungSizes(1080, 2340, DecodeLadder.STILL_IMAGE))
+            .containsExactly(RungSize(738, 1600), RungSize(472, 1024), RungSize(1080, 2340))
+            .inOrder()
+    }
+
+    @Test
+    fun theLargestRungIsCappedSoABombIsNotDecodedAtFullArea() {
+        // 50 MP is what the caller's header caps allow through. Capping the last rung is what
+        // makes the ladder CHEAPER than the single uncapped attempt it replaces.
+        val rungs = rungSizes(12_000, 4_166, DecodeLadder.STILL_IMAGE)
+
+        assertThat(rungs.maxOf { it.width.toLong() * it.height }).isLessThan(6_000_000L)
+    }
+
+    @Test
+    fun singleAttemptNeverResamples() {
+        assertThat(rungSizes(4000, 3000, DecodeLadder.SINGLE_ATTEMPT)).containsExactly(RungSize(4000, 3000))
+    }
+
+    @Test
+    fun anExhaustedBudgetStopsTheLadderAfterTheFirstRung() {
+        // A device slower than the one the caps were measured on must degrade to "no barcode",
+        // not to a decode its caller's watchdog kills. Only the first (downscaled) rung runs, and
+        // this fixture needs a later one, so the budget is observable in the result.
+        val impatient = DecodeLadder.STILL_IMAGE.copy(budget = 1.milliseconds)
+
+        assertThat(decodeLuminance(photo(), impatient)).isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
+    }
+
+    @Test
+    fun theFirstRungAlwaysRunsEvenOnASpentBudget() {
+        assertThat(decodeLuminance(screenshot(), DecodeLadder.STILL_IMAGE.copy(budget = 1.milliseconds)))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(PAYLOAD, ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun aLadderWithoutRungsIsRejected() {
+        assertThat(runCatching { DecodeLadder(emptyList(), 1.seconds) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun aNonPositiveBudgetIsRejected() {
+        assertThat(runCatching { DecodeLadder(listOf(1600), (-1).milliseconds) }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun downscalingAveragesRatherThanPointSamples() {
+        // Averaging is the property that recovers a noisy symbol; point-sampling would alias
+        // thin bars away instead. A 2x2 checkerboard must flatten to its mean, not to one corner.
+        val checker = byteArrayOf(0, 255.toByte(), 255.toByte(), 0)
+
+        val scaled = scaledTo(checker, srcWidth = 2, srcHeight = 2, width = 1, height = 1)
+
+        assertThat(scaled.matrix.single().toInt() and 0xFF).isEqualTo(127)
+    }
+
+    /** A 1080x2340 phone screenshot of a large, noisy Aztec — the reported repro's shape. */
+    private fun screenshot(): RGBLuminanceSource = compose(width = 1080, height = 2340, modulePx = 20, noise = 90)
+
+    /** A 4000x3000 camera photo of a small, clean Aztec — the shape downscaling would destroy. */
+    private fun photo(): RGBLuminanceSource = compose(width = 4000, height = 3000, modulePx = 4, noise = 0)
+
+    /**
+     * Centre an Aztec of [modulePx]-sized modules on a white canvas and perturb every pixel by up
+     * to +/-[noise], standing in for the sensor and compression noise a real screenshot carries.
+     * Deterministic: the seed is fixed so a fixture cannot pass or fail by luck.
+     */
+    private fun compose(
+        width: Int,
+        height: Int,
+        modulePx: Int,
+        noise: Int,
+    ): RGBLuminanceSource {
+        val symbol = SYMBOL
+        val symbolWidth = symbol.width * modulePx
+        val symbolHeight = symbol.height * modulePx
+        val left = (width - symbolWidth) / 2
+        val top = (height - symbolHeight) / 2
+        val random = kotlin.random.Random(11)
+        val pixels =
+            IntArray(width * height) {
+                gray(if (noise > 0) 255 - random.nextInt(noise + 1) else 255)
+            }
+        for (y in 0 until symbolHeight) {
+            for (x in 0 until symbolWidth) {
+                val level = if (symbol.get(x / modulePx, y / modulePx)) 0 else 255
+                val perturbed = if (noise > 0) (level + random.nextInt(-noise, noise + 1)).coerceIn(0, 255) else level
+                pixels[(top + y) * width + (left + x)] = gray(perturbed)
+            }
+        }
+        return RGBLuminanceSource(width, height, pixels)
+    }
+
+    private fun gray(level: Int): Int = 0xFF shl 24 or (level shl 16) or (level shl 8) or level
+
+    /** Counts how many times the reader materialised this source's grayscale — one read per rung. */
+    private class CountingSource(private val delegate: LuminanceSource) :
+        LuminanceSource(delegate.width, delegate.height) {
+        var matrixReads: Int = 0
+            private set
+
+        override fun getRow(
+            y: Int,
+            row: ByteArray?,
+        ): ByteArray = delegate.getRow(y, row)
+
+        override fun getMatrix(): ByteArray {
+            matrixReads++
+            return delegate.matrix
+        }
+    }
+
+    private companion object {
+        /** Same length as the repro's IATA BCBP string; synthetic, so no passenger name or PNR. */
+        val PAYLOAD: String = "M1WALT/TEST".padEnd(126, 'X')
+
+        /** Encoded once at one module per pixel; [compose] scales it up to the fixture's size. */
+        val SYMBOL: BitMatrix = Encoder.encode(PAYLOAD, 33, 0).matrix
+    }
+}

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/DecodeLadderTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/DecodeLadderTest.kt
@@ -1,7 +1,9 @@
 package `is`.walt.passes.barcode
 
 import com.google.common.truth.Truth.assertThat
+import com.google.zxing.BarcodeFormat
 import com.google.zxing.LuminanceSource
+import com.google.zxing.MultiFormatWriter
 import com.google.zxing.RGBLuminanceSource
 import com.google.zxing.aztec.encoder.Encoder
 import com.google.zxing.common.BitMatrix
@@ -12,26 +14,26 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * The wpass-pl7.2 ladder: [decodeLuminance] tries several SCALES of one image, because a single
+ * The wpass-pl7.2 ladder: [decodeLuminance] tries several scales of one image, because a single
  * attempt at the resolution the picker delivers is measurably not enough.
  *
- * Fixtures are SYNTHESISED here rather than committed as images, for the same two reasons as
+ * Fixtures are synthesised here rather than committed as images, for the same two reasons as
  * [ZxingBarcodeSymbolDecoderTest]: the suite stays device-free, and no real boarding pass (whose
  * payload carries passenger name and PNR) enters the repository. [screenshot] reproduces the
- * reported repro's SHAPE — a large Aztec carrying per-pixel screenshot/compression noise on a
+ * reported repro's shape — a large Aztec carrying per-pixel screenshot/compression noise on a
  * 1080x2340 phone canvas — which fails at native resolution and reads once area-averaged down.
  * [photo] is the opposite shape and the reason the ladder keeps a near-native rung: a small
  * symbol inside a 4000x3000 camera photo, which the downscale rungs destroy.
  *
  * Both shapes were found by measurement (the sweep recorded on wpass-pl7.2), not by intuition:
- * decodability is NOT monotonic in scale, so these fixtures pin the ladder that was measured to
+ * decodability is not monotonic in scale, so these fixtures pin the ladder that was measured to
  * cover both, and any future edit to [DecodeLadder.STILL_IMAGE] has to keep clearing them.
  */
 class DecodeLadderTest {
     @Test
     fun noisyScreenshotFailsAtNativeResolution() {
         // Establishes that the fixture reproduces the reported defect rather than passing
-        // trivially: this IS the pre-ladder behaviour, and it is what the live path still runs.
+        // trivially: this is the pre-ladder behaviour, and it is what the live path still runs.
         assertThat(decodeLuminance(screenshot(), DecodeLadder.SINGLE_ATTEMPT))
             .isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
     }
@@ -78,7 +80,7 @@ class DecodeLadderTest {
     @Test
     fun theLargestRungIsCappedSoABombIsNotDecodedAtFullArea() {
         // 50 MP is what the caller's header caps allow through. Capping the last rung is what
-        // makes the ladder CHEAPER than the single uncapped attempt it replaces.
+        // makes the ladder cheaper than the single uncapped attempt it replaces.
         val rungs = rungSizes(12_000, 4_166, DecodeLadder.STILL_IMAGE)
 
         assertThat(rungs.maxOf { it.width.toLong() * it.height }).isLessThan(6_000_000L)
@@ -94,14 +96,14 @@ class DecodeLadderTest {
         // A device slower than the one the caps were measured on must degrade to "no barcode",
         // not to a decode its caller's watchdog kills. Only the first (downscaled) rung runs, and
         // this fixture needs a later one, so the budget is observable in the result.
-        val impatient = DecodeLadder.STILL_IMAGE.copy(budget = 1.milliseconds)
+        val impatient = DecodeLadder.STILL_IMAGE.withBudget(1.milliseconds)
 
         assertThat(decodeLuminance(photo(), impatient)).isEqualTo(BarcodeDecodeResult.NoBarcodeFound)
     }
 
     @Test
     fun theFirstRungAlwaysRunsEvenOnASpentBudget() {
-        assertThat(decodeLuminance(screenshot(), DecodeLadder.STILL_IMAGE.copy(budget = 1.milliseconds)))
+        assertThat(decodeLuminance(screenshot(), DecodeLadder.STILL_IMAGE.withBudget(1.milliseconds)))
             .isEqualTo(BarcodeDecodeResult.DecodedBarcode(PAYLOAD, ScannableFormat.Aztec))
     }
 
@@ -115,6 +117,26 @@ class DecodeLadderTest {
     fun aNonPositiveBudgetIsRejected() {
         assertThat(runCatching { DecodeLadder(listOf(1600), (-1).milliseconds) }.exceptionOrNull())
             .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun rotatedOneDimensionalSymbolSurvivesEveryRungResampling() {
+        // Every rung resamples once the source passes the largest cap, and a resampled rung that
+        // does not support rotation costs OneDReader its 90-degree retry — silently, since the
+        // upright case still passes. 12 MP phone photos (4032x3024, 4080x3072) are over that cap,
+        // so this is the dominant camera input for the 1D loyalty-card case.
+        val rotated = rotatedCode128(width = 4200, height = 3200)
+
+        assertThat(decodeLuminance(rotated))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(CODE_128_PAYLOAD, ScannableFormat.Code128))
+    }
+
+    @Test
+    fun scaledRungsCarryZxingsOwnRotateAndCropSupport() {
+        val scaled = scaledTo(ByteArray(16), srcWidth = 4, srcHeight = 4, width = 2, height = 2)
+
+        assertThat(scaled.isRotateSupported).isTrue()
+        assertThat(scaled.isCropSupported).isTrue()
     }
 
     @Test
@@ -133,6 +155,28 @@ class DecodeLadderTest {
 
     /** A 4000x3000 camera photo of a small, clean Aztec — the shape downscaling would destroy. */
     private fun photo(): RGBLuminanceSource = compose(width = 4000, height = 3000, modulePx = 4, noise = 0)
+
+    /** A Code 128 turned 90 degrees (bars running vertically) on a canvas past every rung's cap. */
+    private fun rotatedCode128(
+        width: Int,
+        height: Int,
+    ): RGBLuminanceSource {
+        val symbol = MultiFormatWriter().encode(CODE_128_PAYLOAD, BarcodeFormat.CODE_128, 600, 200)
+        val symbolWidth = symbol.height * MODULE_SCALE
+        val symbolHeight = symbol.width * MODULE_SCALE
+        val left = (width - symbolWidth) / 2
+        val top = (height - symbolHeight) / 2
+        val pixels = IntArray(width * height) { gray(255) }
+        for (y in 0 until symbolHeight) {
+            for (x in 0 until symbolWidth) {
+                // The quarter turn: canvas (x, y) reads the symbol at (y, x).
+                if (symbol.get(y / MODULE_SCALE, x / MODULE_SCALE)) {
+                    pixels[(top + y) * width + (left + x)] = gray(0)
+                }
+            }
+        }
+        return RGBLuminanceSource(width, height, pixels)
+    }
 
     /**
      * Centre an Aztec of [modulePx]-sized modules on a white canvas and perturb every pixel by up
@@ -190,5 +234,11 @@ class DecodeLadderTest {
 
         /** Encoded once at one module per pixel; [compose] scales it up to the fixture's size. */
         val SYMBOL: BitMatrix = Encoder.encode(PAYLOAD, 33, 0).matrix
+
+        /** A 1D payload: four of the seven roster formats are 1D, and none reached a scaled rung. */
+        const val CODE_128_PAYLOAD: String = "LOYALTY-ABC-123"
+
+        /** Pixels per module for the 1D fixture, enough to survive the downscale rungs. */
+        const val MODULE_SCALE: Int = 3
     }
 }

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -41,7 +41,7 @@ internal data class BarcodeDecodeConfig(
     }
 
     /** The scale ladder the symbol decode runs, bounded by this config's slice of the watchdog. */
-    fun ladder(): DecodeLadder = DecodeLadder.STILL_IMAGE.copy(budget = symbolDecodeBudgetMs.milliseconds)
+    val ladder: DecodeLadder = DecodeLadder.STILL_IMAGE.withBudget(symbolDecodeBudgetMs.milliseconds)
 
     companion object {
         /** Catches the large-file bomb shape; mirrors `PdfImportConfig` / storage's 25 MB. */
@@ -61,9 +61,14 @@ internal data class BarcodeDecodeConfig(
 
         /**
          * How much of [DEFAULT_DECODE_TIMEOUT_MS] the multi-scale symbol decode may spend
-         * (wpass-pl7.2), leaving the descriptor read and the codec decode the rest. The ladder
-         * drops its remaining rungs on expiry, so overrunning this costs a "no barcode found"
-         * — overrunning the watchdog would instead cost the whole sandbox.
+         * (wpass-pl7.2), leaving the descriptor read and the codec decode the rest.
+         *
+         * The ladder holds this by declining to start a rung it predicts would not finish inside
+         * the budget, so exceeding it costs a "no barcode found" where exceeding the watchdog
+         * would cost the whole sandbox. It is a self-imposed bound, not a hard one: the ladder's
+         * first rung is unconditional (bounded instead by being the cheapest and fixed-capped),
+         * and a rung's cost is predicted, not known. The gap between the two numbers is what
+         * absorbs both.
          */
         const val DEFAULT_SYMBOL_DECODE_BUDGET_MS: Long = 3_000L
 

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfig.kt
@@ -1,5 +1,8 @@
 package `is`.walt.passes.barcode.android
 
+import `is`.walt.passes.barcode.DecodeLadder
+import kotlin.time.Duration.Companion.milliseconds
+
 /**
  * Defensive caps for the bounded image decode that runs inside the `:barcodeDecoder`
  * sandbox (wpass-zrt.3). The image-codec step is the dominant RCE surface (CVE-2023-4863
@@ -11,7 +14,8 @@ package `is`.walt.passes.barcode.android
  * checked from the decoded *header* (via `ImageDecoder.OnHeaderDecodedListener`) before the
  * backing bitmap is allocated; [allowedMimeTypes] rejects containers outside the still-image
  * roster at the same header step; [decodeTimeoutMs] is the watchdog budget that bounds a
- * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]).
+ * slow-loris descriptor and terminates the sandbox on expiry ([DecodeWatchdog]);
+ * [symbolDecodeBudgetMs] is the slice of that budget the scale ladder may spend.
  *
  * Every field here is enforced INSIDE the sandbox. [decodeTimeoutMs] is additionally read by the
  * host, which compares elapsed time against it to attribute a dropped binder — see
@@ -26,8 +30,19 @@ internal data class BarcodeDecodeConfig(
     val maxDimensionPx: Int = DEFAULT_MAX_DIMENSION_PX,
     val maxAreaPx: Long = DEFAULT_MAX_AREA_PX,
     val decodeTimeoutMs: Long = DEFAULT_DECODE_TIMEOUT_MS,
+    val symbolDecodeBudgetMs: Long = DEFAULT_SYMBOL_DECODE_BUDGET_MS,
     val allowedMimeTypes: Set<String> = DEFAULT_ALLOWED_MIME_TYPES,
 ) {
+    init {
+        require(symbolDecodeBudgetMs < decodeTimeoutMs) {
+            "The symbol-decode budget ($symbolDecodeBudgetMs ms) must leave the read and codec " +
+                "decode room inside the watchdog timeout ($decodeTimeoutMs ms)."
+        }
+    }
+
+    /** The scale ladder the symbol decode runs, bounded by this config's slice of the watchdog. */
+    fun ladder(): DecodeLadder = DecodeLadder.STILL_IMAGE.copy(budget = symbolDecodeBudgetMs.milliseconds)
+
     companion object {
         /** Catches the large-file bomb shape; mirrors `PdfImportConfig` / storage's 25 MB. */
         const val DEFAULT_MAX_BYTES: Long = 25L * 1024 * 1024
@@ -43,6 +58,14 @@ internal data class BarcodeDecodeConfig(
 
         /** Decode wall-clock budget; on expiry [DecodeWatchdog] kills the sandbox (slow-loris guard). */
         const val DEFAULT_DECODE_TIMEOUT_MS: Long = 5_000L
+
+        /**
+         * How much of [DEFAULT_DECODE_TIMEOUT_MS] the multi-scale symbol decode may spend
+         * (wpass-pl7.2), leaving the descriptor read and the codec decode the rest. The ladder
+         * drops its remaining rungs on expiry, so overrunning this costs a "no barcode found"
+         * — overrunning the watchdog would instead cost the whole sandbox.
+         */
+        const val DEFAULT_SYMBOL_DECODE_BUDGET_MS: Long = 3_000L
 
         /** Still-image containers a card photo realistically arrives in; others are refused before decode. */
         val DEFAULT_ALLOWED_MIME_TYPES: Set<String> =

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -41,7 +41,7 @@ import kotlin.coroutines.cancellation.CancellationException
 public class BarcodeDecodeService : Service() {
     private val config: BarcodeDecodeConfig = BarcodeDecodeConfig()
     private val watchdog: DecodeWatchdog = DecodeWatchdog(config.decodeTimeoutMs)
-    private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder()
+    private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder(config.ladder())
 
     override fun onCreate() {
         super.onCreate()

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/BarcodeDecodeService.kt
@@ -41,7 +41,7 @@ import kotlin.coroutines.cancellation.CancellationException
 public class BarcodeDecodeService : Service() {
     private val config: BarcodeDecodeConfig = BarcodeDecodeConfig()
     private val watchdog: DecodeWatchdog = DecodeWatchdog(config.decodeTimeoutMs)
-    private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder(config.ladder())
+    private val symbolDecoder: BarcodeSymbolDecoder = ZxingBarcodeSymbolDecoder(config.ladder)
 
     override fun onCreate() {
         super.onCreate()

--- a/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
+++ b/passes-barcode/src/main/kotlin/is/walt/passes/barcode/android/ZxingBarcodeSymbolDecoder.kt
@@ -2,6 +2,7 @@ package `is`.walt.passes.barcode.android
 
 import android.graphics.Bitmap
 import com.google.zxing.RGBLuminanceSource
+import `is`.walt.passes.barcode.DecodeLadder
 import `is`.walt.passes.barcode.decodeLuminance
 import `is`.walt.passes.core.BarcodeDecodeResult
 
@@ -11,8 +12,14 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  * ([decodeLuminance]); this only turns the bounded bitmap [BoundedBitmapDecoder] produced into
  * the luminance source the core consumes, so the same decode backs both this path and the
  * in-process live-camera path (wpass-7xo.5). The [Bitmap] and its pixels never leave this process.
+ *
+ * [ladder] carries the scale ladder (wpass-pl7.2) with the service's slice of the watchdog budget,
+ * so the two wall-clock numbers that have to agree — how long the ladder may run and when
+ * [DecodeWatchdog] kills the sandbox — are set together in [BarcodeDecodeConfig].
  */
-internal class ZxingBarcodeSymbolDecoder : BarcodeSymbolDecoder {
+internal class ZxingBarcodeSymbolDecoder(
+    private val ladder: DecodeLadder = DecodeLadder.STILL_IMAGE,
+) : BarcodeSymbolDecoder {
     override fun decode(bitmap: Bitmap): BarcodeDecodeResult {
         val width = bitmap.width
         val height = bitmap.height
@@ -22,6 +29,6 @@ internal class ZxingBarcodeSymbolDecoder : BarcodeSymbolDecoder {
         // still contained as a failed decode by the service's doDecode catch.
         val pixels = IntArray(width * height)
         bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
-        return decodeLuminance(RGBLuminanceSource(width, height, pixels))
+        return decodeLuminance(RGBLuminanceSource(width, height, pixels), ladder)
     }
 }

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfigTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfigTest.kt
@@ -1,0 +1,38 @@
+package `is`.walt.passes.barcode.android
+
+import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.barcode.DecodeLadder
+import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Pins the relationship between the two wall-clock numbers this config carries (wpass-pl7.2).
+ * The scale ladder and [DecodeWatchdog] measure the same window from opposite ends: overrunning
+ * the ladder's budget costs a "no barcode found", overrunning the watchdog costs the sandbox. A
+ * config where the ladder may outlast the watchdog would convert the cheap failure into the
+ * expensive one, so it is rejected at construction rather than discovered on a slow device.
+ */
+class BarcodeDecodeConfigTest {
+    @Test
+    fun defaultBudgetLeavesTheWatchdogRoomForTheReadAndCodecDecode() {
+        val config = BarcodeDecodeConfig()
+
+        assertThat(config.symbolDecodeBudgetMs).isLessThan(config.decodeTimeoutMs)
+    }
+
+    @Test
+    fun ladderCarriesTheConfiguredBudget() {
+        val config = BarcodeDecodeConfig(decodeTimeoutMs = 4_000L, symbolDecodeBudgetMs = 2_000L)
+
+        assertThat(config.ladder().budget).isEqualTo(2_000L.milliseconds)
+        assertThat(config.ladder().rungsPx).isEqualTo(DecodeLadder.STILL_IMAGE.rungsPx)
+    }
+
+    @Test
+    fun aBudgetThatCouldOutlastTheWatchdogIsRejected() {
+        val rejected =
+            runCatching { BarcodeDecodeConfig(decodeTimeoutMs = 2_000L, symbolDecodeBudgetMs = 3_000L) }
+
+        assertThat(rejected.exceptionOrNull()).isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfigTest.kt
+++ b/passes-barcode/src/test/kotlin/is/walt/passes/barcode/android/BarcodeDecodeConfigTest.kt
@@ -7,10 +7,11 @@ import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Pins the relationship between the two wall-clock numbers this config carries (wpass-pl7.2).
- * The scale ladder and [DecodeWatchdog] measure the same window from opposite ends: overrunning
- * the ladder's budget costs a "no barcode found", overrunning the watchdog costs the sandbox. A
- * config where the ladder may outlast the watchdog would convert the cheap failure into the
- * expensive one, so it is rejected at construction rather than discovered on a slow device.
+ * The scale ladder and [DecodeWatchdog] measure the same window from opposite ends: exceeding the
+ * ladder's budget costs a "no barcode found", exceeding the watchdog costs the sandbox. The
+ * ordering below is necessary for the cheap failure to come first, not sufficient — the ladder's
+ * budget bounds when a rung may start, and its first rung is unconditional — so the headroom
+ * between the two numbers is what covers the rung already running when the budget runs out.
  */
 class BarcodeDecodeConfigTest {
     @Test
@@ -24,12 +25,12 @@ class BarcodeDecodeConfigTest {
     fun ladderCarriesTheConfiguredBudget() {
         val config = BarcodeDecodeConfig(decodeTimeoutMs = 4_000L, symbolDecodeBudgetMs = 2_000L)
 
-        assertThat(config.ladder().budget).isEqualTo(2_000L.milliseconds)
-        assertThat(config.ladder().rungsPx).isEqualTo(DecodeLadder.STILL_IMAGE.rungsPx)
+        assertThat(config.ladder.budget).isEqualTo(2_000L.milliseconds)
+        assertThat(config.ladder.rungsPx).isEqualTo(DecodeLadder.STILL_IMAGE.rungsPx)
     }
 
     @Test
-    fun aBudgetThatCouldOutlastTheWatchdogIsRejected() {
+    fun aBudgetLargerThanTheWatchdogTimeoutIsRejected() {
         val rejected =
             runCatching { BarcodeDecodeConfig(decodeTimeoutMs = 2_000L, symbolDecodeBudgetMs = 3_000L) }
 


### PR DESCRIPTION
Second half of the boarding-pass screenshot repro (epic `wpass-pl7`). `wpass-pl7.1` added AZTEC/PDF417 to the roster; that alone does not fix the report, because the symbol is refused at the resolution the picker delivers and reads immediately once the image is area-averaged down.

## What changed

`decodeLuminance` was a single `MultiFormatReader` pass over one full-resolution bitmap. It now runs a ladder of **scales**:

`DecodeLadder.STILL_IMAGE` = longest-side caps `[1600, 1024, 4000]`, cheapest first, stopping at the first rung that decodes.

Steps come from a measured sweep, not intuition — decodability is **not** monotonic in scale (the sweep reproduced that: 640 fails where both 800 and 512 decode). Two opposite shapes drive the choice:

- a **large noisy symbol** (the repro) needs the downscale rungs — averaging is what suppresses the per-pixel noise that defeats the binarizer at native resolution;
- a **small symbol inside a large photo** needs the near-native rung, which the downscales destroy.

Both are pinned as synthetic fixtures. A 640 rung was measured and dropped: it recovered nothing 1024 had not.

## Why this does not widen the DoS surface

The bead's blocking constraint was that stacking attempts onto today's native-resolution one could turn a slow decode into a killed sandbox (`DecodeWatchdog` terminates the isolated process at 5s). Capping the **largest** rung — not just adding small ones — is what avoids that: decode cost stops scaling with a hostile image's area.

| input | today | ladder |
|---|---|---|
| 1080x2340 (2.5MP) | 93ms | 145ms |
| 4000x3000 (12MP) | 291ms | 397ms |
| 4000x4000 (16MP) | 377ms | **495ms** (peak) |
| 12000x4166 (50MP) | 875ms | **262ms** (-70%) |

Host-JVM figures, no barcode present so every rung runs. The 50MP canvas the header caps still admit is now decoded at ~5MP.

Second guard, because those are not device figures: `BarcodeDecodeConfig.symbolDecodeBudgetMs` (3000ms) is passed into the ladder and **required at construction** to stay under `decodeTimeoutMs` (5000ms). On expiry the ladder drops its remaining rungs and reports `NoBarcodeFound`; the first rung always runs. Overrun degrades to "no code found", never to a killed process.

## Live path untouched

`decodeYPlane` passes `DecodeLadder.SINGLE_ATTEMPT` — a frame's retry is the next frame. Independently, every rung collapses onto the source for any image below the smallest cap, so a 640x480 analysis frame runs exactly one attempt even on the still-image ladder (pinned by a test). `wpass-pl7.3`'s latency question is unaffected by this change.

## Notes

- No real BCBP payload enters the repo — fixtures are synthesised in-test from a synthetic 126-char string, matching `ZxingBarcodeSymbolDecoderTest`'s existing discipline.
- Threat-model amendment included, since decode cost is a documented surface there.
- Also corrects a stale comment in `YPlaneFrameDecode` claiming PDF417/Aztec are rejected (false since `wpass-pl7.1`).
- Full measurement record is on `wpass-pl7.2`.