### PR TITLE
Generalize FullScreenDocumentView to image + composite documents (wpass-pl7.4)

### DIFF
--- a/passes-document-ui/src/androidTest/kotlin/is/walt/passes/document/ui/DocumentViewInstrumentedTest.kt
+++ b/passes-document-ui/src/androidTest/kotlin/is/walt/passes/document/ui/DocumentViewInstrumentedTest.kt
@@ -29,9 +29,16 @@ import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ScannableFormat
+import `is`.walt.passes.document.BarcodedImageDocument
+import `is`.walt.passes.document.BarcodedImageDocumentId
 import `is`.walt.passes.document.DocumentRejectedKind
+import `is`.walt.passes.document.ImageDocument
+import `is`.walt.passes.document.ImageDocumentId
 import `is`.walt.passes.document.PdfDocument
 import `is`.walt.passes.document.PdfDocumentId
+import `is`.walt.passes.image.android.ImageDecodeBinder
+import `is`.walt.passes.image.android.ImageDecodeResult
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.ProbeResult
 import `is`.walt.passes.pdf.android.RenderResult
@@ -508,6 +515,148 @@ class DocumentViewInstrumentedTest {
             .isEqualTo((untinted.bottom - untinted.top).value)
     }
 
+    @Test
+    fun tapOnInlineImageInvokesTheFullScreenCallbackAndShowsTheDefaultBanner() {
+        // wpass-pl7.4: the image arm wires onOpenFullScreen exactly as the PDF arm does —
+        // banner docked below the image by default, image tap as the second entry path.
+        var opened = 0
+        composeRule.setContent {
+            ThemedHost {
+                DocumentView(
+                    doc = imageDoc(),
+                    imageFile = pipeRead,
+                    imageDecoder = RecordingImageDecoder(),
+                    onOpenFullScreen = { opened++ },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithText("Tap for full screen").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Image document").performClick()
+        composeRule.onNodeWithText("Tap for full screen").performClick()
+        composeRule.waitForIdle()
+        assertThat(opened).isEqualTo(2)
+    }
+
+    @Test
+    fun fullScreenImageSurfaceShowsTheTrustCaption() {
+        // wpass-pl7.4: the generalized full-screen surface docks the same caption on the
+        // image arm, visible as soon as the surface composes.
+        composeRule.setContent {
+            ThemedHost {
+                FullScreenDocumentView(
+                    doc = imageDoc(),
+                    imageFile = pipeRead,
+                    imageDecoder = RecordingImageDecoder(),
+                    onClose = {},
+                )
+            }
+        }
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun pinchOnFullScreenImageKeepsTheDockedTrustCaptionFixedAndDoesNotRedecode() {
+        // wpass-pl7.4 acceptance: the docked caption stays fixed and legible at zoom. The
+        // caption is structurally outside the zoom transform, so its on-screen bounds
+        // must be IDENTICAL before and after a pinch — not merely still-displayed. And
+        // unlike the PDF arm's sub-rect re-render, the image arm decodes exactly once
+        // (the base decode already carries max-zoom resolution); a pinch must not drive
+        // a second decode call.
+        val decoder = RecordingImageDecoder()
+        composeRule.setContent {
+            ThemedHost {
+                FullScreenDocumentView(
+                    doc = imageDoc(),
+                    imageFile = pipeRead,
+                    imageDecoder = decoder,
+                    onClose = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Image document").assertIsDisplayed()
+        val captionBefore = composeRule
+            .onNodeWithText("User-provided document. Walt has not verified the source.")
+            .getUnclippedBoundsInRoot()
+
+        composeRule.onNodeWithContentDescription("Image document").performTouchInput {
+            pinch(
+                start0 = center + Offset(-100f, 0f),
+                end0 = center + Offset(-300f, 0f),
+                start1 = center + Offset(100f, 0f),
+                end1 = center + Offset(300f, 0f),
+            )
+        }
+        composeRule.waitForIdle()
+
+        val captionAfter = composeRule
+            .onNodeWithText("User-provided document. Walt has not verified the source.")
+            .getUnclippedBoundsInRoot()
+        assertThat(captionAfter).isEqualTo(captionBefore)
+        composeRule.onNodeWithText(
+            "User-provided document. Walt has not verified the source.",
+        ).assertIsDisplayed()
+        assertThat(decoder.decodeCount()).isEqualTo(1)
+    }
+
+    @Test
+    fun pinchOnFullScreenCompositeImageKeepsTheDockedTrustCaptionFixed() {
+        // wpass-pl7.4 acceptance: a composite's retained photo gets the same full-screen
+        // zoom surface as a plain image (wpass-8lu routing), with the caption equally
+        // fixed. Payload is a synthetic non-PII fixture (epic constraint 7).
+        composeRule.setContent {
+            ThemedHost {
+                FullScreenDocumentView(
+                    doc = BarcodedImageDocument(
+                        id = BarcodedImageDocumentId("comp-instrumented"),
+                        displayLabel = "fixture.png",
+                        byteCount = 4096L,
+                        widthPx = 1080,
+                        heightPx = 2340,
+                        barcodePayload = "TEST-PAYLOAD-000",
+                        barcodeFormat = ScannableFormat.Aztec,
+                        importedAtEpochMs = 0L,
+                    ),
+                    imageFile = pipeRead,
+                    imageDecoder = RecordingImageDecoder(),
+                    onClose = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("Image document").assertIsDisplayed()
+        val captionBefore = composeRule
+            .onNodeWithText("User-provided document. Walt has not verified the source.")
+            .getUnclippedBoundsInRoot()
+
+        composeRule.onNodeWithContentDescription("Image document").performTouchInput {
+            pinch(
+                start0 = center + Offset(-100f, 0f),
+                end0 = center + Offset(-300f, 0f),
+                start1 = center + Offset(100f, 0f),
+                end1 = center + Offset(300f, 0f),
+            )
+        }
+        composeRule.waitForIdle()
+
+        val captionAfter = composeRule
+            .onNodeWithText("User-provided document. Walt has not verified the source.")
+            .getUnclippedBoundsInRoot()
+        assertThat(captionAfter).isEqualTo(captionBefore)
+    }
+
+    private fun imageDoc() = ImageDocument(
+        id = ImageDocumentId("img-instrumented"),
+        displayLabel = "fixture.png",
+        byteCount = 4096L,
+        widthPx = 1080,
+        heightPx = 2340,
+        importedAtEpochMs = 0L,
+    )
+
     private fun doc(pageCount: Int) = PdfDocument(
         id = PdfDocumentId("doc-instrumented"),
         displayLabel = "fixture.pdf",
@@ -579,7 +728,32 @@ class DocumentViewInstrumentedTest {
         }
     }
 
+    /**
+     * Image-arm sibling of [RecordingBinder]: records every decode() call and returns a
+     * fresh Ok SharedMemory bounded to the request, like the real sandbox (which never
+     * upscales; a small fixed raster inside any plausible request keeps this simple).
+     */
+    private class RecordingImageDecoder : ImageDecodeBinder {
+        private val calls = AtomicInteger(0)
+
+        override suspend fun decode(
+            image: ParcelFileDescriptor,
+            maxWidthPx: Int,
+            maxHeightPx: Int,
+        ): ImageDecodeResult {
+            val n = calls.incrementAndGet()
+            val w = DECODED_WIDTH.coerceAtMost(maxWidthPx)
+            val h = DECODED_HEIGHT.coerceAtMost(maxHeightPx)
+            val sm = SharedMemory.create("walt-test-image-decode-$n", w * h * BYTES_PER_PIXEL)
+            return ImageDecodeResult.Ok(sm, w, h, w.toFloat() / h.toFloat())
+        }
+
+        fun decodeCount(): Int = calls.get()
+    }
+
     private companion object {
         const val BYTES_PER_PIXEL = 4
+        const val DECODED_WIDTH = 108
+        const val DECODED_HEIGHT = 234
     }
 }

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -115,6 +115,8 @@ public fun DocumentView(
             modifier = modifier,
             telemetry = telemetry,
             trustCaption = trustCaption,
+            onOpenFullScreen = onOpenFullScreen,
+            fullScreenAffordance = fullScreenAffordance,
             faceTint = faceTint,
         )
         // wpass-8lu: a composite renders its IMAGE half through the same isolated image-decode
@@ -132,6 +134,8 @@ public fun DocumentView(
             modifier = modifier,
             telemetry = telemetry,
             trustCaption = trustCaption,
+            onOpenFullScreen = onOpenFullScreen,
+            fullScreenAffordance = fullScreenAffordance,
             faceTint = faceTint,
         )
     }
@@ -308,9 +312,10 @@ private fun PdfDocumentView(
  *  - Fixed 1x: no pinch-zoom or pan inline, matching the PDF inline surface.
  *
  * [imageFile] is the ORIGINAL image bytes, owned by the caller; it MUST stay open while this
- * view is composed. Close after `DocumentView` leaves composition. Full-screen zoom for images
- * is intentionally out of scope here (the PDF `FullScreenDocumentView` is unchanged); the inline
- * surface is the image-document presentation this step ships.
+ * view is composed. Close after `DocumentView` leaves composition. Inline stays fixed 1x;
+ * full-screen zoom lives on `FullScreenDocumentView`, whose image arm this view's
+ * [onOpenFullScreen] / [fullScreenAffordance] pair (wired identically to the PDF arm,
+ * wpass-pl7.4) is the entry path to.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -321,6 +326,8 @@ private fun ImageDocumentView(
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     trustCaption: TrustCaptionPlacement = TrustCaptionPlacement.Docked,
+    onOpenFullScreen: (() -> Unit)? = null,
+    fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)? = null,
     faceTint: Color = Color.Unspecified,
 ) {
     Column(
@@ -346,36 +353,79 @@ private fun ImageDocumentView(
                 .weight(1f)
                 .documentFace(faceTint),
         ) {
-            val density = LocalDensity.current
-            val requestWidthPx = with(density) {
-                TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1)
-            }
-            val requestHeightPx = with(density) {
-                TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1)
-            }
-            val state = rememberDocumentImage(
-                documentId = documentId,
-                imageFile = imageFile,
-                decoder = decoder,
-                targetSizePx = IntSize(requestWidthPx, requestHeightPx),
-                telemetry = telemetry,
-            )
-            // Loading / Failed render nothing inline; the lane tone is the placeholder, matching
-            // DocumentPage. A future retry affordance belongs on DocumentTile, not here.
-            when (state) {
-                is DocumentImageState.Loading, is DocumentImageState.Failed -> Unit
-                is DocumentImageState.Rendered -> Image(
-                    bitmap = state.image,
-                    // ADR 0005 D4 forbids extracting text/metadata from the image; a fixed
-                    // neutral description is the only safe TalkBack fallback.
-                    contentDescription = "Image document",
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp)),
+            // Image tap opens full screen, mirroring the PDF arm's page tap (wpass-pl7.4).
+            // The clickable sits on the slot-filling region, not the bitmap, so the tap
+            // target exists through Loading / Failed too — same as the pager.
+            val imageRegionModifier = Modifier
+                .fillMaxSize()
+                .let {
+                    if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
+                }
+                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+            Box(modifier = imageRegionModifier) {
+                InlineDecodedImage(
+                    documentId = documentId,
+                    imageFile = imageFile,
+                    decoder = decoder,
+                    telemetry = telemetry,
                 )
             }
+
+            // A host-supplied affordance floats over the image bottom-centre (wpass-emn);
+            // the host accepts that overlap by choosing a floating affordance.
+            if (onOpenFullScreen != null && fullScreenAffordance != null) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 16.dp),
+                ) {
+                    fullScreenAffordance(onOpenFullScreen)
+                }
+            }
         }
+
+        // No custom affordance: the neutral banner docks below the image (matching the
+        // PDF arm), so default consumers' content is never obscured.
+        if (onOpenFullScreen != null && fullScreenAffordance == null) {
+            FullScreenBanner(onClick = onOpenFullScreen)
+        }
+    }
+}
+
+/** The inline image arm's decode-and-render body, the single-image analogue of [DocumentPage]. */
+@Composable
+private fun InlineDecodedImage(
+    documentId: DocumentId,
+    imageFile: ParcelFileDescriptor,
+    decoder: ImageDecodeBinder,
+    telemetry: DocumentTelemetryGuard,
+) {
+    val density = LocalDensity.current
+    val requestWidthPx = with(density) {
+        TARGET_PAGE_WIDTH_DP.dp.toPx().toInt().coerceAtLeast(1)
+    }
+    val requestHeightPx = with(density) {
+        TARGET_PAGE_HEIGHT_DP.dp.toPx().toInt().coerceAtLeast(1)
+    }
+    val state = rememberDocumentImage(
+        documentId = documentId,
+        imageFile = imageFile,
+        decoder = decoder,
+        targetSizePx = IntSize(requestWidthPx, requestHeightPx),
+        telemetry = telemetry,
+    )
+    // Loading / Failed render nothing inline; the lane tone is the placeholder, matching
+    // DocumentPage. A future retry affordance belongs on DocumentTile, not here.
+    when (state) {
+        is DocumentImageState.Loading, is DocumentImageState.Failed -> Unit
+        is DocumentImageState.Rendered -> Image(
+            bitmap = state.image,
+            // ADR 0005 D4 forbids extracting text/metadata from the image; a fixed
+            // neutral description is the only safe TalkBack fallback.
+            contentDescription = "Image document",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }
 

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/DocumentView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -108,28 +109,17 @@ public fun DocumentView(
             fullScreenAffordance = fullScreenAffordance,
             faceTint = faceTint,
         )
-        is ImageDocument -> ImageDocumentView(
-            documentId = doc.id,
-            imageFile = requireNotNull(imageFile) { "DocumentView(ImageDocument) requires a non-null imageFile" },
-            decoder = requireNotNull(imageDecoder) { "DocumentView(ImageDocument) requires a non-null imageDecoder" },
-            modifier = modifier,
-            telemetry = telemetry,
-            trustCaption = trustCaption,
-            onOpenFullScreen = onOpenFullScreen,
-            fullScreenAffordance = fullScreenAffordance,
-            faceTint = faceTint,
-        )
         // wpass-8lu: a composite renders its IMAGE half through the same isolated image-decode
         // surface as a plain image (same imageFile / imageDecoder pair, no new DocumentView
         // parameter). The generated barcode + format switcher are composed by the consumer with
         // passes-ui, keeping the two UI towers independent — this surface stays image-only.
-        is BarcodedImageDocument -> ImageDocumentView(
+        is ImageDocument, is BarcodedImageDocument -> ImageDocumentView(
             documentId = doc.id,
             imageFile = requireNotNull(imageFile) {
-                "DocumentView(BarcodedImageDocument) requires a non-null imageFile"
+                "DocumentView(${doc::class.simpleName}) requires a non-null imageFile"
             },
             decoder = requireNotNull(imageDecoder) {
-                "DocumentView(BarcodedImageDocument) requires a non-null imageDecoder"
+                "DocumentView(${doc::class.simpleName}) requires a non-null imageDecoder"
             },
             modifier = modifier,
             telemetry = telemetry,
@@ -234,28 +224,16 @@ private fun PdfDocumentView(
             TrustCaptionPlacement.HostedTypeRow -> Unit
         }
 
-        // The face paints behind the pager only — the document-surface tone the page sits
-        // on (showing through ContentScale.Fit letterbox bars). The page region is a Box so
-        // a host-supplied affordance can float over its bottom edge.
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .documentFace(faceTint),
-        ) {
-            // Page tap opens full screen; clickable and the pager's drag coexist (Compose
-            // routes quick press-release to the click, horizontal drag to the pager).
-            val pagerModifier = Modifier
-                .fillMaxSize()
-                .let {
-                    if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
-                }
-                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+        DocumentFaceSlot(
+            faceTint = faceTint,
+            onOpenFullScreen = onOpenFullScreen,
+            fullScreenAffordance = fullScreenAffordance,
+        ) { contentModifier ->
             // Adjacent page rasterises ahead of the viewport so a swipe or peek reveals a
             // ready page (wpass-tjc.3); up to 4 live pages mid-swipe, inside DEFAULT_PAGE_WINDOW.
             HorizontalPager(
                 state = pagerState,
-                modifier = pagerModifier,
+                modifier = contentModifier,
                 beyondViewportPageCount = 1,
             ) { page ->
                 DocumentPage(
@@ -267,25 +245,6 @@ private fun PdfDocumentView(
                     telemetry = telemetry,
                 )
             }
-
-            // A host-supplied affordance floats over the page bottom-centre (wpass-emn);
-            // the host accepts that overlap by choosing a floating affordance.
-            if (onOpenFullScreen != null && fullScreenAffordance != null) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp),
-                ) {
-                    fullScreenAffordance(onOpenFullScreen)
-                }
-            }
-        }
-
-        // No custom affordance: the neutral banner docks below the page (original
-        // layout), so default consumers' page content is never obscured. The trust
-        // caption above this Column cannot be pushed off-screen by it.
-        if (onOpenFullScreen != null && fullScreenAffordance == null) {
-            FullScreenBanner(onClick = onOpenFullScreen)
         }
     }
 }
@@ -344,25 +303,12 @@ private fun ImageDocumentView(
             TrustCaptionPlacement.HostedTypeRow -> Unit
         }
 
-        // The face paints behind the image only — the document-surface tone the image sits on
-        // (showing through the ContentScale.Fit letterbox bars), so the caption above reads as
-        // host chrome rather than part of the document surface, matching the PDF arm.
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f)
-                .documentFace(faceTint),
-        ) {
-            // Image tap opens full screen, mirroring the PDF arm's page tap (wpass-pl7.4).
-            // The clickable sits on the slot-filling region, not the bitmap, so the tap
-            // target exists through Loading / Failed too — same as the pager.
-            val imageRegionModifier = Modifier
-                .fillMaxSize()
-                .let {
-                    if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
-                }
-                .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
-            Box(modifier = imageRegionModifier) {
+        DocumentFaceSlot(
+            faceTint = faceTint,
+            onOpenFullScreen = onOpenFullScreen,
+            fullScreenAffordance = fullScreenAffordance,
+        ) { contentModifier ->
+            Box(modifier = contentModifier) {
                 InlineDecodedImage(
                     documentId = documentId,
                     imageFile = imageFile,
@@ -370,25 +316,64 @@ private fun ImageDocumentView(
                     telemetry = telemetry,
                 )
             }
+        }
+    }
+}
 
-            // A host-supplied affordance floats over the image bottom-centre (wpass-emn);
-            // the host accepts that overlap by choosing a floating affordance.
-            if (onOpenFullScreen != null && fullScreenAffordance != null) {
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(bottom = 16.dp),
-                ) {
-                    fullScreenAffordance(onOpenFullScreen)
-                }
+/**
+ * The face-slot trio both arms compose identically: the [documentFace] frame holding the
+ * tappable content region, the floating host affordance, and the docked [FullScreenBanner]
+ * fallback. One implementation so the PDF and image arms cannot drift apart on the
+ * full-screen entry path — the same reason [documentFace] itself is shared.
+ *
+ * The face paints behind the content only — the document-surface tone the page render /
+ * decoded image sits on (showing through ContentScale.Fit letterbox bars), so the caption
+ * above reads as host chrome rather than part of the document surface.
+ *
+ * [content] receives the slot-filling, tap-wired, padded modifier to place its surface
+ * with. Content tap opens full screen; the clickable and drag gestures coexist (Compose
+ * routes quick press-release to the click, drags to the content), and it sits on the slot
+ * region rather than the bitmap so the tap target exists through Loading / Failed too.
+ */
+@Composable
+private fun ColumnScope.DocumentFaceSlot(
+    faceTint: Color,
+    onOpenFullScreen: (() -> Unit)?,
+    fullScreenAffordance: (@Composable (onOpen: () -> Unit) -> Unit)?,
+    content: @Composable (contentModifier: Modifier) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .weight(1f)
+            .documentFace(faceTint),
+    ) {
+        val contentModifier = Modifier
+            .fillMaxSize()
+            .let {
+                if (onOpenFullScreen != null) it.clickable(onClick = onOpenFullScreen) else it
+            }
+            .padding(PaddingValues(horizontal = 16.dp, vertical = 8.dp))
+        content(contentModifier)
+
+        // A host-supplied affordance floats over the content bottom-centre (wpass-emn);
+        // the host accepts that overlap by choosing a floating affordance.
+        if (onOpenFullScreen != null && fullScreenAffordance != null) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 16.dp),
+            ) {
+                fullScreenAffordance(onOpenFullScreen)
             }
         }
+    }
 
-        // No custom affordance: the neutral banner docks below the image (matching the
-        // PDF arm), so default consumers' content is never obscured.
-        if (onOpenFullScreen != null && fullScreenAffordance == null) {
-            FullScreenBanner(onClick = onOpenFullScreen)
-        }
+    // No custom affordance: the neutral banner docks below the content (original layout),
+    // so default consumers' content is never obscured. The trust caption above this
+    // Column cannot be pushed off-screen by it.
+    if (onOpenFullScreen != null && fullScreenAffordance == null) {
+        FullScreenBanner(onClick = onOpenFullScreen)
     }
 }
 

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
@@ -97,9 +97,9 @@ public fun FullScreenDocumentView(
     doc: Document,
     pdfFile: ParcelFileDescriptor? = null,
     renderer: PdfRendererBinder? = null,
-    onClose: () -> Unit,
     imageFile: ParcelFileDescriptor? = null,
     imageDecoder: ImageDecodeBinder? = null,
+    onClose: () -> Unit,
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     closeButton: @Composable (onClose: () -> Unit) -> Unit = { handler ->
@@ -133,26 +133,16 @@ public fun FullScreenDocumentView(
                     },
                     telemetry = telemetry,
                 )
-                is ImageDocument -> FullScreenImagePage(
-                    documentId = doc.id,
-                    imageFile = requireNotNull(imageFile) {
-                        "FullScreenDocumentView(ImageDocument) requires a non-null imageFile"
-                    },
-                    decoder = requireNotNull(imageDecoder) {
-                        "FullScreenDocumentView(ImageDocument) requires a non-null imageDecoder"
-                    },
-                    telemetry = telemetry,
-                )
                 // wpass-8lu / wpass-pl7.4: a composite's retained photo zooms through the same
                 // isolated image-decode surface as a plain image; the barcode half stays with
                 // the consumer's passes-ui composition.
-                is BarcodedImageDocument -> FullScreenImagePage(
+                is ImageDocument, is BarcodedImageDocument -> FullScreenImagePage(
                     documentId = doc.id,
                     imageFile = requireNotNull(imageFile) {
-                        "FullScreenDocumentView(BarcodedImageDocument) requires a non-null imageFile"
+                        "FullScreenDocumentView(${doc::class.simpleName}) requires a non-null imageFile"
                     },
                     decoder = requireNotNull(imageDecoder) {
-                        "FullScreenDocumentView(BarcodedImageDocument) requires a non-null imageDecoder"
+                        "FullScreenDocumentView(${doc::class.simpleName}) requires a non-null imageDecoder"
                     },
                     telemetry = telemetry,
                 )
@@ -216,10 +206,11 @@ private fun FullScreenPdfPager(
 
 /**
  * The image-arm zoom surface: a single decoded raster inside [ZoomableImage], no pager. The
- * decode is requested at the slot size scaled by [DEFAULT_MAX_SCALE] (clamped to the 4 MP
- * cap) so pinching to max zoom shows real source pixels where the source has them — the
- * sandbox bounds the output to fit the request and never upscales beyond the source, so
- * over-asking costs only what the image actually carries.
+ * decode is requested at the slot size scaled by [DEFAULT_MAX_SCALE], clamped to the 4 MP
+ * cap — the sandbox bounds the output to fit the request and never upscales beyond the
+ * source, so over-asking costs only what the image actually carries. On a phone-sized slot
+ * the cap binds well below the full 5x request, so deep zoom still upsamples; the raster is
+ * simply the sharpest one the sandbox will legally produce.
  */
 @Composable
 private fun FullScreenImagePage(

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/FullScreenDocumentView.kt
@@ -27,11 +27,17 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import `is`.walt.passes.document.BarcodedImageDocument
+import `is`.walt.passes.document.Document
+import `is`.walt.passes.document.DocumentId
 import `is`.walt.passes.document.DocumentTelemetryGuard
+import `is`.walt.passes.document.ImageDocument
 import `is`.walt.passes.document.PdfDocument
+import `is`.walt.passes.image.android.ImageDecodeBinder
 import `is`.walt.passes.pdf.android.PdfRendererBinder
 import `is`.walt.passes.pdf.android.RenderResult
 import `is`.walt.passes.pdf.android.RenderSourceRect
+import `is`.walt.passes.document.ui.internal.DEFAULT_MAX_SCALE
 import `is`.walt.passes.document.ui.internal.ZoomableImage
 import `is`.walt.passes.document.ui.internal.decodePage
 import `is`.walt.passes.document.ui.internal.renderOrDiscard
@@ -39,25 +45,44 @@ import `is`.walt.passes.document.ui.theme.LocalDocumentSemantics
 import `is`.walt.passes.ui.core.toComposeColor
 
 /**
- * Full-screen detail surface for a [PdfDocument] (`wpass-jil`). The ONLY place inside
- * `passes-document-ui` where pinch-zoom and pan are available; inline `DocumentView` is
- * fixed 1x after the `wpass-ny4` pivot.
+ * Full-screen detail surface for a [Document] (`wpass-jil`; generalized past PDF-only by
+ * `wpass-pl7.4`). The ONLY place inside `passes-document-ui` where pinch-zoom and pan are
+ * available; inline `DocumentView` is fixed 1x after the `wpass-ny4` pivot.
+ *
+ * Like [DocumentView], this is a dispatcher on the sealed [Document] type: [PdfDocument]
+ * gets a swipeable pager of zoomable pages over the isolated PDF renderer;
+ * [ImageDocument] gets a single zoomable image over the isolated image-decode sandbox;
+ * [BarcodedImageDocument] (wpass-8lu) routes to the SAME image surface for its image half —
+ * the generated barcode and format switcher are composed by the consumer with `passes-ui`,
+ * so this surface stays image-only and the two UI towers remain independent.
+ *
+ * The backend handles are kind-specific and nullable, mirroring [DocumentView]: supply the
+ * [pdfFile] / [renderer] pair for a [PdfDocument] and the [imageFile] / [imageDecoder] pair
+ * for an [ImageDocument] or [BarcodedImageDocument]. The dispatcher requires the pair that
+ * matches the arm; passing a document without its backend pair is a programming error and
+ * fails fast.
  *
  * Trust contract:
  *
  *  - The non-suppressible [DocumentTrustCaption] is composed inside this surface and
  *    docked to the bottom edge of the screen, structurally outside the zoom transform
- *    (ADR 0005 D5 / Z.8).
+ *    (ADR 0005 D5 / Z.8) — the dock is a sibling of the arm dispatch, so no arm can scale
+ *    or translate it. Zooming can never push the caption off-surface.
  *  - Zoom is purely view-side. No share / export / print / open-with affordance
  *    (ADR 0005 D8); `DocumentPublicApiSurfaceTest` continues to enforce the
  *    classpath-scan rule on `Intent.ACTION_SEND`.
- *  - On pinch settle the surface fires a `renderer.render(SubRect)` call against the
- *    currently-visible normalised page rect and SWAPS the displayed bitmap when the
+ *  - PDF arm: on pinch settle the surface fires a `renderer.render(SubRect)` call against
+ *    the currently-visible normalised page rect and SWAPS the displayed bitmap when the
  *    result returns, so the visible region stays sharp within the 4 MP per-bitmap cap
  *    (`wpass-f4b`).
+ *  - Image arm: `ImageDecodeBinder` has no sub-rect API, so there is no re-render on
+ *    settle. Instead the single decode is requested at the slot size scaled by the max
+ *    zoom factor (clamped to the same 4 MP cap the decode service enforces), and the
+ *    sandbox never upscales beyond the source — so the raster already carries the
+ *    sharpest legal pixels for every zoom level this surface allows.
  *
- * Page cache: fit-resolution renders are cached per page; sub-rect renders are not
- * (cache-keying them would explode the key space and stale entries surface as a
+ * Page cache (PDF arm): fit-resolution renders are cached per page; sub-rect renders are
+ * not (cache-keying them would explode the key space and stale entries surface as a
  * sharper-but-wrong region after a pan).
  *
  * @param closeButton Host-supplied close affordance, rendered at [Alignment.TopStart].
@@ -69,10 +94,12 @@ import `is`.walt.passes.ui.core.toComposeColor
 @Composable
 @Suppress("LongParameterList")
 public fun FullScreenDocumentView(
-    doc: PdfDocument,
-    pdfFile: ParcelFileDescriptor,
-    renderer: PdfRendererBinder,
+    doc: Document,
+    pdfFile: ParcelFileDescriptor? = null,
+    renderer: PdfRendererBinder? = null,
     onClose: () -> Unit,
+    imageFile: ParcelFileDescriptor? = null,
+    imageDecoder: ImageDecodeBinder? = null,
     modifier: Modifier = Modifier,
     telemetry: DocumentTelemetryGuard = DocumentTelemetryGuard.NoOp,
     closeButton: @Composable (onClose: () -> Unit) -> Unit = { handler ->
@@ -80,41 +107,53 @@ public fun FullScreenDocumentView(
     },
 ) {
     val semantics = LocalDocumentSemantics.current
-    val cache = remember(doc.id) { PdfThumbnailCache() }
-    DisposableEffect(doc.id) {
-        onDispose { cache.clear() }
-    }
-
-    val pagerState = rememberPagerState(pageCount = { doc.pageCount })
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(semantics.laneBackground.toComposeColor()),
     ) {
-        // Trust caption docked to bottom edge; outside the zoom transform (Z.8). The
-        // pager is offset above it via a BottomDockedLayout so the page surface uses
-        // the actual measured caption height instead of a hardcoded constant
-        // (`wpass-6ag` review M2 partial — drives the pager padding from the caption's
-        // intrinsic height, no SubcomposeLayout needed because the caption is a sibling
-        // in a Box layered above).
+        // Trust caption docked to bottom edge; outside the zoom transform (Z.8) for EVERY
+        // arm — the dock is a sibling of the arm dispatch, so a new Document arm cannot
+        // put content around the caption. The content region is offset above it via a
+        // BottomDockedLayout so the surface uses the actual measured caption height
+        // instead of a hardcoded constant (`wpass-6ag` review M2 partial).
         BottomDockedLayout(
             dock = { DocumentTrustCaption() },
             modifier = Modifier.fillMaxSize(),
         ) {
-            // Deliberately no beyondViewportPageCount here (unlike DocumentView's inline
-            // pager): full-screen rasters are far larger and the peek redesign does not
-            // apply to this surface (wpass-tjc.3).
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier.fillMaxSize(),
-            ) { page ->
-                FullScreenPage(
-                    document = doc,
-                    pageIndex = page,
-                    pdfFile = pdfFile,
-                    renderer = renderer,
-                    cache = cache,
+            when (doc) {
+                is PdfDocument -> FullScreenPdfPager(
+                    doc = doc,
+                    pdfFile = requireNotNull(pdfFile) {
+                        "FullScreenDocumentView(PdfDocument) requires a non-null pdfFile"
+                    },
+                    renderer = requireNotNull(renderer) {
+                        "FullScreenDocumentView(PdfDocument) requires a non-null renderer"
+                    },
+                    telemetry = telemetry,
+                )
+                is ImageDocument -> FullScreenImagePage(
+                    documentId = doc.id,
+                    imageFile = requireNotNull(imageFile) {
+                        "FullScreenDocumentView(ImageDocument) requires a non-null imageFile"
+                    },
+                    decoder = requireNotNull(imageDecoder) {
+                        "FullScreenDocumentView(ImageDocument) requires a non-null imageDecoder"
+                    },
+                    telemetry = telemetry,
+                )
+                // wpass-8lu / wpass-pl7.4: a composite's retained photo zooms through the same
+                // isolated image-decode surface as a plain image; the barcode half stays with
+                // the consumer's passes-ui composition.
+                is BarcodedImageDocument -> FullScreenImagePage(
+                    documentId = doc.id,
+                    imageFile = requireNotNull(imageFile) {
+                        "FullScreenDocumentView(BarcodedImageDocument) requires a non-null imageFile"
+                    },
+                    decoder = requireNotNull(imageDecoder) {
+                        "FullScreenDocumentView(BarcodedImageDocument) requires a non-null imageDecoder"
+                    },
                     telemetry = telemetry,
                 )
             }
@@ -140,6 +179,83 @@ private fun BottomDockedLayout(
     Column(modifier = modifier) {
         Box(modifier = Modifier.fillMaxWidth().weight(1f)) { content() }
         Box(modifier = Modifier.fillMaxWidth()) { dock() }
+    }
+}
+
+@Composable
+private fun FullScreenPdfPager(
+    doc: PdfDocument,
+    pdfFile: ParcelFileDescriptor,
+    renderer: PdfRendererBinder,
+    telemetry: DocumentTelemetryGuard,
+) {
+    val cache = remember(doc.id) { PdfThumbnailCache() }
+    DisposableEffect(doc.id) {
+        onDispose { cache.clear() }
+    }
+
+    val pagerState = rememberPagerState(pageCount = { doc.pageCount })
+
+    // Deliberately no beyondViewportPageCount here (unlike DocumentView's inline
+    // pager): full-screen rasters are far larger and the peek redesign does not
+    // apply to this surface (wpass-tjc.3).
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxSize(),
+    ) { page ->
+        FullScreenPage(
+            document = doc,
+            pageIndex = page,
+            pdfFile = pdfFile,
+            renderer = renderer,
+            cache = cache,
+            telemetry = telemetry,
+        )
+    }
+}
+
+/**
+ * The image-arm zoom surface: a single decoded raster inside [ZoomableImage], no pager. The
+ * decode is requested at the slot size scaled by [DEFAULT_MAX_SCALE] (clamped to the 4 MP
+ * cap) so pinching to max zoom shows real source pixels where the source has them — the
+ * sandbox bounds the output to fit the request and never upscales beyond the source, so
+ * over-asking costs only what the image actually carries.
+ */
+@Composable
+private fun FullScreenImagePage(
+    documentId: DocumentId,
+    imageFile: ParcelFileDescriptor,
+    decoder: ImageDecodeBinder,
+    telemetry: DocumentTelemetryGuard,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val density = LocalDensity.current
+        val (requestW, requestH) = with(density) {
+            val rawW = (maxWidth.toPx() * DEFAULT_MAX_SCALE).toInt().coerceAtLeast(1)
+            val rawH = (maxHeight.toPx() * DEFAULT_MAX_SCALE).toInt().coerceAtLeast(1)
+            clampToMaxPixels(rawW, rawH, MAX_REQUEST_PIXELS)
+        }
+
+        val state = rememberDocumentImage(
+            documentId = documentId,
+            imageFile = imageFile,
+            decoder = decoder,
+            targetSizePx = IntSize(requestW, requestH),
+            telemetry = telemetry,
+        )
+        // Loading / Failed render nothing; the lane tone is the placeholder, matching the
+        // PDF arm's base-bitmap gate.
+        when (state) {
+            is DocumentImageState.Loading, is DocumentImageState.Failed -> Unit
+            is DocumentImageState.Rendered -> ZoomableImage(
+                bitmap = state.image,
+                // ADR 0005 D4 forbids extracting text/metadata from the image; a fixed
+                // neutral description is the only safe TalkBack fallback.
+                contentDescription = "Image document",
+                modifier = Modifier.fillMaxSize(),
+                pageAspect = state.sourceAspect,
+            )
+        }
     }
 }
 
@@ -278,7 +394,8 @@ private fun clampToMaxPixels(widthPx: Int, heightPx: Int, maxPixels: Long): Pair
     return w to h
 }
 
-// Mirrors PdfRendererService.MAX_PIXELS so the request never asks for a bitmap the
-// renderer would have to downsize on its end. Concrete value lives in passes-pdf; this
-// re-declaration is a defensive ceiling, not the load-bearing cap.
+// Mirrors PdfRendererService.MAX_PIXELS (and ImageDecodeConfig.maxOutputPixels) so the
+// request never asks for a bitmap the sandbox would have to downsize on its end. Concrete
+// values live in passes-pdf / passes-image; this re-declaration is a defensive ceiling,
+// not the load-bearing cap.
 private const val MAX_REQUEST_PIXELS: Long = 4L * 1024 * 1024

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/TrustCaptionPlacement.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/TrustCaptionPlacement.kt
@@ -23,8 +23,8 @@ package `is`.walt.passes.document.ui
  * walt-android test that the details section renders a "Pass type" row enumerating the
  * artifact class — NOT (as before) that the host mounts the kernel caption.
  *
- * Relocation applies to the inline `DocumentView` only. `FullScreenDocumentView` is
- * unchanged: its caption stays docked and non-suppressible (ADR 0005 Z.8). A host's
+ * Relocation applies to the inline `DocumentView` only. `FullScreenDocumentView` takes no
+ * placement: its caption stays docked and non-suppressible on every arm (ADR 0005 Z.8). A host's
  * collapsible details section is an inline-surface affordance; the full-screen zoom
  * surface has no host details chrome to fold into.
  */

--- a/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/internal/ZoomableImage.kt
+++ b/passes-document-ui/src/main/kotlin/is/walt/passes/document/ui/internal/ZoomableImage.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
@@ -116,6 +117,11 @@ internal fun ZoomableImage(
     Box(
         modifier = modifier
             .fillMaxSize()
+            // The graphicsLayer scale below draws outside layout bounds unless an ancestor
+            // clips. Clip HERE (an unscaled layer) — not via clip=true on the scaled layer,
+            // whose clip shape would scale with it — so zoomed content can never overdraw
+            // the trust-caption dock beside this slot (ADR 0005 Z.8, ZoomableImageClipTest).
+            .clipToBounds()
             .onSizeChanged { slotSize = it }
             .pointerInput(Unit) {
                 detectTapGestures(

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
@@ -99,19 +99,36 @@ class DocumentSurfaceLockTest {
     }
 
     @Test
-    fun fullScreenDocumentViewHasExactlySevenUserVisibleParameters() {
-        // (doc, pdfFile, renderer, onClose, modifier, telemetry, closeButton). D5:
-        // trust caption is composed inside the surface; no parameter omits it. Required
-        // onClose forces the host to provide a back path — there is no "stuck in
-        // full-screen" state. The seventh slot is a host-supplied close-button
-        // composable (icon vs. text, host chrome) that does not touch the trust caption
-        // or any other surface affordance, so D5 is unaffected. Bumping from 6 to 7 is
-        // the deliberate change for that slot, not a slip.
+    fun fullScreenDocumentViewHasExactlyNineUserVisibleParameters() {
+        // (doc, pdfFile, renderer, onClose, imageFile, imageDecoder, modifier,
+        // telemetry, closeButton). D5: trust caption is composed inside the surface,
+        // docked outside the zoom transform; no parameter omits it. Required onClose
+        // forces the host to provide a back path — there is no "stuck in full-screen"
+        // state. `closeButton` is a host-supplied close-button composable (icon vs.
+        // text, host chrome) that does not touch the trust caption or any other surface
+        // affordance. Bumping from 7 to 9 is the deliberate wpass-pl7.4 generalization:
+        // `doc` widened to the sealed Document, and the image / composite arms take the
+        // `imageFile` / `imageDecoder` backend pair exactly as DocumentView does —
+        // neither new slot can suppress the caption or add an extraction affordance.
         assertUserVisibleParamCount(
             "FullScreenDocumentViewKt",
             "FullScreenDocumentView",
-            expected = 7,
+            expected = 9,
         )
+    }
+
+    @Test
+    fun fullScreenDocumentViewConsumesImageDecodeBinderInterfaceNotConcreteClient() {
+        // Same contract as DocumentView's image arm: the full-screen surface takes the
+        // binder interface so test fakes inject cleanly.
+        val method = findComposable("FullScreenDocumentViewKt", "FullScreenDocumentView")
+        val typeNames = method.parameterTypes.map { it.simpleName }
+        assertWithMessage("FullScreenDocumentView must accept the ImageDecodeBinder interface")
+            .that(typeNames)
+            .contains("ImageDecodeBinder")
+        assertWithMessage("FullScreenDocumentView must NOT bind to the concrete ImageDecodeClient")
+            .that(typeNames)
+            .doesNotContain("ImageDecodeClient")
     }
 
     @Test

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentSurfaceLockTest.kt
@@ -100,7 +100,7 @@ class DocumentSurfaceLockTest {
 
     @Test
     fun fullScreenDocumentViewHasExactlyNineUserVisibleParameters() {
-        // (doc, pdfFile, renderer, onClose, imageFile, imageDecoder, modifier,
+        // (doc, pdfFile, renderer, imageFile, imageDecoder, onClose, modifier,
         // telemetry, closeButton). D5: trust caption is composed inside the surface,
         // docked outside the zoom transform; no parameter omits it. Required onClose
         // forces the host to provide a back path — there is no "stuck in full-screen"

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentTrustSurfaceTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/DocumentTrustSurfaceTest.kt
@@ -9,9 +9,12 @@ import androidx.compose.ui.test.onNodeWithText
 import android.os.ParcelFileDescriptor
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import `is`.walt.passes.core.ScannableFormat
 import `is`.walt.passes.image.android.ImageDecodeBinder
 import `is`.walt.passes.image.android.ImageDecodeRejectedKind
 import `is`.walt.passes.image.android.ImageDecodeResult
+import `is`.walt.passes.document.BarcodedImageDocument
+import `is`.walt.passes.document.BarcodedImageDocumentId
 import `is`.walt.passes.document.ImageDocument
 import `is`.walt.passes.document.ImageDocumentId
 import `is`.walt.passes.document.PdfDocument
@@ -232,6 +235,88 @@ class DocumentTrustSurfaceTest {
             ).fetchSemanticsNodes().let { nodes ->
                 assertThat(nodes).isEmpty()
             }
+        } finally {
+            pfd.close()
+            file.delete()
+        }
+    }
+
+    @Test
+    fun fullScreenImageDocumentRendersTheNonSuppressibleTrustCaption() {
+        // wpass-pl7.4: the full-screen surface generalized past PDF-only. The image arm
+        // composes the same docked caption as the PDF arm — structurally outside the zoom
+        // transform — and it shows regardless of decode outcome (a rejecting fake keeps
+        // the zoom region empty; the caption must still display).
+        val doc = ImageDocument(
+            id = ImageDocumentId("img-fs"),
+            displayLabel = "boarding.png",
+            byteCount = 2048L,
+            widthPx = 1080,
+            heightPx = 2340,
+            importedAtEpochMs = 0L,
+        )
+        withImagePfd { pfd ->
+            composeRule.setContent {
+                ThemedHost {
+                    FullScreenDocumentView(
+                        doc = doc,
+                        imageFile = pfd,
+                        imageDecoder = rejectingDecoder(),
+                        onClose = {},
+                    )
+                }
+            }
+            composeRule.onNodeWithText(
+                "User-provided document. Walt has not verified the source.",
+            ).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun fullScreenBarcodedImageDocumentRendersTheNonSuppressibleTrustCaption() {
+        // wpass-pl7.4: the composite arm routes its retained photo through the same
+        // full-screen image surface (wpass-8lu routing), so the docked caption anchors
+        // it identically. Payload is a synthetic non-PII fixture (epic constraint 7).
+        val doc = BarcodedImageDocument(
+            id = BarcodedImageDocumentId("comp-fs"),
+            displayLabel = "boarding.png",
+            byteCount = 2048L,
+            widthPx = 1080,
+            heightPx = 2340,
+            barcodePayload = "TEST-PAYLOAD-000",
+            barcodeFormat = ScannableFormat.Aztec,
+            importedAtEpochMs = 0L,
+        )
+        withImagePfd { pfd ->
+            composeRule.setContent {
+                ThemedHost {
+                    FullScreenDocumentView(
+                        doc = doc,
+                        imageFile = pfd,
+                        imageDecoder = rejectingDecoder(),
+                        onClose = {},
+                    )
+                }
+            }
+            composeRule.onNodeWithText(
+                "User-provided document. Walt has not verified the source.",
+            ).assertIsDisplayed()
+        }
+    }
+
+    private fun rejectingDecoder(): ImageDecodeBinder = object : ImageDecodeBinder {
+        override suspend fun decode(
+            image: ParcelFileDescriptor,
+            maxWidthPx: Int,
+            maxHeightPx: Int,
+        ): ImageDecodeResult = ImageDecodeResult.Rejected(ImageDecodeRejectedKind.DecodeFailed)
+    }
+
+    private fun withImagePfd(block: (ParcelFileDescriptor) -> Unit) {
+        val file = File.createTempFile("walt-image-doc", ".png").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        try {
+            block(pfd)
         } finally {
             pfd.close()
             file.delete()

--- a/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/internal/ZoomableImageClipTest.kt
+++ b/passes-document-ui/src/test/kotlin/is/walt/passes/document/ui/internal/ZoomableImageClipTest.kt
@@ -1,0 +1,137 @@
+package `is`.walt.passes.document.ui.internal
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import kotlin.math.roundToInt
+
+/**
+ * Pixel-level lock that zoomed [ZoomableImage] content cannot draw outside its slot
+ * (ADR 0005 Z.8 / wpass-pl7.4 review). The bitmap is scaled with `graphicsLayer`, which
+ * draws OUTSIDE layout bounds unless clipped; on the full-screen surface the slot's
+ * sibling is the docked trust-caption band, so un-clipped overdraw puts attacker-chosen
+ * document pixels behind and around the caption. The PDF arm was only incidentally
+ * protected by `HorizontalPager`'s own clipping; the image arm has no pager, so the clip
+ * must live on [ZoomableImage] itself.
+ *
+ * Layout-bounds assertions cannot see overdraw, so this renders to pixels: a solid-red
+ * bitmap in the full-screen dock structure, the deterministic double-tap 2x zoom, then a
+ * `view.draw` capture (compose-test's window capture does not run under Robolectric)
+ * asserting no red reaches the dock band. The dock is deliberately UNPAINTED: the theme
+ * contract permits a transparent captionBackground, and an opaque dock would mask the
+ * overdraw in sibling draw order — precisely the configuration under which the defect is
+ * user-visible. A vacuous pass is ruled out by asserting the zoom really engaged (red
+ * reaches the slot edges the letterboxed 1x fit leaves white).
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ZoomableImageClipTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun doubleTapZoomedBitmapNeverDrawsIntoTheDockBandBelowItsSlot() {
+        val red = Bitmap.createBitmap(40, 80, Bitmap.Config.ARGB_8888)
+            .apply { eraseColor(RED) }
+            .asImageBitmap()
+
+        composeRule.setContent {
+            // The full-screen surface's BottomDockedLayout shape: the zoom slot takes the
+            // space above a dock band, exactly how FullScreenDocumentView hosts the arms.
+            Box(modifier = Modifier.size(200.dp, 400.dp).background(Color.White)) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Box(modifier = Modifier.fillMaxWidth().height(340.dp)) {
+                        ZoomableImage(
+                            bitmap = red,
+                            contentDescription = "zoom-target",
+                            modifier = Modifier.fillMaxSize(),
+                            pageAspect = 0.5f,
+                        )
+                    }
+                    // No background: models the transparent-captionBackground theme, where
+                    // overdraw into the dock band is not masked by the dock's own paint.
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(60.dp)
+                            .testTag("dock"),
+                    )
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        composeRule.onNodeWithContentDescription("zoom-target").performTouchInput {
+            doubleClick()
+        }
+        composeRule.waitForIdle()
+
+        val view = (composeRule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
+        val capture = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+        view.draw(Canvas(capture))
+        val density = composeRule.density.density
+        val dockTopPx = (
+            composeRule.onNodeWithTag("dock").getUnclippedBoundsInRoot().top.value * density
+            ).roundToInt()
+
+        val counts = countRed(capture, dockTopPx)
+        // Sanity: the red bitmap rendered AND the double-tap zoom engaged — otherwise
+        // the dock assertion would pass vacuously against an unzoomed (in-bounds) fit.
+        assertThat(counts.inSlot).isGreaterThan(0)
+        assertThat(counts.atSlotEdge).isGreaterThan(0)
+        assertWithMessage(
+            "zoomed content pixels drew into the dock band below the slot (Z.8); " +
+                "ZoomableImage must clip to its own bounds",
+        ).that(counts.inDock).isEqualTo(0)
+    }
+
+    private data class RedCounts(val inSlot: Int, val inDock: Int, val atSlotEdge: Int)
+
+    private fun countRed(capture: Bitmap, dockTopPx: Int): RedCounts {
+        var inSlot = 0
+        var inDock = 0
+        var atSlotEdge = 0
+        for (i in 0 until capture.width * capture.height) {
+            val x = i % capture.width
+            val y = i / capture.width
+            if (capture.getPixel(x, y) != RED) continue
+            if (y >= dockTopPx) inDock++ else inSlot++
+            // At 1x the 0.5-aspect fit leaves letterbox gutters at the slot's horizontal
+            // edges; red there proves the 2x zoom really engaged.
+            if (y < dockTopPx && (x < 4 || x > capture.width - 5)) atSlotEdge++
+        }
+        return RedCounts(inSlot, inDock, atSlotEdge)
+    }
+
+    private companion object {
+        const val RED = 0xFFFF0000.toInt()
+    }
+}


### PR DESCRIPTION
Kernel half of the full-screen image-viewing gap in epic wpass-pl7 (defect 2 of the boarding-pass screenshot report). Unblocks walt-android wlt-wanx.

## What

- **FullScreenDocumentView widened from `PdfDocument` to the sealed `Document`**, mirroring `DocumentView`'s dispatcher shape (nullable kind-specific backend pairs, fail-fast `requireNotNull` per arm). This was the API-shape decision recorded in wpass-pl7.4; the consumer preference in wlt-wanx (generalize the existing view rather than ship a sibling + public zoom primitive) is followed. Keeping `ZoomableImage` internal keeps the caption-outside-zoom property structural: no consumer can compose zoom without the docked caption.
- **Image arm**: single `ZoomableImage` over the isolated `passes-image` sandbox. No sub-rect re-render exists on `ImageDecodeBinder`, so the one decode is requested at slot size x max zoom factor, clamped to the same 4 MP cap the service enforces — the sandbox never upscales beyond source, so the raster already carries the sharpest legal pixels at every zoom level.
- **Composite arm**: `BarcodedImageDocument` routes to the same image surface for its retained photo (wpass-8lu routing); the barcode half stays consumer-composed with `passes-ui`.
- **Trust caption**: the docked `DocumentTrustCaption` is a sibling of the arm dispatch inside `BottomDockedLayout` — structurally outside the zoom transform for every arm (ADR 0005 Z.8). No arm can scale it or push it off-surface.
- **Entry path**: `DocumentView`'s `onOpenFullScreen` / `fullScreenAffordance` now wire through the image and composite arms exactly as the PDF arm (banner docked below by default, tap-to-open on the slot region). Without this the generalized surface would be unreachable from inline.

## Tests

- `DocumentSurfaceLockTest`: full-screen param count 7 → 9 (deliberate bump, comment documents why), new ImageDecodeBinder-interface-not-concrete-client lock. Updated, not deleted.
- `DocumentTrustSurfaceTest`: caption pinned on both new full-screen arms (rejecting fake decoder — caption shows regardless of decode outcome).
- `DocumentViewInstrumentedTest`: caption bounds identical before/after pinch on image AND composite full screen; image arm decodes exactly once (no re-decode on pinch); inline image tap + banner invoke the callback. Compile-verified; no device attached in this session.

`./gradlew build` and `:passes-document-ui:check` green.