### PR TITLE
Rewind the source PFD before each bounded raster read so decode is idempotent per fd (wpass-07h)

### DIFF
--- a/passes-image/build.gradle.kts
+++ b/passes-image/build.gradle.kts
@@ -68,6 +68,10 @@ dependencies {
 
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.test.runner)
+    // For the wpass-07h regression guard: materialize a real memfd (MemfdPfdFactory) and
+    // decode it twice through the real service. Compile-time visibility only; the main
+    // dependency above stays implementation.
+    androidTestImplementation(project(":passes-isolation"))
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.truth)
     androidTestImplementation(libs.kotlinx.coroutines.test)

--- a/passes-image/src/androidTest/kotlin/is/walt/passes/image/android/ImageDecodeServiceInstrumentedTest.kt
+++ b/passes-image/src/androidTest/kotlin/is/walt/passes/image/android/ImageDecodeServiceInstrumentedTest.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.os.Build
 import android.os.IBinder
 import android.os.Parcel
 import android.os.ParcelFileDescriptor
@@ -14,7 +15,10 @@ import android.os.Process
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import `is`.walt.passes.isolation.MemfdPfdFactory
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.ByteArrayOutputStream
@@ -100,6 +104,40 @@ class ImageDecodeServiceInstrumentedTest {
 
         assertThat(result)
             .isEqualTo(ImageDecodeResult.Rejected(ImageDecodeRejectedKind.DimensionsTooLarge))
+    }
+
+    @Test
+    fun sameMemfdDecodesTwiceThroughTheRealService() {
+        // wpass-07h regression guard: decoding one shared PFD from two surfaces (inline card +
+        // full-screen overlay) must both succeed. dup()/binder passing share the open file
+        // description, so without the per-decode rewind the second decode reads from EOF and
+        // silently renders blank. memfd is the production shape (passes-isolation materializes
+        // stored bytes into one); memfd_create needs API 30, so API 28 relies on the
+        // file-backed variant below — the shared-offset semantics are identical.
+        assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+        val png = ByteArrayOutputStream()
+            .also { solidBitmap(80, 40, Color.YELLOW).compress(Bitmap.CompressFormat.PNG, 100, it) }
+            .toByteArray()
+        val pfd = MemfdPfdFactory("wpass-07h-guard").fromBytes(png)
+        pfd.use { assertDecodesTwice(it) }
+    }
+
+    @Test
+    fun sameFileFdDecodesTwiceThroughTheRealService() {
+        // File-backed companion to the memfd guard: runs on the full API matrix (28+), same
+        // shared-offset semantics.
+        val pfd = pngFd("decode-twice", solidBitmap(80, 40, Color.YELLOW))
+        pfd.use { assertDecodesTwice(it) }
+    }
+
+    private fun assertDecodesTwice(pfd: ParcelFileDescriptor) {
+        repeat(2) { pass ->
+            val result = decode(pfd, maxWidthPx = 64, maxHeightPx = 64)
+            assertWithMessage("decode pass ${pass + 1} of the same PFD")
+                .that(result)
+                .isInstanceOf(ImageDecodeResult.Ok::class.java)
+            (result as ImageDecodeResult.Ok).sharedMemory.close()
+        }
     }
 
     @Test

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/BoundedRasterDecoder.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/BoundedRasterDecoder.kt
@@ -4,6 +4,8 @@ import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.os.ParcelFileDescriptor
 import android.os.SharedMemory
+import android.system.ErrnoException
+import android.system.Os
 import android.system.OsConstants
 import `is`.walt.passes.image.decode.BoundedBitmap
 import `is`.walt.passes.image.decode.BoundedDecodePolicy
@@ -31,6 +33,13 @@ import kotlin.math.roundToInt
  * source fd. Pulling the compressed bytes into the sandbox heap is fine: isolation keeps them
  * off the *caller's* heap; the file-size cap bounds how many can be read.
  *
+ * The read starts with a rewind to offset 0 ([rewindToStart]) rather than trusting the fd's
+ * inherited offset: `dup()` and binder fd passing share the open file *description*, so after
+ * one decode a shared fd sits at EOF and a second decode of the same PFD would silently read
+ * zero bytes (wpass-07h — two surfaces decoding one stored image fd). Non-seekable sources
+ * (pipes) reject the seek with `ESPIPE`, which is swallowed: a pipe has no offset to inherit,
+ * so stream semantics are already correct there.
+ *
  * Stays a top-level function (not a class) so its phases are unit-testable without a live
  * service: [readBoundedBytes] against a pipe, [headerRejection] against the cap table, and
  * [outputDims] against the scaling math.
@@ -49,6 +58,7 @@ internal fun decodeRasterFromPfd(
     }
     val read =
         runCatching {
+            rewindToStart(image)
             ParcelFileDescriptor.AutoCloseInputStream(image.dup()).use { readBoundedBytes(it, config.maxBytes) }
         }
     val bytes = read.getOrNull()
@@ -61,6 +71,20 @@ internal fun decodeRasterFromPfd(
 
 internal fun isOutputSizeValid(maxWidthPx: Int, maxHeightPx: Int, maxOutputPixels: Long): Boolean =
     maxWidthPx > 0 && maxHeightPx > 0 && maxWidthPx.toLong() * maxHeightPx.toLong() <= maxOutputPixels
+
+/**
+ * Seek [image] back to offset 0 so a decode never depends on the offset a shared open file
+ * description arrived with, making decode idempotent for a given PFD. `ESPIPE` (non-seekable
+ * source: pipes here and in the tests, some `ContentResolver` fds) is swallowed — such an fd
+ * has no offset to rewind. Any other errno propagates to the caller's containment.
+ */
+internal fun rewindToStart(image: ParcelFileDescriptor) {
+    try {
+        Os.lseek(image.fileDescriptor, 0, OsConstants.SEEK_SET)
+    } catch (e: ErrnoException) {
+        if (e.errno != OsConstants.ESPIPE) throw e
+    }
+}
 
 /**
  * Read at most [maxBytes] from [input], returning null the moment the source exceeds the cap

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/BoundedRasterDecoder.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/BoundedRasterDecoder.kt
@@ -33,13 +33,6 @@ import kotlin.math.roundToInt
  * source fd. Pulling the compressed bytes into the sandbox heap is fine: isolation keeps them
  * off the *caller's* heap; the file-size cap bounds how many can be read.
  *
- * The read starts with a rewind to offset 0 ([rewindToStart]) rather than trusting the fd's
- * inherited offset: `dup()` and binder fd passing share the open file *description*, so after
- * one decode a shared fd sits at EOF and a second decode of the same PFD would silently read
- * zero bytes (wpass-07h — two surfaces decoding one stored image fd). Non-seekable sources
- * (pipes) reject the seek with `ESPIPE`, which is swallowed: a pipe has no offset to inherit,
- * so stream semantics are already correct there.
- *
  * Stays a top-level function (not a class) so its phases are unit-testable without a live
  * service: [readBoundedBytes] against a pipe, [headerRejection] against the cap table, and
  * [outputDims] against the scaling math.

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageDecodeBinder.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageDecodeBinder.kt
@@ -30,8 +30,10 @@ import android.os.SharedMemory
  *
  * PFD ownership: the caller retains ownership of the [ParcelFileDescriptor] it passes. The
  * binder duplicates the underlying fd on the way across; the decode service owns and closes
- * its received copy. The returned [ImageDecodeResult.Ok.sharedMemory] is owned by the caller,
- * which must [SharedMemory.close] it once the raster has been consumed.
+ * its received copy. Duplication shares the open file description — offset included — so the
+ * service rewinds seekable fds before reading; decoding the same PFD from several surfaces is
+ * supported (wpass-07h). The returned [ImageDecodeResult.Ok.sharedMemory] is owned by the
+ * caller, which must [SharedMemory.close] it once the raster has been consumed.
  */
 public interface ImageDecodeBinder {
     /**

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageDecodeBinder.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageDecodeBinder.kt
@@ -32,8 +32,9 @@ import android.os.SharedMemory
  * binder duplicates the underlying fd on the way across; the decode service owns and closes
  * its received copy. Duplication shares the open file description — offset included — so the
  * service rewinds seekable fds before reading; decoding the same PFD from several surfaces is
- * supported (wpass-07h). The returned [ImageDecodeResult.Ok.sharedMemory] is owned by the
- * caller, which must [SharedMemory.close] it once the raster has been consumed.
+ * supported sequentially — concurrent decodes of one descriptor race the shared offset
+ * (wpass-07h). The returned [ImageDecodeResult.Ok.sharedMemory] is owned by the caller,
+ * which must [SharedMemory.close] it once the raster has been consumed.
  */
 public interface ImageDecodeBinder {
     /**

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageSource.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageSource.kt
@@ -20,7 +20,8 @@ import android.os.ParcelFileDescriptor
  * Ownership: the caller retains ownership of the [ContentResolver], the [Uri], and any
  * [ParcelFileDescriptor] passed in. The decoder reads from these but does not close them;
  * closing remains the caller's responsibility once `decode` returns. A seekable descriptor is
- * rewound per decode, so the same PFD may be decoded any number of times (wpass-07h).
+ * rewound per decode, so the same PFD may be decoded any number of times — sequentially;
+ * concurrent decodes of one descriptor race the shared offset (wpass-07h).
  */
 public sealed interface ImageSource {
     public class ContentUri(

--- a/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageSource.kt
+++ b/passes-image/src/main/kotlin/is/walt/passes/image/android/ImageSource.kt
@@ -19,7 +19,8 @@ import android.os.ParcelFileDescriptor
  *
  * Ownership: the caller retains ownership of the [ContentResolver], the [Uri], and any
  * [ParcelFileDescriptor] passed in. The decoder reads from these but does not close them;
- * closing remains the caller's responsibility once `decode` returns.
+ * closing remains the caller's responsibility once `decode` returns. A seekable descriptor is
+ * rewound per decode, so the same PFD may be decoded any number of times (wpass-07h).
  */
 public sealed interface ImageSource {
     public class ContentUri(

--- a/passes-image/src/test/kotlin/is/walt/passes/image/android/ImageDecodeServiceTest.kt
+++ b/passes-image/src/test/kotlin/is/walt/passes/image/android/ImageDecodeServiceTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.io.File
 
 /**
  * Behavioural coverage for [doDecode], the service-side orchestration that wraps the bounded
@@ -21,7 +22,9 @@ import org.robolectric.annotation.Config
  *    escaping the sandbox;
  *  - the source descriptor is closed on every outcome;
  *  - the real fd glue ([decodeRasterFromPfd]) rejects an over-cap source and an out-of-bounds
- *    output request without closing the source PFD (the dup idiom prevents a double-close).
+ *    output request without closing the source PFD (the dup idiom prevents a double-close);
+ *  - the read rewinds a seekable fd to offset 0 and tolerates a non-seekable pipe, so a decode
+ *    never inherits another consumer's EOF offset (wpass-07h).
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -84,6 +87,31 @@ class ImageDecodeServiceTest {
 
         assertThat(result).isEqualTo(ImageDecodeResult.Rejected(ImageDecodeRejectedKind.OversizedAtImport))
         assertThat(readEnd.fileDescriptor.valid()).isTrue()
+        readEnd.close()
+    }
+
+    @Test
+    fun decodeRasterFromPfdRereadsFromOffsetZeroAfterAPriorFullConsume() {
+        // wpass-07h regression pin: dup() shares the open file description, so a shared fd
+        // arrives at EOF after another consumer read it. The decode must rewind rather than
+        // silently read zero bytes; with the tiny cap the re-read trips OversizedAtImport,
+        // which proves the bytes were read again from offset 0.
+        val file = File.createTempFile("wpass-07h", ".bin").apply { writeBytes(ByteArray(64)) }
+        val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        ParcelFileDescriptor.AutoCloseInputStream(pfd.dup()).use { it.readBytes() }
+
+        val result = decodeRasterFromPfd(pfd, MAX_W, MAX_H, ImageDecodeConfig(maxBytes = 4))
+
+        assertThat(result).isEqualTo(ImageDecodeResult.Rejected(ImageDecodeRejectedKind.OversizedAtImport))
+        pfd.close()
+        file.delete()
+    }
+
+    @Test
+    fun rewindToStartToleratesANonSeekablePipe() {
+        // Pipes have no offset to rewind; ESPIPE is swallowed rather than failing the decode.
+        val readEnd = pipeReadEnd()
+        rewindToStart(readEnd)
         readEnd.close()
     }
 


### PR DESCRIPTION
## Summary
- `decodeRasterFromPfd` now seeks the source PFD to offset 0 before reading (`rewindToStart`), so a decode never depends on the offset a shared open file description arrived with. `dup()` and binder fd passing share the open file description, so after one decode a shared memfd sat at EOF and a second decode of the same PFD read zero bytes - surfacing in the consumer as a silent blank full-screen image (walt-android wlt-ppox, FP4 / Android 15).
- `ESPIPE` from non-seekable sources (pipes in the tests, some `ContentResolver` fds) is swallowed: a pipe has no offset to inherit, so stream semantics are already correct there. Any other errno folds into the existing containment.
- Contract docs on `ImageDecodeBinder` / `ImageSource` now state the same-PFD-decodes-repeatedly guarantee they previously only implied.
- Follow-up filed for the same latent idiom in `passes-barcode` (decode-once today, no symptom).

## Test plan
- [x] JVM pins: re-read from offset 0 after a prior full consume trips `OversizedAtImport` (proves bytes were re-read); `rewindToStart` tolerates a pipe. `./gradlew check` green.
- [x] Instrumented regression guards: the same memfd (API 30+) and the same file-backed fd (full matrix incl. API 28) each decode twice through the real `ImageDecodeService`, both `Ok`.
- [x] Guards verified to fail on device (FP4 / Android 15) with the rewind removed, then pass with it restored.