### PR TITLE
Trial-encode a scannable card before persisting it (wpass-1kg)

### DIFF
--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -191,25 +191,32 @@ public interface PassRepository {
      * single insert-time choke point: a validation rejection bubbles up as
      * [StorageError.ScannableCardRejected] with the typed reason preserved, never as a
      * generic infra failure, and the row never reaches disk.
+     *
+     * An approved input is then trial-encoded with the kernel's `BarcodeEncoder` before
+     * the write, and an encoder refusal is rejected the same way, under
+     * [ScannableCardRejectionReason.EncoderFailure]. The validator alone cannot decide
+     * this: the 2D length caps count characters while writer capacity is spent in bytes,
+     * so a multibyte payload can clear its cap and still overflow the symbology. Without
+     * the encode such a card persists and renders blank with no reason attached.
      */
     public suspend fun createScannableCard(
         input: ScannableCardCreateInput,
     ): StorageResult<ScannableCardRecordId>
 
     /**
-     * Overwrites the payload / format / label of an existing scannable-card row. Re-runs
-     * the kernel `ScannableCardInputValidator` (the single insert-time choke point per
-     * [createScannableCard]'s KDoc) on the new [input] before the row is touched; a
-     * validation rejection bubbles up as [StorageError.ScannableCardRejected] with the
-     * typed reason preserved and shares the same `onScannableCardRejected` telemetry
-     * channel as [createScannableCard]. The row is not modified on rejection.
+     * Overwrites the payload / format / label of an existing scannable-card row. Runs the
+     * same validate-then-trial-encode gate as [createScannableCard] on the new [input]
+     * before the row is touched; either rejection bubbles up as
+     * [StorageError.ScannableCardRejected] with the typed reason preserved and shares the
+     * same `onScannableCardRejected` telemetry channel. The row is not modified on
+     * rejection, so an edit cannot turn a rendering card into a blank one.
      *
-     * Validation is checked before the row is loaded, so an invalid [input] against an
-     * unknown [id] surfaces as [StorageError.ScannableCardRejected], not
+     * The gate runs before the row is loaded, so an invalid [input] against an unknown
+     * [id] surfaces as [StorageError.ScannableCardRejected], not
      * [StorageError.IntegrityViolation], mirroring [updateDocumentLabel]'s precedence.
      *
      * Returns [StorageError.IntegrityViolation] if no row matches [id] and the input
-     * passed validation. On success the row's `created_at_epoch_ms` is unchanged (edit
+     * cleared the gate. On success the row's `created_at_epoch_ms` is unchanged (edit
      * is not a re-insert), so the row's position in [observeScannableCards] is preserved.
      */
     public suspend fun updateScannableCard(

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/PassRepository.kt
@@ -192,12 +192,11 @@ public interface PassRepository {
      * [StorageError.ScannableCardRejected] with the typed reason preserved, never as a
      * generic infra failure, and the row never reaches disk.
      *
-     * An approved input is then trial-encoded with the kernel's `BarcodeEncoder` before
-     * the write, and an encoder refusal is rejected the same way, under
-     * [ScannableCardRejectionReason.EncoderFailure]. The validator alone cannot decide
-     * this: the 2D length caps count characters while writer capacity is spent in bytes,
-     * so a multibyte payload can clear its cap and still overflow the symbology. Without
-     * the encode such a card persists and renders blank with no reason attached.
+     * An approved input is then trial-encoded with the kernel's `BarcodeEncoder` before the
+     * write, and an encoder refusal is rejected the same way, under
+     * [ScannableCardRejectionReason.EncoderFailure]. The length caps cannot decide this on
+     * their own (`ScannableFormatConstraints`' cap KDoc derives why), and without the
+     * encode such a card persists and renders blank with no reason attached.
      */
     public suspend fun createScannableCard(
         input: ScannableCardCreateInput,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -231,11 +231,10 @@ public class SqlCipherPassRepository internal constructor(
     override suspend fun createScannableCard(
         input: ScannableCardCreateInput,
     ): StorageResult<ScannableCardRecordId> = runIo {
-        // Validator does not use the id for validation; storage mints the real one
-        // post-insert and listAll() rehydrates the StateFlow with the stringified row id.
-        val approved = when (val approval = approveScannableCard(input, ScannableCardId(""))) {
+        // listAll() rehydrates the StateFlow with the stringified row id storage mints below.
+        val approved = when (val approval = approveScannableCard(input)) {
             is StorageResult.Success -> approval.value
-            is StorageResult.Failure -> return@runIo StorageResult.Failure(approval.error)
+            is StorageResult.Failure -> return@runIo approval
         }
 
         val outcome = writeMutex.withLock {
@@ -261,13 +260,11 @@ public class SqlCipherPassRepository internal constructor(
         id: ScannableCardRecordId,
         input: ScannableCardCreateInput,
     ): StorageResult<Unit> = runIo {
-        // Validator does not consume the id or timestamp for validation logic; storage
-        // preserves the existing row's created_at_epoch_ms at the SQL layer, so the
-        // placeholders below never reach disk.
-        val cardId = ScannableCardId(id.value.toString())
-        val approved = when (val approval = approveScannableCard(input, cardId)) {
+        // The existing row's created_at_epoch_ms is preserved at the SQL layer, so the
+        // approved card's placeholder timestamp never reaches disk.
+        val approved = when (val approval = approveScannableCard(input)) {
             is StorageResult.Success -> approval.value
-            is StorageResult.Failure -> return@runIo StorageResult.Failure(approval.error)
+            is StorageResult.Failure -> return@runIo approval
         }
 
         val matched = writeMutex.withLock {
@@ -375,64 +372,68 @@ public class SqlCipherPassRepository internal constructor(
 
     /**
      * The approval gate both scannable-card write paths share: kernel validation, then a
-     * trial encode of the approved `(payload, format)`.
+     * trial encode of what the validator approved. This is the "orchestrator wrapping
+     * validation + encoding into a single create flow" that [BarcodeEncoder]'s KDoc names,
+     * so the encoder refusal re-enters the kernel result family as
+     * [ScannableCardCreateResult.EncoderFailure] and one `when` maps every arm — validator
+     * and encoder alike — onto its storage rejection.
      *
-     * The trial encode is what keeps a card that cannot be rendered off disk. The 2D length
-     * caps count characters while writer capacity is spent in bytes, so a multibyte payload
-     * can clear [ScannableCardInputValidator] and still overflow the symbology; without an
-     * encode here the row persists and first surfaces as an empty barcode with no reason
-     * attached (wpass-1kg). The matrix is discarded — the renderer re-encodes at draw time
-     * against its own size — so only the outcome is used.
+     * The trial encode is what keeps a card nothing can render off disk: a payload can
+     * clear [ScannableCardInputValidator] and still overflow its symbology (see
+     * `ScannableFormatConstraints`' cap KDoc for why the caps cannot predict this), and
+     * without an encode here the row persists and first surfaces as an empty barcode with
+     * no reason attached (wpass-1kg).
+     *
+     * The [ScannableCardId] is a placeholder: the validator does not read it, and both
+     * write paths take only payload / format / label off the approved card — storage mints
+     * the real id at insert and preserves it across an update.
      *
      * A rejection has already emitted its `onScannableCardRejected` event; callers
      * propagate the [StorageResult.Failure] unchanged.
      */
-    // ReturnCount: one early return per rejection arm, matching the validator's own
-    // fail-fast shape; collapsing them would hide which stage said no.
-    @Suppress("ReturnCount")
-    private fun approveScannableCard(
-        input: ScannableCardCreateInput,
-        id: ScannableCardId,
-    ): StorageResult<ScannableCard> {
+    private fun approveScannableCard(input: ScannableCardCreateInput): StorageResult<ScannableCard> {
         val validation = ScannableCardInputValidator.validate(
             input = input,
-            id = id,
+            id = ScannableCardId(""),
             createdAt = PassInstant(clock()),
         )
-        val card = when (validation) {
-            is ScannableCardCreateResult.Success -> validation.card
-            is ScannableCardCreateResult.InvalidLabel ->
-                return rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
-                )
-            is ScannableCardCreateResult.InvalidPayload ->
-                return rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
-                )
-            is ScannableCardCreateResult.UnsupportedFormat ->
-                return rejectScannableCard(
-                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
-                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
-                )
-            // Unreachable from the validator, which never runs an encoder; kept so the
-            // kernel result family stays exhaustively answered here.
-            is ScannableCardCreateResult.EncoderFailure ->
-                return rejectScannableCard(
-                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
-                )
+        // Only an approved card is worth an encode; every other arm passes through
+        // untouched to the single mapping below.
+        val approval = when (validation) {
+            is ScannableCardCreateResult.Success -> trialEncode(validation.card)
+            else -> validation
         }
-
-        return when (val encoded = BarcodeEncoder.encode(card.payload, card.format)) {
-            is EncodeResult.Success -> StorageResult.Success(card)
-            is EncodeResult.Failure -> rejectScannableCard(
-                ScannableCardRejectionReason.EncoderFailure(encoded.reason),
+        return when (approval) {
+            is ScannableCardCreateResult.Success -> StorageResult.Success(approval.card)
+            is ScannableCardCreateResult.InvalidLabel -> rejectScannableCard(
+                ScannableCardRejectionReason.InvalidLabel(approval.reason),
+                telemetryKind = ScannableCardRejectedKind.LabelInvalid,
+            )
+            is ScannableCardCreateResult.InvalidPayload -> rejectScannableCard(
+                ScannableCardRejectionReason.InvalidPayload(approval.reason),
+                telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
+            )
+            is ScannableCardCreateResult.UnsupportedFormat -> rejectScannableCard(
+                ScannableCardRejectionReason.UnsupportedFormat(approval.format),
+                telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
+            )
+            is ScannableCardCreateResult.EncoderFailure -> rejectScannableCard(
+                ScannableCardRejectionReason.EncoderFailure(approval.reason),
                 telemetryKind = ScannableCardRejectedKind.EncoderFailed,
             )
         }
     }
+
+    /**
+     * Re-approves [card] only if its `(payload, format)` actually encodes. The matrix is
+     * discarded — the renderer re-encodes at draw time against its own size — so this
+     * costs one encode per save on a non-hot path and yields only the verdict.
+     */
+    private fun trialEncode(card: ScannableCard): ScannableCardCreateResult =
+        when (val encoded = BarcodeEncoder.encode(card.payload, card.format)) {
+            is EncodeResult.Success -> ScannableCardCreateResult.Success(card)
+            is EncodeResult.Failure -> ScannableCardCreateResult.EncoderFailure(encoded.reason)
+        }
 
     /**
      * Single emission point for a scannable-card rejection, validator or encoder. Same

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/SqlCipherPassRepository.kt
@@ -1,6 +1,8 @@
 package `is`.walt.passes.storage
 
 import android.content.Context
+import `is`.walt.passes.core.BarcodeEncoder
+import `is`.walt.passes.core.EncodeResult
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.ScannableCard
@@ -231,33 +233,9 @@ public class SqlCipherPassRepository internal constructor(
     ): StorageResult<ScannableCardRecordId> = runIo {
         // Validator does not use the id for validation; storage mints the real one
         // post-insert and listAll() rehydrates the StateFlow with the stringified row id.
-        val validation = ScannableCardInputValidator.validate(
-            input = input,
-            id = ScannableCardId(""),
-            createdAt = PassInstant(clock()),
-        )
-        val approved = when (validation) {
-            is ScannableCardCreateResult.Success -> validation.card
-            is ScannableCardCreateResult.InvalidLabel ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
-                )
-            is ScannableCardCreateResult.InvalidPayload ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
-                )
-            is ScannableCardCreateResult.UnsupportedFormat ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
-                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
-                )
-            is ScannableCardCreateResult.EncoderFailure ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
-                )
+        val approved = when (val approval = approveScannableCard(input, ScannableCardId(""))) {
+            is StorageResult.Success -> approval.value
+            is StorageResult.Failure -> return@runIo StorageResult.Failure(approval.error)
         }
 
         val outcome = writeMutex.withLock {
@@ -286,33 +264,10 @@ public class SqlCipherPassRepository internal constructor(
         // Validator does not consume the id or timestamp for validation logic; storage
         // preserves the existing row's created_at_epoch_ms at the SQL layer, so the
         // placeholders below never reach disk.
-        val validation = ScannableCardInputValidator.validate(
-            input = input,
-            id = ScannableCardId(id.value.toString()),
-            createdAt = PassInstant(clock()),
-        )
-        val approved = when (validation) {
-            is ScannableCardCreateResult.Success -> validation.card
-            is ScannableCardCreateResult.InvalidLabel ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
-                )
-            is ScannableCardCreateResult.InvalidPayload ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
-                )
-            is ScannableCardCreateResult.UnsupportedFormat ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
-                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
-                )
-            is ScannableCardCreateResult.EncoderFailure ->
-                return@runIo rejectScannableCard(
-                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
-                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
-                )
+        val cardId = ScannableCardId(id.value.toString())
+        val approved = when (val approval = approveScannableCard(input, cardId)) {
+            is StorageResult.Success -> approval.value
+            is StorageResult.Failure -> return@runIo StorageResult.Failure(approval.error)
         }
 
         val matched = writeMutex.withLock {
@@ -419,8 +374,70 @@ public class SqlCipherPassRepository internal constructor(
     }
 
     /**
-     * Single emission point for a scannable-card validator rejection. Same discipline
-     * as [rejectDocument]: skip [failure] so `onStorageFailure` does not double-fire.
+     * The approval gate both scannable-card write paths share: kernel validation, then a
+     * trial encode of the approved `(payload, format)`.
+     *
+     * The trial encode is what keeps a card that cannot be rendered off disk. The 2D length
+     * caps count characters while writer capacity is spent in bytes, so a multibyte payload
+     * can clear [ScannableCardInputValidator] and still overflow the symbology; without an
+     * encode here the row persists and first surfaces as an empty barcode with no reason
+     * attached (wpass-1kg). The matrix is discarded — the renderer re-encodes at draw time
+     * against its own size — so only the outcome is used.
+     *
+     * A rejection has already emitted its `onScannableCardRejected` event; callers
+     * propagate the [StorageResult.Failure] unchanged.
+     */
+    // ReturnCount: one early return per rejection arm, matching the validator's own
+    // fail-fast shape; collapsing them would hide which stage said no.
+    @Suppress("ReturnCount")
+    private fun approveScannableCard(
+        input: ScannableCardCreateInput,
+        id: ScannableCardId,
+    ): StorageResult<ScannableCard> {
+        val validation = ScannableCardInputValidator.validate(
+            input = input,
+            id = id,
+            createdAt = PassInstant(clock()),
+        )
+        val card = when (validation) {
+            is ScannableCardCreateResult.Success -> validation.card
+            is ScannableCardCreateResult.InvalidLabel ->
+                return rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidLabel(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.LabelInvalid,
+                )
+            is ScannableCardCreateResult.InvalidPayload ->
+                return rejectScannableCard(
+                    ScannableCardRejectionReason.InvalidPayload(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.PayloadInvalid,
+                )
+            is ScannableCardCreateResult.UnsupportedFormat ->
+                return rejectScannableCard(
+                    ScannableCardRejectionReason.UnsupportedFormat(validation.format),
+                    telemetryKind = ScannableCardRejectedKind.FormatUnsupported,
+                )
+            // Unreachable from the validator, which never runs an encoder; kept so the
+            // kernel result family stays exhaustively answered here.
+            is ScannableCardCreateResult.EncoderFailure ->
+                return rejectScannableCard(
+                    ScannableCardRejectionReason.EncoderFailure(validation.reason),
+                    telemetryKind = ScannableCardRejectedKind.EncoderFailed,
+                )
+        }
+
+        return when (val encoded = BarcodeEncoder.encode(card.payload, card.format)) {
+            is EncodeResult.Success -> StorageResult.Success(card)
+            is EncodeResult.Failure -> rejectScannableCard(
+                ScannableCardRejectionReason.EncoderFailure(encoded.reason),
+                telemetryKind = ScannableCardRejectedKind.EncoderFailed,
+            )
+        }
+    }
+
+    /**
+     * Single emission point for a scannable-card rejection, validator or encoder. Same
+     * discipline as [rejectDocument]: skip [failure] so `onStorageFailure` does not
+     * double-fire.
      */
     private fun <T> rejectScannableCard(
         reason: ScannableCardRejectionReason,

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -66,9 +66,10 @@ public sealed interface StorageError {
 
     /**
      * A scannable-card insert was rejected by the kernel validator
-     * (`ScannableCardInputValidator`). Carries the typed kernel rejection so the
-     * consumer's error UI can localize a specific message without re-running
-     * validation. The row never reaches disk.
+     * (`ScannableCardInputValidator`) or by the trial encode that follows it
+     * (`BarcodeEncoder`). Carries the typed kernel rejection so the consumer's error UI
+     * can localize a specific message without re-running validation. The row never
+     * reaches disk.
      */
     public data class ScannableCardRejected(
         public val reason: ScannableCardRejectionReason,
@@ -103,12 +104,13 @@ public sealed interface StorageError {
 }
 
 /**
- * Why a [PassRepository.createScannableCard] call was refused. The first two arms
- * mirror what `ScannableCardInputValidator` produces today (structural payload and
- * label checks). The latter two cover the kernel result family's remaining arms; the
- * validator does not produce them in the current build, but typing them here keeps
- * the defensive path loud rather than collapsing them into [StorageError.Unknown] on
- * the day the kernel does start surfacing one.
+ * Why a [PassRepository.createScannableCard] or [PassRepository.updateScannableCard]
+ * call was refused. The first two arms mirror what `ScannableCardInputValidator`
+ * produces (structural payload and label checks); [EncoderFailure] comes from the trial
+ * encode the repository runs before persisting, which is the only check that can see a
+ * payload no writer can render. [UnsupportedFormat] is the one arm nothing produces in
+ * the current build — typed here so a decode-only format reaching the create path stays
+ * loud rather than collapsing into [StorageError.Unknown].
  */
 public sealed interface ScannableCardRejectionReason {
     public data class InvalidLabel(public val reason: LabelRejection) : ScannableCardRejectionReason

--- a/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
+++ b/passes-storage/src/main/kotlin/is/walt/passes/storage/StorageResult.kt
@@ -70,6 +70,10 @@ public sealed interface StorageError {
      * (`BarcodeEncoder`). Carries the typed kernel rejection so the consumer's error UI
      * can localize a specific message without re-running validation. The row never
      * reaches disk.
+     *
+     * One arm needs care: `EncoderFailure(WriterRejected)` carries a raw third-party
+     * message on its `detail` field. Read that field's kernel KDoc before surfacing or
+     * reporting it — the telemetry this repository emits carries only the enum kind.
      */
     public data class ScannableCardRejected(
         public val reason: ScannableCardRejectionReason,

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -66,11 +66,12 @@ import org.robolectric.annotation.Config
  *     when the input passed validation; an invalid input against an unknown id
  *     surfaces as [StorageError.ScannableCardRejected] (validation precedes the row
  *     lookup, mirroring `updateDocumentLabel`).
- * 11. Both write paths trial-encode before persisting: a multibyte payload that clears
- *     the validator's character cap but overflows the symbology's byte capacity is
- *     rejected with [EncoderFailureReason.PayloadTooDense] rather than stored blank,
- *     and an accented payload at the full character cap still encodes and is stored,
- *     so the gate does not over-reject what the caps admit.
+ * 11. Both write paths trial-encode before persisting, so a card nothing can render is
+ *     rejected rather than stored blank: over-capacity payloads surface
+ *     [EncoderFailureReason.PayloadTooDense] and writer-refused ones
+ *     [EncoderFailureReason.WriterRejected], both on the `EncoderFailed` telemetry
+ *     channel. A payload at the full character cap still encodes and is stored, so the
+ *     gate does not over-reject what the caps admit.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -183,8 +184,7 @@ class ScannableCardRepositoryTest {
     @Test
     fun createWithAztecPayloadOverEncoderCapacityIsRejectedAsTooDense() = runTest {
         // 700 three-byte characters: under the 1500-character Aztec cap the validator
-        // enforces, over the ~623 three-byte characters the writer can hold at 33% ECC.
-        // Without the trial encode this row persists and renders as an empty barcode.
+        // enforces, over the ~623 three-byte characters the writer holds at 33% ECC.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)
@@ -238,6 +238,37 @@ class ScannableCardRepositoryTest {
     }
 
     @Test
+    fun createWithPayloadTheWriterRefusesOutrightIsRejectedAsWriterRejected() = runTest {
+        // The gate's other reachable arm. An emoji is a surrogate pair, which the validator
+        // admits (visible, neither Cf nor Cc) and PDF417 cannot encode at any length.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = SUPPLEMENTARY_PLANE_PAYLOAD,
+                format = ScannableFormat.Pdf417,
+                label = "Boarding pass",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        val reason = rejected.reason as ScannableCardRejectionReason.EncoderFailure
+        val writerRejected = reason.reason as EncoderFailureReason.WriterRejected
+        assertThat(writerRejected.format).isEqualTo(ScannableFormat.Pdf417)
+        // `detail` is the one third-party string crossing this API; it must never carry
+        // the payload back out (see the arm's kernel KDoc).
+        assertThat(writerRejected.detail).doesNotContain(SUPPLEMENTARY_PLANE_PAYLOAD)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:EncoderFailed",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
     fun updateWithPayloadOverEncoderCapacityIsRejectedAndStoredRowIsUnchanged() = runTest {
         // Edit shares the create gate, so a rendering card cannot be edited into a blank one.
         val cards = FakeScannableCardStore()
@@ -279,8 +310,9 @@ class ScannableCardRepositoryTest {
 
     @Test
     fun createWithAccentedPayloadAtTheFullPdf417CapStillPersists() = runTest {
-        // The gate must not become a stricter cap: 800 two-byte characters is the full
-        // PDF417 character cap and 1,600 bytes, which the writer encodes.
+        // The gate must not become a stricter cap. "é" is inside ISO-8859-1, so PDF417's
+        // AUTO_ECI spends one byte on it: this is the full 800-character cap in the
+        // cheapest case, well inside the writer's 1,766 single-byte characters.
         val cards = FakeScannableCardStore()
         val telemetry = RecordingGuard()
         val repo = repo(cards, telemetry)
@@ -746,5 +778,8 @@ class ScannableCardRepositoryTest {
         // Synthetic, not lifted from a real pass: the epic treats decoded payload content
         // as PII, and the property under test is byte length, not what the bytes say.
         val DENSE_MULTIBYTE_PAYLOAD: String = "東".repeat(700)
+
+        // Short on purpose — no writer refuses this for its size.
+        const val SUPPLEMENTARY_PLANE_PAYLOAD: String = "WALT-🎫-1"
     }
 }

--- a/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
+++ b/passes-storage/src/test/kotlin/is/walt/passes/storage/ScannableCardRepositoryTest.kt
@@ -2,6 +2,7 @@ package `is`.walt.passes.storage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.EncoderFailureReason
 import `is`.walt.passes.core.Pass
 import `is`.walt.passes.core.PassInstant
 import `is`.walt.passes.core.PassType
@@ -65,6 +66,11 @@ import org.robolectric.annotation.Config
  *     when the input passed validation; an invalid input against an unknown id
  *     surfaces as [StorageError.ScannableCardRejected] (validation precedes the row
  *     lookup, mirroring `updateDocumentLabel`).
+ * 11. Both write paths trial-encode before persisting: a multibyte payload that clears
+ *     the validator's character cap but overflows the symbology's byte capacity is
+ *     rejected with [EncoderFailureReason.PayloadTooDense] rather than stored blank,
+ *     and an accented payload at the full character cap still encodes and is stored,
+ *     so the gate does not over-reject what the caps admit.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -172,6 +178,127 @@ class ScannableCardRepositoryTest {
         val rows = repo.observeScannableCards().first()
         assertThat(rows).hasSize(1)
         assertThat(rows[0].format).isEqualTo(ScannableFormat.Aztec)
+    }
+
+    @Test
+    fun createWithAztecPayloadOverEncoderCapacityIsRejectedAsTooDense() = runTest {
+        // 700 three-byte characters: under the 1500-character Aztec cap the validator
+        // enforces, over the ~623 three-byte characters the writer can hold at 33% ECC.
+        // Without the trial encode this row persists and renders as an empty barcode.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = DENSE_MULTIBYTE_PAYLOAD,
+                format = ScannableFormat.Aztec,
+                label = "Boarding pass",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        val reason = rejected.reason as ScannableCardRejectionReason.EncoderFailure
+        assertThat(reason.reason).isEqualTo(EncoderFailureReason.PayloadTooDense)
+        // Encoder rejection shares the validator's channel and does NOT also emit
+        // `failure:ScannableCardRejected:...`.
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:EncoderFailed",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
+    fun createWithPdf417PayloadOverEncoderCapacityIsRejectedAsTooDense() = runTest {
+        // Same payload against PDF417's 800-character cap, where the writer holds ~528
+        // three-byte characters at error-correction level 3.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = DENSE_MULTIBYTE_PAYLOAD,
+                format = ScannableFormat.Pdf417,
+                label = "Boarding pass",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        val reason = rejected.reason as ScannableCardRejectionReason.EncoderFailure
+        assertThat(reason.reason).isEqualTo(EncoderFailureReason.PayloadTooDense)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-rejected:EncoderFailed",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).isEmpty()
+    }
+
+    @Test
+    fun updateWithPayloadOverEncoderCapacityIsRejectedAndStoredRowIsUnchanged() = runTest {
+        // Edit shares the create gate, so a rendering card cannot be edited into a blank one.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val seed = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "WALT-CHECK-1",
+                format = ScannableFormat.Aztec,
+                label = "seed",
+            ),
+        )
+        check(seed is StorageResult.Success)
+
+        val result = repo.updateScannableCard(
+            seed.value,
+            ScannableCardCreateInput(
+                payload = DENSE_MULTIBYTE_PAYLOAD,
+                format = ScannableFormat.Aztec,
+                label = "new",
+            ),
+        )
+
+        check(result is StorageResult.Failure)
+        val rejected = result.error as StorageError.ScannableCardRejected
+        val reason = rejected.reason as ScannableCardRejectionReason.EncoderFailure
+        assertThat(reason.reason).isEqualTo(EncoderFailureReason.PayloadTooDense)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Aztec",
+            "card-rejected:EncoderFailed",
+        ).inOrder()
+        val rows = repo.observeScannableCards().first()
+        assertThat(rows).hasSize(1)
+        assertThat(rows[0].payload).isEqualTo("WALT-CHECK-1")
+        assertThat(rows[0].label).isEqualTo("seed")
+    }
+
+    @Test
+    fun createWithAccentedPayloadAtTheFullPdf417CapStillPersists() = runTest {
+        // The gate must not become a stricter cap: 800 two-byte characters is the full
+        // PDF417 character cap and 1,600 bytes, which the writer encodes.
+        val cards = FakeScannableCardStore()
+        val telemetry = RecordingGuard()
+        val repo = repo(cards, telemetry)
+
+        val result = repo.createScannableCard(
+            ScannableCardCreateInput(
+                payload = "é".repeat(800),
+                format = ScannableFormat.Pdf417,
+                label = "Accented",
+            ),
+        )
+
+        check(result is StorageResult.Success)
+        assertThat(telemetry.events).containsExactly(
+            "init:Tee",
+            "card-created:Pdf417",
+        ).inOrder()
+        assertThat(repo.observeScannableCards().first()).hasSize(1)
     }
 
     @Test
@@ -613,5 +740,11 @@ class ScannableCardRepositoryTest {
             clearing: Boolean,
         ) = Unit
         override fun onPassRejected(kind: PassUpdateRejectedKind) = Unit
+    }
+
+    private companion object {
+        // Synthetic, not lifted from a real pass: the epic treats decoded payload content
+        // as PII, and the property under test is byte length, not what the bytes say.
+        val DENSE_MULTIBYTE_PAYLOAD: String = "東".repeat(700)
     }
 }


### PR DESCRIPTION
## Why

`StorageError.ScannableCardRejected(EncoderFailure)` and its `onScannableCardRejected(EncoderFailed)` telemetry arm were both consumed — `SqlCipherPassRepository.kt:256,311`, `SqlCipherScannableCardStore.kt:145` — and **nothing produced them**. `ScannableCardInputValidator` applies charset, length and structural rules only; it never calls `BarcodeEncoder`. So a payload the validator accepts but no writer can render was persisted, and the failure first appeared as `ScannableCardView`'s accessible-but-empty `Spacer`, with no way for the user to learn why.

The gap is reachable from ordinary input, not just hostile input. The 2D length caps count **characters** while writer capacity is spent in **bytes** (measured against ZXing 3.5.4, derived in `ScannableFormatConstraints`' cap KDoc):

| Format | Cap | One-byte capacity | Three-byte capacity |
|---|---|---|---|
| Aztec | 1500 chars | 2,995 | 623 |
| PDF417 | 800 chars | 1,766 | 528 |

A 700-character CJK payload clears the validator on either format and cannot encode. Same class of gap for any multibyte script — Greek, Cyrillic, Hebrew, Arabic, CJK, emoji.

wpass-pl7.6 did what it could at the encoder: the writers' over-capacity errors lift to `EncoderFailureReason.PayloadTooDense` rather than an opaque `WriterRejected`. That arm was unreachable to the user until something ran the encoder on the create path. Not introduced by that bead — QR has had this shape since v1 — but it widened the exposure by making two more byte-capable formats creatable.

**Why not tighten the caps instead:** an exact character-level predicate is not available at the validator. Both writers choose a compaction mode per run, so capacity swings with composition — Aztec fits 2,995 ASCII characters but 934 accented ones, and a mixed ASCII+CJK payload outperforms both rates. A flat byte ceiling low enough to be safe (PDF417 ~1,584) would reject ordinary accented text at well under the character cap: 800 accented characters encodes fine today.

## What

`createScannableCard` and `updateScannableCard` now share one `approveScannableCard` gate — validate, then trial-encode what the validator approved, before any row is touched.

The encoder refusal re-enters the **kernel** result family as `ScannableCardCreateResult.EncoderFailure`, which is what `BarcodeEncoder`'s KDoc already promised to "an orchestrator wrapping validation + encoding into a single create flow (storage layer, Child 6)". One `when` then maps every arm — validator and encoder alike — onto its storage rejection, so no arm of that family is documented-but-dead.

- The matrix is discarded; the renderer re-encodes at draw time against its own size. Cost is one encode per save on a non-hot path.
- The gate runs outside the write mutex and before the row lookup, so `updateScannableCard` keeps its rejection-before-`IntegrityViolation` precedence and cannot turn a rendering card into a blank one.
- Rejections stay off the `onStorageFailure` channel, matching the existing `rejectDocument` discipline.

This belongs in the kernel rather than in a consumer-side pre-save preview: walt-android does not parallel-implement trust-claim-bearing logic (CLAUDE.md's decisive constraint). No new public API — the arms already existed.

## Privacy

No decoded payload reaches logs, default labels or committed fixtures; the epic treats BCBP content as PII. Test payloads are synthetic (`"東".repeat(700)`) — the property under test is byte length, not what the bytes say.

One arm carries third-party text: `EncoderFailureReason.WriterRejected.detail` is a raw ZXing message, and this PR is what first makes it reachable from `passes-storage`. Telemetry is unaffected (only the enum kind is emitted, pinned by tests), and `StorageError.ScannableCardRejected`'s KDoc now carries the kernel's "hash or bucket before reporting" warning forward — walt-android reads that KDoc, not the kernel's. A test asserts `detail` does not carry the payload back out.

## Tests

`./gradlew check assemble assembleDebugAndroidTest` green (detekt + ktlint + lint). Five added to `ScannableCardRepositoryTest`, JUnit 4 + Truth against the existing in-memory fakes:

- 700-char CJK on **Aztec** → `PayloadTooDense`, telemetry exactly `card-rejected:EncoderFailed` with no `failure:` double-emit, row never persisted
- same payload on **PDF417** → same
- **update** with that payload → rejected, and the stored row's payload and label are unchanged
- a supplementary-plane payload on PDF417 → `WriterRejected`, pinning the gate's other reachable arm, and its `detail` does not contain the payload
- 800 characters at the full PDF417 cap still persists, so the gate does not become a stricter cap

The pre-existing ASCII create/update paths are unchanged and still covered.

Closes wpass-1kg.
