### PR TITLE
Pin QR CHARACTER_SET to UTF-8 so non-Latin-1 payloads stop silently transliterating (wpass-qj6)

### DIFF
--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -355,10 +355,9 @@ re-derived.
 What is in place instead is attribution rather than prevention: the encoder lifts
 both writers' over-capacity errors to `EncoderFailureReason.PayloadTooDense`, so
 the failure is typed and actionable ("shorten this") rather than opaque. That arm
-only reaches a user if something runs the encoder before persisting, and nothing
-currently does — `ScannableCardCreateResult.EncoderFailure` exists and is consumed
-but never produced. Tracked as `wpass-1kg`; until it lands, an oversized multibyte
-payload saves and renders as the accessible-but-empty placeholder.
+reaches the user because the repository trial-encodes before persisting
+(`wpass-1kg`): an oversized multibyte payload is refused at create/update time
+instead of saving and rendering as the accessible-but-empty placeholder.
 
 The same bead closed the charset half of that property, which the length caps do
 not cover. Both new writers default to ISO-8859-1 while the validator admits any

--- a/docs/SCANNABLE_CARD_THREAT_MODEL.md
+++ b/docs/SCANNABLE_CARD_THREAT_MODEL.md
@@ -366,10 +366,14 @@ visible character on a byte-capable format, so a payload the user can legitimate
 type was unrenderable: `PDF417Writer` threw outright, and `AztecWriter` did worse
 — it encoded and decoded back transliterated, a silent corruption. Pinned
 `PDF417_AUTO_ECI` and `CHARACTER_SET` respectively; both measured to leave the
-all-ASCII case byte-identical in matrix size and capacity. **QR has the same
-silent-transliteration defect and is not yet fixed** (`wpass-qj6`): it predates
-these writers, and adding an ECI header changes the symbol emitted for every
-non-ASCII QR card already stored, so it needs its own scanner verification.
+all-ASCII case byte-identical in matrix size and capacity. QR had the same
+silent-transliteration defect (it predates these writers) and was closed
+separately by `wpass-qj6` with the same `CHARACTER_SET` pin. QR's pin is not free
+the way Aztec's was: `QRCodeWriter` prepends a UTF-8 ECI header to every
+byte-mode symbol, so ASCII byte-mode symbols keep their matrix size but change
+bit pattern, the v40-M byte-mode ceiling drops one byte (2,331 to 2,330, tracked
+in `ScannableFormatConstraints`), and every stored non-ASCII QR card re-renders
+as a different — now correctly decoding — symbol.
 
 **C4. Create-time URI-scheme preview for the byte-capable symbologies.** When the
 user creates a ScannableCard in a format that can carry an actionable payload,

--- a/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
+++ b/passes-barcode-core/src/test/kotlin/is/walt/passes/barcode/BarcodeEncoderRoundTripTest.kt
@@ -78,26 +78,30 @@ class BarcodeEncoderRoundTripTest {
     }
 
     @Test
-    fun nonAsciiPayloadsSurviveOnBothTwoDimensionalFormats() {
+    fun nonAsciiPayloadsSurviveOnTheCharsetPinnedFormats() {
         // The charset pins, and the reason they are pins rather than defaults. At ZXing's
-        // ISO-8859-1 default PDF417 throws outright while AZTEC IS THE DANGEROUS ONE: it encodes
-        // happily and decodes back "café ? naïve ? ??", a wrong scan with no error at any layer.
-        // Dropping either hint has to fail here, so both formats share the one payload.
-        for (format in listOf(ScannableFormat.Pdf417, ScannableFormat.Aztec)) {
+        // ISO-8859-1 default PDF417 throws outright while AZTEC AND QR ARE THE DANGEROUS ONES:
+        // they encode happily and decode back "café ? naïve ? ??", a wrong scan with no error at
+        // any layer (QR's fix is wpass-qj6). Dropping any of the three hints has to fail here,
+        // so all byte-capable formats share the one payload.
+        for (format in listOf(ScannableFormat.Pdf417, ScannableFormat.Aztec, ScannableFormat.Qr)) {
             assertThat(decodeLuminance(render(NON_ASCII_PAYLOAD, format)))
                 .isEqualTo(BarcodeDecodeResult.DecodedBarcode(NON_ASCII_PAYLOAD, format))
         }
     }
 
     @Test
-    fun aztecCarriesSupplementaryPlaneCharactersPdf417RefusesThem() {
-        // The validator admits emoji on both formats. Aztec round-trips them; ZXing cannot put a
-        // surrogate pair through PDF417 under any configuration, so the encoder names that limit
-        // itself rather than letting the writer raise a message with the payload inside it.
+    fun aztecAndQrCarrySupplementaryPlaneCharactersPdf417RefusesThem() {
+        // The validator admits emoji on all three formats. Aztec and QR round-trip them; ZXing
+        // cannot put a surrogate pair through PDF417 under any configuration, so the encoder
+        // names that limit itself rather than letting the writer raise a message with the
+        // payload inside it.
         val payload = "https://example.org/é/👍"
 
-        assertThat(decodeLuminance(render(payload, ScannableFormat.Aztec)))
-            .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, ScannableFormat.Aztec))
+        for (format in listOf(ScannableFormat.Aztec, ScannableFormat.Qr)) {
+            assertThat(decodeLuminance(render(payload, format)))
+                .isEqualTo(BarcodeDecodeResult.DecodedBarcode(payload, format))
+        }
         assertThat(BarcodeEncoder.encode(payload, ScannableFormat.Pdf417))
             .isInstanceOf(EncodeResult.Failure::class.java)
     }

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -118,17 +118,21 @@ internal object ScannableFormatConstraints {
 
     /**
      * UTF-8 byte ceiling for a **byte-mode** QR payload at the encoder's pinned ECC level
-     * (M) and the largest QR version (40). Sourced from the QR spec's capacity tables.
-     * Used by the encoder for a proactive PayloadTooDense check that does not depend on
-     * matching ZXing's English exception text. ECC-M was chosen at the encoder; if that
-     * pin changes, this constant must change in lockstep.
+     * (M) and the largest QR version (40). The spec's table says 2,331, minus one for the
+     * 12-bit ECI header the encoder's pinned UTF-8 CHARACTER_SET adds to every byte-mode
+     * symbol (measured against ZXing 3.5.4: the longest fitting byte-mode payload drops
+     * from 2,331 to 2,330 with the pin). Used by the encoder for a proactive
+     * PayloadTooDense check that does not depend on matching ZXing's English exception
+     * text. ECC-M and UTF-8 were chosen at the encoder; if either pin changes, this
+     * constant must change in lockstep.
      *
      * **Mode-scoped.** QR's numeric and alphanumeric modes have larger ceilings (~5,596
-     * digits, ~3,391 alphanumeric chars at v40-M). The encoder gates this byte-mode
-     * ceiling behind a charset check ([isQrAlphanumericChar]); payloads that fit a denser
-     * mode bypass the proactive check and fall through to ZXing's mode selection.
+     * digits, ~3,391 alphanumeric chars at v40-M) and carry no ECI header. The encoder
+     * gates this byte-mode ceiling behind a charset check ([isQrAlphanumericChar]);
+     * payloads that fit a denser mode bypass the proactive check and fall through to
+     * ZXing's mode selection.
      */
-    internal const val QR_BYTE_CEILING_ECC_M_BYTE_MODE: Int = 2_331
+    internal const val QR_BYTE_CEILING_ECC_M_BYTE_MODE: Int = 2_330
 
     /**
      * QR alphanumeric mode's character set (per ISO/IEC 18004): digits, uppercase A-Z, and

--- a/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/ScannableFormatConstraints.kt
@@ -174,8 +174,8 @@ internal object ScannableFormatConstraints {
      *
      * What closes the hole instead is the encoder lifting the writers' over-capacity errors to
      * [EncoderFailureReason.PayloadTooDense], so an oversized multibyte payload gets an
-     * actionable "shorten this" rather than a silent failure. That arm only reaches the user if
-     * something runs the encoder before persisting, which nothing currently does — see wpass-1kg.
+     * actionable "shorten this" rather than a silent failure. The arm reaches the user because
+     * the repository trial-encodes before persisting (wpass-1kg).
      *
      * A boarding pass is the sizing case that matters and is nowhere near either: an IATA
      * BCBP payload runs ~60 characters per leg.

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -66,25 +66,31 @@ import com.google.zxing.BarcodeFormat as ZxingFormat
  * space the render layer then letterboxes, on top of the quiet zone it already applies
  * itself. This is the one place the kernel overrides a writer's own margin.
  *
- * **Character set.** Both writers default to ISO-8859-1, and the validator admits any visible
+ * **Character set.** The writers default to ISO-8859-1, and the validator admits any visible
  * character for the byte-capable formats, so the default loses payloads a user can legitimately
- * type. The two symbologies fail differently and both are addressed: `PDF417Writer` throws
+ * type. The three symbologies fail differently and all are addressed: `PDF417Writer` throws
  * outright on a non-Latin-1 character, fixed by `PDF417_AUTO_ECI`, which emits an ECI header
- * only when one is actually needed; `AztecWriter` is the worse case — it encodes happily and
- * decodes back transliterated ("東京" returns as "??"), a silent corruption fixed by pinning
- * CHARACTER_SET. Measured: both fixes leave the all-ASCII case byte-identical in matrix size
- * and capacity, so they cost nothing at boarding-pass payloads.
+ * only when one is actually needed; `AztecWriter` and `QRCodeWriter` are the worse case — they
+ * encode happily and decode back transliterated ("東京" returns as "??"), a silent corruption
+ * fixed by pinning CHARACTER_SET. Measured: the PDF417 and Aztec pins leave the all-ASCII case
+ * byte-identical in matrix size and capacity, so they cost nothing at boarding-pass payloads.
  *
- * QR has the same silent-transliteration defect and is NOT fixed here — it predates this bead
- * and changing the emitted symbol for existing QR cards needs its own scanner verification.
- * Tracked as wpass-qj6.
+ * The QR pin (wpass-qj6) is not free in the same way, because `QRCodeWriter` prepends a UTF-8
+ * ECI header to every BYTE-MODE symbol once the hint is set: numeric/alphanumeric-mode symbols
+ * stay byte-identical, ASCII byte-mode symbols keep their matrix size but change bit pattern,
+ * and the 12-bit header lowers the v40-M byte-mode ceiling by one byte (see
+ * [ScannableFormatConstraints.QR_BYTE_CEILING_ECC_M_BYTE_MODE]). Every non-ASCII QR card
+ * created before the pin re-renders as a different (now correct) symbol.
  */
 internal object ZxingBarcodeEncoder {
     // Per-writer hint maps. Each writer reads ERROR_CORRECTION as a different type —
     // ErrorCorrectionLevel for QR, an Int percentage for Aztec, an Int level for PDF417 —
     // so the maps cannot be merged. See the class KDoc for how each value was chosen.
     private val qrHints: Map<EncodeHintType, Any> =
-        mapOf(EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M)
+        mapOf(
+            EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+            EncodeHintType.CHARACTER_SET to UTF_8,
+        )
 
     private val aztecHints: Map<EncodeHintType, Any> =
         mapOf(

--- a/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
+++ b/passes-core/src/main/kotlin/is/walt/passes/core/internal/ZxingBarcodeEncoder.kt
@@ -151,7 +151,7 @@ internal object ZxingBarcodeEncoder {
      *
      * The QR check is a proactive [EncoderFailureReason.PayloadTooDense], gated by the alphanumeric-mode
      * membership test: a payload that fits QR's numeric or alphanumeric mode has a much larger
-     * capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs 2,331
+     * capacity than byte mode (~5,596 digits or ~3,391 alphanumeric chars at v40-M vs 2,330
      * bytes), and ZXing's QRCodeWriter auto-selects the densest fitting mode, so pre-rejecting
      * such payloads against the byte-mode ceiling would over-reject. Anything outside the
      * alphanumeric set must use byte mode, where the byte-count check applies — UTF-8 because

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -173,7 +173,7 @@ class BarcodeEncoderTest {
     @Test
     fun qrPayloadTooDenseLiftsToDedicatedArm() {
         // Largest QR version maxes out around ~2,953 bytes at error correction L; at level M
-        // (the kernel's pin) the byte ceiling is ~2,331. A 4,000-char payload exceeds every
+        // (the kernel's pin) the byte ceiling is ~2,330. A 4,000-char payload exceeds every
         // version regardless of mode, forcing the writer's "Data too big" path.
         val result = BarcodeEncoder.encode("A".repeat(4_000), ScannableFormat.Qr)
         val failure = (result as EncodeResult.Failure).reason
@@ -224,7 +224,7 @@ class BarcodeEncoderTest {
 
     @Test
     fun proactiveQrByteCeilingHandlesNonAsciiByteCountCorrectly() {
-        // Char count of 1,200 sits below QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,331) — but each
+        // Char count of 1,200 sits below QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,330) — but each
         // "é" is two UTF-8 bytes, so the byte count is 2,400 and the proactive guard must
         // fire. Pins the load-bearing detail that the byte-length check is on UTF-8 bytes,
         // not chars; a regression to String.length would let this slip through to ZXing.
@@ -238,7 +238,7 @@ class BarcodeEncoderTest {
 
     @Test
     fun denseNumericQrPayloadEncodesViaNumericMode() {
-        // Pure-digit payload of 3,000 chars: above QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,331)
+        // Pure-digit payload of 3,000 chars: above QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,330)
         // and above QR v40-M alphanumeric capacity (~3,391 chars — close but under), but
         // well under v40-M numeric capacity (~5,596 digits). ZXing's QRCodeWriter
         // auto-selects numeric mode and encodes successfully. Pins that the proactive

--- a/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
+++ b/passes-core/src/test/kotlin/is/walt/passes/core/BarcodeEncoderTest.kt
@@ -237,6 +237,22 @@ class BarcodeEncoderTest {
     }
 
     @Test
+    fun qrByteModeCeilingIsExactAtTheBoundary() {
+        // Pins the measured ceiling itself, not just the far-over cases: 2,330 one-byte chars
+        // is the longest byte-mode payload ZXing 3.5.4 fits at v40-M with the UTF-8 ECI header
+        // the CHARACTER_SET pin adds, and 2,331 must refuse as PayloadTooDense. Lowercase keeps
+        // the payload out of alphanumeric mode so the byte-mode path is the one exercised. If a
+        // ZXing bump moves real capacity, the success half fails and the constant gets
+        // re-measured rather than silently going stale.
+        val atCeiling = BarcodeEncoder.encode("a".repeat(2_330), ScannableFormat.Qr)
+        assertThat(atCeiling).isInstanceOf(EncodeResult.Success::class.java)
+
+        val overCeiling = BarcodeEncoder.encode("a".repeat(2_331), ScannableFormat.Qr)
+        assertThat((overCeiling as EncodeResult.Failure).reason)
+            .isEqualTo(EncoderFailureReason.PayloadTooDense)
+    }
+
+    @Test
     fun denseNumericQrPayloadEncodesViaNumericMode() {
         // Pure-digit payload of 3,000 chars: above QR_BYTE_CEILING_ECC_M_BYTE_MODE (2,330)
         // and above QR v40-M alphanumeric capacity (~3,391 chars — close but under), but


### PR DESCRIPTION
## Summary

`QRCodeWriter` fell back to ISO-8859-1 because `qrHints` never set `CHARACTER_SET`, so a payload the validator accepts (`café — naïve — 東京`) encoded to a symbol that decoded back corrupted (`café ? naïve ? ??`) with no error at any layer — the card saved, rendered, and scanned back wrong. Aztec had the identical defect and was fixed in wpass-pl7.6; this closes the QR half (wpass-qj6).

## Changes

- Pin `EncodeHintType.CHARACTER_SET` to UTF-8 on `qrHints` in `ZxingBarcodeEncoder`.
- Move `QR_BYTE_CEILING_ECC_M_BYTE_MODE` 2,331 → 2,330: the 12-bit UTF-8 ECI header the pin adds to every byte-mode symbol costs one byte of v40-M capacity (measured by binary search against ZXing 3.5.4).
- Round-trip coverage: QR joins Aztec/PDF417 in the non-ASCII and supplementary-plane cases in `BarcodeEncoderRoundTripTest`, plus a new exact-boundary test (`2,330` encodes, `2,331` refuses as `PayloadTooDense`) so the measured constant fails loudly on a ZXing bump.
- Threat model and constants docs updated, including retiring the stale "nothing runs the encoder before persisting" claim (wpass-1kg landed in #215).

## Measured ASCII impact (ZXing 3.5.4)

- Numeric/alphanumeric-mode symbols: byte-identical with the pin.
- ASCII byte-mode symbols: same matrix size, bit pattern changes (the ECI header).
- Every stored non-ASCII QR card re-renders as a different — now correctly decoding — symbol.

## Testing

- `:passes-core:test` and `:passes-barcode-core:test` green (21 encoder tests, 6 round-trip suites).
- ktlint + detekt clean.
- Bead close bar note: third-party-scanner verification of a rendered non-ASCII QR is tracked on wpass-qj6 and stays open until confirmed on a phone.