### PR TITLE
Generate AZTEC + PDF417: writer arms, pinned EC/compaction/charset (wpass-pl7.6)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -334,37 +334,57 @@ mirrors the discipline that `FieldLinkScanner.kt:67` and the PDF document-label
 path already enforce.
 
 The PDF417 and Aztec caps (`wpass-pl7.1`) were set to hold at any plausible
-error-correction level, because the level itself is not pinned until the writer
-arms land in `wpass-pl7.6`. That bead must re-derive them against its own pin:
-a cap the validator accepts but the encoder cannot fit converts a clean
+error-correction level, because the level itself was not pinned until the writer
+arms landed. `wpass-pl7.6` pinned PDF417 at error-correction level 3 and Aztec
+at 33%, and re-derived both caps against those pins by binary-searching the
+largest payload each writer accepts: PDF417 holds 1,766 characters against the
+800 the validator allows, Aztec 3,000 against 1,500. Both stand unchanged, with
+better than 2x headroom. Re-derive again if either pin rises — a cap the
+validator accepts but the encoder cannot fit converts a clean
 `InvalidPayload(TooLong)` rejection into a blank render.
 
-**C4. Create-time URI-scheme preview for QR.** When the user creates a QR
-ScannableCard, `passes-core`'s URI-scheme classifier inspects the payload
-against a conservative allowlist (`http`, `https`, `tel`, `sms`, `mailto`,
-`geo`, `wifi`, `bitcoin`, `ethereum`, `magnet`, `market`, `intent`). A
-match (or a "looks URI-shaped but unrecognized scheme" fallback) raises the
-walt-android-side confirmation dialog before the row is persisted. The user
-must explicitly confirm "yes, this QR is meant to encode an actionable URI."
-Pattern source: `B3UrlConfirmSheet` in `passes-ui/src/main/kotlin/.../SecuritySheets.kt`.
+The same bead closed the charset half of that property, which the length caps do
+not cover. Both new writers default to ISO-8859-1 while the validator admits any
+visible character on a byte-capable format, so a payload the user can legitimately
+type was unrenderable: `PDF417Writer` threw outright, and `AztecWriter` did worse
+— it encoded and decoded back transliterated, a silent corruption. Pinned
+`PDF417_AUTO_ECI` and `CHARACTER_SET` respectively; both measured to leave the
+all-ASCII case byte-identical in matrix size and capacity. **QR has the same
+silent-transliteration defect and is not yet fixed** (`wpass-qj6`): it predates
+these writers, and adding an ECI header changes the symbol emitted for every
+non-ASCII QR card already stored, so it needs its own scanner verification.
 
-**C4 forward obligation (`wpass-pl7.6`).** PDF417 and Aztec are byte-capable and
-can carry the same actionable URIs, so this gate must widen to them when they
-become creatable. It is not a gap today, and the reason is enforcement rather
-than convention: `wpass-pl7.1` added them to the *decode* roster only, and
-`ScannableCardInputValidator` returns
-`ScannableCardCreateResult.UnsupportedFormat` for both, so no such card can be
-minted, persisted, or rendered in this build. The refusal lives at the kernel
-choke point on purpose — consumers build their format pickers from
-`ScannableFormat.entries` (walt-android's `CreateScannableCardScreen` does), so
-a roster addition would otherwise surface as a selectable chip that nobody
-decided to offer. `ScannableFormatConstraints.decodeOnly` is the single set both
-the validator and the encoder read, so the two cannot drift.
+**C4. Create-time URI-scheme preview for the byte-capable symbologies.** When the
+user creates a ScannableCard in a format that can carry an actionable payload,
+`passes-core`'s URI-scheme classifier inspects the payload against a conservative
+allowlist (`http`, `https`, `tel`, `sms`, `mailto`, `geo`, `wifi`, `bitcoin`,
+`ethereum`, `magnet`, `market`, `intent`). A match (or a "looks URI-shaped but
+unrecognized scheme" fallback) raises the confirmation dialog before the row is
+persisted. The user must explicitly confirm "yes, this code is meant to encode an
+actionable URI." Pattern source: `B3UrlConfirmSheet` in
+`passes-ui/src/main/kotlin/.../SecuritySheets.kt`.
 
-The gate trigger itself is `QrPayloadKind`-scoped (`requiresCreateConfirmation()`
-takes no format argument), so widening it is a deliberate edit that no compiler
-error will prompt — which is why it is recorded here and on `wpass-pl7.6`'s
-acceptance rather than left to be noticed.
+**C4 forward obligation — DISCHARGED (`wpass-pl7.6`).** PDF417 and Aztec are
+byte-capable and carry the same actionable URIs, so the gate had to widen to them
+when their writers landed. It was not a gap before that, because
+`ScannableCardInputValidator` refused both formats outright; the moment they became
+creatable it would have been one, and nothing in the compiler would have said so —
+`requiresCreateConfirmation()` was `QrPayloadKind`-scoped and took no format
+argument.
+
+The fix makes the format part of the signature:
+`QrPayloadKind.requiresCreateConfirmation(format)` now consults
+`ScannableFormat.canCarryActionablePayload()`, an exhaustive `when` in `passes-core`.
+Two properties follow. A future roster member is a compile error at one kernel site
+rather than a gate that quietly stops covering a format. And the predicate lives in
+this repository rather than in the consumer, which the trust claim requires — the
+decision about which symbologies need confirming is security-critical, and
+walt-android must not parallel-implement it.
+
+Widening the trigger also made the sheet's own copy wrong: every arm read "this QR
+will…". The strings now say "this code", since an Aztec boarding pass raising a
+dialog about a QR is a trust surface that describes something other than what the
+user is about to save.
 
 **C5. ZXing-JVM as encoder only; no runtime decoding of untrusted bytes.**
 The kernel uses `com.google.zxing:core` (Apache 2.0, pure JVM) exclusively to
@@ -473,7 +493,7 @@ URIs the recipient device trusts because the QR is in someone's wallet."
 **Mitigation.** C4: at create time, the URI-scheme classifier raises a
 confirmation dialog naming the scheme and the rendered payload (with `payload`
 wrapped in FSI/PDI bidi isolates per C3). The user must explicitly accept
-"this QR is meant to encode an actionable URI" before the row is persisted.
+"this code is meant to encode an actionable URI" before the row is persisted.
 Unrecognized-but-URI-shaped strings (`unknown-scheme://x`) trigger the
 fallback warning path rather than silent acceptance.
 
@@ -781,7 +801,7 @@ in-scope for the Threat 6 upgrade cadence.
 | Manifest hash + PKCS#7 signature                | Not applicable; provenance is "user-typed", structurally a sibling class                |
 | `SignatureStatus` four-band badge               | "Created by you" caption + visually distinct tile in its own lane (C1 + C2)             |
 | `FieldLinkScanner` Cf/Cc rejection              | Same posture; applied to `payload` and `label` at the create boundary (C3)              |
-| `B3UrlConfirmSheet`                             | Create-time URI-scheme preview for QR payloads (C4); same dialog pattern                |
+| `B3UrlConfirmSheet`                             | Create-time URI-scheme preview on the byte-capable formats (C4); same dialog pattern                |
 | `ExpiredOverlayState`                           | Not applicable (no expiration metadata; user can delete)                                |
 | `TelemetryGuard` PII discipline                 | New `ScannableCardTelemetryGuard` mirrors the existing discipline (counts / formats only, no payload bytes) |
 | Encrypted-at-rest (SQLCipher) + Auto Backup off | Same database, same XML rules apply automatically                                       |
@@ -843,7 +863,7 @@ can trace back here.
 |---------|--------------------------------------------|
 | C1      | `wpass-lzi.2` (data model surface test), `wpass-lzi.6` (separate table assertion), `wpass-lzi.8` (separate-lane composable test) |
 | C2      | `wpass-lzi.8` (non-suppressible caption test, ≥2-distinct-elements snapshot); `wpass-pnb`'s wallet-row pins (`scannableCardRowTileHasExactlyFourUserVisibleParameters`, `rowTileDoesNotRenderTrustCaption`, `rowTileRendersFormatSubtitle`) were removed with the concession and the composable in `wpass-80y.4`; `wpass-gv6` adds `scannableCardScreenHasExactlyFiveUserVisibleParameters` (four at the time; `wpass-80y.1`'s `faceTint` bumped it) + `scannableCardScreenTrustCaptionParamIsThePlacementType` (placement is the audited carrier-of-provenance choice, not a Boolean) and `fullScreenHostedTypeRowOmitsKernelCaption` / `hostedTypeRowStillRendersBarcodeAndPayloadCaption` to pin the "Pass type" row concession; the consumer-side pin (Walt details section renders a "Pass type" row) lives in walt-android `wlt-3cer`; `wpass-80y` pins the colour-is-not-trust row with `ScannableCardTrustSurfaceTest.faceTintDoesNotSuppressBarcodeLabelPayloadOrTrustCaption` (+ its dark-tint twin), `codePanelIsLiterallyWhiteNotAThemeTokenOrTheFaceTint`, `inkOnClearsWcagAaAgainstEveryTintIncludingTheWorstCase`, and `DocumentFaceTintTest.faceTintDoesNotSuppressTheTrustCaptionOnEitherArm` / `faceTintLeavesThePageRenderRequestUnchanged`; `wpass-80y.5` pins the shared tint gate with `passes-ui-core`'s `FaceTintTest` plus `fullyTransparentTintFallsBackToTheDefaultFace` (scannable face and ink resolution, via `facePaint`) and `…DefaultFrame` (document arm composes intact) |
-| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests); `wpass-pl7.1` pins the decode-only refusal at the create boundary (`decodeOnlyFormatsAreRefusedAtTheCreateBoundary`, `decodeOnlyRefusalOutranksPayloadAndLabelProblems`, `isCreatableAgreesWithWhatTheValidatorAccepts`, and `createWithADecodeOnlyFormatIsRejectedAndPersistsNothing` end-to-end in `passes-storage`) plus the PDF417 / Aztec cap and byte-capable-charset rules in `ScannableFormatConstraintsTest` |
+| C3      | `wpass-lzi.4` (length caps, charset, Cf/Cc rejection unit tests); `wpass-pl7.6` re-derives the PDF417 / Aztec caps against the pinned error-correction levels (`theTwoDimensionalFormatsEncodeAtTheirValidatorCap`, `theTwoDimensionalFormatsRoundTripAtTheirValidatorCap`) and pins the charset fix (`nonAsciiPdf417PayloadSurvivesAutoCompaction`); `noFormatIsDecodeOnly` and `isCreatableAgreesWithWhatTheValidatorAccepts` keep the now-empty decode-only refusal wired for a future decode-first addition, plus the byte-capable-charset rules in `ScannableFormatConstraintsTest` |
 | C4      | `wpass-lzi.5` (URI classifier unit tests), `wpass-lzi.9` (dialog gating test) |
 | C5      | `wpass-lzi.3` (encoder integration). C5 amendment (wpass-7rv): the original "decoder not in dependency closure" build assertion no longer holds — decode confinement is pinned instead by the isolated-decode tests (`BarcodeDecodeServiceInstrumentedTest`, `YPlaneFrameDecodeTest`) and, consumer-side, by walt-android `CompositeImportInstrumentedTest` (no host-process decode of source bytes) + `CameraScanSecurityGuardTest` (no CameraX `ImageCapture` in `src/main`) |
 | C6      | `wpass-lzi.2` (schema snapshot — no `secret`/`hmac`/`totp` fields permitted) |

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -343,12 +343,14 @@ largest payload each writer accepts: **for single-byte payloads** PDF417 holds
 
 **The caps do not, however, guarantee encodability, and this section previously
 overstated that they did.** They count characters while writer capacity is
-consumed in bytes. Measured over three-byte characters the same writers hold 528
-(PDF417) and 623 (Aztec) — both far under the caps, so a 700-character CJK
-payload clears the validator and cannot be rendered. No exact predicate is
-available at the validator: each writer picks a compaction mode per run, so
-capacity swings with the payload's composition, and a byte ceiling tight enough
-to be safe would reject ordinary accented text well inside the character cap.
+consumed in bytes. Measured over three-byte characters the same writers hold far less
+than their caps allow, so a 700-character CJK payload clears the validator and
+cannot be rendered. No exact predicate is available at the validator: each writer
+picks a compaction mode per run, so capacity swings with the payload's
+composition, and a byte ceiling tight enough to be safe would reject ordinary
+accented text well inside the character cap. The per-width measurements live on
+the caps themselves in `ScannableFormatConstraints`, which is where they would be
+re-derived.
 
 What is in place instead is attribution rather than prevention: the encoder lifts
 both writers' over-capacity errors to `EncoderFailureReason.PayloadTooDense`, so

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -337,11 +337,26 @@ The PDF417 and Aztec caps (`wpass-pl7.1`) were set to hold at any plausible
 error-correction level, because the level itself was not pinned until the writer
 arms landed. `wpass-pl7.6` pinned PDF417 at error-correction level 3 and Aztec
 at 33%, and re-derived both caps against those pins by binary-searching the
-largest payload each writer accepts: PDF417 holds 1,766 characters against the
-800 the validator allows, Aztec 3,000 against 1,500. Both stand unchanged, with
-better than 2x headroom. Re-derive again if either pin rises — a cap the
-validator accepts but the encoder cannot fit converts a clean
-`InvalidPayload(TooLong)` rejection into a blank render.
+largest payload each writer accepts: **for single-byte payloads** PDF417 holds
+1,766 characters against the 800 the validator allows, and Aztec 3,000 against
+1,500. Re-derive if either pin rises.
+
+**The caps do not, however, guarantee encodability, and this section previously
+overstated that they did.** They count characters while writer capacity is
+consumed in bytes. Measured over three-byte characters the same writers hold 528
+(PDF417) and 623 (Aztec) — both far under the caps, so a 700-character CJK
+payload clears the validator and cannot be rendered. No exact predicate is
+available at the validator: each writer picks a compaction mode per run, so
+capacity swings with the payload's composition, and a byte ceiling tight enough
+to be safe would reject ordinary accented text well inside the character cap.
+
+What is in place instead is attribution rather than prevention: the encoder lifts
+both writers' over-capacity errors to `EncoderFailureReason.PayloadTooDense`, so
+the failure is typed and actionable ("shorten this") rather than opaque. That arm
+only reaches a user if something runs the encoder before persisting, and nothing
+currently does — `ScannableCardCreateResult.EncoderFailure` exists and is consumed
+but never produced. Tracked as `wpass-1kg`; until it lands, an oversized multibyte
+payload saves and renders as the accessible-but-empty placeholder.
 
 The same bead closed the charset half of that property, which the length caps do
 not cover. Both new writers default to ISO-8859-1 while the validator admits any
@@ -376,10 +391,16 @@ The fix makes the format part of the signature:
 `QrPayloadKind.requiresCreateConfirmation(format)` now consults
 `ScannableFormat.canCarryActionablePayload()`, an exhaustive `when` in `passes-core`.
 Two properties follow. A future roster member is a compile error at one kernel site
-rather than a gate that quietly stops covering a format. And the predicate lives in
-this repository rather than in the consumer, which the trust claim requires — the
-decision about which symbologies need confirming is security-critical, and
-walt-android must not parallel-implement it.
+rather than a gate that quietly stops covering a format. And the kernel now owns a
+predicate for which symbologies need confirming, which is where the trust claim
+requires that decision to live.
+
+**The consumer's copy is not yet retired.** walt-android still carries an identical
+`canCarryAutoActingPayload()` in `feature/passes/common/AutoActingSymbologies.kt`,
+and it is the copy actually in the path — called ahead of the kernel predicate at
+both create-time call sites. Until it is deleted (`wpass-j6b`) the two can drift,
+and a correction made here would not take effect on its own. The discharge above is
+therefore complete on the kernel side only.
 
 Widening the trigger also made the sheet's own copy wrong: every arm read "this QR
 will…". The strings now say "this code", since an Aztec boarding pass raising a

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
@@ -9,9 +9,8 @@ import `is`.walt.passes.core.ScannableFormat
 import org.junit.Test
 
 /**
- * The wpass-pl7.6 acceptance round trip: every roster symbology encodes through the KERNEL's
- * [BarcodeEncoder] and decodes back through the KERNEL's [decodeLuminance], to the same payload
- * and the same [ScannableFormat].
+ * Every roster symbology encodes through the KERNEL's [BarcodeEncoder] and decodes back
+ * through the KERNEL's [decodeLuminance], to the same payload and the same [ScannableFormat].
  *
  * Distinct from [ZxingBarcodeSymbolDecoderTest], which encodes its fixtures with ZXing's own
  * `MultiFormatWriter` and therefore proves only the decoder. This suite closes the loop over
@@ -79,13 +78,28 @@ class BarcodeEncoderRoundTripTest {
     }
 
     @Test
-    fun nonAsciiPdf417PayloadSurvivesAutoCompaction() {
-        // AUTO compaction picks the mode; a payload outside the text alphabet must still come
-        // back byte-exact rather than transliterated.
-        val payload = "café — naïve — 東京"
+    fun nonAsciiPayloadsSurviveOnBothTwoDimensionalFormats() {
+        // The charset pins, and the reason they are pins rather than defaults. At ZXing's
+        // ISO-8859-1 default PDF417 throws outright while AZTEC IS THE DANGEROUS ONE: it encodes
+        // happily and decodes back "café ? naïve ? ??", a wrong scan with no error at any layer.
+        // Dropping either hint has to fail here, so both formats share the one payload.
+        for (format in listOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+            assertThat(decodeLuminance(render(NON_ASCII_PAYLOAD, format)))
+                .isEqualTo(BarcodeDecodeResult.DecodedBarcode(NON_ASCII_PAYLOAD, format))
+        }
+    }
 
-        assertThat(decodeLuminance(render(payload, ScannableFormat.Pdf417)))
-            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Pdf417))
+    @Test
+    fun aztecCarriesSupplementaryPlaneCharactersPdf417RefusesThem() {
+        // The validator admits emoji on both formats. Aztec round-trips them; ZXing cannot put a
+        // surrogate pair through PDF417 under any configuration, so the encoder names that limit
+        // itself rather than letting the writer raise a message with the payload inside it.
+        val payload = "https://example.org/é/👍"
+
+        assertThat(decodeLuminance(render(payload, ScannableFormat.Aztec)))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Aztec))
+        assertThat(BarcodeEncoder.encode(payload, ScannableFormat.Pdf417))
+            .isInstanceOf(EncodeResult.Failure::class.java)
     }
 
     /**
@@ -136,6 +150,9 @@ class BarcodeEncoderRoundTripTest {
 
         /** Stand-in vertical extent for the 1D writers, whose matrices are one module tall. */
         const val MIN_LINEAR_BAR_MODULES = 40
+
+        /** Spans Latin-1 (é), BMP punctuation (—) and CJK, the three widths UTF-8 encodes. */
+        const val NON_ASCII_PAYLOAD = "café — naïve — 東京"
 
         /** Synthetic, of IATA BCBP shape and length. Never a decoded boarding pass — those are PII. */
         const val BCBP_SHAPED_PAYLOAD =

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
@@ -1,0 +1,145 @@
+package `is`.walt.passes.barcode
+
+import com.google.common.truth.Truth.assertThat
+import com.google.zxing.RGBLuminanceSource
+import `is`.walt.passes.core.BarcodeDecodeResult
+import `is`.walt.passes.core.BarcodeEncoder
+import `is`.walt.passes.core.EncodeResult
+import `is`.walt.passes.core.ScannableFormat
+import org.junit.Test
+
+/**
+ * The wpass-pl7.6 acceptance round trip: every roster symbology encodes through the KERNEL's
+ * [BarcodeEncoder] and decodes back through the KERNEL's [decodeLuminance], to the same payload
+ * and the same [ScannableFormat].
+ *
+ * Distinct from [ZxingBarcodeSymbolDecoderTest], which encodes its fixtures with ZXing's own
+ * `MultiFormatWriter` and therefore proves only the decoder. This suite closes the loop over
+ * the encoder's pinned error-correction, compaction and quiet-zone choices — a wrong writer or
+ * a wrong `BarcodeFormat` in the dispatch would still produce a plausible symbol there, and
+ * only a decode that reports the format back catches it.
+ *
+ * Lives here rather than in `passes-core` because that module cannot see the decoder:
+ * `passes-barcode-core` depends on `passes-core`, not the other way round.
+ *
+ * This is NOT the whole acceptance criterion. A symbol only Walt can read is not a working
+ * symbol, so the third-party-scanner and on-device legs are tracked separately (wpass-sw2).
+ *
+ * Fixtures are synthetic. A real BCBP boarding pass carries passenger name and PNR, which
+ * wpass-pl7 bars from any committed fixture.
+ */
+class BarcodeEncoderRoundTripTest {
+    @Test
+    fun everyRosterFormatRoundTripsThroughTheKernel() {
+        val payloads =
+            mapOf(
+                ScannableFormat.Code128 to "WALT-RT-128",
+                ScannableFormat.Code39 to "WALT-RT-39",
+                ScannableFormat.Ean13 to "1234567890128",
+                ScannableFormat.UpcA to "036000291452",
+                ScannableFormat.Qr to "https://example.org/loyalty/123",
+                ScannableFormat.Pdf417 to "WALT-RT-PDF417",
+                ScannableFormat.Aztec to "WALT-RT-AZTEC",
+            )
+        // Fails closed when a roster member is added without a round trip being proven for it.
+        assertThat(payloads.keys).containsExactlyElementsIn(ScannableFormat.entries)
+
+        for ((format, payload) in payloads) {
+            assertThat(decodeLuminance(render(payload, format)))
+                .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, format))
+        }
+    }
+
+    @Test
+    fun anExtractedBoardingPassPayloadReRendersAsAScannableAztec() {
+        // The epic's user-visible outcome: a payload lifted off an imported boarding-pass
+        // screenshot has to become a symbol a gate scanner reads, or extraction solved nothing.
+        val payload = BCBP_SHAPED_PAYLOAD
+
+        assertThat(decodeLuminance(render(payload, ScannableFormat.Aztec)))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Aztec))
+    }
+
+    @Test
+    fun pdf417RoundTripsABoardingPassLengthPayload() {
+        assertThat(decodeLuminance(render(BCBP_SHAPED_PAYLOAD, ScannableFormat.Pdf417)))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(BCBP_SHAPED_PAYLOAD, ScannableFormat.Pdf417))
+    }
+
+    @Test
+    fun theTwoDimensionalFormatsRoundTripAtTheirValidatorCap() {
+        // Encoding at the cap is pinned in passes-core; this adds that the symbol produced there
+        // is still readable, which is the half a capacity check alone does not cover.
+        for ((format, cap) in listOf(ScannableFormat.Pdf417 to 800, ScannableFormat.Aztec to 1_500)) {
+            val payload = "WALT".repeat(cap / 4)
+
+            assertThat(decodeLuminance(render(payload, format)))
+                .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, format))
+        }
+    }
+
+    @Test
+    fun nonAsciiPdf417PayloadSurvivesAutoCompaction() {
+        // AUTO compaction picks the mode; a payload outside the text alphabet must still come
+        // back byte-exact rather than transliterated.
+        val payload = "café — naïve — 東京"
+
+        assertThat(decodeLuminance(render(payload, ScannableFormat.Pdf417)))
+            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Pdf417))
+    }
+
+    /**
+     * Encodes through [BarcodeEncoder] and paints the matrix the way the render layer does —
+     * nearest-neighbour upscale onto white, plus a quiet zone. Both are load-bearing: at one
+     * pixel per module the binarizer cannot resolve an Aztec's finder pattern, and the 1D
+     * writers emit a one-module-tall strip that needs vertical extent to be locatable.
+     */
+    private fun render(
+        payload: String,
+        format: ScannableFormat,
+        scale: Int = 4,
+    ): RGBLuminanceSource {
+        val matrix = (BarcodeEncoder.encode(payload, format) as EncodeResult.Success).matrix
+        val barHeight = if (matrix.height == 1) MIN_LINEAR_BAR_MODULES else matrix.height
+        val quiet = QUIET_ZONE_MODULES * scale
+        val width = matrix.width * scale + 2 * quiet
+        val height = barHeight * scale + 2 * quiet
+        val pixels = IntArray(width * height) { WHITE }
+        for (y in 0 until barHeight) {
+            for (x in 0 until matrix.width) {
+                if (!matrix.isSet(x, y.coerceAtMost(matrix.height - 1))) continue
+                paintModule(pixels, width, quiet + x * scale, quiet + y * scale, scale)
+            }
+        }
+        return RGBLuminanceSource(width, height, pixels)
+    }
+
+    private fun paintModule(
+        pixels: IntArray,
+        rowStride: Int,
+        left: Int,
+        top: Int,
+        scale: Int,
+    ) {
+        for (dy in 0 until scale) {
+            val row = (top + dy) * rowStride
+            for (dx in 0 until scale) {
+                pixels[row + left + dx] = BLACK
+            }
+        }
+    }
+
+    private companion object {
+        const val BLACK = 0xFF000000.toInt()
+        const val WHITE = 0xFFFFFFFF.toInt()
+        const val QUIET_ZONE_MODULES = 8
+
+        /** Stand-in vertical extent for the 1D writers, whose matrices are one module tall. */
+        const val MIN_LINEAR_BAR_MODULES = 40
+
+        /** Synthetic, of IATA BCBP shape and length. Never a decoded boarding pass — those are PII. */
+        const val BCBP_SHAPED_PAYLOAD =
+            "M1TEST/PASSENGER      EABC123 CPHLHRSK 0501 227M014A0058 147>5180      " +
+                "B1A              2A05512345678901 0                          "
+    }
+}

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -104,10 +104,14 @@ public sealed interface EncoderFailureReason {
     ) : EncoderFailureReason
 
     /**
-     * The payload is too dense to encode at the symbology's maximum version (only QR can
-     * surface this — the 1D writers reject density mismatches under [WriterRejected]). Distinct
-     * arm so the consumer UI can specifically suggest shortening the payload rather than
-     * switching format.
+     * The payload is too dense to encode at the symbology's maximum size. Surfaced by the three
+     * 2D symbologies — QR, PDF417 and Aztec; the 1D writers reject density mismatches under
+     * [WriterRejected]. Distinct arm so the consumer UI can specifically suggest shortening the
+     * payload rather than switching format.
+     *
+     * Reachable even for a payload that cleared [ScannableCardInputValidator]: the 2D length
+     * caps count characters while capacity is spent in bytes, so a multibyte payload can sit
+     * under its cap and still overflow.
      */
     public object PayloadTooDense : EncoderFailureReason
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableCardCreateResult.kt
@@ -110,12 +110,4 @@ public sealed interface EncoderFailureReason {
      * switching format.
      */
     public object PayloadTooDense : EncoderFailureReason
-
-    /**
-     * This kernel build has no writer wired for [format], so the symbol cannot be rendered.
-     * Distinct from [WriterRejected], which means a wired writer looked at this payload and
-     * said no: this arm is about the build, not the input, so a shorter payload cannot help.
-     * Temporary — wpass-pl7.6 removes it once every roster member encodes.
-     */
-    public data class FormatNotEncodable(public val format: ScannableFormat) : EncoderFailureReason
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -19,9 +19,8 @@ package `is`.walt.passes.core
  * DataMatrix stays out deliberately — it widens the same surface (encoder, storage, consumer
  * format pickers) for no reported user need.
  *
- * Every member both decodes and encodes; wpass-pl7.6 closed the read/write asymmetry by
- * wiring the [Pdf417] and [Aztec] writer arms with pinned error-correction, compaction and
- * quiet-zone defaults (see `ZxingBarcodeEncoder`).
+ * Every member both decodes and encodes. The error-correction, compaction and quiet-zone
+ * defaults each writer runs under are pinned and argued in `ZxingBarcodeEncoder`.
  *
  * Distinct type from [BarcodeFormat] (the PKPASS-pass barcode enum). The two are
  * deliberately not unified — a verified PKPASS barcode and a user-typed card barcode are
@@ -41,8 +40,8 @@ public enum class ScannableFormat {
 
 /**
  * Whether a user can create a [ScannableCard] in this format — which is to say whether this
- * build can render one. True for every member since wpass-pl7.6; it stays on the surface as
- * the gate a future decode-first roster addition needs.
+ * build can render one. True for every member today; it stays on the surface as the gate a
+ * decode-first roster addition would need.
  *
  * **Consumers building a format picker must filter on this.** The picker cannot be derived from
  * [ScannableFormat.entries] alone: [ScannableCardInputValidator] refuses a non-creatable format
@@ -60,10 +59,9 @@ public fun ScannableFormat.isCreatable(): Boolean = this !in ScannableFormatCons
  * hold membership numbers a scanner hands back as text.
  *
  * This is the format half of the C4 create-time confirmation gate in
- * `docs/SCANNABLE_CARD_THREAT_MODEL.md`; [QrPayloadClassifier] is the payload half. Keying
- * that gate on `== Qr` was correct only while QR was the roster's one byte-capable format —
- * wpass-pl7.6 wired the [Pdf417] and [Aztec] writers, so an Aztec carrying a URL would
- * otherwise render as a scannable code having never been confirmed.
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`; [QrPayloadClassifier] is the payload half. Gating on
+ * `== Qr` instead would let an Aztec carrying a URL render as a scannable code having never
+ * been confirmed.
  *
  * An exhaustive `when` rather than a set lookup on purpose: a new roster member is a decision
  * someone has to make here, surfaced as a compile error. Deliberately NOT folded into

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormat.kt
@@ -19,10 +19,9 @@ package `is`.walt.passes.core
  * DataMatrix stays out deliberately — it widens the same surface (encoder, storage, consumer
  * format pickers) for no reported user need.
  *
- * **Read/write asymmetry (transitional).** Every member here decodes today; [Pdf417] and
- * [Aztec] do NOT yet encode — the writer arms, with their error-correction and compaction
- * defaults, land in wpass-pl7.6. Until then the encoder reports
- * [EncoderFailureReason.FormatNotEncodable] for those two.
+ * Every member both decodes and encodes; wpass-pl7.6 closed the read/write asymmetry by
+ * wiring the [Pdf417] and [Aztec] writer arms with pinned error-correction, compaction and
+ * quiet-zone defaults (see `ZxingBarcodeEncoder`).
  *
  * Distinct type from [BarcodeFormat] (the PKPASS-pass barcode enum). The two are
  * deliberately not unified — a verified PKPASS barcode and a user-typed card barcode are
@@ -42,8 +41,8 @@ public enum class ScannableFormat {
 
 /**
  * Whether a user can create a [ScannableCard] in this format — which is to say whether this
- * build can render one. False only for the decode-only members ([Pdf417] / [Aztec] until
- * wpass-pl7.6 wires their writers).
+ * build can render one. True for every member since wpass-pl7.6; it stays on the surface as
+ * the gate a future decode-first roster addition needs.
  *
  * **Consumers building a format picker must filter on this.** The picker cannot be derived from
  * [ScannableFormat.entries] alone: [ScannableCardInputValidator] refuses a non-creatable format
@@ -51,6 +50,35 @@ public enum class ScannableFormat {
  * whose Save fails on every tap. Exposed rather than left implicit because nothing about adding
  * a decode-only member breaks a consumer's build — the failure is silent by construction.
  *
- * Backed by the same set the validator and encoder read, so the three cannot disagree.
+ * Backed by the same set the validator reads, so the two cannot disagree.
  */
 public fun ScannableFormat.isCreatable(): Boolean = this !in ScannableFormatConstraints.decodeOnly
+
+/**
+ * Whether a rendered symbol in this format can carry a payload a scanner acts on without
+ * asking — a URL, `tel:`, `mailto:`. True for the byte-capable 2D symbologies; the 1D ones
+ * hold membership numbers a scanner hands back as text.
+ *
+ * This is the format half of the C4 create-time confirmation gate in
+ * `docs/SCANNABLE_CARD_THREAT_MODEL.md`; [QrPayloadClassifier] is the payload half. Keying
+ * that gate on `== Qr` was correct only while QR was the roster's one byte-capable format —
+ * wpass-pl7.6 wired the [Pdf417] and [Aztec] writers, so an Aztec carrying a URL would
+ * otherwise render as a scannable code having never been confirmed.
+ *
+ * An exhaustive `when` rather than a set lookup on purpose: a new roster member is a decision
+ * someone has to make here, surfaced as a compile error. Deliberately NOT folded into
+ * [ScannableFormatConstraints]'s charset rule, which holds the same three formats today but
+ * answers "does this symbology accept any character" — a question that will not stay in step.
+ */
+public fun ScannableFormat.canCarryActionablePayload(): Boolean =
+    when (this) {
+        ScannableFormat.Qr,
+        ScannableFormat.Pdf417,
+        ScannableFormat.Aztec,
+        -> true
+        ScannableFormat.Code128,
+        ScannableFormat.Code39,
+        ScannableFormat.Ean13,
+        ScannableFormat.UpcA,
+        -> false
+    }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -11,12 +11,16 @@ package `is`.walt.passes.core
  */
 internal object ScannableFormatConstraints {
     /**
-     * Roster members this build decodes but cannot render: wpass-pl7.1 added them to the decode
-     * allowlist, and the writer arms land in wpass-pl7.6. Read by BOTH the validator (refuses to
-     * mint a card) and the encoder (refuses to encode) so the two cannot drift into a state where
-     * a card is creatable but unrenderable. wpass-pl7.6 empties this set.
+     * Roster members this build decodes but cannot render. Empty since wpass-pl7.6 wired the
+     * Pdf417 / Aztec writer arms — every roster member now encodes.
+     *
+     * Kept rather than deleted because it is the create-boundary refusal a decode-first roster
+     * addition needs: put a format here and [ScannableCardInputValidator] refuses to mint the
+     * card, so consumers building a picker off [ScannableFormat.entries] cannot offer a choice
+     * whose Save always fails. The encoder no longer reads it — `ZxingBarcodeEncoder.writeMatrix`
+     * is compiler-exhaustive, so a new member breaks that build until someone decides on a writer.
      */
-    val decodeOnly: Set<ScannableFormat> = setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)
+    val decodeOnly: Set<ScannableFormat> = emptySet()
 
     /** Soft cap on payload length per symbology. Numeric symbologies use their exact length. */
     fun maxPayloadLength(format: ScannableFormat): Int =
@@ -151,10 +155,15 @@ internal object ScannableFormatConstraints {
 
     /**
      * Soft caps for the two 2D symbologies added in wpass-pl7.1, in characters (same unit as
-     * [QR_MAX]; the byte-exact ceiling is an encoder concern). Both sit well under the spec
-     * maxima at any plausible error-correction level — PDF417 holds ~1,100 bytes and Aztec
-     * ~1,900 at MINIMUM EC, and both shrink as EC rises. wpass-pl7.6 pins the EC defaults; if
-     * it picks anything below PDF417 level 5 or Aztec 23%, re-derive these against that pin.
+     * [QR_MAX]; the byte-exact ceiling is an encoder concern).
+     *
+     * RE-DERIVED in wpass-pl7.6 against the error-correction levels that bead pinned, measured
+     * with ZXing 3.5.4 by binary-searching the largest ASCII payload each writer accepts:
+     * PDF417 at level 3 holds 1,766 characters against the 800 here, Aztec at 33% holds 3,000
+     * against the 1,500 here. Both caps therefore stand unchanged, with better than 2x headroom
+     * — the property that matters is that a payload the validator accepts always fits the
+     * encoder, or a clean `InvalidPayload(TooLong)` rejection becomes a blank render instead.
+     * Re-derive again if either EC pin rises.
      *
      * A boarding pass is the sizing case that matters and is nowhere near either: an IATA
      * BCBP payload runs ~60 characters per leg.

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -11,14 +11,13 @@ package `is`.walt.passes.core
  */
 internal object ScannableFormatConstraints {
     /**
-     * Roster members this build decodes but cannot render. Empty since wpass-pl7.6 wired the
-     * Pdf417 / Aztec writer arms — every roster member now encodes.
+     * Roster members this build decodes but cannot render. Empty — every member encodes.
      *
-     * Kept rather than deleted because it is the create-boundary refusal a decode-first roster
-     * addition needs: put a format here and [ScannableCardInputValidator] refuses to mint the
-     * card, so consumers building a picker off [ScannableFormat.entries] cannot offer a choice
-     * whose Save always fails. The encoder no longer reads it — `ZxingBarcodeEncoder.writeMatrix`
-     * is compiler-exhaustive, so a new member breaks that build until someone decides on a writer.
+     * Kept as the create-boundary refusal a decode-first roster addition needs: put a format
+     * here and [ScannableCardInputValidator] refuses to mint the card, so consumers building a
+     * picker off [ScannableFormat.entries] cannot offer a choice whose Save always fails. The
+     * encoder does not read it; `ZxingBarcodeEncoder.writeMatrix` is compiler-exhaustive, so a
+     * new member breaks that build until someone decides on a writer.
      */
     val decodeOnly: Set<ScannableFormat> = emptySet()
 
@@ -154,16 +153,25 @@ internal object ScannableFormatConstraints {
     private const val QR_MAX = 2000
 
     /**
-     * Soft caps for the two 2D symbologies added in wpass-pl7.1, in characters (same unit as
-     * [QR_MAX]; the byte-exact ceiling is an encoder concern).
+     * Soft caps for the two 2D symbologies, in characters (same unit as [QR_MAX]).
      *
-     * RE-DERIVED in wpass-pl7.6 against the error-correction levels that bead pinned, measured
-     * with ZXing 3.5.4 by binary-searching the largest ASCII payload each writer accepts:
-     * PDF417 at level 3 holds 1,766 characters against the 800 here, Aztec at 33% holds 3,000
-     * against the 1,500 here. Both caps therefore stand unchanged, with better than 2x headroom
-     * — the property that matters is that a payload the validator accepts always fits the
-     * encoder, or a clean `InvalidPayload(TooLong)` rejection becomes a blank render instead.
-     * Re-derive again if either EC pin rises.
+     * Derived against the encoder's pinned error-correction levels, measured with ZXing 3.5.4
+     * by binary-searching the largest payload each writer accepts: **for single-byte payloads**
+     * PDF417 at level 3 holds 1,766 characters against the 800 here, and Aztec at 33% holds
+     * 3,000 against the 1,500 here. Re-derive if either EC pin rises.
+     *
+     * **These caps do NOT guarantee encodability, because they count characters while capacity
+     * is consumed in bytes.** The same measurement over three-byte characters gives PDF417 528
+     * and Aztec 623 — both far below the caps here, and both payloads this object accepts. An
+     * exact predicate is not available at this layer: the writers pick a compaction mode per
+     * run, so capacity swings with the payload's composition (Aztec fits 2,995 ASCII characters
+     * but 934 accented ones; a mixed payload does better than either rate predicts). A flat byte
+     * ceiling tight enough to be safe would reject ordinary accented text well under the cap.
+     *
+     * What closes the hole instead is the encoder lifting the writers' over-capacity errors to
+     * [EncoderFailureReason.PayloadTooDense], so an oversized multibyte payload gets an
+     * actionable "shorten this" rather than a silent failure. That arm only reaches the user if
+     * something runs the encoder before persisting, which nothing currently does — see wpass-1kg.
      *
      * A boarding pass is the sizing case that matters and is nowhere near either: an IATA
      * BCBP payload runs ~60 characters per leg.

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -1,11 +1,14 @@
 package `is`.walt.passes.core.internal
 
 import com.google.zxing.EncodeHintType
+import com.google.zxing.aztec.AztecWriter
 import com.google.zxing.common.BitMatrix
 import com.google.zxing.oned.Code128Writer
 import com.google.zxing.oned.Code39Writer
 import com.google.zxing.oned.EAN13Writer
 import com.google.zxing.oned.UPCAWriter
+import com.google.zxing.pdf417.PDF417Writer
+import com.google.zxing.pdf417.encoder.Compaction
 import com.google.zxing.qrcode.QRCodeWriter
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import `is`.walt.passes.core.BarcodeMatrix
@@ -24,28 +27,78 @@ import com.google.zxing.BarcodeFormat as ZxingFormat
  * encoder. The intermediate `MultiFormatWriter` would silently accept anything ZXing
  * supports, including formats the validator has not been taught to gate.
  *
- * **Pdf417 and Aztec decode but do not yet encode.** They joined the decode roster in
- * wpass-pl7.1 and are refused here as [EncoderFailureReason.FormatNotEncodable] until
- * wpass-pl7.6 wires `PDF417Writer` / `AztecWriter` with scan-verified EC and compaction
- * defaults. That gap is why the dispatch is per-format: `MultiFormatWriter` would have
- * silently emitted an unverified symbol for both the moment the enum grew.
+ * Every roster member encodes as of wpass-pl7.6. A future decode-only addition has no
+ * refusal path to opt into: [writeMatrix]'s `when` is compiler-exhaustive, so a new
+ * [ScannableFormat] member breaks the build here and forces the writer (or a deliberate
+ * refusal) to be a decision someone makes rather than one `MultiFormatWriter` makes for them.
  *
  * Hidden behind [BarcodeEncoder]; this object is package-internal so consumers cannot
  * reach for ZXing types directly.
  *
- * **Quiet zone.** Most ZXing writers emit their own quiet zone (margin) at default
- * settings. The kernel does not strip or extend it here — the render layer (passes-ui,
- * Child 7) controls visual padding.
+ * **Quiet zone.** Most ZXing writers emit their own quiet zone (margin) at default settings
+ * and the kernel leaves it alone — the render layer (passes-ui) controls visual padding.
+ * `PDF417Writer` is the one exception, see the margin note below.
  *
  * **QR error correction.** Fixed at [ErrorCorrectionLevel.M] (~15% redundancy). High
  * enough to survive moderate scratch/damage on a phone screen but low enough that long
  * payloads still fit. v1 does not expose a tuning knob; if scanner reliability demands it
  * later, surface a parameter on [BarcodeEncoder.encode] without changing the default.
+ *
+ * **Aztec error correction.** Fixed at [AZTEC_ERROR_CORRECTION_PERCENT] (33%), which is both
+ * ZXing's default and the Aztec spec's recommended level. Measured against ZXing 3.5.4: a
+ * 132-character BCBP boarding pass yields the same 37x37 matrix at every level from 23% to
+ * 50%, so the redundancy is free at the payload size this roster addition exists to serve.
+ * Capacity at 33% is ~3,000 ASCII characters, twice the validator's 1,500-character cap.
+ *
+ * **PDF417 error correction, compaction and margin.** Error correction is pinned at
+ * [PDF417_ERROR_CORRECTION_LEVEL] (3) rather than ZXing's hardcoded default of 2:
+ * ISO/IEC 15438 recommends level 3 for 41-160 data codewords, which is where a BCBP
+ * boarding pass lands. Measured cost at that length is one extra row and no extra column
+ * (209x48 to 209x52), so module width at a fixed render width is unchanged. Capacity at
+ * level 3 is ~1,766 ASCII characters, well above the validator's 800-character cap.
+ *
+ * Compaction is left [Compaction.AUTO]: it emits a symbol no larger than forced BYTE
+ * compaction, so forcing a mode only costs area.
+ *
+ * Margin is pinned to [PDF417_QUIET_ZONE_MODULES] (2, the spec quiet zone) because
+ * `PDF417Writer` otherwise pads 30 modules on all four sides. On a 44-module-tall symbol
+ * that more than doubles the height and drags the aspect ratio from 4.66 to 2.55 — dead
+ * space the render layer then letterboxes, on top of the quiet zone it already applies
+ * itself. This is the one place the kernel overrides a writer's own margin.
+ *
+ * **Character set.** Both writers default to ISO-8859-1, and the validator admits any visible
+ * character for the byte-capable formats, so the default loses payloads a user can legitimately
+ * type. The two symbologies fail differently and both are addressed: `PDF417Writer` throws
+ * outright on a non-Latin-1 character, fixed by `PDF417_AUTO_ECI`, which emits an ECI header
+ * only when one is actually needed; `AztecWriter` is the worse case — it encodes happily and
+ * decodes back transliterated ("東京" returns as "??"), a silent corruption fixed by pinning
+ * CHARACTER_SET. Measured: both fixes leave the all-ASCII case byte-identical in matrix size
+ * and capacity, so they cost nothing at boarding-pass payloads.
+ *
+ * QR has the same silent-transliteration defect and is NOT fixed here — it predates this bead
+ * and changing the emitted symbol for existing QR cards needs its own scanner verification.
+ * Tracked as wpass-qj6.
  */
 internal object ZxingBarcodeEncoder {
-    // The QR writer's hint for error correction. Other writers ignore the hint map.
+    // Per-writer hint maps. Each writer reads ERROR_CORRECTION as a different type —
+    // ErrorCorrectionLevel for QR, an Int percentage for Aztec, an Int level for PDF417 —
+    // so the maps cannot be merged. See the class KDoc for how each value was chosen.
     private val qrHints: Map<EncodeHintType, Any> =
         mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M)
+
+    private val aztecHints: Map<EncodeHintType, Any> =
+        mapOf(
+            EncodeHintType.ERROR_CORRECTION to AZTEC_ERROR_CORRECTION_PERCENT,
+            EncodeHintType.CHARACTER_SET to UTF_8,
+        )
+
+    private val pdf417Hints: Map<EncodeHintType, Any> =
+        mapOf(
+            EncodeHintType.ERROR_CORRECTION to PDF417_ERROR_CORRECTION_LEVEL,
+            EncodeHintType.PDF417_COMPACTION to Compaction.AUTO,
+            EncodeHintType.MARGIN to PDF417_QUIET_ZONE_MODULES,
+            EncodeHintType.PDF417_AUTO_ECI to true,
+        )
 
     fun encode(
         payload: String,
@@ -72,10 +125,15 @@ internal object ZxingBarcodeEncoder {
     }
 
     /**
-     * The two refusals that are decided without running a writer, or null to proceed.
+     * The refusals that are decided without running a writer, or null to proceed.
      *
-     * Pdf417/Aztec are decode-only in this build (see the class KDoc). The QR check is a
-     * proactive [EncoderFailureReason.PayloadTooDense], gated by the alphanumeric-mode
+     * An empty payload is refused for every format. The validator rejects it upstream, so this
+     * is defense in depth — but it cannot be left to the writers: five of the six throw on an
+     * empty input and `AztecWriter` does not once a CHARACTER_SET is pinned, happily emitting a
+     * 15x15 symbol that encodes nothing. Uniform refusal here beats six incidental behaviors
+     * that a hint change can flip.
+     *
+     * The QR check is a proactive [EncoderFailureReason.PayloadTooDense], gated by the alphanumeric-mode
      * membership test: a payload that fits QR's numeric or alphanumeric mode has a much larger
      * capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs 2,331
      * bytes), and ZXing's QRCodeWriter auto-selects the densest fitting mode, so pre-rejecting
@@ -90,8 +148,8 @@ internal object ZxingBarcodeEncoder {
         format: ScannableFormat,
     ): EncoderFailureReason? =
         when {
-            format in ScannableFormatConstraints.decodeOnly ->
-                EncoderFailureReason.FormatNotEncodable(format)
+            payload.isEmpty() ->
+                EncoderFailureReason.WriterRejected(format, EMPTY_PAYLOAD_MESSAGE)
             format == ScannableFormat.Qr &&
                 payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&
                 payload.toByteArray(Charsets.UTF_8).size >
@@ -114,9 +172,10 @@ internal object ZxingBarcodeEncoder {
                 ScannableFormat.Ean13 -> EAN13Writer().encode(payload, ZxingFormat.EAN_13, 0, 0)
                 ScannableFormat.UpcA -> UPCAWriter().encode(payload, ZxingFormat.UPC_A, 0, 0)
                 ScannableFormat.Qr -> QRCodeWriter().encode(payload, ZxingFormat.QR_CODE, 0, 0, qrHints)
-                // Unreachable: encode() refuses these before dispatching. No payload in the
-                // message — the format name alone is enough to diagnose a lost guard.
-                ScannableFormat.Pdf417, ScannableFormat.Aztec -> error("No writer wired for $format")
+                ScannableFormat.Pdf417 ->
+                    PDF417Writer().encode(payload, ZxingFormat.PDF_417, 0, 0, pdf417Hints)
+                ScannableFormat.Aztec ->
+                    AztecWriter().encode(payload, ZxingFormat.AZTEC, 0, 0, aztecHints)
             }
         return bitMatrix.toBarcodeMatrix()
     }
@@ -152,4 +211,14 @@ internal object ZxingBarcodeEncoder {
     // The exact substring is load-bearing — see PayloadTooDense lift above. Pinned by
     // BarcodeEncoderTest.qrPayloadTooDenseLiftsToDedicatedArm.
     private const val DATA_TOO_BIG_MESSAGE = "Data too big"
+
+    // The pins the class KDoc argues for. ScannableFormatConstraints' PDF417 / Aztec caps were
+    // derived against these values; changing one means re-deriving the other.
+    private const val AZTEC_ERROR_CORRECTION_PERCENT = 33
+    private const val PDF417_ERROR_CORRECTION_LEVEL = 3
+    private const val PDF417_QUIET_ZONE_MODULES = 2
+    private const val UTF_8 = "UTF-8"
+
+    // Walt's own wording, not a ZXing message — this refusal never reaches a writer.
+    private const val EMPTY_PAYLOAD_MESSAGE = "Empty payload"
 }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -48,14 +48,14 @@ import com.google.zxing.BarcodeFormat as ZxingFormat
  * ZXing's default and the Aztec spec's recommended level. Measured against ZXing 3.5.4: a
  * 132-character BCBP boarding pass yields the same 37x37 matrix at every level from 23% to
  * 50%, so the redundancy is free at the payload size this roster addition exists to serve.
- * Capacity at 33% is ~3,000 ASCII characters, twice the validator's 1,500-character cap.
+ * Capacity headroom against the validator's cap is recorded on that cap, in
+ * `ScannableFormatConstraints`, so the numbers and the limits they justify stay together.
  *
  * **PDF417 error correction, compaction and margin.** Error correction is pinned at
  * [PDF417_ERROR_CORRECTION_LEVEL] (3) rather than ZXing's hardcoded default of 2:
  * ISO/IEC 15438 recommends level 3 for 41-160 data codewords, which is where a BCBP
  * boarding pass lands. Measured cost at that length is one extra row and no extra column
- * (209x48 to 209x52), so module width at a fixed render width is unchanged. Capacity at
- * level 3 is ~1,766 ASCII characters, well above the validator's 800-character cap.
+ * (209x48 to 209x52), so module width at a fixed render width is unchanged.
  *
  * Compaction is left [Compaction.AUTO]: it emits a symbol no larger than forced BYTE
  * compaction, so forcing a mode only costs area.
@@ -197,14 +197,8 @@ internal object ZxingBarcodeEncoder {
         payload: String,
         cause: Throwable,
     ): EncoderFailureReason {
-        // Belt-and-suspenders: the proactive byte-length check above handles the common QR
-        // overflow path; this string match catches the same condition when ZXing surfaces it
-        // for a payload that slipped under the byte ceiling (e.g. some mixed-mode inputs).
-        // The match is intentionally lossy — if ZXing rewords the message on a future bump,
-        // the encoder still surfaces WriterRejected and the consumer still gets a usable
-        // error path, just without the PayloadTooDense-specific UI hint.
         val message = cause.message.orEmpty()
-        if (OVER_CAPACITY_MESSAGES.getValue(format).any { it in message }) {
+        if (overCapacityMessages(format).any { it in message }) {
             return EncoderFailureReason.PayloadTooDense
         }
         return EncoderFailureReason.WriterRejected(format, message.withoutPayload(payload))
@@ -221,38 +215,57 @@ internal object ZxingBarcodeEncoder {
     }
 
     /**
-     * Strips [payload] out of a third-party exception message. `PDF417Writer` interpolates the
-     * whole input into its "Failed to encode" text, and [EncoderFailureReason.WriterRejected.
-     * detail] is the one third-party string that crosses the kernel boundary — its own KDoc
-     * warns consumers not to ship it verbatim. Removing the payload here means that warning no
-     * longer has to hold back the user's card number.
+     * Strips [payload] out of a third-party exception message. [EncoderFailureReason.
+     * WriterRejected.detail] is the one third-party string that crosses the kernel boundary, and
+     * its own KDoc warns consumers not to ship it verbatim because ZXing has historically
+     * embedded input-derived substrings in its messages.
+     *
+     * **No writer reaches this with a payload in the message today**, verified across the roster
+     * against ZXing 3.5.4: the only message that interpolates the whole input is `PDF417Writer`'s
+     * "Failed to encode", which needs a surrogate, and [refuseBeforeWriter] rejects those before
+     * the writer runs. Every other failure names one character, one ASCII value, or a length.
+     *
+     * It stays because the guard is what makes that true. If a later ZXing gains surrogate
+     * support and the refusal above is relaxed, or a reworded message starts echoing input, the
+     * leak returns silently — this keeps that change safe by default rather than depending on
+     * whoever makes it noticing. Exercised directly by `BarcodeEncoderTest`, since no
+     * end-to-end input can currently reach it.
      */
-    private fun String.withoutPayload(payload: String): String =
+    internal fun String.withoutPayload(payload: String): String =
         if (payload.isNotEmpty() && payload in this) replace(payload, REDACTED) else this
 
-    // Per-format substrings that mean "this payload does not fit", lifted to the dedicated
-    // PayloadTooDense arm so the consumer can say "shorten it" rather than "try another
-    // format". The matches are intentionally lossy: if ZXing rewords one on a version bump the
-    // encoder still reports WriterRejected, just without the specific UI hint.
-    //
-    // The three 2D formats need this because their length caps are in CHARACTERS while their
-    // capacity is in bytes, so a multibyte payload can clear the validator and still overflow
-    // (see ScannableFormatConstraints' cap KDoc). The 1D formats have no over-capacity message
-    // of their own — their fixed or short caps are reached long before any density limit.
-    private val OVER_CAPACITY_MESSAGES: Map<ScannableFormat, List<String>> =
-        mapOf(
-            ScannableFormat.Qr to listOf("Data too big"),
-            ScannableFormat.Aztec to listOf("Data too large for an Aztec code"),
-            ScannableFormat.Pdf417 to
+    /**
+     * ZXing message substrings meaning "this payload does not fit", lifted to the dedicated
+     * [EncoderFailureReason.PayloadTooDense] arm so the consumer can say "shorten it" rather
+     * than "try another format". The matches are intentionally lossy: if ZXing rewords one on a
+     * version bump the encoder still reports `WriterRejected`, just without the specific hint.
+     *
+     * The three 2D formats need this because their length caps are in CHARACTERS while their
+     * capacity is spent in bytes, so a multibyte payload can clear the validator and still
+     * overflow (see `ScannableFormatConstraints`' cap KDoc). The 1D formats have no
+     * over-capacity message of their own — their fixed or short caps are reached long before
+     * any density limit.
+     *
+     * An exhaustive `when` rather than a map because [translateFailure] runs in the `onFailure`
+     * lambda, OUTSIDE the `runCatching` above: a missing key there would throw straight through
+     * [BarcodeEncoder]'s no-throw contract, and only in the failure path where nobody is
+     * looking. A roster addition has to be answered here at compile time instead.
+     */
+    private fun overCapacityMessages(format: ScannableFormat): List<String> =
+        when (format) {
+            ScannableFormat.Qr -> listOf("Data too big")
+            ScannableFormat.Aztec -> listOf("Data too large for an Aztec code")
+            ScannableFormat.Pdf417 ->
                 listOf(
                     "Unable to fit message in columns",
                     "Encoded message contains too many code words",
-                ),
-            ScannableFormat.Code128 to emptyList(),
-            ScannableFormat.Code39 to emptyList(),
-            ScannableFormat.Ean13 to emptyList(),
-            ScannableFormat.UpcA to emptyList(),
-        )
+                )
+            ScannableFormat.Code128,
+            ScannableFormat.Code39,
+            ScannableFormat.Ean13,
+            ScannableFormat.UpcA,
+            -> emptyList()
+        }
 
     // The pins the class KDoc argues for. ScannableFormatConstraints' PDF417 / Aztec caps were
     // derived against these values; changing one means re-deriving the other.

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -27,10 +27,10 @@ import com.google.zxing.BarcodeFormat as ZxingFormat
  * encoder. The intermediate `MultiFormatWriter` would silently accept anything ZXing
  * supports, including formats the validator has not been taught to gate.
  *
- * Every roster member encodes as of wpass-pl7.6. A future decode-only addition has no
- * refusal path to opt into: [writeMatrix]'s `when` is compiler-exhaustive, so a new
- * [ScannableFormat] member breaks the build here and forces the writer (or a deliberate
- * refusal) to be a decision someone makes rather than one `MultiFormatWriter` makes for them.
+ * Every roster member encodes. A decode-only addition has no refusal path to opt into:
+ * [writeMatrix]'s `when` is compiler-exhaustive, so a new [ScannableFormat] member breaks the
+ * build here and forces the writer (or a deliberate refusal) to be a decision someone makes
+ * rather than one `MultiFormatWriter` makes for them.
  *
  * Hidden behind [BarcodeEncoder]; this object is package-internal so consumers cannot
  * reach for ZXing types directly.
@@ -119,7 +119,7 @@ internal object ZxingBarcodeEncoder {
                 onSuccess = { EncodeResult.Success(it) },
                 onFailure = {
                     if (it is CancellationException) throw it
-                    EncodeResult.Failure(translateFailure(format, it))
+                    EncodeResult.Failure(translateFailure(format, payload, it))
                 },
             )
     }
@@ -132,6 +132,16 @@ internal object ZxingBarcodeEncoder {
      * empty input and `AztecWriter` does not once a CHARACTER_SET is pinned, happily emitting a
      * 15x15 symbol that encodes nothing. Uniform refusal here beats six incidental behaviors
      * that a hint change can flip.
+     *
+     * PDF417 refuses supplementary-plane characters (emoji, historic scripts — anything outside
+     * the BMP, which Kotlin holds as a surrogate pair). ZXing cannot encode one in PDF417 under
+     * any configuration tried: with `PDF417_AUTO_ECI` it raises an `IllegalStateException` whose
+     * message embeds THE ENTIRE PAYLOAD, and without it a `WriterException` naming one half of
+     * the pair as an unpaired code unit. The validator admits these characters (they are visible
+     * and not Cf/Cc) and Aztec encodes them fine, so this is a PDF417-specific writer limit that
+     * has to be named as one rather than surfacing as an unattributable failure. Catching it
+     * before the writer runs is also what keeps the payload out of [EncoderFailureReason.
+     * WriterRejected.detail].
      *
      * The QR check is a proactive [EncoderFailureReason.PayloadTooDense], gated by the alphanumeric-mode
      * membership test: a payload that fits QR's numeric or alphanumeric mode has a much larger
@@ -150,6 +160,8 @@ internal object ZxingBarcodeEncoder {
         when {
             payload.isEmpty() ->
                 EncoderFailureReason.WriterRejected(format, EMPTY_PAYLOAD_MESSAGE)
+            format == ScannableFormat.Pdf417 && payload.any { it.isSurrogate() } ->
+                EncoderFailureReason.WriterRejected(format, NO_SUPPLEMENTARY_CHARS_MESSAGE)
             format == ScannableFormat.Qr &&
                 payload.any { !ScannableFormatConstraints.isQrAlphanumericChar(it) } &&
                 payload.toByteArray(Charsets.UTF_8).size >
@@ -182,6 +194,7 @@ internal object ZxingBarcodeEncoder {
 
     private fun translateFailure(
         format: ScannableFormat,
+        payload: String,
         cause: Throwable,
     ): EncoderFailureReason {
         // Belt-and-suspenders: the proactive byte-length check above handles the common QR
@@ -191,10 +204,10 @@ internal object ZxingBarcodeEncoder {
         // the encoder still surfaces WriterRejected and the consumer still gets a usable
         // error path, just without the PayloadTooDense-specific UI hint.
         val message = cause.message.orEmpty()
-        if (format == ScannableFormat.Qr && DATA_TOO_BIG_MESSAGE in message) {
+        if (OVER_CAPACITY_MESSAGES.getValue(format).any { it in message }) {
             return EncoderFailureReason.PayloadTooDense
         }
-        return EncoderFailureReason.WriterRejected(format, message)
+        return EncoderFailureReason.WriterRejected(format, message.withoutPayload(payload))
     }
 
     private fun BitMatrix.toBarcodeMatrix(): BarcodeMatrix {
@@ -207,10 +220,39 @@ internal object ZxingBarcodeEncoder {
         return BarcodeMatrix(width, height, flat)
     }
 
-    // ZXing's QRCodeWriter throws WriterException("Data too big") when no QR version fits.
-    // The exact substring is load-bearing — see PayloadTooDense lift above. Pinned by
-    // BarcodeEncoderTest.qrPayloadTooDenseLiftsToDedicatedArm.
-    private const val DATA_TOO_BIG_MESSAGE = "Data too big"
+    /**
+     * Strips [payload] out of a third-party exception message. `PDF417Writer` interpolates the
+     * whole input into its "Failed to encode" text, and [EncoderFailureReason.WriterRejected.
+     * detail] is the one third-party string that crosses the kernel boundary — its own KDoc
+     * warns consumers not to ship it verbatim. Removing the payload here means that warning no
+     * longer has to hold back the user's card number.
+     */
+    private fun String.withoutPayload(payload: String): String =
+        if (payload.isNotEmpty() && payload in this) replace(payload, REDACTED) else this
+
+    // Per-format substrings that mean "this payload does not fit", lifted to the dedicated
+    // PayloadTooDense arm so the consumer can say "shorten it" rather than "try another
+    // format". The matches are intentionally lossy: if ZXing rewords one on a version bump the
+    // encoder still reports WriterRejected, just without the specific UI hint.
+    //
+    // The three 2D formats need this because their length caps are in CHARACTERS while their
+    // capacity is in bytes, so a multibyte payload can clear the validator and still overflow
+    // (see ScannableFormatConstraints' cap KDoc). The 1D formats have no over-capacity message
+    // of their own — their fixed or short caps are reached long before any density limit.
+    private val OVER_CAPACITY_MESSAGES: Map<ScannableFormat, List<String>> =
+        mapOf(
+            ScannableFormat.Qr to listOf("Data too big"),
+            ScannableFormat.Aztec to listOf("Data too large for an Aztec code"),
+            ScannableFormat.Pdf417 to
+                listOf(
+                    "Unable to fit message in columns",
+                    "Encoded message contains too many code words",
+                ),
+            ScannableFormat.Code128 to emptyList(),
+            ScannableFormat.Code39 to emptyList(),
+            ScannableFormat.Ean13 to emptyList(),
+            ScannableFormat.UpcA to emptyList(),
+        )
 
     // The pins the class KDoc argues for. ScannableFormatConstraints' PDF417 / Aztec caps were
     // derived against these values; changing one means re-deriving the other.
@@ -219,6 +261,9 @@ internal object ZxingBarcodeEncoder {
     private const val PDF417_QUIET_ZONE_MODULES = 2
     private const val UTF_8 = "UTF-8"
 
-    // Walt's own wording, not a ZXing message — this refusal never reaches a writer.
+    // Walt's own wording, not ZXing messages — these refusals never reach a writer.
     private const val EMPTY_PAYLOAD_MESSAGE = "Empty payload"
+    private const val NO_SUPPLEMENTARY_CHARS_MESSAGE =
+        "PDF417 cannot encode supplementary-plane characters"
+    private const val REDACTED = "<payload>"
 }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -62,6 +62,42 @@ class BarcodeEncoderTest {
         assertThat(anyModuleSet(matrix)).isTrue()
     }
 
+    @Test
+    fun aztecEncodesProducingSquareMatrix() {
+        val result = BarcodeEncoder.encode(BCBP_SHAPED_PAYLOAD, ScannableFormat.Aztec)
+        val matrix = (result as EncodeResult.Success).matrix
+        // Aztec is square. Locks the dispatch to AztecWriter rather than the stacked PDF417
+        // writer, which the same boarding-pass payload would also encode successfully.
+        assertThat(matrix.width).isEqualTo(matrix.height)
+        assertThat(anyModuleSet(matrix)).isTrue()
+    }
+
+    @Test
+    fun pdf417EncodesProducingWideStackedMatrix() {
+        val result = BarcodeEncoder.encode(BCBP_SHAPED_PAYLOAD, ScannableFormat.Pdf417)
+        val matrix = (result as EncodeResult.Success).matrix
+        assertThat(anyModuleSet(matrix)).isTrue()
+        // Stacked, so taller than the one-module strip a 1D writer emits but far wider than
+        // tall. The band also pins the 2-module MARGIN: at ZXing's default 30-module quiet
+        // zone this same payload lands at 2.55:1 and fails the lower bound, which is the
+        // regression that would silently letterbox the render slot.
+        assertThat(matrix.height).isGreaterThan(1)
+        val aspect = matrix.width.toDouble() / matrix.height
+        assertThat(aspect).isGreaterThan(3.0)
+        assertThat(aspect).isLessThan(5.0)
+    }
+
+    @Test
+    fun theTwoDimensionalFormatsEncodeAtTheirValidatorCap() {
+        // The property the caps exist for: anything the validator accepts must fit the writer,
+        // or a clean InvalidPayload(TooLong) rejection becomes a blank render. Re-derive both
+        // caps if either error-correction pin rises.
+        for ((format, cap) in listOf(ScannableFormat.Pdf417 to 800, ScannableFormat.Aztec to 1_500)) {
+            val result = BarcodeEncoder.encode("A".repeat(cap), format)
+            assertThat(result).isInstanceOf(EncodeResult.Success::class.java)
+        }
+    }
+
     // ---- per-format encoder rejection ----
 
     @Test
@@ -103,7 +139,7 @@ class BarcodeEncoderTest {
         // Locks no-throw AND per-format dispatch correctness in one test. Asserts on
         // WriterRejected.format specifically; PayloadTooDense is not a plausible arm for an
         // empty input (zero bytes can never exceed any ceiling).
-        for (format in ScannableFormat.entries - notEncodable) {
+        for (format in ScannableFormat.entries) {
             val result = BarcodeEncoder.encode("", format)
             val reason = (result as EncodeResult.Failure).reason
             assertThat(reason).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
@@ -112,16 +148,13 @@ class BarcodeEncoderTest {
     }
 
     @Test
-    fun decodeOnlyFormatsReportFormatNotEncodable() {
-        // Pdf417/Aztec decode but have no writer until wpass-pl7.6. The refusal must be the
-        // dedicated build-capability arm, not WriterRejected — a consumer that reads
-        // WriterRejected would tell the user to shorten a payload that was never the problem.
-        // Asserted on a valid payload so this cannot pass for the empty-input reason above.
-        for (format in notEncodable) {
-            val result = BarcodeEncoder.encode("WALT-CHECK-1", format)
-
-            assertThat((result as EncodeResult.Failure).reason)
-                .isEqualTo(EncoderFailureReason.FormatNotEncodable(format))
+    fun everyRosterFormatEncodes() {
+        // The whole roster renders as of wpass-pl7.6. Fails closed on a future decode-first
+        // addition: whoever adds it has to decide here whether it is genuinely unrenderable
+        // (then ScannableFormatConstraints.decodeOnly is the create-boundary refusal) rather
+        // than shipping a format that saves successfully and then shows blank.
+        for (format in ScannableFormat.entries) {
+            assertThat(format.isCreatable()).isTrue()
         }
     }
 
@@ -181,9 +214,6 @@ class BarcodeEncoderTest {
         assertThat(a).isNotEqualTo(different)
     }
 
-    /** Roster members that decode but do not yet encode; wpass-pl7.6 empties this set. */
-    private val notEncodable = setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)
-
     private fun anyModuleSet(matrix: BarcodeMatrix): Boolean {
         for (y in 0 until matrix.height) {
             for (x in 0 until matrix.width) {
@@ -191,5 +221,17 @@ class BarcodeEncoderTest {
             }
         }
         return false
+    }
+
+    private companion object {
+        /**
+         * A synthetic payload of IATA BCBP shape and length — the sizing case the Pdf417 /
+         * Aztec writers exist to serve. Invented, never a decoded boarding pass: a real BCBP
+         * string carries passenger name and PNR, which wpass-pl7 bars from any committed
+         * fixture, log line or bead note.
+         */
+        const val BCBP_SHAPED_PAYLOAD =
+            "M1TEST/PASSENGER      EABC123 CPHLHRSK 0501 227M014A0058 147>5180      " +
+                "B1A              2A05512345678901 0                          "
     }
 }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -89,9 +89,10 @@ class BarcodeEncoderTest {
 
     @Test
     fun theTwoDimensionalFormatsEncodeAtTheirValidatorCap() {
-        // The property the caps exist for: anything the validator accepts must fit the writer,
-        // or a clean InvalidPayload(TooLong) rejection becomes a blank render. Re-derive both
-        // caps if either error-correction pin rises.
+        // Single-byte only, which is as far as the caps reach: they count characters while
+        // capacity is spent in bytes, so a multibyte payload can sit under the cap and still
+        // overflow (see multibytePayloadUnderTheCharacterCapStillLiftsToPayloadTooDense).
+        // Re-derive both caps if either error-correction pin rises.
         for ((format, cap) in listOf(ScannableFormat.Pdf417 to 800, ScannableFormat.Aztec to 1_500)) {
             val result = BarcodeEncoder.encode("A".repeat(cap), format)
             assertThat(result).isInstanceOf(EncodeResult.Success::class.java)
@@ -117,6 +118,34 @@ class BarcodeEncoderTest {
         val failure = (result as EncodeResult.Failure).reason
         assertThat(failure).isInstanceOf(EncoderFailureReason.WriterRejected::class.java)
         assertThat((failure as EncoderFailureReason.WriterRejected).format).isEqualTo(ScannableFormat.UpcA)
+    }
+
+    @Test
+    fun multibytePayloadUnderTheCharacterCapStillLiftsToPayloadTooDense() {
+        // The caps are in CHARACTERS, capacity is in bytes: 700 CJK characters is under both
+        // 2D caps and over both byte capacities (Aztec fits 623, PDF417 528). The user has to
+        // be told to shorten it — WriterRejected would send them to change format instead, and
+        // no arm at all leaves a card that saves and then renders blank.
+        for (format in listOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+            val result = BarcodeEncoder.encode("東".repeat(700), format)
+
+            assertThat((result as EncodeResult.Failure).reason)
+                .isEqualTo(EncoderFailureReason.PayloadTooDense)
+        }
+    }
+
+    @Test
+    fun writerRejectionNeverCarriesThePayloadInDetail() {
+        // PDF417Writer interpolates the whole input into its "Failed to encode" message, and
+        // detail is the one third-party string crossing the kernel boundary. A card number
+        // reaching a consumer's diagnostic surface through an error field is the leak.
+        val payload = "https://example.org/secret-token-abc123/👍"
+
+        val reason = (BarcodeEncoder.encode(payload, ScannableFormat.Pdf417) as EncodeResult.Failure).reason
+
+        assertThat((reason as EncoderFailureReason.WriterRejected).detail).doesNotContain(payload)
+        assertThat(reason.detail).doesNotContain("secret-token-abc123")
+        assertThat(reason.format).isEqualTo(ScannableFormat.Pdf417)
     }
 
     @Test
@@ -149,11 +178,24 @@ class BarcodeEncoderTest {
 
     @Test
     fun everyRosterFormatEncodes() {
-        // The whole roster renders as of wpass-pl7.6. Fails closed on a future decode-first
-        // addition: whoever adds it has to decide here whether it is genuinely unrenderable
-        // (then ScannableFormatConstraints.decodeOnly is the create-boundary refusal) rather
-        // than shipping a format that saves successfully and then shows blank.
-        for (format in ScannableFormat.entries) {
+        // Runs a writer per format rather than asking isCreatable(), which with an empty
+        // decodeOnly set answers true without encoding anything. Fails closed on a roster
+        // addition: the map has to gain a payload, and that payload has to actually render.
+        val payloads =
+            mapOf(
+                ScannableFormat.Code128 to "ABC123 xyz",
+                ScannableFormat.Code39 to "HELLO-123",
+                ScannableFormat.Ean13 to "1234567890128",
+                ScannableFormat.UpcA to "036000291452",
+                ScannableFormat.Qr to "https://example.org/loyalty/123",
+                ScannableFormat.Pdf417 to "WALT-CHECK-1",
+                ScannableFormat.Aztec to "WALT-CHECK-1",
+            )
+        assertThat(payloads.keys).containsExactlyElementsIn(ScannableFormat.entries)
+
+        for ((format, payload) in payloads) {
+            val matrix = (BarcodeEncoder.encode(payload, format) as EncodeResult.Success).matrix
+            assertThat(anyModuleSet(matrix)).isTrue()
             assertThat(format.isCreatable()).isTrue()
         }
     }

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -1,6 +1,7 @@
 package `is`.walt.passes.core
 
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.internal.ZxingBarcodeEncoder
 import org.junit.Test
 
 /**
@@ -135,17 +136,38 @@ class BarcodeEncoderTest {
     }
 
     @Test
-    fun writerRejectionNeverCarriesThePayloadInDetail() {
-        // PDF417Writer interpolates the whole input into its "Failed to encode" message, and
-        // detail is the one third-party string crossing the kernel boundary. A card number
-        // reaching a consumer's diagnostic surface through an error field is the leak.
+    fun pdf417RefusesSupplementaryCharactersWithoutEchoingThePayload() {
+        // Refused before the writer runs, which is what keeps the payload out of detail:
+        // PDF417Writer's own "Failed to encode" message interpolates the WHOLE input, and
+        // detail is the one third-party string crossing the kernel boundary. Named for the
+        // refusal rather than the scrub, because the refusal is what this input exercises.
         val payload = "https://example.org/secret-token-abc123/👍"
 
         val reason = (BarcodeEncoder.encode(payload, ScannableFormat.Pdf417) as EncodeResult.Failure).reason
 
-        assertThat((reason as EncoderFailureReason.WriterRejected).detail).doesNotContain(payload)
+        assertThat((reason as EncoderFailureReason.WriterRejected).format).isEqualTo(ScannableFormat.Pdf417)
         assertThat(reason.detail).doesNotContain("secret-token-abc123")
-        assertThat(reason.format).isEqualTo(ScannableFormat.Pdf417)
+    }
+
+    @Test
+    fun payloadScrubberRemovesThePayloadFromAThirdPartyMessage() {
+        // Exercised directly because no input reaches it end-to-end: the surrogate refusal
+        // above blocks the one ZXing message that echoes a whole payload. The scrub is the
+        // backstop if that guard is ever relaxed or a reworded message starts echoing input,
+        // so it needs coverage of its own or it rots unnoticed.
+        val payload = "MEMBER-9988776655-SECRET"
+
+        with(ZxingBarcodeEncoder) {
+            assertThat("""Failed to encode "$payload"""".withoutPayload(payload))
+                .doesNotContain(payload)
+            // Messages that never carried the payload are passed through untouched, so
+            // ordinary diagnostics keep their detail.
+            assertThat("Bad character in input: ASCII value=233".withoutPayload(payload))
+                .isEqualTo("Bad character in input: ASCII value=233")
+            // An empty payload must not turn every message into redactions.
+            assertThat("Empty message not allowed".withoutPayload(""))
+                .isEqualTo("Empty message not allowed")
+        }
     }
 
     @Test

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -52,18 +52,15 @@ class ScannableCardInputValidatorTest {
         assertSuccessWithPayload(result, "https://example.org/é/👍")
     }
 
-    // ---- decode-only formats ----
+    // ---- the two-dimensional formats wpass-pl7.6 opened for creation ----
 
     @Test
-    fun decodeOnlyFormatsAreRefusedAtTheCreateBoundary() {
-        // Pdf417/Aztec decode but have no writer until wpass-pl7.6, so a card in either would
-        // render as the failure placeholder forever. The validator is the choke point that
-        // stops one being minted — consumers build format pickers from ScannableFormat.entries,
-        // so nothing downstream would otherwise refuse it.
+    fun pdf417AndAztecHappyPath() {
+        // Both were refused at this boundary until their writers landed. Now they validate like
+        // any other byte-capable format, which is what makes an extracted boarding-pass payload
+        // mintable as a card the user can present at a gate.
         for (format in setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
-            val result = validate("WALT-CHECK-1", format)
-
-            assertThat(result).isEqualTo(ScannableCardCreateResult.UnsupportedFormat(format))
+            assertSuccessWithPayload(validate("WALT-CHECK-1", format), "WALT-CHECK-1")
         }
     }
 
@@ -80,13 +77,18 @@ class ScannableCardInputValidatorTest {
     }
 
     @Test
-    fun decodeOnlyRefusalOutranksPayloadAndLabelProblems() {
-        // The format is unusable regardless of what was typed, so reporting a charset or label
-        // error would send the user to fix the wrong field.
-        val result = validateInput("x".repeat(1501), ScannableFormat.Aztec, label = "")
+    fun aztecOverItsCapReportsTooLongRatherThanUnsupportedFormat() {
+        // Before wpass-pl7.6 the format refusal outranked everything typed. Now an over-cap
+        // payload has to reach the length rule, or the user is told the format is unusable
+        // when the fix is to shorten what they typed.
+        val result = validate("x".repeat(1501), ScannableFormat.Aztec)
 
         assertThat(result)
-            .isEqualTo(ScannableCardCreateResult.UnsupportedFormat(ScannableFormat.Aztec))
+            .isEqualTo(
+                ScannableCardCreateResult.InvalidPayload(
+                    PayloadRejection.TooLong(actual = 1501, max = 1500),
+                ),
+            )
     }
 
     // ---- length caps ----

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableCardInputValidatorTest.kt
@@ -52,13 +52,12 @@ class ScannableCardInputValidatorTest {
         assertSuccessWithPayload(result, "https://example.org/é/👍")
     }
 
-    // ---- the two-dimensional formats wpass-pl7.6 opened for creation ----
+    // ---- the byte-capable two-dimensional formats ----
 
     @Test
     fun pdf417AndAztecHappyPath() {
-        // Both were refused at this boundary until their writers landed. Now they validate like
-        // any other byte-capable format, which is what makes an extracted boarding-pass payload
-        // mintable as a card the user can present at a gate.
+        // Validate like any other byte-capable format, which is what makes an extracted
+        // boarding-pass payload mintable as a card the user can present at a gate.
         for (format in setOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
             assertSuccessWithPayload(validate("WALT-CHECK-1", format), "WALT-CHECK-1")
         }
@@ -78,9 +77,8 @@ class ScannableCardInputValidatorTest {
 
     @Test
     fun aztecOverItsCapReportsTooLongRatherThanUnsupportedFormat() {
-        // Before wpass-pl7.6 the format refusal outranked everything typed. Now an over-cap
-        // payload has to reach the length rule, or the user is told the format is unusable
-        // when the fix is to shorten what they typed.
+        // An over-cap payload has to reach the length rule rather than a format refusal, or
+        // the user is told the format is unusable when the fix is to shorten what they typed.
         val result = validate("x".repeat(1501), ScannableFormat.Aztec)
 
         assertThat(result)

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
@@ -6,14 +6,13 @@ import org.junit.Test
 /**
  * Behavior lock for [ScannableFormatConstraints], the per-symbology charset / length / structural
  * table. [ScannableCardInputValidatorTest] covers the same rules end-to-end for the formats a card
- * can actually be minted in — which, since wpass-pl7.6 wired the Pdf417 / Aztec writers, is
- * every one of them.
+ * can actually be minted in, which is every one of them.
  */
 class ScannableFormatConstraintsTest {
     @Test
     fun noFormatIsDecodeOnly() {
-        // Empty since wpass-pl7.6: every roster member both decodes and encodes. The set stays
-        // on the surface as the create-boundary refusal a future decode-first addition needs.
+        // Every roster member both decodes and encodes. The set stays on the surface as the
+        // create-boundary refusal a decode-first addition would need.
         assertThat(ScannableFormatConstraints.decodeOnly).isEmpty()
     }
 

--- a/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/ScannableFormatConstraintsTest.kt
@@ -6,17 +6,15 @@ import org.junit.Test
 /**
  * Behavior lock for [ScannableFormatConstraints], the per-symbology charset / length / structural
  * table. [ScannableCardInputValidatorTest] covers the same rules end-to-end for the formats a card
- * can actually be minted in; this suite is where the rules for the DECODE-ONLY formats live,
- * because the validator refuses those before any of them is consulted (wpass-pl7.1).
- *
- * When wpass-pl7.6 wires the writers and empties [ScannableFormatConstraints.decodeOnly], the
- * Pdf417 / Aztec cases below should gain validator-level twins rather than move.
+ * can actually be minted in — which, since wpass-pl7.6 wired the Pdf417 / Aztec writers, is
+ * every one of them.
  */
 class ScannableFormatConstraintsTest {
     @Test
-    fun decodeOnlyHoldsExactlyTheFormatsWithNoWriter() {
-        assertThat(ScannableFormatConstraints.decodeOnly)
-            .containsExactly(ScannableFormat.Pdf417, ScannableFormat.Aztec)
+    fun noFormatIsDecodeOnly() {
+        // Empty since wpass-pl7.6: every roster member both decodes and encodes. The set stays
+        // on the surface as the create-boundary refusal a future decode-first addition needs.
+        assertThat(ScannableFormatConstraints.decodeOnly).isEmpty()
     }
 
     @Test

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -150,9 +150,8 @@ class ScannableCardRepositoryTest {
 
     @Test
     fun createWithAnAztecCardPersistsIt() = runTest {
-        // Refused at this boundary until wpass-pl7.6 wired the writer. The whole point of the
-        // epic is that a boarding-pass payload lifted off a screenshot becomes a card the user
-        // can present, so persistence has to succeed and read back in the same format.
+        // A boarding-pass payload lifted off a screenshot has to become a card the user can
+        // present, so persistence must succeed and read back in the same format.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)
@@ -285,8 +284,8 @@ class ScannableCardRepositoryTest {
 
     @Test
     fun updateToPdf417RewritesTheStoredRow() = runTest {
-        // Edit shares the create gate, so the format the gate reopened has to be reachable on
-        // this path too — otherwise a card could be created as Pdf417 but never changed to it.
+        // Edit shares the create gate, so every creatable format has to be reachable here too
+        // — otherwise a card could be created as Pdf417 but never changed to it.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -149,10 +149,10 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
-    fun createWithADecodeOnlyFormatIsRejectedAndPersistsNothing() = runTest {
-        // Aztec decodes but has no writer until wpass-pl7.6. Persisting the row would leave a
-        // card that renders as the failure placeholder forever, so the kernel refuses it here
-        // rather than relying on every consumer's format picker to omit the chip.
+    fun createWithAnAztecCardPersistsIt() = runTest {
+        // Refused at this boundary until wpass-pl7.6 wired the writer. The whole point of the
+        // epic is that a boarding-pass payload lifted off a screenshot becomes a card the user
+        // can present, so persistence has to succeed and read back in the same format.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)
@@ -165,15 +165,14 @@ class ScannableCardRepositoryTest {
             ),
         )
 
-        check(result is StorageResult.Failure)
-        val rejected = result.error as StorageError.ScannableCardRejected
-        assertThat(rejected.reason)
-            .isEqualTo(ScannableCardRejectionReason.UnsupportedFormat(ScannableFormat.Aztec))
+        check(result is StorageResult.Success)
         assertThat(telemetry.events).containsExactly(
             "init:Tee",
-            "card-rejected:FormatUnsupported",
+            "card-created:Aztec",
         ).inOrder()
-        assertThat(repo.observeScannableCards().first()).isEmpty()
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].format).isEqualTo(ScannableFormat.Aztec)
     }
 
     @Test
@@ -285,9 +284,9 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
-    fun updateToADecodeOnlyFormatIsRejectedAndStoredRowIsUnchanged() = runTest {
-        // Edit shares the create gate. Without this the format could be switched to one that
-        // cannot render, turning an existing working card into a blank one.
+    fun updateToPdf417RewritesTheStoredRow() = runTest {
+        // Edit shares the create gate, so the format the gate reopened has to be reachable on
+        // this path too — otherwise a card could be created as Pdf417 but never changed to it.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)
@@ -310,18 +309,15 @@ class ScannableCardRepositoryTest {
             ),
         )
 
-        check(result is StorageResult.Failure)
-        val rejected = result.error as StorageError.ScannableCardRejected
-        assertThat(rejected.reason)
-            .isEqualTo(ScannableCardRejectionReason.UnsupportedFormat(ScannableFormat.Pdf417))
+        check(result is StorageResult.Success)
+        // Update emits no success telemetry, so nothing follows the original card-created event.
         assertThat(telemetry.events).containsExactly(
             "init:Tee",
             "card-created:Ean13",
-            "card-rejected:FormatUnsupported",
         ).inOrder()
         val rows = repo.observeScannableCards().first()
         assertThat(rows).hasSize(1)
-        assertThat(rows[0].format).isEqualTo(ScannableFormat.Ean13)
+        assertThat(rows[0].format).isEqualTo(ScannableFormat.Pdf417)
     }
 
     @Test

--- a/passes-ui/COMPOSABLE_SIGNATURES.md
+++ b/passes-ui/COMPOSABLE_SIGNATURES.md
@@ -208,11 +208,11 @@ The sheets fire `telemetry.onSecuritySheetShown` on first composition,
 `telemetry.onSecuritySheetDismissed` on any other dismissal. Confirming closes the
 sheet AND calls `onConfirm`; dismissal closes WITHOUT firing `onConfirm`.
 
-## Create-time URI confirmation gate (QR only)
+## Create-time URI confirmation gate (byte-capable formats)
 
 ```kotlin
 /**
- * Create-time URI-scheme confirmation gate for a QR `ScannableCard`. Shown by the
+ * Create-time URI-scheme confirmation gate for a `ScannableCard`. Shown by the
  * consumer's create flow between input validation and persistence whenever the
  * classified [QrPayloadKind] would auto-act on a future scanner phone. Cancel is
  * the focused, filled action; Confirm is the lower-emphasis text button - inverted
@@ -240,10 +240,13 @@ public fun BarcodeCreateConfirmSheet(
 )
 
 /**
- * Returns `false` only for [QrPayloadKind.PlainText]. Consumer create flows
- * branch on this to persist a plain-text QR directly without invoking the gate.
+ * Returns `false` for [QrPayloadKind.PlainText] and for the 1D symbologies, which
+ * no scanner auto-acts on. Consumer create flows branch on this to persist
+ * directly without invoking the gate. [format] is a parameter rather than an
+ * assumed `Qr` so that a roster member added later is a compile error here rather
+ * than a gate that quietly stops covering a format (C4).
  */
-public fun QrPayloadKind.requiresCreateConfirmation(): Boolean
+public fun QrPayloadKind.requiresCreateConfirmation(format: ScannableFormat): Boolean
 
 /**
  * Test tags for the two action buttons on `BarcodeCreateConfirmSheet`. Exposed

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -229,11 +229,11 @@ private fun BarcodeCreateActions(
  * symbologies, which no scanner auto-acts on. Callers branch on this to persist directly
  * without showing a no-op sheet.
  *
- * [format] is a parameter rather than an assumed `Qr` because that assumption was the C4
- * gate's silent-bypass risk: wpass-pl7.6 made Pdf417 and Aztec renderable, and both carry
- * the same actionable URIs QR does. Taking the format here puts the decision behind
- * [canCarryActionablePayload]'s exhaustive `when`, so a future roster member is a compile
- * error at one kernel site rather than a gate that quietly stops covering a format.
+ * [format] is a parameter rather than an assumed `Qr` because Pdf417 and Aztec carry the
+ * same actionable URIs QR does, and assuming the format is the C4 gate's silent-bypass risk.
+ * Taking it here puts the decision behind [canCarryActionablePayload]'s exhaustive `when`, so
+ * a new roster member is a compile error at one kernel site rather than a gate that quietly
+ * stops covering a format.
  */
 public fun QrPayloadKind.requiresCreateConfirmation(format: ScannableFormat): Boolean =
     format.canCarryActionablePayload() && this !is QrPayloadKind.PlainText

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheet.kt
@@ -30,13 +30,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import `is`.walt.passes.core.QrPayloadKind
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.core.canCarryActionablePayload
 import `is`.walt.passes.ui.core.isolated
 import `is`.walt.passes.ui.theme.LocalPassesSemantics
 import `is`.walt.passes.ui.theme.SecuritySheetStyle
 import `is`.walt.passes.ui.theme.toComposeColor
 
 /**
- * Create-time URI-scheme confirmation gate for a QR `ScannableCard`. Mirrors the
+ * Create-time URI-scheme confirmation gate for a `ScannableCard`. Mirrors the
  * verbatim-rendering / FSI-PDI isolation / trust-styling-token posture of the
  * back-field [B3UrlConfirmSheet], but inverts the button prominence: Cancel is the
  * focused, filled action; Confirm is the lower-emphasis text button. That divergence
@@ -45,10 +47,10 @@ import `is`.walt.passes.ui.theme.toComposeColor
  * persistence so a payload classified by [QrPayloadKind] as auto-acting on a future
  * scanner phone cannot land in the wallet without an explicit confirm tap.
  *
- * Triggered ONLY for the QR symbology - linear formats do not auto-act when
- * scanned and skip this gate at the caller. [QrPayloadKind.PlainText] also skips:
- * the composable short-circuits to no output so the caller's create flow can be a
- * single unconditional `BarcodeCreateConfirmSheet` invocation.
+ * Triggered for the byte-capable symbologies only - linear formats do not auto-act when
+ * scanned and skip this gate at the caller, via [requiresCreateConfirmation].
+ * [QrPayloadKind.PlainText] also skips: the composable short-circuits to no output so the
+ * caller's create flow can be a single unconditional `BarcodeCreateConfirmSheet` invocation.
  *
  * The trust claim that this gate enforces is "the user saw, in their own typed
  * form, what a scanner phone would do" - the verbatim payload is the load-bearing
@@ -222,12 +224,19 @@ private fun BarcodeCreateActions(
 }
 
 /**
- * Whether [BarcodeCreateConfirmSheet] should be invoked for [QrPayloadKind]. Returns
- * `false` only for [QrPayloadKind.PlainText]; callers branch on this to persist a
- * plain-text QR directly without showing a no-op sheet.
+ * Whether [BarcodeCreateConfirmSheet] should be invoked for this payload in [format].
+ * False for [QrPayloadKind.PlainText], which has nothing to confirm, and false for the 1D
+ * symbologies, which no scanner auto-acts on. Callers branch on this to persist directly
+ * without showing a no-op sheet.
+ *
+ * [format] is a parameter rather than an assumed `Qr` because that assumption was the C4
+ * gate's silent-bypass risk: wpass-pl7.6 made Pdf417 and Aztec renderable, and both carry
+ * the same actionable URIs QR does. Taking the format here puts the decision behind
+ * [canCarryActionablePayload]'s exhaustive `when`, so a future roster member is a compile
+ * error at one kernel site rather than a gate that quietly stops covering a format.
  */
-public fun QrPayloadKind.requiresCreateConfirmation(): Boolean =
-    this !is QrPayloadKind.PlainText
+public fun QrPayloadKind.requiresCreateConfirmation(format: ScannableFormat): Boolean =
+    format.canCarryActionablePayload() && this !is QrPayloadKind.PlainText
 
 /**
  * Test tags for the two action buttons. Exposed so per-arm focus and click assertions

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -149,9 +149,11 @@ private fun BarcodeImage(
 /** Per-symbology min on-screen size in dp. Mirrors [BarcodeView] for gate consistency. */
 private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
     ScannableFormat.Qr, ScannableFormat.Aztec -> 240 to 240
-    // Taller floor than the 1D row so the stacked rows are not collapsed. Provisional:
-    // wpass-pl7.6 verifies it against the writer's actual aspect ratio.
-    ScannableFormat.Pdf417 -> 320 to 120
+    // 4:1 matches the writer's measured output at the pinned EC and 2-module quiet zone
+    // (3.7:1 to 4.3:1 across the payload range), so ContentScale.Fit barely letterboxes and
+    // the modules land square. The provisional 320x120 this replaces was 2.7:1 and left a
+    // third of the slot as dead space.
+    ScannableFormat.Pdf417 -> 320 to 80
     ScannableFormat.Code128,
     ScannableFormat.Ean13,
     ScannableFormat.UpcA,

--- a/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
+++ b/passes-ui/src/main/kotlin/is/walt/passes/ui/ScannableCardView.kt
@@ -149,10 +149,9 @@ private fun BarcodeImage(
 /** Per-symbology min on-screen size in dp. Mirrors [BarcodeView] for gate consistency. */
 private fun ScannableFormat.minRenderSizeDp(): Pair<Int, Int> = when (this) {
     ScannableFormat.Qr, ScannableFormat.Aztec -> 240 to 240
-    // 4:1 matches the writer's measured output at the pinned EC and 2-module quiet zone
-    // (3.7:1 to 4.3:1 across the payload range), so ContentScale.Fit barely letterboxes and
-    // the modules land square. The provisional 320x120 this replaces was 2.7:1 and left a
-    // third of the slot as dead space.
+    // 4:1 approximates the writer's measured output at the pinned EC and quiet zone
+    // (3.4:1 to 4.4:1 across the payload range), so ContentScale.Fit letterboxes little and
+    // the modules land close to square.
     ScannableFormat.Pdf417 -> 320 to 80
     ScannableFormat.Code128,
     ScannableFormat.Ean13,

--- a/passes-ui/src/main/res/values/strings.xml
+++ b/passes-ui/src/main/res/values/strings.xml
@@ -11,21 +11,21 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools"
     tools:locale="en">
-    <string name="barcode_create_confirm_title">Confirm what this QR will do</string>
+    <string name="barcode_create_confirm_title">Confirm what this code will do</string>
     <string name="barcode_create_confirm_confirm">Add card</string>
     <string name="barcode_create_confirm_cancel">Cancel</string>
 
-    <string name="barcode_create_confirm_url">When scanned, this QR will open a website:</string>
-    <string name="barcode_create_confirm_phone">When scanned, this QR will dial:</string>
-    <string name="barcode_create_confirm_sms">When scanned, this QR will text:</string>
-    <string name="barcode_create_confirm_mailto">When scanned, this QR will email:</string>
-    <string name="barcode_create_confirm_geo">When scanned, this QR will show a location on a map:</string>
-    <string name="barcode_create_confirm_wifi">When scanned, this QR will offer to join Wi-Fi network:</string>
-    <string name="barcode_create_confirm_wifi_unnamed">When scanned, this QR will offer to join a Wi-Fi network.</string>
-    <string name="barcode_create_confirm_bitcoin">When scanned, this QR will prepare a Bitcoin payment to:</string>
-    <string name="barcode_create_confirm_ethereum">When scanned, this QR will prepare an Ethereum payment to:</string>
-    <string name="barcode_create_confirm_magnet">When scanned, this QR will start a torrent download.</string>
-    <string name="barcode_create_confirm_market">When scanned, this QR will open a Play Store listing:</string>
-    <string name="barcode_create_confirm_intent">When scanned, this QR can trigger an app action. This is uncommon for loyalty cards. Continue?</string>
-    <string name="barcode_create_confirm_unknown">When scanned, this QR uses a scheme Walt doesn\'t recognize. If you didn\'t expect this, cancel.</string>
+    <string name="barcode_create_confirm_url">When scanned, this code will open a website:</string>
+    <string name="barcode_create_confirm_phone">When scanned, this code will dial:</string>
+    <string name="barcode_create_confirm_sms">When scanned, this code will text:</string>
+    <string name="barcode_create_confirm_mailto">When scanned, this code will email:</string>
+    <string name="barcode_create_confirm_geo">When scanned, this code will show a location on a map:</string>
+    <string name="barcode_create_confirm_wifi">When scanned, this code will offer to join Wi-Fi network:</string>
+    <string name="barcode_create_confirm_wifi_unnamed">When scanned, this code will offer to join a Wi-Fi network.</string>
+    <string name="barcode_create_confirm_bitcoin">When scanned, this code will prepare a Bitcoin payment to:</string>
+    <string name="barcode_create_confirm_ethereum">When scanned, this code will prepare an Ethereum payment to:</string>
+    <string name="barcode_create_confirm_magnet">When scanned, this code will start a torrent download.</string>
+    <string name="barcode_create_confirm_market">When scanned, this code will open a Play Store listing:</string>
+    <string name="barcode_create_confirm_intent">When scanned, this code can trigger an app action. This is uncommon for loyalty cards. Continue?</string>
+    <string name="barcode_create_confirm_unknown">When scanned, this code uses a scheme Walt doesn\'t recognize. If you didn\'t expect this, cancel.</string>
 </resources>

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
@@ -13,6 +13,8 @@ import com.google.common.truth.Truth.assertThat
 import `is`.walt.passes.core.ParseFailureKind
 import `is`.walt.passes.core.PassType
 import `is`.walt.passes.core.QrPayloadKind
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.core.canCarryActionablePayload
 import `is`.walt.passes.ui.theme.ArgbColor
 import `is`.walt.passes.ui.theme.CategoryAccentColors
 import `is`.walt.passes.ui.theme.ExpiredBadgeStyle
@@ -65,7 +67,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will open a website:",
+            "When scanned, this code will open a website:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText("⁨example.com⁩").assertIsDisplayed()
     }
@@ -97,7 +99,7 @@ class BarcodeCreateConfirmSheetTest {
                 )
             }
         }
-        composeRule.onNodeWithText("When scanned, this QR will dial:").assertIsDisplayed()
+        composeRule.onNodeWithText("When scanned, this code will dial:").assertIsDisplayed()
         composeRule.onNodeWithText("⁨+44 7700 900000⁩").assertIsDisplayed()
     }
 
@@ -113,7 +115,7 @@ class BarcodeCreateConfirmSheetTest {
                 )
             }
         }
-        composeRule.onNodeWithText("When scanned, this QR will text:").assertIsDisplayed()
+        composeRule.onNodeWithText("When scanned, this code will text:").assertIsDisplayed()
         composeRule.onNodeWithText("⁨+44 7700 900000⁩").assertIsDisplayed()
     }
 
@@ -129,7 +131,7 @@ class BarcodeCreateConfirmSheetTest {
                 )
             }
         }
-        composeRule.onNodeWithText("When scanned, this QR will email:").assertIsDisplayed()
+        composeRule.onNodeWithText("When scanned, this code will email:").assertIsDisplayed()
         composeRule.onNodeWithText("⁨alice@example.com⁩").assertIsDisplayed()
     }
 
@@ -146,7 +148,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will show a location on a map:",
+            "When scanned, this code will show a location on a map:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText("⁨51.5074,-0.1278⁩").assertIsDisplayed()
     }
@@ -164,7 +166,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will offer to join Wi-Fi network:",
+            "When scanned, this code will offer to join Wi-Fi network:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText("⁨MyNetwork⁩").assertIsDisplayed()
     }
@@ -182,7 +184,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will offer to join a Wi-Fi network.",
+            "When scanned, this code will offer to join a Wi-Fi network.",
         ).assertIsDisplayed()
     }
 
@@ -204,7 +206,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will prepare a Bitcoin payment to:",
+            "When scanned, this code will prepare a Bitcoin payment to:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText(
             "⁨1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa⁩",
@@ -226,7 +228,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will prepare an Ethereum payment to:",
+            "When scanned, this code will prepare an Ethereum payment to:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText(
             "⁨0x71C7656EC7ab88b098defB751B7401B5f6d8976F⁩",
@@ -246,7 +248,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will start a torrent download.",
+            "When scanned, this code will start a torrent download.",
         ).assertIsDisplayed()
     }
 
@@ -263,7 +265,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR will open a Play Store listing:",
+            "When scanned, this code will open a Play Store listing:",
         ).assertIsDisplayed()
         composeRule.onNodeWithText("⁨details?id=com.example.app⁩").assertIsDisplayed()
     }
@@ -283,7 +285,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR can trigger an app action. " +
+            "When scanned, this code can trigger an app action. " +
                 "This is uncommon for loyalty cards. Continue?",
         ).assertIsDisplayed()
         composeRule.onNodeWithText(
@@ -307,7 +309,7 @@ class BarcodeCreateConfirmSheetTest {
             }
         }
         composeRule.onNodeWithText(
-            "When scanned, this QR uses a scheme Walt doesn't recognize. " +
+            "When scanned, this code uses a scheme Walt doesn't recognize. " +
                 "If you didn't expect this, cancel.",
         ).assertIsDisplayed()
         composeRule.onNodeWithText("⁨myapp://action?id=1⁩").assertIsDisplayed()
@@ -325,18 +327,43 @@ class BarcodeCreateConfirmSheetTest {
                 )
             }
         }
-        composeRule.onNodeWithText("Confirm what this QR will do").assertDoesNotExist()
+        composeRule.onNodeWithText("Confirm what this code will do").assertDoesNotExist()
     }
 
     @Test
-    fun requiresCreateConfirmationIsFalseOnlyForPlainText() {
-        assertThat(QrPayloadKind.PlainText.requiresCreateConfirmation()).isFalse()
-        assertThat(QrPayloadKind.Magnet.requiresCreateConfirmation()).isTrue()
+    fun requiresCreateConfirmationIsFalseOnlyForPlainTextOnAByteCapableFormat() {
+        val qr = ScannableFormat.Qr
+        assertThat(QrPayloadKind.PlainText.requiresCreateConfirmation(qr)).isFalse()
+        assertThat(QrPayloadKind.Magnet.requiresCreateConfirmation(qr)).isTrue()
         assertThat(
             QrPayloadKind.Url("https", "example.com", "https://example.com")
-                .requiresCreateConfirmation(),
+                .requiresCreateConfirmation(qr),
         ).isTrue()
-        assertThat(QrPayloadKind.Wifi(ssid = null).requiresCreateConfirmation()).isTrue()
+        assertThat(QrPayloadKind.Wifi(ssid = null).requiresCreateConfirmation(qr)).isTrue()
+    }
+
+    @Test
+    fun theGateCoversEveryFormatThatCanCarryAnActionablePayload() {
+        // The C4 silent-bypass guard. Before wpass-pl7.6 the gate was keyed on QR alone, which
+        // was safe only while QR was the roster's one renderable byte-capable format; an Aztec
+        // carrying a URL would otherwise reach storage unconfirmed. Driven off
+        // ScannableFormat.entries so a future roster member cannot slip past unconsidered.
+        val url = QrPayloadKind.Url("https", "example.com", "https://example.com")
+        for (format in ScannableFormat.entries) {
+            assertThat(url.requiresCreateConfirmation(format))
+                .isEqualTo(format.canCarryActionablePayload())
+        }
+        assertThat(ScannableFormat.entries.filter { it.canCarryActionablePayload() })
+            .containsExactly(ScannableFormat.Qr, ScannableFormat.Pdf417, ScannableFormat.Aztec)
+    }
+
+    @Test
+    fun linearFormatsSkipTheGateEvenForAnActionablePayload() {
+        // A scanner hands a Code128 payload back as text; nothing auto-acts on it, so gating
+        // there would train the user to tap through a dialog that protects nothing.
+        val url = QrPayloadKind.Url("https", "example.com", "https://example.com")
+
+        assertThat(url.requiresCreateConfirmation(ScannableFormat.Code128)).isFalse()
     }
 
     @Test

--- a/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
+++ b/passes-ui/src/test/kotlin/is/walt/passes/ui/BarcodeCreateConfirmSheetTest.kt
@@ -344,10 +344,9 @@ class BarcodeCreateConfirmSheetTest {
 
     @Test
     fun theGateCoversEveryFormatThatCanCarryAnActionablePayload() {
-        // The C4 silent-bypass guard. Before wpass-pl7.6 the gate was keyed on QR alone, which
-        // was safe only while QR was the roster's one renderable byte-capable format; an Aztec
-        // carrying a URL would otherwise reach storage unconfirmed. Driven off
-        // ScannableFormat.entries so a future roster member cannot slip past unconsidered.
+        // The C4 silent-bypass guard. Keying the gate on QR alone would let an Aztec carrying
+        // a URL reach storage unconfirmed. Driven off ScannableFormat.entries so a new roster
+        // member cannot slip past unconsidered.
         val url = QrPayloadKind.Url("https", "example.com", "https://example.com")
         for (format in ScannableFormat.entries) {
             assertThat(url.requiresCreateConfirmation(format))


### PR DESCRIPTION
Wires `AztecWriter` and `PDF417Writer`, closing the read/write asymmetry `wpass-pl7.1` opened. An extracted boarding-pass payload can now be re-rendered as a scannable symbol, which is the point of the [epic](../../issues) — extraction alone solved nothing if the code cannot be presented at a gate.

## Pins, chosen by measurement

Every value was measured against ZXing 3.5.4 rather than inherited from a library default.

| Pin | Value | Why |
|---|---|---|
| Aztec EC | 33% | ZXing and spec default. Free at the payload size that motivated this: a 132-char BCBP payload yields the same 37x37 matrix at every level from 23% to 50%. |
| PDF417 EC | level 3 | ISO/IEC 15438 recommends level 3 for 41–160 data codewords, where BCBP lands; ZXing hardcodes 2. Costs one row, no extra column, so module width at a fixed render width is unchanged. |
| PDF417 margin | 2 modules | The spec quiet zone. ZXing's 30-module default more than doubles the height of a boarding-pass symbol and drags its aspect from 4.66:1 to 2.55:1. |
| PDF417 compaction | AUTO | Emits a symbol no larger than forced BYTE, so forcing a mode only costs area. |

`PDF417_MAX` (800) and `AZTEC_MAX` (1500) were re-derived against those pins and both stand unchanged.

## Two charset defects found and fixed

Both writers default to ISO-8859-1 while the validator admits any visible character, so a legitimately typeable payload was unrenderable. They fail differently:

- **PDF417** threw outright on non-Latin-1 → fixed with `PDF417_AUTO_ECI`.
- **Aztec** did worse: it encoded happily and decoded back **transliterated** (`東京` → `??`) — a wrong scan with no error at any layer. Fixed by pinning `CHARACTER_SET`.

Both fixes measured to leave the all-ASCII case byte-identical in matrix size and capacity.

**QR has the same silent-corruption defect and is deliberately not fixed here** (`wpass-qj6`). It predates this work, and adding an ECI header changes the symbol emitted for every non-ASCII QR card already stored — that needs its own scanner verification.

## C4 gate discharged (kernel side)

`requiresCreateConfirmation` now takes the format and consults a new exhaustive `ScannableFormat.canCarryActionablePayload()`. Previously `QrPayloadKind`-scoped, so nothing would have flagged an Aztec carrying a URL reaching storage unconfirmed. The signature change broke every call site at compile time, which is exactly what the old shape could not do. Sheet copy generalized from "this QR" to "this code".

The consumer's parallel `canCarryAutoActingPayload()` still exists and is still the copy in the path; the threat model says so explicitly and `wpass-j6b` tracks its removal.

## Review rounds

Two review passes; all ten findings verified against ZXing before acting, and all fixed or filed.

Round 1 surfaced that the 2D caps count **characters** while capacity is spent in **bytes** — PDF417 holds 528 three-byte characters against a cap of 800 — so a payload can clear the validator and render blank. No exact predicate is available at the validator (each writer picks a compaction mode per run), so this adds attribution rather than prevention: over-capacity errors now lift to `PayloadTooDense`. The residual is filed as `wpass-1kg`. It also caught a payload leak — `PDF417Writer` interpolates the whole input into an exception message that was being copied verbatim into `WriterRejected.detail`.

Round 2 caught a hole in the no-throw contract (`getValue` on a hand-maintained map, called from outside the `runCatching`) and a test that named the payload scrubber but never reached it.

## Not covered here

Two acceptance items need real hardware and remain open under `wpass-sw2`: a third-party scanner reading a rendered Aztec and PDF417 off a device screen, and the extracted payload verified against the original repro artifact. A code only Walt's own decoder can read is not a working code, and the host-JVM round trip cannot tell the difference.

**API break:** `EncoderFailureReason.FormatNotEncodable` is removed. walt-android may have a `when` on that type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)