### PR TITLE
test(barcode): measure the live-frame roster cost and accept it (wpass-pl7.3)

### DIFF
--- a/passes-barcode-core/build.gradle.kts
+++ b/passes-barcode-core/build.gradle.kts
@@ -19,5 +19,7 @@ dependencies {
 tasks.test {
     // Opt-in gate for LiveFrameRosterLatencyHarness. Gradle does not forward -D to the test JVM,
     // so without this the harness is unreachable rather than merely skipped.
-    System.getProperty("walt.latencyHarness")?.let { systemProperty("walt.latencyHarness", it) }
+    providers.systemProperty("walt.latencyHarness").orNull?.let {
+        systemProperty("walt.latencyHarness", it)
+    }
 }

--- a/passes-barcode-core/build.gradle.kts
+++ b/passes-barcode-core/build.gradle.kts
@@ -15,3 +15,9 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }
+
+tasks.test {
+    // Opt-in gate for LiveFrameRosterLatencyHarness. Gradle does not forward -D to the test JVM,
+    // so without this the harness is unreachable rather than merely skipped.
+    System.getProperty("walt.latencyHarness")?.let { systemProperty("walt.latencyHarness", it) }
+}

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
@@ -21,6 +21,15 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  * here: a live frame's retry is the next frame, so re-decoding this one at further scales would
  * spend an analysis budget that is already tight (wpass-pl7.3) on an image about to be replaced.
  *
+ * ### Roster cost per frame (wpass-pl7.3)
+ * The live path carries the SAME roster as the still path, measured rather than assumed. Adding
+ * Aztec and PDF417 costs ~4.4ms per 640x480 frame on a host JVM: QR is unaffected, because ZXing
+ * reaches `QRCodeReader` before the added readers, while a 1D symbol pays all of it, because
+ * `TRY_HARDER` makes ZXing append the 1D reader LAST. That is a 3.7x relative rise on the 1D path
+ * and it was ACCEPTED — the absolute cost is small, and a narrower live roster would give up
+ * scanning a physical boarding pass to buy it back. `LiveFrameRosterLatencyHarness` re-measures
+ * this; run it before widening the roster again.
+ *
  * ### Stride handling (ZXing #1387)
  * An Android YUV_420_888 Y plane is rarely densely packed. Two HAL realities have to be stripped
  * before ZXing sees the pixels, and getting them wrong feeds garbage rows into the binarizer:

--- a/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
+++ b/passes-barcode-core/src/main/kotlin/is/walt/passes/barcode/YPlaneFrameDecode.kt
@@ -22,13 +22,15 @@ import `is`.walt.passes.core.BarcodeDecodeResult
  * spend an analysis budget that is already tight (wpass-pl7.3) on an image about to be replaced.
  *
  * ### Roster cost per frame (wpass-pl7.3)
- * The live path carries the SAME roster as the still path, measured rather than assumed. Adding
- * Aztec and PDF417 costs ~4.4ms per 640x480 frame on a host JVM: QR is unaffected, because ZXing
- * reaches `QRCodeReader` before the added readers, while a 1D symbol pays all of it, because
- * `TRY_HARDER` makes ZXing append the 1D reader LAST. That is a 3.7x relative rise on the 1D path
- * and it was ACCEPTED — the absolute cost is small, and a narrower live roster would give up
- * scanning a physical boarding pass to buy it back. `LiveFrameRosterLatencyHarness` re-measures
- * this; run it before widening the roster again.
+ * The live path carries the SAME roster as the still path: adding Aztec and PDF417 costs ~4.8ms
+ * per 640x480 frame, ACCEPTED rather than narrowing the live roster, which would have given up
+ * scanning a physical boarding pass to buy it back. The figure that bounds this path is not that
+ * delta but the no-symbol frame — every frame before lock-on — at ~16ms per 640x480 frame and
+ * ~30ms per 1280x720 frame on a host JVM, against a 33ms interval at 30fps. Analyzer RESOLUTION,
+ * not roster width, is the live budget's lever.
+ *
+ * `LiveFrameRosterLatencyHarness` holds the full breakdown and re-measures it; run it before
+ * widening the roster again.
  *
  * ### Stride handling (ZXing #1387)
  * An Android YUV_420_888 Y plane is rarely densely packed. Two HAL realities have to be stripped

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
@@ -1,0 +1,226 @@
+package `is`.walt.passes.barcode
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.EncodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.MultiFormatWriter
+import com.google.zxing.PlanarYUVLuminanceSource
+import com.google.zxing.ReaderException
+import com.google.zxing.Result
+import com.google.zxing.common.HybridBinarizer
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.util.Random
+
+/**
+ * The wpass-pl7.3 measurement harness: what one live-camera frame costs per symbology roster.
+ * It ASSERTS NOTHING and prints a table — timings are not a CI gate, so it is skipped unless
+ * asked for:
+ *
+ *     ./gradlew :passes-barcode-core:test --tests '*LiveFrameRosterLatencyHarness*' \
+ *         -Dwalt.latencyHarness=1 --rerun-tasks -i
+ *
+ * It replicates `decodeOnce` (HybridBinarizer + a fresh MultiFormatReader per frame) rather than
+ * calling it, so the pre-wpass-pl7.1 five-format roster and the current seven-format one can be
+ * A/B'd inside ONE warm process — a cross-commit comparison cannot separate a roster delta from
+ * JIT state. Fidelity is checked at the end against the real [decodeYPlane].
+ *
+ * Its wpass-pl7.3 result, which is why the live path still carries the full roster: the added
+ * Aztec + PDF417 readers cost ~4.4ms per frame at 640x480. QR is unaffected (ZXing reaches
+ * QRCodeReader before them), Code128 pays all of it (TRY_HARDER appends the 1D reader LAST), and
+ * the absolute cost was judged small enough to accept rather than narrow the live roster.
+ *
+ * Re-running this is the cheap check when a symbology is added — WATCH OUT for one ZXing trap it
+ * hides: `TRY_HARDER` is read with `containsKey`, NOT by value, so mapping it to `false` still
+ * enables it. A variant that disables the hint must OMIT the key.
+ */
+class LiveFrameRosterLatencyHarness {
+    @Test
+    fun measure() {
+        assumeTrue(System.getProperty(HARNESS_PROPERTY) != null)
+        val rosters =
+            listOf(
+                Variant("baseline-5", BASELINE_FORMATS, tryHarder = true),
+                Variant("current-7", CURRENT_FORMATS, tryHarder = true),
+                // Mitigation A: TRY_HARDER off. ZXing appends the 1D reader LAST when it is set, so
+                // dropping it should move 1D back in front of the 2D sweep.
+                Variant("current-7-noTH", CURRENT_FORMATS, tryHarder = false),
+                // Mitigation B: alternate two half-rosters across frames. A live frame's retry is
+                // the next frame, so each frame pays for half the roster.
+                Variant("split-1d+qr", BASELINE_FORMATS, tryHarder = true),
+                Variant("split-2d", listOf(BarcodeFormat.AZTEC, BarcodeFormat.PDF_417), tryHarder = true),
+            )
+        val geometries = listOf(640 to 480, 1280 to 720)
+
+        println("scene            geom      roster          median_ms  p95_ms   hit")
+        for ((w, h) in geometries) {
+            for (scene in scenes(w, h)) {
+                for ((name, formats, tryHarder) in rosters) {
+                    // TRY_HARDER must be ABSENT to be off: ZXing tests containsKey, not the value.
+                    val hints =
+                        buildMap<DecodeHintType, Any> {
+                            put(DecodeHintType.POSSIBLE_FORMATS, formats)
+                            if (tryHarder) put(DecodeHintType.TRY_HARDER, true)
+                        }
+                    val samples = ArrayList<Long>(RUNS)
+                    var hit = false
+                    repeat(WARMUP + RUNS) { i ->
+                        val started = System.nanoTime()
+                        val result = decodeFrame(scene.plane, w, h, hints)
+                        val elapsed = System.nanoTime() - started
+                        if (i >= WARMUP) samples.add(elapsed)
+                        hit = result != null
+                    }
+                    samples.sort()
+                    println(
+                        "%-16s %-9s %-15s %8.2f %8.2f   %s".format(
+                            scene.name,
+                            "${w}x$h",
+                            name,
+                            samples[samples.size / 2] / 1_000_000.0,
+                            samples[samples.size * 95 / 100] / 1_000_000.0,
+                            if (hit) "yes" else "no",
+                        ),
+                    )
+                }
+            }
+        }
+
+        // Sanity check: the production entry point on the current roster should land on the
+        // current-7 numbers above, confirming the replication is faithful.
+        val (w, h) = 640 to 480
+        val production =
+            scenes(w, h).associate { scene ->
+                repeat(WARMUP) { decodeYPlane(scene.plane, w, h, rowStride = w) }
+                val samples =
+                    (0 until RUNS).map {
+                        val started = System.nanoTime()
+                        decodeYPlane(scene.plane, w, h, rowStride = w)
+                        System.nanoTime() - started
+                    }.sorted()
+                scene.name to samples[samples.size / 2] / 1_000_000.0
+            }
+        println("production decodeYPlane 640x480 medians (current roster): $production")
+    }
+
+    private fun decodeFrame(
+        plane: ByteArray,
+        width: Int,
+        height: Int,
+        hints: Map<DecodeHintType, Any>,
+    ): Result? {
+        val source = PlanarYUVLuminanceSource(plane, width, height, 0, 0, width, height, false)
+        val binary = BinaryBitmap(HybridBinarizer(source))
+        return try {
+            MultiFormatReader().decode(binary, hints)
+        } catch (_: ReaderException) {
+            null
+        }
+    }
+
+    private data class Variant(
+        val name: String,
+        val formats: List<BarcodeFormat>,
+        val tryHarder: Boolean,
+    )
+
+    private class Scene(val name: String, val plane: ByteArray)
+
+    /**
+     * Frames a live analyzer actually sees. `empty` is the dominant one — every frame before
+     * lock-on — and is textured rather than blank so the binarizer and locators do real work.
+     */
+    private fun scenes(
+        width: Int,
+        height: Int,
+    ): List<Scene> =
+        listOf(
+            Scene("empty-scene", noiseFrame(width, height)),
+            Scene("qr", frameWith(BarcodeFormat.QR_CODE, "WALT-LIVE-QR-PAYLOAD", width, height)),
+            // 1D symbols are wide and short: give the writer an explicit aspect, or it returns a
+            // one-pixel-tall matrix that no row-sampling reader can find.
+            Scene(
+                "code128",
+                frameWith(
+                    BarcodeFormat.CODE_128,
+                    "LOYALTY-ABC-123456",
+                    width,
+                    height,
+                    requestedSize = width * 70 / 100 to height * 35 / 100,
+                ),
+            ),
+            Scene("aztec", frameWith(BarcodeFormat.AZTEC, "M1TEST/PASSENGER  EABC123 CPHLHRSK", width, height)),
+        )
+
+    /** A textured, deterministic stand-in for a real scene: soft gradient plus per-pixel noise. */
+    private fun noiseFrame(
+        width: Int,
+        height: Int,
+    ): ByteArray {
+        val random = Random(SEED)
+        val plane = ByteArray(width * height)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val gradient = 60 + 140 * x / width
+                val noise = random.nextInt(48) - 24
+                plane[y * width + x] = (gradient + noise).coerceIn(0, 255).toByte()
+            }
+        }
+        return plane
+    }
+
+    /** The same textured scene with a symbol composited into the middle ~55% of the frame. */
+    private fun frameWith(
+        format: BarcodeFormat,
+        content: String,
+        width: Int,
+        height: Int,
+        requestedSize: Pair<Int, Int>? = null,
+    ): ByteArray {
+        val plane = noiseFrame(width, height)
+        val matrix =
+            MultiFormatWriter().encode(
+                content,
+                format,
+                requestedSize?.first ?: 0,
+                requestedSize?.second ?: 0,
+                mapOf(EncodeHintType.MARGIN to 1),
+            )
+        val scale =
+            if (requestedSize != null) {
+                1
+            } else {
+                maxOf(1, minOf(width, height) * 55 / 100 / maxOf(matrix.width, matrix.height))
+            }
+        val drawW = matrix.width * scale
+        val drawH = matrix.height * scale
+        val left = (width - drawW) / 2
+        val top = (height - drawH) / 2
+        for (y in 0 until drawH) {
+            for (x in 0 until drawW) {
+                val black = matrix.get(x / scale, y / scale)
+                plane[(top + y) * width + left + x] = if (black) 0x10.toByte() else 0xF0.toByte()
+            }
+        }
+        return plane
+    }
+
+    private companion object {
+        const val HARNESS_PROPERTY = "walt.latencyHarness"
+        const val WARMUP = 30
+        const val RUNS = 120
+        const val SEED = 20260813L
+
+        val BASELINE_FORMATS =
+            listOf(
+                BarcodeFormat.CODE_128,
+                BarcodeFormat.EAN_13,
+                BarcodeFormat.UPC_A,
+                BarcodeFormat.CODE_39,
+                BarcodeFormat.QR_CODE,
+            )
+        val CURRENT_FORMATS = BASELINE_FORMATS + listOf(BarcodeFormat.PDF_417, BarcodeFormat.AZTEC)
+    }
+}

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
@@ -10,6 +10,7 @@ import com.google.zxing.PlanarYUVLuminanceSource
 import com.google.zxing.ReaderException
 import com.google.zxing.Result
 import com.google.zxing.common.HybridBinarizer
+import `is`.walt.passes.core.BarcodeDecodeResult
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.util.Random
@@ -25,16 +26,24 @@ import java.util.Random
  * It replicates `decodeOnce` (HybridBinarizer + a fresh MultiFormatReader per frame) rather than
  * calling it, so the pre-wpass-pl7.1 five-format roster and the current seven-format one can be
  * A/B'd inside ONE warm process — a cross-commit comparison cannot separate a roster delta from
- * JIT state. Fidelity is checked at the end against the real [decodeYPlane].
+ * JIT state. The real [decodeYPlane] is measured alongside and printed as `production` rows, for
+ * comparison against `current-7`; that replication is this harness's one load-bearing assumption.
  *
- * Its wpass-pl7.3 result, which is why the live path still carries the full roster: the added
- * Aztec + PDF417 readers cost ~4.4ms per frame at 640x480. QR is unaffected (ZXing reaches
- * QRCodeReader before them), Code128 pays all of it (TRY_HARDER appends the 1D reader LAST), and
- * the absolute cost was judged small enough to accept rather than narrow the live roster.
+ * ### The wpass-pl7.3 result, and why the live path still carries the full roster
+ * Adding Aztec + PDF417 costs ~4.8ms per 640x480 frame. Where that lands is uneven, because ZXing
+ * runs its readers QR → Aztec → PDF417 → 1D (TRY_HARDER appends the 1D reader LAST):
+ *  - **QR pays nothing** (~1.4ms either way) — it exits before reaching the added readers.
+ *  - **1D pays all of it** — a loyalty card queues behind three failed 2D attempts, 1.3 → 4.4ms.
+ *  - **PDF417 is the dearest hit** (2.2ms, against Aztec's 1.5ms), being last in that order.
  *
- * Re-running this is the cheap check when a symbology is added — WATCH OUT for one ZXing trap it
- * hides: `TRY_HARDER` is read with `containsKey`, NOT by value, so mapping it to `false` still
- * enables it. A variant that disables the hint must OMIT the key.
+ * That delta was judged small enough in absolute terms to accept rather than narrow the live
+ * roster. But the delta is not what bounds this path — the NO-SYMBOL frame is, being every frame
+ * before lock-on, and it runs ~16ms at 640x480 and ~30ms at 1280x720 on a host JVM. Against a
+ * 33ms frame interval at 30fps, that is the number to look at before widening the roster again,
+ * and it says the analyzer RESOLUTION is the live budget's real lever.
+ *
+ * Host-JVM figures move with the machine; what survives re-measurement is the shape, not the
+ * millisecond. On-device confirmation is wpass-hzh.
  */
 class LiveFrameRosterLatencyHarness {
     @Test
@@ -49,6 +58,8 @@ class LiveFrameRosterLatencyHarness {
                 Variant("current-7-noTH", CURRENT_FORMATS, tryHarder = false),
                 // Mitigation B: alternate two half-rosters across frames. A live frame's retry is
                 // the next frame, so each frame pays for half the roster.
+                // Identical to baseline-5 by construction; run last, so the two rows double as a
+                // run-to-run control on how much variant order and JIT drift move a number.
                 Variant("split-1d+qr", BASELINE_FORMATS, tryHarder = true),
                 Variant("split-2d", listOf(BarcodeFormat.AZTEC, BarcodeFormat.PDF_417), tryHarder = true),
             )
@@ -58,51 +69,57 @@ class LiveFrameRosterLatencyHarness {
         for ((w, h) in geometries) {
             for (scene in scenes(w, h)) {
                 for ((name, formats, tryHarder) in rosters) {
-                    // TRY_HARDER must be ABSENT to be off: ZXing tests containsKey, not the value.
+                    // TRY_HARDER must be ABSENT to be off: ZXing tests containsKey, NOT the value,
+                    // so mapping it to `false` still enables it.
                     val hints =
                         buildMap<DecodeHintType, Any> {
                             put(DecodeHintType.POSSIBLE_FORMATS, formats)
                             if (tryHarder) put(DecodeHintType.TRY_HARDER, true)
                         }
-                    val samples = ArrayList<Long>(RUNS)
-                    var hit = false
-                    repeat(WARMUP + RUNS) { i ->
-                        val started = System.nanoTime()
-                        val result = decodeFrame(scene.plane, w, h, hints)
-                        val elapsed = System.nanoTime() - started
-                        if (i >= WARMUP) samples.add(elapsed)
-                        hit = result != null
-                    }
-                    samples.sort()
-                    println(
-                        "%-16s %-9s %-15s %8.2f %8.2f   %s".format(
-                            scene.name,
-                            "${w}x$h",
-                            name,
-                            samples[samples.size / 2] / 1_000_000.0,
-                            samples[samples.size * 95 / 100] / 1_000_000.0,
-                            if (hit) "yes" else "no",
-                        ),
-                    )
+                    val samples = timed { decodeFrame(scene.plane, w, h, hints) }
+                    val hit = decodeFrame(scene.plane, w, h, hints) != null
+                    report(scene.name, w, h, name, samples, hit)
                 }
+
+                // The real entry point on the current roster, printed as a row so confirming the
+                // replication is a glance down the column rather than a hand-match across formats.
+                val samples = timed { decodeYPlane(scene.plane, w, h, rowStride = w) }
+                val hit = decodeYPlane(scene.plane, w, h, rowStride = w) is BarcodeDecodeResult.DecodedBarcode
+                report(scene.name, w, h, "production", samples, hit)
             }
         }
+    }
 
-        // Sanity check: the production entry point on the current roster should land on the
-        // current-7 numbers above, confirming the replication is faithful.
-        val (w, h) = 640 to 480
-        val production =
-            scenes(w, h).associate { scene ->
-                repeat(WARMUP) { decodeYPlane(scene.plane, w, h, rowStride = w) }
-                val samples =
-                    (0 until RUNS).map {
-                        val started = System.nanoTime()
-                        decodeYPlane(scene.plane, w, h, rowStride = w)
-                        System.nanoTime() - started
-                    }.sorted()
-                scene.name to samples[samples.size / 2] / 1_000_000.0
-            }
-        println("production decodeYPlane 640x480 medians (current roster): $production")
+    /** Sorted per-call durations of [RUNS] timed invocations, after [WARMUP] untimed ones. */
+    private fun timed(decode: () -> Unit): List<Long> {
+        repeat(WARMUP) { decode() }
+        return (0 until RUNS)
+            .map {
+                val started = System.nanoTime()
+                decode()
+                System.nanoTime() - started
+            }.sorted()
+    }
+
+    @Suppress("LongParameterList") // A table row is its columns; a holder type would only hide them.
+    private fun report(
+        scene: String,
+        width: Int,
+        height: Int,
+        roster: String,
+        samples: List<Long>,
+        hit: Boolean,
+    ) {
+        println(
+            "%-16s %-9s %-15s %8.2f %8.2f   %s".format(
+                scene,
+                "${width}x$height",
+                roster,
+                samples[samples.size / 2] / 1_000_000.0,
+                samples[samples.size * 95 / 100] / 1_000_000.0,
+                if (hit) "yes" else "no",
+            ),
+        )
     }
 
     private fun decodeFrame(
@@ -151,7 +168,23 @@ class LiveFrameRosterLatencyHarness {
                     requestedSize = width * 70 / 100 to height * 35 / 100,
                 ),
             ),
-            Scene("aztec", frameWith(BarcodeFormat.AZTEC, "M1TEST/PASSENGER  EABC123 CPHLHRSK", width, height)),
+            Scene("aztec", frameWith(BarcodeFormat.AZTEC, BOARDING_PASS, width, height)),
+            // The dearest hit in the roster: PDF417 is LAST in ZXing's reader order, so it pays a
+            // failed QR and a failed Aztec first. Stacked like a 1D symbol, so it needs an aspect.
+            // READ THE 640x480 ROW ONLY. Against this per-pixel noise the PDF417 detector stops
+            // locating the symbol above 640x480 whatever its size (measured), so the 1280x720 row
+            // reports the cost of a MISS, not of a hit. Uninvestigated: it is a property of the
+            // synthetic texture, and 640x480 is the resolution the live path actually runs at.
+            Scene(
+                "pdf417",
+                frameWith(
+                    BarcodeFormat.PDF_417,
+                    BOARDING_PASS,
+                    width,
+                    height,
+                    requestedSize = width * 70 / 100 to height * 35 / 100,
+                ),
+            ),
         )
 
     /** A textured, deterministic stand-in for a real scene: soft gradient plus per-pixel noise. */
@@ -196,12 +229,25 @@ class LiveFrameRosterLatencyHarness {
             }
         val drawW = matrix.width * scale
         val drawH = matrix.height * scale
+        // A symbol wider than the frame would centre to a negative origin and index out of the
+        // plane; say so, rather than surfacing it as an ArrayIndexOutOfBoundsException.
+        require(drawW <= width && drawH <= height) {
+            "$format at ${drawW}x$drawH does not fit a ${width}x$height frame."
+        }
         val left = (width - drawW) / 2
         val top = (height - drawH) / 2
+
+        // A white quiet zone around the symbol, as the card or screen it sits on would provide;
+        // without one the noise runs straight into the modules.
+        val quietZone = minOf(width, height) / 12
+        for (y in (top - quietZone).coerceAtLeast(0) until (top + drawH + quietZone).coerceAtMost(height)) {
+            for (x in (left - quietZone).coerceAtLeast(0) until (left + drawW + quietZone).coerceAtMost(width)) {
+                plane[y * width + x] = WHITE
+            }
+        }
         for (y in 0 until drawH) {
             for (x in 0 until drawW) {
-                val black = matrix.get(x / scale, y / scale)
-                plane[(top + y) * width + left + x] = if (black) 0x10.toByte() else 0xF0.toByte()
+                plane[(top + y) * width + left + x] = if (matrix.get(x / scale, y / scale)) BLACK else WHITE
             }
         }
         return plane
@@ -209,9 +255,18 @@ class LiveFrameRosterLatencyHarness {
 
     private companion object {
         const val HARNESS_PROPERTY = "walt.latencyHarness"
+        const val BLACK = 0x10.toByte()
+        const val WHITE = 0xF0.toByte()
         const val WARMUP = 30
         const val RUNS = 120
         const val SEED = 20260813L
+
+        /**
+         * BCBP-SHAPED, INVENTED. A real boarding-pass payload carries a passenger name and PNR, so
+         * none is committed here (wpass-pl7 constraint 7); this only needs the right length and
+         * character mix to size the symbol realistically.
+         */
+        const val BOARDING_PASS = "M1TEST/PASSENGER  EABC123 CPHLHRSK 0123 456Y028A0001 100"
 
         val BASELINE_FORMATS =
             listOf(

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/LiveFrameRosterLatencyHarness.kt
@@ -34,7 +34,7 @@ import java.util.Random
  * runs its readers QR → Aztec → PDF417 → 1D (TRY_HARDER appends the 1D reader LAST):
  *  - **QR pays nothing** (~1.4ms either way) — it exits before reaching the added readers.
  *  - **1D pays all of it** — a loyalty card queues behind three failed 2D attempts, 1.3 → 4.4ms.
- *  - **PDF417 is the dearest hit** (2.2ms, against Aztec's 1.5ms), being last in that order.
+ *  - **PDF417 is the dearest 2D hit** (2.2ms, against Aztec's 1.5ms), being last of the 2D readers.
  *
  * That delta was judged small enough in absolute terms to accept rather than narrow the live
  * roster. But the delta is not what bounds this path — the NO-SYMBOL frame is, being every frame
@@ -76,29 +76,35 @@ class LiveFrameRosterLatencyHarness {
                             put(DecodeHintType.POSSIBLE_FORMATS, formats)
                             if (tryHarder) put(DecodeHintType.TRY_HARDER, true)
                         }
-                    val samples = timed { decodeFrame(scene.plane, w, h, hints) }
-                    val hit = decodeFrame(scene.plane, w, h, hints) != null
-                    report(scene.name, w, h, name, samples, hit)
+                    val (samples, last) = timed { decodeFrame(scene.plane, w, h, hints) }
+                    report(scene.name, w, h, name, samples, hit = last != null)
                 }
 
                 // The real entry point on the current roster, printed as a row so confirming the
                 // replication is a glance down the column rather than a hand-match across formats.
-                val samples = timed { decodeYPlane(scene.plane, w, h, rowStride = w) }
-                val hit = decodeYPlane(scene.plane, w, h, rowStride = w) is BarcodeDecodeResult.DecodedBarcode
-                report(scene.name, w, h, "production", samples, hit)
+                val (samples, last) = timed { decodeYPlane(scene.plane, w, h, rowStride = w) }
+                report(scene.name, w, h, "production", samples, last is BarcodeDecodeResult.DecodedBarcode)
             }
         }
     }
 
-    /** Sorted per-call durations of [RUNS] timed invocations, after [WARMUP] untimed ones. */
-    private fun timed(decode: () -> Unit): List<Long> {
-        repeat(WARMUP) { decode() }
-        return (0 until RUNS)
-            .map {
-                val started = System.nanoTime()
-                decode()
-                System.nanoTime() - started
-            }.sorted()
+    /**
+     * Sorted per-call durations of [RUNS] timed invocations of [decode], after [WARMUP] untimed
+     * ones, paired with its last result. Returning the value rather than discarding it both saves
+     * the caller a second decode to learn whether the frame hit, and sinks the result so no part
+     * of the measured work can be optimised away as dead.
+     */
+    private fun <T> timed(decode: () -> T): Pair<List<Long>, T> {
+        var last = decode()
+        repeat(WARMUP - 1) { last = decode() }
+        val samples =
+            (0 until RUNS)
+                .map {
+                    val started = System.nanoTime()
+                    last = decode()
+                    System.nanoTime() - started
+                }.sorted()
+        return samples to last
     }
 
     @Suppress("LongParameterList") // A table row is its columns; a holder type would only hide them.
@@ -169,12 +175,11 @@ class LiveFrameRosterLatencyHarness {
                 ),
             ),
             Scene("aztec", frameWith(BarcodeFormat.AZTEC, BOARDING_PASS, width, height)),
-            // The dearest hit in the roster: PDF417 is LAST in ZXing's reader order, so it pays a
+            // The dearest 2D hit in the roster: PDF417 is LAST of the 2D readers, so it pays a
             // failed QR and a failed Aztec first. Stacked like a 1D symbol, so it needs an aspect.
-            // READ THE 640x480 ROW ONLY. Against this per-pixel noise the PDF417 detector stops
-            // locating the symbol above 640x480 whatever its size (measured), so the 1280x720 row
-            // reports the cost of a MISS, not of a hit. Uninvestigated: it is a property of the
-            // synthetic texture, and 640x480 is the resolution the live path actually runs at.
+            // Read the 640x480 row only: above that size the detector stops locating this symbol
+            // against the fixture's per-pixel noise (measured, uninvestigated — a property of the
+            // synthetic texture, and 640x480 is what the live path runs at).
             Scene(
                 "pdf417",
                 frameWith(


### PR DESCRIPTION
Closes wpass-pl7.3.

wpass-pl7.1 grew the symbology roster from five formats to seven, and `decodeYPlane` shares `decodeLuminance` with the still-image path, so every live camera frame started paying for the added Aztec and PDF417 readers. That cost was unmeasured on main. This measures it and records the decision it led to.

The live path was **already** insulated from wpass-pl7.2 — `decodeYPlane` passes `DecodeLadder.SINGLE_ATTEMPT`, so the scale ladder adds nothing per frame. The whole delta below is roster growth.

## Result

640x480 medians, host JVM:

| scene | baseline-5 | current-7 |
|---|---|---|
| no symbol in view | 11.4 | 16.0 |
| QR | 1.29 | 1.24 |
| Code128 | 1.26 | 4.33 |
| Aztec | miss | 1.39 |
| PDF417 | miss | 2.17 |

ZXing orders its readers QR → Aztec → PDF417 → 1D, because `TRY_HARDER` appends the 1D reader **last**. So QR pays nothing, a loyalty card queues behind three failed 2D attempts, and PDF417 is the dearest 2D hit.

Against the acceptance criteria: QR lock-on holds; **Code128 fails it at 3.5x**, landing on the 1D path wlt-o2d6 already reports as marginal.

## Decision

**Accepted rather than fixed** (owner call). The ratio is large but sits on a small base — ~3-5ms — and every mitigation trades away something real: narrowing the live roster gives up scanning a physical boarding pass; splitting it across alternate frames restores 1D and QR exactly but needs per-frame state `decodeYPlane` does not have; dropping `TRY_HARDER` is by far the cheapest and cannot be justified from clean synthetic fixtures, which by construction cannot measure the hit rate on blurry frames that the hint exists for. All three are measured and recorded in wpass-pl7.3's notes.

The figure that actually bounds this path is not the delta but the no-symbol frame — every frame before lock-on — at ~16ms (640x480) and ~30ms (1280x720) against a 33ms interval at 30fps. Analyzer **resolution**, not roster width, is the live budget's lever.

## What lands

- `LiveFrameRosterLatencyHarness` in the `passes-barcode-core` test source set. It asserts nothing and is gated behind `-Dwalt.latencyHarness`, so `check` neither runs it nor can flake on it. It A/Bs both rosters inside one warm process by replicating `decodeOnce`, since a cross-commit comparison cannot separate a roster delta from JIT state; the real `decodeYPlane` is measured alongside as `production` rows to confirm the replication.
- A `decodeYPlane` KDoc note recording the accepted cost and the resolution lever.

No production behaviour changes.

## Notes for the reviewer

- Read the PDF417 **640x480 row only**. Above that size the detector stops locating the symbol against the fixture's per-pixel noise (measured across five sizes and four geometries; a fully clean background decodes at all of them). Left uninvestigated and labelled in the code — it is a property of the synthetic texture, and 640x480 is what the live path runs at.
- `split-1d+qr` is `baseline-5` by construction and run last, so the two rows double as a run-to-run control on how much variant order and JIT drift move a number.
- ZXing reads `TRY_HARDER` with `containsKey`, **not** by value, so mapping it to `false` still enables it. Flagged at the point of use; an early arm of this harness measured nothing because of it.
- On-device confirmation on the FP4 is split out as wpass-hzh (P3). Host-JVM figures establish the ratio the decision turned on, not the absolute per-frame budget.
- The BCBP-shaped fixture payload is invented, not lifted from the repro artifact (wpass-pl7 constraint 7).