### PR TITLE
Name the reason an image import stays non-composite (wpass-pl7.5)

### DIFF
--- a/docs/adr/0005-pdf-document-support.md
+++ b/docs/adr/0005-pdf-document-support.md
@@ -798,6 +798,18 @@ image contains several codes, the kernel returns the **first** detected code (co
 decision, `wlt-yjn5`; ZXing's `MultiFormatReader` stops at the first match). No content
 beyond the barcode is extracted (D4 holds: no EXIF / XMP / payload-derived label).
 
+**Degrading names its reason (`wpass-pl7.5`).** Every non-composite outcome reaches the
+consumer as `DocumentPersist.Image.barcodeExtraction`: `NotAttempted` (no hook),
+`NoCodeFound`, `Failed(DecodeFailureReason)` — the decoder's own bucket verbatim,
+including the `DecodeTimedOut` / `DecoderUnavailable` split `wpass-qw3` exists to
+preserve — or `Declined`. Collapsing all four to one null made a watchdog kill read as
+"no code found in this image" to the user and to whoever was debugging, which is exactly
+the failure mode the `wpass-pl7.2` scale ladder is most likely to introduce. The outcome
+carries **no payload and no image bytes**: a BCBP payload holds passenger name and PNR,
+and the composite arm (`DocumentPersist.BarcodedImage`) stays the only place a payload
+crosses this seam — and only after the user confirmed it. Rendering per-reason copy is
+the consumer's half.
+
 ### C4. Storage: `documents` schema v6 → v7 (forward-only)
 
 The `documents` table gains nullable `barcode_payload TEXT` / `barcode_format TEXT`

--- a/passes-document/src/main/kotlin/is/walt/passes/document/BarcodeExtractionOutcome.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/BarcodeExtractionOutcome.kt
@@ -5,19 +5,16 @@ import `is`.walt.passes.core.DecodeFailureReason
 /**
  * Why an imported image is a plain image rather than a composite (wpass-pl7.5). Carried on
  * [DocumentPersist.Image] so the consumer's confirm sheet can say what actually happened instead
- * of rendering "no code found" for every non-composite outcome.
+ * of rendering one caption for every non-composite outcome.
  *
- * The arms are the four distinguishable ways the composite path declines to produce a barcode,
- * and they call for different copy AND different affordances: [Failed] with
- * [DecodeFailureReason.DecodeTimedOut] is a load signal that a user-initiated retry may clear,
- * [DecodeFailureReason.ImageTooLarge] never will, [NoCodeFound] means the sandbox read the image
- * fine, and [Declined] means the user already rejected the read. Collapsing them to a single null
- * hid a watchdog kill behind "no code found" — the failure mode the wpass-pl7.2 retry ladder is
- * most likely to introduce.
+ * The arms are kept apart because they call for different copy AND different affordances:
+ * [Failed] with [DecodeFailureReason.DecodeTimedOut] is a load signal a user-initiated retry may
+ * clear, [DecodeFailureReason.ImageTooLarge] never will, [NoCodeFound] means the sandbox read the
+ * image fine, and [Declined] means the user already rejected the read.
  *
  * NOTHING here carries the decoded payload or any image bytes: a BCBP boarding pass payload
- * carries passenger name and PNR, and the composite arm ([DocumentPersist.BarcodedImage]) is the
- * only place a payload crosses this seam — and only after the user has confirmed it.
+ * carries passenger name and PNR, and [DocumentPersist.BarcodedImage] is the only place a payload
+ * crosses this seam — and only after the user has confirmed it.
  */
 public sealed interface BarcodeExtractionOutcome {
     /**

--- a/passes-document/src/main/kotlin/is/walt/passes/document/BarcodeExtractionOutcome.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/BarcodeExtractionOutcome.kt
@@ -1,0 +1,42 @@
+package `is`.walt.passes.document
+
+import `is`.walt.passes.core.DecodeFailureReason
+
+/**
+ * Why an imported image is a plain image rather than a composite (wpass-pl7.5). Carried on
+ * [DocumentPersist.Image] so the consumer's confirm sheet can say what actually happened instead
+ * of rendering "no code found" for every non-composite outcome.
+ *
+ * The arms are the four distinguishable ways the composite path declines to produce a barcode,
+ * and they call for different copy AND different affordances: [Failed] with
+ * [DecodeFailureReason.DecodeTimedOut] is a load signal that a user-initiated retry may clear,
+ * [DecodeFailureReason.ImageTooLarge] never will, [NoCodeFound] means the sandbox read the image
+ * fine, and [Declined] means the user already rejected the read. Collapsing them to a single null
+ * hid a watchdog kill behind "no code found" — the failure mode the wpass-pl7.2 retry ladder is
+ * most likely to introduce.
+ *
+ * NOTHING here carries the decoded payload or any image bytes: a BCBP boarding pass payload
+ * carries passenger name and PNR, and the composite arm ([DocumentPersist.BarcodedImage]) is the
+ * only place a payload crosses this seam — and only after the user has confirmed it.
+ */
+public sealed interface BarcodeExtractionOutcome {
+    /**
+     * The caller did not opt into composites (no `confirmBarcode` hook), so no isolated decode
+     * ran. Distinct from [NoCodeFound]: nothing looked at the image, so the absence of a code is
+     * unknown, not observed.
+     */
+    public data object NotAttempted : BarcodeExtractionOutcome
+
+    /** The isolated decode completed and located no barcode in the image. */
+    public data object NoCodeFound : BarcodeExtractionOutcome
+
+    /** The isolated decode could not complete; [reason] is the decoder's own bucket, verbatim. */
+    public data class Failed(public val reason: DecodeFailureReason) : BarcodeExtractionOutcome
+
+    /**
+     * A code was decoded and shown to the user, who declined it at the confirm gate (or the
+     * consumer's confirm hook threw, which is treated as a decline so a confirm-UI bug cannot fail
+     * the import). The payload is deliberately not carried: the user has just rejected it.
+     */
+    public data object Declined : BarcodeExtractionOutcome
+}

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
@@ -143,11 +143,10 @@ internal class DefaultDocumentImporter(
         }
 
         // Composite path (wpass-8lu): extract a barcode from the same bytes in the isolated
-        // decoder. A found+confirmed code makes this a composite; anything else (no code,
-        // extraction failure, declined confirmation) degrades to a plain image carrying its own
-        // BarcodeExtractionOutcome — extraction never fails the import. Resolved BEFORE persist so
-        // nothing is stored until the consumer's confirm step has run ("before the code becomes
-        // usable").
+        // decoder. A found+confirmed code makes this a composite; anything else degrades to a
+        // plain image carrying its own [BarcodeExtractionOutcome] — extraction never fails the
+        // import. Resolved BEFORE persist so nothing is stored until the consumer's confirm step
+        // has run ("before the code becomes usable").
         val extraction = extractConfirmedBarcode(bytes, confirmBarcode)
 
         runCatching {
@@ -214,12 +213,8 @@ internal class DefaultDocumentImporter(
      * Opts into and runs the isolated barcode extraction plus the consumer's confirm gate. When
      * [confirmBarcode] is `null` the caller has not opted into composites: extraction does NOT run
      * (no isolated barcode-decode cost) and the result is always a plain image. Otherwise returns
-     * the `(payload, format)` to persist as a composite, or the [BarcodeExtractionOutcome] that
-     * degraded the artifact to a plain image.
-     *
-     * Every degrade path keeps its own outcome (wpass-pl7.5) rather than collapsing to one null:
-     * a watchdog kill (`DecodeTimedOut`) and an oversize rejection (`ImageTooLarge`) both used to
-     * read as "no code found in this image" to the user AND to whoever was debugging.
+     * the `(payload, format)` to persist as a composite, or the [BarcodeExtractionOutcome] naming
+     * why it degraded to a plain image — each path keeps its own, see that type.
      *
      * A `CancellationException` from the confirm hook propagates (structured concurrency); any
      * other throw is folded to [BarcodeExtractionOutcome.Declined] so a confirm-UI bug cannot fail
@@ -233,13 +228,15 @@ internal class DefaultDocumentImporter(
         bytes: ByteArray,
         confirmBarcode: (suspend (String, ScannableFormat) -> Boolean)?,
     ): BarcodeExtraction {
-        if (confirmBarcode == null) return degraded(BarcodeExtractionOutcome.NotAttempted)
+        if (confirmBarcode == null) {
+            return BarcodeExtraction.Degraded(BarcodeExtractionOutcome.NotAttempted)
+        }
         val decoded = when (val extracted = barcodeExtract(bytes)) {
             is BarcodeDecodeResult.DecodedBarcode -> extracted
             BarcodeDecodeResult.NoBarcodeFound ->
-                return degraded(BarcodeExtractionOutcome.NoCodeFound)
+                return BarcodeExtraction.Degraded(BarcodeExtractionOutcome.NoCodeFound)
             is BarcodeDecodeResult.DecodeFailed ->
-                return degraded(BarcodeExtractionOutcome.Failed(extracted.reason))
+                return BarcodeExtraction.Degraded(BarcodeExtractionOutcome.Failed(extracted.reason))
         }
         val confirmed = try {
             confirmBarcode(decoded.payload, decoded.format)
@@ -251,12 +248,9 @@ internal class DefaultDocumentImporter(
         return if (confirmed) {
             BarcodeExtraction.Confirmed(decoded.payload, decoded.format)
         } else {
-            degraded(BarcodeExtractionOutcome.Declined)
+            BarcodeExtraction.Degraded(BarcodeExtractionOutcome.Declined)
         }
     }
-
-    private fun degraded(outcome: BarcodeExtractionOutcome): BarcodeExtraction.Degraded =
-        BarcodeExtraction.Degraded(outcome)
 
     private fun buildPersist(
         extraction: BarcodeExtraction,

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DefaultDocumentImporter.kt
@@ -144,13 +144,14 @@ internal class DefaultDocumentImporter(
 
         // Composite path (wpass-8lu): extract a barcode from the same bytes in the isolated
         // decoder. A found+confirmed code makes this a composite; anything else (no code,
-        // extraction failure, declined confirmation) degrades to a plain image — extraction never
-        // fails the import. Resolved BEFORE persist so nothing is stored until the consumer's
-        // confirm step has run ("before the code becomes usable").
-        val barcode = extractConfirmedBarcode(bytes, confirmBarcode)
+        // extraction failure, declined confirmation) degrades to a plain image carrying its own
+        // BarcodeExtractionOutcome — extraction never fails the import. Resolved BEFORE persist so
+        // nothing is stored until the consumer's confirm step has run ("before the code becomes
+        // usable").
+        val extraction = extractConfirmedBarcode(bytes, confirmBarcode)
 
         runCatching {
-            persist(buildPersist(barcode, displayLabel, bytes, decoded, format))
+            persist(buildPersist(extraction, displayLabel, bytes, decoded, format))
         }.getOrElse { t ->
             if (t is CancellationException) throw t
             guard.onImportFailed(
@@ -171,31 +172,32 @@ internal class DefaultDocumentImporter(
                 durationMillis = now() - startedAt,
             ),
         )
-        return buildImportedResult(barcode, displayLabel, byteCount, decoded)
+        return buildImportedResult(extraction, displayLabel, byteCount, decoded)
     }
 
     private fun buildImportedResult(
-        barcode: DecodedBarcode?,
+        extraction: BarcodeExtraction,
         displayLabel: String,
         byteCount: Long,
         decoded: ImageDecodeOutcome.Decoded,
     ): DocumentImportResult {
         val importedAt = wallClock()
-        return if (barcode != null) {
-            DocumentImportResult.ImportedBarcodedImage(
+        return when (extraction) {
+            is BarcodeExtraction.Confirmed -> DocumentImportResult.ImportedBarcodedImage(
                 BarcodedImageDocument(
                     id = BarcodedImageDocumentId(idGenerator()),
                     displayLabel = displayLabel,
                     byteCount = byteCount,
                     widthPx = decoded.widthPx,
                     heightPx = decoded.heightPx,
-                    barcodePayload = barcode.payload,
-                    barcodeFormat = barcode.format,
+                    barcodePayload = extraction.payload,
+                    barcodeFormat = extraction.format,
                     importedAtEpochMs = importedAt,
                 ),
             )
-        } else {
-            DocumentImportResult.ImportedImage(
+            // The degrade reason rides the persist seam (the confirm sheet reads it there), not the
+            // stored ImageDocument: it describes this import attempt, not the artifact.
+            is BarcodeExtraction.Degraded -> DocumentImportResult.ImportedImage(
                 ImageDocument(
                     id = ImageDocumentId(idGenerator()),
                     displayLabel = displayLabel,
@@ -212,22 +214,33 @@ internal class DefaultDocumentImporter(
      * Opts into and runs the isolated barcode extraction plus the consumer's confirm gate. When
      * [confirmBarcode] is `null` the caller has not opted into composites: extraction does NOT run
      * (no isolated barcode-decode cost) and the result is always a plain image. Otherwise returns
-     * the `(payload, format)` to persist as a composite, or `null` to degrade to a plain image —
-     * for no detected code, an extraction failure, OR a declined/failed confirmation. A
-     * `CancellationException` from the confirm hook propagates (structured concurrency); any
-     * other throw is swallowed to a declined confirmation so a confirm-UI bug cannot fail the
-     * whole import.
+     * the `(payload, format)` to persist as a composite, or the [BarcodeExtractionOutcome] that
+     * degraded the artifact to a plain image.
+     *
+     * Every degrade path keeps its own outcome (wpass-pl7.5) rather than collapsing to one null:
+     * a watchdog kill (`DecodeTimedOut`) and an oversize rejection (`ImageTooLarge`) both used to
+     * read as "no code found in this image" to the user AND to whoever was debugging.
+     *
+     * A `CancellationException` from the confirm hook propagates (structured concurrency); any
+     * other throw is folded to [BarcodeExtractionOutcome.Declined] so a confirm-UI bug cannot fail
+     * the whole import.
      */
-    // ReturnCount: three guard-style early exits (not-opted-in, no code, declined) each read as a
-    // distinct reason to stay a plain image; collapsing them behind one expression would obscure
-    // which condition degraded the artifact. Same precedent as importImage above.
+    // ReturnCount: three guard-style early exits (not-opted-in, no code, extraction failed) each
+    // read as a distinct reason to stay a plain image; collapsing them behind one expression would
+    // obscure which condition degraded the artifact. Same precedent as importImage above.
     @Suppress("ReturnCount")
     private suspend fun extractConfirmedBarcode(
         bytes: ByteArray,
         confirmBarcode: (suspend (String, ScannableFormat) -> Boolean)?,
-    ): DecodedBarcode? {
-        if (confirmBarcode == null) return null
-        val decoded = barcodeExtract(bytes) as? BarcodeDecodeResult.DecodedBarcode ?: return null
+    ): BarcodeExtraction {
+        if (confirmBarcode == null) return degraded(BarcodeExtractionOutcome.NotAttempted)
+        val decoded = when (val extracted = barcodeExtract(bytes)) {
+            is BarcodeDecodeResult.DecodedBarcode -> extracted
+            BarcodeDecodeResult.NoBarcodeFound ->
+                return degraded(BarcodeExtractionOutcome.NoCodeFound)
+            is BarcodeDecodeResult.DecodeFailed ->
+                return degraded(BarcodeExtractionOutcome.Failed(extracted.reason))
+        }
         val confirmed = try {
             confirmBarcode(decoded.payload, decoded.format)
         } catch (e: CancellationException) {
@@ -235,35 +248,42 @@ internal class DefaultDocumentImporter(
         } catch (_: Throwable) {
             false
         }
-        return if (confirmed) DecodedBarcode(decoded.payload, decoded.format) else null
+        return if (confirmed) {
+            BarcodeExtraction.Confirmed(decoded.payload, decoded.format)
+        } else {
+            degraded(BarcodeExtractionOutcome.Declined)
+        }
     }
 
+    private fun degraded(outcome: BarcodeExtractionOutcome): BarcodeExtraction.Degraded =
+        BarcodeExtraction.Degraded(outcome)
+
     private fun buildPersist(
-        barcode: DecodedBarcode?,
+        extraction: BarcodeExtraction,
         displayLabel: String,
         bytes: ByteArray,
         decoded: ImageDecodeOutcome.Decoded,
         format: ImageFormat,
     ): DocumentPersist =
-        if (barcode != null) {
-            DocumentPersist.BarcodedImage(
+        when (extraction) {
+            is BarcodeExtraction.Confirmed -> DocumentPersist.BarcodedImage(
                 label = displayLabel,
                 bytes = bytes,
                 thumbnailBytes = decoded.thumbnailBytes,
                 format = format,
                 widthPx = decoded.widthPx,
                 heightPx = decoded.heightPx,
-                barcodePayload = barcode.payload,
-                barcodeFormat = barcode.format,
+                barcodePayload = extraction.payload,
+                barcodeFormat = extraction.format,
             )
-        } else {
-            DocumentPersist.Image(
+            is BarcodeExtraction.Degraded -> DocumentPersist.Image(
                 label = displayLabel,
                 bytes = bytes,
                 thumbnailBytes = decoded.thumbnailBytes,
                 format = format,
                 widthPx = decoded.widthPx,
                 heightPx = decoded.heightPx,
+                barcodeExtraction = extraction.outcome,
             )
         }
 
@@ -327,14 +347,18 @@ internal class DefaultDocumentImporter(
     }
 
     /**
-     * A confirmed barcode to persist as a composite — the pure `(payload, format)` distilled from
-     * the isolated [BarcodeDecodeResult] once the consumer's confirm gate passed. Internal so the
-     * importer never threads a raw [BarcodeDecodeResult] (with its reject arms) past the seam.
+     * What the composite path produced: either a confirmed barcode to persist, or the reason the
+     * artifact stays a plain image. Internal so the importer never threads a raw
+     * [BarcodeDecodeResult] past the seam; only the distilled `(payload, format)` and the
+     * payload-free [BarcodeExtractionOutcome] cross it.
      */
-    internal data class DecodedBarcode(
-        val payload: String,
-        val format: ScannableFormat,
-    )
+    internal sealed interface BarcodeExtraction {
+        /** The confirmed `(payload, format)` to persist as a composite. */
+        data class Confirmed(val payload: String, val format: ScannableFormat) : BarcodeExtraction
+
+        /** No composite: [outcome] is the reason, forwarded to the consumer's confirm sheet. */
+        data class Degraded(val outcome: BarcodeExtractionOutcome) : BarcodeExtraction
+    }
 
     internal companion object {
         // Read buffer for the bounded materialization loop. 64 KiB matches the

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
@@ -23,9 +23,8 @@ import `is`.walt.passes.core.ScannableFormat
  * the consumer declines via `confirmBarcode`) it degrades to a plain
  * [DocumentImportResult.ImportedImage]. Without the hook (the default) no extraction runs and the
  * result is always a plain image. Barcode extraction never runs in the host process; only the
- * decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant. Every
- * degrade path names itself on [DocumentPersist.Image.barcodeExtraction] (wpass-pl7.5) so the
- * consumer's confirm sheet can tell a genuinely code-free image from a decoder timeout.
+ * decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant. Each
+ * degrade path names itself on [DocumentPersist.Image.barcodeExtraction].
  *
  * Storage is wired through a `persist` callback rather than a `PassRepository` dependency so
  * `passes-document` stays independent of `passes-storage` (matching `PdfImporter`). The
@@ -59,8 +58,7 @@ public interface DocumentImporter {
      * UX can pass `{ _, _ -> true }` to accept every read. The hook is never called for PDFs, for
      * images with no detected barcode, or when extraction fails. A `CancellationException` from the
      * hook propagates; any other throw is treated as a declined confirmation (degrade to image) so
-     * a confirm-UI bug cannot fail the whole import. Whichever way the composite path degrades, the
-     * reason reaches [persist] as [DocumentPersist.Image.barcodeExtraction].
+     * a confirm-UI bug cannot fail the whole import.
      */
     public suspend fun import(
         source: DocumentImportSource,

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentImporter.kt
@@ -23,7 +23,9 @@ import `is`.walt.passes.core.ScannableFormat
  * the consumer declines via `confirmBarcode`) it degrades to a plain
  * [DocumentImportResult.ImportedImage]. Without the hook (the default) no extraction runs and the
  * result is always a plain image. Barcode extraction never runs in the host process; only the
- * decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant.
+ * decoded payload + symbology cross the binder, matching the wpass-i9x isolation invariant. Every
+ * degrade path names itself on [DocumentPersist.Image.barcodeExtraction] (wpass-pl7.5) so the
+ * consumer's confirm sheet can tell a genuinely code-free image from a decoder timeout.
  *
  * Storage is wired through a `persist` callback rather than a `PassRepository` dependency so
  * `passes-document` stays independent of `passes-storage` (matching `PdfImporter`). The
@@ -57,7 +59,8 @@ public interface DocumentImporter {
      * UX can pass `{ _, _ -> true }` to accept every read. The hook is never called for PDFs, for
      * images with no detected barcode, or when extraction fails. A `CancellationException` from the
      * hook propagates; any other throw is treated as a declined confirmation (degrade to image) so
-     * a confirm-UI bug cannot fail the whole import.
+     * a confirm-UI bug cannot fail the whole import. Whichever way the composite path degrades, the
+     * reason reaches [persist] as [DocumentPersist.Image.barcodeExtraction].
      */
     public suspend fun import(
         source: DocumentImportSource,

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
@@ -31,6 +31,12 @@ public sealed interface DocumentPersist {
         public val pageCount: Int,
     ) : DocumentPersist
 
+    /**
+     * A plain image. [barcodeExtraction] says why it is not a composite (wpass-pl7.5) so the
+     * consumer's confirm sheet can distinguish "no code in this image" from a watchdog kill, an
+     * oversize rejection, or a code the user declined. It defaults to
+     * [BarcodeExtractionOutcome.NotAttempted], the outcome for a caller that never opted in.
+     */
     public data class Image(
         public override val label: String,
         public override val bytes: ByteArray,
@@ -38,6 +44,7 @@ public sealed interface DocumentPersist {
         public val format: ImageFormat,
         public val widthPx: Int,
         public val heightPx: Int,
+        public val barcodeExtraction: BarcodeExtractionOutcome = BarcodeExtractionOutcome.NotAttempted,
     ) : DocumentPersist
 
     /**

--- a/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
+++ b/passes-document/src/main/kotlin/is/walt/passes/document/DocumentPersist.kt
@@ -32,9 +32,7 @@ public sealed interface DocumentPersist {
     ) : DocumentPersist
 
     /**
-     * A plain image. [barcodeExtraction] says why it is not a composite (wpass-pl7.5) so the
-     * consumer's confirm sheet can distinguish "no code in this image" from a watchdog kill, an
-     * oversize rejection, or a code the user declined. It defaults to
+     * A plain image. [barcodeExtraction] names why it is not a composite; it defaults to
      * [BarcodeExtractionOutcome.NotAttempted], the outcome for a caller that never opted in.
      */
     public data class Image(

--- a/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
+++ b/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
@@ -209,11 +209,13 @@ class DocumentImporterTest {
         )
 
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
-        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+        val image = persisted.single() as DocumentPersist.Image
+        assertThat(image.barcodeExtraction).isEqualTo(BarcodeExtractionOutcome.NoCodeFound)
     }
 
     @Test
     fun barcodeExtractionFailureDegradesToPlainImageRatherThanFailingImport() = runTest {
+        val persisted = mutableListOf<DocumentPersist>()
         val importer = importer(
             imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
             barcodeExtract = { BarcodeDecodeResult.DecodeFailed(DecodeFailureReason.ImageDecodeFailed) },
@@ -222,9 +224,65 @@ class DocumentImporterTest {
             source = source(pngBytes),
             displayLabel = "plain.png",
             confirmBarcode = { _, _ -> true },
-            persist = {},
+            persist = { persisted += it },
         )
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
+        val image = persisted.single() as DocumentPersist.Image
+        assertThat(image.barcodeExtraction)
+            .isEqualTo(BarcodeExtractionOutcome.Failed(DecodeFailureReason.ImageDecodeFailed))
+    }
+
+    // -- degrade reasons stay distinguishable (wpass-pl7.5) --------------------------
+
+    @Test
+    fun timedOutAndOversizeExtractionsProduceDistinguishableReasonsAtTheSeam() = runTest {
+        // The acceptance case: a watchdog kill and an oversize rejection both degrade to a plain
+        // image, but they must NOT read alike to the consumer — a timeout is a load signal a
+        // user-initiated retry may clear, an oversize image never will.
+        val timedOut = persistedImageFor(DecodeFailureReason.DecodeTimedOut)
+        val oversize = persistedImageFor(DecodeFailureReason.ImageTooLarge)
+
+        assertThat(timedOut.barcodeExtraction)
+            .isEqualTo(BarcodeExtractionOutcome.Failed(DecodeFailureReason.DecodeTimedOut))
+        assertThat(oversize.barcodeExtraction)
+            .isEqualTo(BarcodeExtractionOutcome.Failed(DecodeFailureReason.ImageTooLarge))
+        assertThat(timedOut.barcodeExtraction).isNotEqualTo(oversize.barcodeExtraction)
+        // ...and neither collapses onto the genuinely code-free outcome.
+        assertThat(timedOut.barcodeExtraction).isNotEqualTo(BarcodeExtractionOutcome.NoCodeFound)
+        assertThat(oversize.barcodeExtraction).isNotEqualTo(BarcodeExtractionOutcome.NoCodeFound)
+    }
+
+    @Test
+    fun everyDecodeFailureReasonReachesTheSeamVerbatim() = runTest {
+        // No reason is folded into a neighbour on the way through the importer; the consumer sees
+        // the decoder's own bucket, including the DecoderUnavailable/DecodeTimedOut split wpass-qw3
+        // exists to preserve.
+        for (reason in DecodeFailureReason.entries) {
+            assertThat(persistedImageFor(reason).barcodeExtraction)
+                .isEqualTo(BarcodeExtractionOutcome.Failed(reason))
+        }
+    }
+
+    @Test
+    fun aDeclinedReadNamesItselfAndCarriesNoPayload() = runTest {
+        // A BCBP payload carries passenger name and PNR: the degrade reason says the user declined,
+        // never what they declined.
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode(SECRET_PAYLOAD, ScannableFormat.Aztec) },
+        )
+
+        importer.import(
+            source = source(pngBytes),
+            displayLabel = "boarding.png",
+            confirmBarcode = { _, _ -> false },
+            persist = { persisted += it },
+        )
+
+        val image = persisted.single() as DocumentPersist.Image
+        assertThat(image.barcodeExtraction).isEqualTo(BarcodeExtractionOutcome.Declined)
+        assertThat(image.barcodeExtraction.toString()).doesNotContain(SECRET_PAYLOAD)
     }
 
     @Test
@@ -245,7 +303,9 @@ class DocumentImporterTest {
 
         assertThat(extractionCalled).isFalse()
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
-        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+        val image = persisted.single() as DocumentPersist.Image
+        // NotAttempted, not NoCodeFound: nothing looked at the image, so absence is unknown.
+        assertThat(image.barcodeExtraction).isEqualTo(BarcodeExtractionOutcome.NotAttempted)
     }
 
     @Test
@@ -266,7 +326,8 @@ class DocumentImporterTest {
         )
 
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
-        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+        val image = persisted.single() as DocumentPersist.Image
+        assertThat(image.barcodeExtraction).isEqualTo(BarcodeExtractionOutcome.Declined)
     }
 
     @Test
@@ -312,6 +373,7 @@ class DocumentImporterTest {
 
         assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
         assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
+
     }
 
     @Test
@@ -383,6 +445,22 @@ class DocumentImporterTest {
             idGenerator = { "fixed-id" },
         )
 
+    /** Imports an image whose isolated barcode extraction failed with [reason]. */
+    private suspend fun persistedImageFor(reason: DecodeFailureReason): DocumentPersist.Image {
+        val persisted = mutableListOf<DocumentPersist>()
+        val importer = importer(
+            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
+            barcodeExtract = { BarcodeDecodeResult.DecodeFailed(reason) },
+        )
+        importer.import(
+            source = source(pngBytes),
+            displayLabel = "card.png",
+            confirmBarcode = { _, _ -> true },
+            persist = { persisted += it },
+        )
+        return persisted.single() as DocumentPersist.Image
+    }
+
     private fun source(bytes: ByteArray): DocumentImportSource.FileDescriptor {
         val file: File = tmp.newFile()
         file.writeBytes(bytes)
@@ -413,5 +491,9 @@ class DocumentImporterTest {
     private companion object {
         // Arbitrary fixed epoch-ms the injected wall clock returns, so importedAt is pinnable.
         const val FIXED_WALL_CLOCK_MS: Long = 1_700_000_000_000L
+
+        // Stands in for a BCBP payload (passenger name + PNR) to assert it never rides a
+        // degrade reason.
+        const val SECRET_PAYLOAD: String = "M1DOE/JANE       EABC123 SFOJFK"
     }
 }

--- a/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
+++ b/passes-document/src/test/kotlin/is/walt/passes/document/DocumentImporterTest.kt
@@ -264,7 +264,7 @@ class DocumentImporterTest {
     }
 
     @Test
-    fun aDeclinedReadNamesItselfAndCarriesNoPayload() = runTest {
+    fun aDeclinedReadDegradesToAPlainImageNamingItselfAndCarryingNoPayload() = runTest {
         // A BCBP payload carries passenger name and PNR: the degrade reason says the user declined,
         // never what they declined.
         val persisted = mutableListOf<DocumentPersist>()
@@ -273,13 +273,14 @@ class DocumentImporterTest {
             barcodeExtract = { BarcodeDecodeResult.DecodedBarcode(SECRET_PAYLOAD, ScannableFormat.Aztec) },
         )
 
-        importer.import(
+        val result = importer.import(
             source = source(pngBytes),
             displayLabel = "boarding.png",
             confirmBarcode = { _, _ -> false },
             persist = { persisted += it },
         )
 
+        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
         val image = persisted.single() as DocumentPersist.Image
         assertThat(image.barcodeExtraction).isEqualTo(BarcodeExtractionOutcome.Declined)
         assertThat(image.barcodeExtraction.toString()).doesNotContain(SECRET_PAYLOAD)
@@ -354,26 +355,6 @@ class DocumentImporterTest {
 
         assertThat(propagated).isTrue()
         assertThat(persisted).isFalse()
-    }
-
-    @Test
-    fun declinedConfirmationDegradesToPlainImageAndPersistsNoBarcode() = runTest {
-        val persisted = mutableListOf<DocumentPersist>()
-        val importer = importer(
-            imageDecode = { _, _ -> ImageDecodeOutcome.Decoded(byteArrayOf(7), 100, 100) },
-            barcodeExtract = { BarcodeDecodeResult.DecodedBarcode("MAYBE-MISREAD", ScannableFormat.Qr) },
-        )
-
-        val result = importer.import(
-            source = source(pngBytes),
-            displayLabel = "card.png",
-            confirmBarcode = { _, _ -> false },
-            persist = { persisted += it },
-        )
-
-        assertThat(result).isInstanceOf(DocumentImportResult.ImportedImage::class.java)
-        assertThat(persisted.single()).isInstanceOf(DocumentPersist.Image::class.java)
-
     }
 
     @Test


### PR DESCRIPTION
## Why

`DefaultDocumentImporter.extractConfirmedBarcode` did

```kotlin
barcodeExtract(bytes) as? BarcodeDecodeResult.DecodedBarcode ?: return null
```

so `NoBarcodeFound`, `DecodeFailed(ImageTooLarge)`, `DecodeTimedOut`, `DecoderUnavailable` and "not opted in" all collapsed to the same `null` at the persist seam. The consumer renders one caption for every case ("No code found in this image"), which is why the original bug report was ambiguous: a genuinely code-free image, a watchdog kill and an oversize rejection are indistinguishable to the user *and* to whoever is debugging.

That matters now rather than later: wpass-pl7.2's scale ladder made watchdog kills more likely, and a watchdog kill surfaces as a dropped binder that reads as "no code" — so wpass-sw2's device results would be unreadable exactly where the ladder is most likely to have introduced a regression.

## What

- New public `BarcodeExtractionOutcome` (`passes-document`): `NotAttempted` / `NoCodeFound` / `Failed(DecodeFailureReason)` / `Declined`.
- `DocumentPersist.Image` gains `barcodeExtraction`, defaulted to `NotAttempted` so callers that never opted into composites are unaffected.
- The composite path returns an internal sealed `BarcodeExtraction` (`Confirmed` | `Degraded`) instead of a nullable barcode, and `Failed` carries the decoder's own bucket verbatim — including the `DecodeTimedOut` / `DecoderUnavailable` split wpass-qw3 exists to preserve.
- ADR 0005 C3 records the degrade contract.

Rendering per-reason copy is walt-android's half; the richer copy already exists there.

## Privacy

No decoded payload and no image bytes on the widened type — a BCBP payload carries passenger name and PNR. `DocumentPersist.BarcodedImage` stays the only place a payload crosses this seam, and only after the user confirmed it. `Declined` deliberately carries nothing: the user just rejected that read.

## Tests

`:passes-document:testDebugUnitTest`, plus full `./gradlew check` (detekt + ktlint + lint) green. New/updated coverage:

- a forced timeout and a forced oversize input produce distinguishable reasons at the seam (the acceptance case), and neither collapses onto `NoCodeFound`
- every `DecodeFailureReason` reaches the seam verbatim
- a declined read reports `Declined` and its outcome does not contain the payload
- no-opt-in reports `NotAttempted`, not `NoCodeFound` (nothing looked at the image, so absence is unknown rather than observed)

Closes wpass-pl7.5.